### PR TITLE
R authoring gaps: NA-bearing pattern-family cases, and delete_support_file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,7 +789,7 @@ browser (Pyodide/wasm) and native worker grading paths sharing one RunnerCore
 implementation; per-student personalization; pattern-generated test families
 (8 kinds) and notebook checks (10 kinds); achievements; student slip days;
 per-course roles; BrightSpace grade sync (awaiting UW IST prod credentials);
-an MCP authoring surface of 51 tools plus a read-only admin-diagnostics MCP
+an MCP authoring surface of 52 tools plus a read-only admin-diagnostics MCP
 of 19 (`MCPToolCatalog.live` in
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift` is the count's
 source of truth); OIDC SSO; and zero-downtime auto-deploys.

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -158,7 +158,10 @@ enum MCPServerInstructions {
         with update_solution (which stores it as the validation submission and re-runs validation).
         - Support files — non-graded helper/data files bundled in the setup zip (e.g. a CSV a check \
         loads, a helper module tests import). List or read them with get_support_files (byte-capped \
-        reads, so big datasets return a useful head); write one with author_script(tier:"support") — \
+        reads, so big datasets return a useful head); remove one with delete_support_file (support \
+        files only — a graded row belongs to delete_suite_item or its family/check, and the reserved \
+        setup members are refused; any graderOnly / dataset mark naming the file is cleared with it); \
+        write one with author_script(tier:"support") — \
         passing the body inline as content, or, for a data file too large to inline faithfully (e.g. a \
         big CSV), passing sourceUrl (an https URL the server fetches under an SSRF guard: https only, \
         no private/loopback/metadata hosts, no redirects, 8 MB cap, UTF-8 body). \
@@ -225,7 +228,8 @@ enum MCPServerInstructions {
         family, or check into a section, or ungroup it), delete_suite_item (remove a script, family, \
         or check). Notebook/solution: update_notebook (replace the starter notebook), update_solution \
         (replace the reference solution and re-validate). Escape hatch: author_script (create/replace \
-        a hand-written test — only when no native kind fits — or a non-graded support/helper file). \
+        a hand-written test — only when no native kind fits — or a non-graded support/helper file), \
+        and delete_support_file to remove a support file outright rather than blanking it. \
         To create a new assignment, either clone_assignment from a known-good one and then edit the \
         copy (the safest path) or create_assignment to start a fresh notebook-based assignment from a \
         starter .ipynb.

--- a/Sources/APIServer/MCP/Tools/DeleteSupportFileTool.swift
+++ b/Sources/APIServer/MCP/Tools/DeleteSupportFileTool.swift
@@ -1,0 +1,213 @@
+// APIServer/MCP/Tools/DeleteSupportFileTool.swift
+//
+// Write tool: remove one non-graded support/data file from an assignment's
+// test-setup zip.  content:write, course-scoped.  The counterpart to
+// author_script(tier: "support"), which could create and replace a support file
+// but never remove one — the only way to retire a support file through MCP was
+// to overwrite it with a stub, leaving a dead entry in the zip that students
+// could still download.
+//
+// Deliberately narrow: this deletes *support* files only.  A graded suite row
+// (hand-written test, pattern-family case, notebook check) is owned by
+// delete_suite_item / the family / the check, and reserved setup members
+// (the manifest, the starter and solution notebooks) are structural — deleting
+// any of them through this door would corrupt the setup, so each is refused
+// with a pointer at the right tool.
+//
+// Removing the file also drops any `graderOnlyFiles` / `datasets` manifest
+// marks that named it, so a later file of the same name doesn't silently
+// inherit the old marks.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+struct DeleteSupportFileTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// Bare support filename to remove (from get_support_files).
+        let filename: String
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let removed: String
+        /// Support files left in the setup after the removal.
+        let remainingSupportFileCount: Int
+        /// true when the removal also cleared a graderOnly / dataset mark.
+        let clearedManifestMarks: Bool
+        let validationStatus: String?
+        /// true when this edit closed a previously-open (or preview) assignment.
+        let assignmentClosed: Bool
+    }
+
+    static let name = "delete_support_file"
+    static let description =
+        "Remove one non-graded support/data file from an assignment's test setup, by public ID + "
+        + "filename (names come from get_support_files). Use it to retire a helper module, a stale "
+        + "CSV fixture, or a file left behind by earlier content — overwriting it with a stub is no "
+        + "longer necessary. Support files only: a graded test, a pattern-family case, or a notebook "
+        + "check is refused (use delete_suite_item, or edit the family/check), and so are the "
+        + "reserved setup members test.properties.json / assignment.ipynb / solution.ipynb. Any "
+        + "graderOnly or per-student dataset mark naming the file is cleared with it. Saving "
+        + "re-packs the setup zip, re-syncs the shared support directory (student symlinks to the "
+        + "file disappear), closes the assignment if it was open (reported as `assignmentClosed`; "
+        + "re-open with update_assignment once validation passes), and re-runs validation — which "
+        + "will fail if a remaining test still sources the file, so check get_suite first."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.assignmentPublicID,
+            "filename": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Bare support filename to remove, no path separators (from get_support_files)."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("filename")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.string,
+            "removed": MCPSchema.string,
+            "remainingSupportFileCount": MCPSchema.integer,
+            "clearedManifestMarks": MCPSchema.boolean,
+            "validationStatus": MCPSchema.string,
+            "assignmentClosed": MCPSchema.boolean,
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("removed"),
+            .string("remainingSupportFileCount"), .string("clearedManifestMarks"),
+            .string("assignmentClosed"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: true, idempotentHint: false)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    /// Structural members of a test setup. None is a support file, and removing
+    /// any would corrupt the setup rather than tidy it.
+    static let reservedFilenames: Set<String> = [
+        "test.properties.json", "assignment.ipynb", "solution.ipynb",
+    ]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let cleaned = sanitizeSuiteFilename(input.filename)
+        guard !cleaned.isEmpty, cleaned == input.filename else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail:
+                    "filename must be a bare filename with no path separators (got \"\(input.filename)\").")
+        }
+
+        guard !Self.reservedFilenames.contains(cleaned) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "\"\(cleaned)\" is a reserved part of the test setup, not a support file. "
+                    + "Edit it with update_notebook / update_solution, or the suite tools.")
+        }
+
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .ta)
+
+        // A graded row is owned by the suite tools; point at the right one
+        // rather than tearing the file out from under its manifest entry.
+        if let familyID = generatedByFamilyID(manifestJSON: setup.manifest, filename: cleaned) {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "\"\(cleaned)\" is generated from pattern family \"\(familyID)\"; "
+                    + "remove the family with delete_suite_item(familyID: \"\(familyID)\") instead.")
+        }
+        let manifest = setup.decodedManifest()
+        if manifest?.testSuites.contains(where: { $0.script == cleaned }) == true {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "\"\(cleaned)\" is a graded test, not a support file. Remove it with "
+                    + "delete_suite_item(script: \"\(cleaned)\").")
+        }
+
+        guard listZipEntries(zipPath: setup.zipPath).contains(cleaned) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "No support file \"\(cleaned)\" in this test setup (see get_support_files).")
+        }
+
+        do {
+            try removeScriptFromZip(zipPath: setup.zipPath, filename: cleaned)
+        } catch {
+            throw MCPToolError.executionFailed(
+                tool: Self.name, detail: "Failed to remove \"\(cleaned)\" from the setup zip.")
+        }
+
+        // Drop any manifest marks that named the file, so a future file reusing
+        // the name doesn't inherit them.
+        let clearedMarks = try await Self.clearManifestMarks(
+            setup: setup, filename: cleaned, on: context.db)
+
+        // Re-sync the shared support directory: it is wiped and re-extracted
+        // from the zip, so the removed file (and student symlinks to it) go too.
+        let testSuiteScripts: Set<String> = {
+            guard let props = setup.decodedManifest() else { return [] }
+            return Set(props.testSuites.map(\.script))
+        }()
+        extractSupportFilesToSharedDirectory(
+            zipPath: setup.zipPath,
+            setupID: assignment.testSetupID,
+            testSuiteScripts: testSuiteScripts,
+            testSetupsDirectory: context.request.application.testSetupsDirectory)
+
+        // Close, re-grade, and re-validate (matching the web Save button). A
+        // test that still sources the deleted file surfaces here as a failed
+        // validation rather than as a surprise at submission time.
+        let finalized = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
+
+        // Count with get_support_files' own predicate so the number a caller
+        // gets back matches the list they'd read next.
+        let remaining = listZipEntries(zipPath: setup.zipPath).filter {
+            !testSuiteScripts.contains($0) && !GetSupportFilesTool.reservedNames.contains($0)
+        }
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            removed: cleaned,
+            remainingSupportFileCount: remaining.count,
+            clearedManifestMarks: clearedMarks,
+            validationStatus: assignment.validationStatus,
+            assignmentClosed: finalized.assignmentClosed)
+    }
+
+    /// Removes `filename` from the manifest's `graderOnlyFiles` and `datasets`
+    /// lists. Returns true when either actually changed.
+    private static func clearManifestMarks(
+        setup: APITestSetup, filename: String, on db: any Database
+    ) async throws -> Bool {
+        let dict = (try? JSONSerialization.jsonObject(with: Data(setup.manifest.utf8))) as? [String: Any]
+        let wasGraderOnly = ((dict?["graderOnlyFiles"] as? [String]) ?? []).contains(filename)
+        let wasDataset = ((dict?["datasets"] as? [[String: Any]]) ?? []).contains {
+            ($0["filename"] as? String) == filename
+        }
+        guard wasGraderOnly || wasDataset else { return false }
+
+        try await mutateManifest(setup: setup, on: db) { dict in
+            if wasGraderOnly {
+                var files = (dict["graderOnlyFiles"] as? [String]) ?? []
+                files.removeAll { $0 == filename }
+                dict["graderOnlyFiles"] = files
+            }
+            if wasDataset {
+                var specs = (dict["datasets"] as? [[String: Any]]) ?? []
+                specs.removeAll { ($0["filename"] as? String) == filename }
+                if specs.isEmpty {
+                    dict.removeValue(forKey: "datasets")
+                } else {
+                    dict["datasets"] = specs
+                }
+            }
+        }
+        return true
+    }
+}

--- a/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
@@ -109,7 +109,9 @@ struct GetSupportFilesTool: ContentTool {
 
     /// Zip entries that are never support files: the canonical notebooks have
     /// dedicated read tools. Matches `extractSupportFilesToSharedDirectory`.
-    private static let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+    /// `DeleteSupportFileTool` reuses this so its remaining-count agrees with
+    /// what this tool lists, instead of the two filters drifting apart.
+    static let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         let (assignment, setup) = try await context.authorizedAssignmentAndSetup(

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -53,6 +53,7 @@ enum MCPToolCatalog {
             UpdateNotebookTool().erased(),
             UpdateSolutionTool().erased(),
             AuthorScriptTool().erased(),
+            DeleteSupportFileTool().erased(),
             CreateCourseSectionTool().erased(),
             RenameCourseSectionTool().erased(),
             DeleteCourseSectionTool().erased(),

--- a/Sources/Core/JSONValue.swift
+++ b/Sources/Core/JSONValue.swift
@@ -77,14 +77,20 @@ public indirect enum JSONValue: Codable, Equatable, Sendable {
     /// Deterministic R literal representation, suitable for embedding inside
     /// generated R test scripts and the `_ck_inputs.R` inputs file. Mirrors
     /// `pythonLiteral` but emits R syntax:
-    ///   - null → NULL; true/false → TRUE/FALSE
+    ///   - null → NA; true/false → TRUE/FALSE
     ///   - an array whose elements are all the same scalar kind (all logical,
-    ///     all numeric, or all character) → `c(...)`; anything else (mixed,
-    ///     nested, containing null/objects, or empty) → `list(...)`
+    ///     all numeric, or all character), optionally interleaved with nulls
+    ///     → `c(...)`; anything else (mixed kinds, nested, containing objects,
+    ///     or empty) → `list(...)`
     ///   - object → named `list(...)` with keys in sorted order
+    ///
+    /// A JSON null is a *missing value*, which in R is `NA` — not `NULL`.
+    /// `NULL` is a zero-length object that silently vanishes inside `c()`, so
+    /// rendering it here would shorten the vector and break the alignment an
+    /// authored case depends on (`[60, null, 20]` must stay length 3).
     public var rLiteral: String {
         switch self {
-        case .null: return "NULL"
+        case .null: return "NA"
         case .bool(let b): return b ? "TRUE" : "FALSE"
         case .int(let i): return String(i)
         case .double(let d):
@@ -130,20 +136,36 @@ private func encodePythonString(_ s: String) -> String {
 /// True when every element is a scalar of the *same* R atomic kind (all
 /// logical, all numeric — int/double mix is fine — or all character), so the
 /// array renders as a homogeneous `c(...)` vector. Empty arrays and anything
-/// containing null / arrays / objects fall through to `list(...)` (base R's
-/// `c()` would silently drop NULLs or flatten nested vectors).
+/// containing arrays / objects fall through to `list(...)` (base R's `c()`
+/// would flatten nested vectors).
+///
+/// Nulls are *wildcards*: they render as `NA`, which R admits into an atomic
+/// vector of any type, so `[60, null, 20]` is still a numeric vector and
+/// `["G2", null, "G4"]` is still a character one. An all-null array is
+/// homogeneous too — `c(NA, NA)` is a logical NA vector, which is what R's own
+/// JSON readers produce. Without this, a single authored null would demote the
+/// whole case to `list(...)` and the student's function would be handed a list
+/// where it expects an atomic vector.
 private func isHomogeneousScalarArray(_ items: [JSONValue]) -> Bool {
     guard !items.isEmpty else { return false }
-    func kind(_ v: JSONValue) -> Int? {
+    // nil = null (compatible with every kind); .some(nil) = not a scalar at all.
+    func kind(_ v: JSONValue) -> Int?? {
         switch v {
+        case .null: return Int??.some(nil)
         case .bool: return 0
         case .int, .double: return 1  // numeric
         case .string: return 2
-        case .null, .array, .object: return nil
+        case .array, .object: return Int??.none
         }
     }
-    guard let first = kind(items[0]) else { return false }
-    return items.allSatisfy { kind($0) == first }
+    var seen: Int?
+    for item in items {
+        guard let scalar = kind(item) else { return false }  // array / object
+        guard let k = scalar else { continue }  // null: compatible with anything
+        if let s = seen, s != k { return false }
+        seen = k
+    }
+    return true
 }
 
 private func encodeRString(_ s: String) -> String {

--- a/Tests/APITests/MCP/DeleteSupportFileToolTests.swift
+++ b/Tests/APITests/MCP/DeleteSupportFileToolTests.swift
@@ -1,0 +1,197 @@
+// Tests for DeleteSupportFileTool (removing a non-graded support/data file from
+// a test setup), backed by a real test database.
+//
+// The tool is deliberately narrow — it must delete support files and refuse
+// everything else — so most of these assert the refusals, which are what keep a
+// caller from corrupting a setup through the wrong door.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct DeleteSupportFileToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+
+    /// Course + enrolled instructor + setup + assignment, with `support` written
+    /// into the zip as non-graded files and `seedScript` (if given) as a graded
+    /// hand-written test.
+    private func fixture(
+        on app: Application, support: [String: String] = [:], seedScript: String? = nil,
+        manifest: String? = nil
+    ) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        let setup = try await makeTestSetup(
+            on: app, id: "setup_sup", courseID: courseID, manifest: manifest ?? emptyManifest)
+        let zipPath = app.testSetupsDirectory + "setup_sup.zip"
+        try pfWriteEmptyZip(at: zipPath)
+        for (name, body) in support.sorted(by: { $0.key < $1.key }) {
+            try updateScriptInZip(zipPath: zipPath, filename: name, content: body)
+        }
+        if let name = seedScript {
+            try await applyPatternFamilies(
+                to: setup, nextFamilies: [],
+                authoredItems: [
+                    .script(
+                        AuthoredRawScript(
+                            script: name, tier: .pub, points: 1, displayName: nil,
+                            dependsOn: [], sectionID: nil,
+                            content: "#!/usr/bin/env python3\nprint('ok')", hint: nil))
+                ], on: app.db)
+        }
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_sup", courseID: courseID, title: "Lab")
+    }
+
+    private func entries(_ app: Application) -> [String] {
+        listZipEntries(zipPath: app.testSetupsDirectory + "setup_sup.zip")
+    }
+
+    private func run(
+        _ app: Application, _ assignment: APIAssignment, _ filename: String
+    ) async throws
+        -> DeleteSupportFileTool.Output
+    {
+        try await DeleteSupportFileTool().execute(
+            DeleteSupportFileTool.Input(
+                assignmentPublicID: assignment.publicID, filename: filename),
+            context(app))
+    }
+
+    @Test func removesASupportFileFromTheZip() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(
+                on: app, support: ["helpers.R": "f <- function() 1\n", "keep.R": "g <- function() 2\n"])
+            #expect(entries(app).contains("helpers.R"))
+
+            let output = try await run(app, assignment, "helpers.R")
+            #expect(output.removed == "helpers.R")
+            #expect(!output.clearedManifestMarks)
+
+            #expect(!entries(app).contains("helpers.R"))
+            #expect(entries(app).contains("keep.R"), "an unrelated support file must survive")
+        }
+    }
+
+    /// A graded test is owned by delete_suite_item; tearing the file out from
+    /// under its manifest entry would leave a suite row pointing at nothing.
+    @Test func refusesAGradedTest() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, seedScript: "publictest_thing.py")
+            await #expect(throws: MCPToolError.self) {
+                try await run(app, assignment, "publictest_thing.py")
+            }
+            #expect(entries(app).contains("publictest_thing.py"), "the graded test must survive")
+        }
+    }
+
+    @Test func refusesReservedSetupMembers() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(
+                on: app,
+                support: [
+                    "test.properties.json": "{}", "assignment.ipynb": "{}", "solution.ipynb": "{}",
+                ])
+            for reserved in ["test.properties.json", "assignment.ipynb", "solution.ipynb"] {
+                await #expect(throws: MCPToolError.self) {
+                    try await run(app, assignment, reserved)
+                }
+                #expect(entries(app).contains(reserved))
+            }
+        }
+    }
+
+    @Test func refusesAnUnknownFilename() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, support: ["helpers.R": "x <- 1\n"])
+            await #expect(throws: MCPToolError.self) {
+                try await run(app, assignment, "nope.R")
+            }
+        }
+    }
+
+    @Test func refusesAPathSeparator() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, support: ["helpers.R": "x <- 1\n"])
+            await #expect(throws: MCPToolError.self) {
+                try await run(app, assignment, "../helpers.R")
+            }
+            #expect(entries(app).contains("helpers.R"))
+        }
+    }
+
+    /// A graderOnly mark naming the deleted file must go with it, so a later
+    /// file reusing the name doesn't silently inherit "withhold from students".
+    @Test func clearsAGraderOnlyMark() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let manifest = #"""
+                {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,\#
+                "graderOnlyFiles":["answers.R","other.R"]}
+                """#
+            let assignment = try await fixture(
+                on: app, support: ["answers.R": "key <- 1\n"], manifest: manifest)
+
+            let output = try await run(app, assignment, "answers.R")
+            #expect(output.clearedManifestMarks)
+
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let props = try #require(reloaded.decodedManifest())
+            #expect(!props.graderOnlyFileSet.contains("answers.R"))
+            #expect(props.graderOnlyFileSet.contains("other.R"), "unrelated marks must survive")
+        }
+    }
+
+    /// Removing a support file closes a currently-open assignment so students
+    /// can't submit against the not-yet-revalidated setup, and reports it.
+    @Test func closesAnOpenAssignmentAndReportsIt() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, support: ["helpers.R": "x <- 1\n"])
+            #expect(assignment.visibility == .open)  // makeTestAssignment defaults isOpen: true
+
+            let output = try await run(app, assignment, "helpers.R")
+            #expect(output.assignmentClosed)
+
+            let reloaded = try #require(
+                try await APIAssignment.find(assignment.requireID(), on: app.db))
+            #expect(reloaded.visibility != .open)
+        }
+    }
+
+    /// The reported count uses get_support_files' own predicate, so it matches
+    /// the list a caller reads next. The fixture zip also carries a
+    /// `.placeholder` entry (an empty zip is invalid), which is a support file
+    /// by that predicate — hence b.R, c.R, .placeholder.
+    @Test func reportsTheRemainingSupportFileCount() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(
+                on: app, support: ["a.R": "1\n", "b.R": "2\n", "c.R": "3\n"])
+            let output = try await run(app, assignment, "a.R")
+
+            let listed = entries(app).filter { !GetSupportFilesTool.reservedNames.contains($0) }
+            #expect(output.remainingSupportFileCount == listed.count)
+            #expect(listed.sorted() == [".placeholder", "b.R", "c.R"])
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPContentEditCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPContentEditCoverageTests.swift
@@ -34,6 +34,9 @@ import Testing
         "AuthorScriptTool.swift",
         "CreatePatternFamilyTool.swift",
         "DeleteSuiteItemTool.swift",
+        // Removing a support file can break a test that sources it, so the
+        // suite's behaviour changes even though no graded row is touched.
+        "DeleteSupportFileTool.swift",
         "MoveSuiteItemTool.swift",  // placement-only: finalize with retest: false
         // Puts back a recorded version of the manifest + setup files: the graded
         // suite changes wholesale, so it closes and re-grades like any other edit.

--- a/Tests/APITests/PatternFamilyRendererRTests.swift
+++ b/Tests/APITests/PatternFamilyRendererRTests.swift
@@ -58,6 +58,25 @@ import Testing
         #expect(!source.contains("['a', 'b']"), "must not emit a Python list")
     }
 
+    /// Nulls in a case must reach the generated script as `NA` inside an atomic
+    /// `c(...)`, never as `NULL` or a `list(...)`. Asserted on the rendered
+    /// source so it holds on machines without Rscript, where the execution
+    /// suite skips.
+    @Test func rRendersNullsAsNAInsideAtomicVectors() throws {
+        let fam = family(
+            kind: .boundaryEquality,
+            cases: [
+                onlyCase(
+                    [.array([.double(60), .null, .double(20)])],
+                    expected: .array([.string("G2"), .null, .string("G4")]))
+            ])
+        let source = try #require(renderPatternFamily(fam, language: .r).first).source
+        #expect(source.contains("c(60.0, NA, 20.0)"))
+        #expect(source.contains("expected <- c(\"G2\", NA, \"G4\")"))
+        #expect(!source.contains("NULL"), "NULL would drop out of c() and shorten the vector")
+        #expect(!source.contains("list(60"), "must stay an atomic vector, not a list")
+    }
+
     @Test func rExistenceGuardUsesRAndFailsNotErrors() throws {
         let fam = family(
             kind: .boundaryEquality, cases: [onlyCase([.int(1)], expected: .int(1))])
@@ -228,6 +247,44 @@ import Testing
                 submission: "letters_of <- function(s) strsplit(s, \"\")[[1]]\n") == 0)
         #expect(
             try run(script: script, submission: "letters_of <- function(s) c(\"b\", \"a\")\n") == 1)
+    }
+
+    /// An authored `null` is R's `NA`, so a case may cover the "NA in, NA out"
+    /// half of a function's contract. Regression: nulls used to render as
+    /// `NULL`, which demoted the whole arg to `list(...)` and blew up with
+    /// "'list' object cannot be coerced to type 'double'" before the student's
+    /// function was ever really exercised.
+    @Test func nullArgsAndExpectationsBecomeRNAs() throws {
+        guard Self.hasRscript else { return }
+        let stage =
+            "egfr_stage <- function(e) ifelse(e >= 60, \"G2\", \"G4\")\n"
+        let script = single(
+            kind: .boundaryEquality, functionName: "egfr_stage", paramNames: ["e"],
+            args: [.array([.double(60), .null, .double(20)])],
+            expected: .array([.string("G2"), .null, .string("G4")]))
+        // ifelse() propagates NA on its own, so the contract holds and it passes.
+        #expect(try run(script: script, submission: stage) == 0)
+        // Dropping the NA (length 2, not 3) must fail rather than error.
+        #expect(
+            try run(
+                script: script,
+                submission: "egfr_stage <- function(e) { e <- e[!is.na(e)]; "
+                    + "ifelse(e >= 60, \"G2\", \"G4\") }\n") == 1)
+        // Substituting a string for the NA must fail too.
+        #expect(
+            try run(
+                script: script,
+                submission: "egfr_stage <- function(e) ifelse(is.na(e), \"unknown\", "
+                    + "ifelse(e >= 60, \"G2\", \"G4\"))\n") == 1)
+    }
+
+    /// A lone NA argument is still an atomic vector, not a list.
+    @Test func aLoneNullArgIsAnAtomicNA() throws {
+        guard Self.hasRscript else { return }
+        let script = single(
+            kind: .boundaryEquality, functionName: "is_missing", paramNames: ["x"],
+            args: [.array([.null])], expected: .array([.bool(true)]))
+        #expect(try run(script: script, submission: "is_missing <- function(x) is.na(x)\n") == 0)
     }
 
     /// An integer return against a JSON-decoded double expectation must pass —

--- a/Tests/CoreTests/AssignmentLanguageStrategyTests.swift
+++ b/Tests/CoreTests/AssignmentLanguageStrategyTests.swift
@@ -13,7 +13,8 @@ import Testing
         #expect(AssignmentLanguage.python.literal(.bool(true)) == "True")
         #expect(AssignmentLanguage.r.literal(.bool(true)) == "TRUE")
         #expect(AssignmentLanguage.python.literal(.null) == "None")
-        #expect(AssignmentLanguage.r.literal(.null) == "NULL")
+        // R's missing value is NA; NULL is zero-length and would drop out of c().
+        #expect(AssignmentLanguage.r.literal(.null) == "NA")
         #expect(AssignmentLanguage.r.literal(.array([.string("a"), .string("b")])) == "c(\"a\", \"b\")")
     }
 

--- a/Tests/CoreTests/JSONValueRLiteralTests.swift
+++ b/Tests/CoreTests/JSONValueRLiteralTests.swift
@@ -4,7 +4,9 @@ import Testing
 
 @Suite struct JSONValueRLiteralTests {
     @Test func scalars() {
-        #expect(JSONValue.null.rLiteral == "NULL")
+        // A JSON null is a missing value: NA, not NULL. NULL is zero-length and
+        // would vanish inside c(), silently shortening the vector.
+        #expect(JSONValue.null.rLiteral == "NA")
         #expect(JSONValue.bool(true).rLiteral == "TRUE")
         #expect(JSONValue.bool(false).rLiteral == "FALSE")
         #expect(JSONValue.int(5).rLiteral == "5")
@@ -38,8 +40,38 @@ import Testing
                 .array([.string("a"), .string("b")]),
                 .array([.string("c")]),
             ]).rLiteral == "list(c(\"a\", \"b\"), c(\"c\"))")
-        // An array containing null falls through to list() (c() would drop it).
-        #expect(JSONValue.array([.int(1), .null]).rLiteral == "list(1, NULL)")
+        // Nested arrays still list(), even when they carry nulls.
+        #expect(
+            JSONValue.array([
+                .array([.int(1), .null]),
+                .array([.int(2)]),
+            ]).rLiteral == "list(c(1, NA), c(2))")
+    }
+
+    /// A null is a wildcard: it renders as NA, which R admits into an atomic
+    /// vector of any type, so interleaving one must not demote the array to a
+    /// list. This is what makes an NA-bearing pattern-family case authorable —
+    /// previously `[60, null, 20]` became `list(60, NULL, 20)` and the student's
+    /// function was handed a list, failing with "'list' object cannot be
+    /// coerced to type 'double'".
+    @Test func nullsInterleaveIntoHomogeneousVectors() {
+        #expect(JSONValue.array([.int(60), .null, .int(20)]).rLiteral == "c(60, NA, 20)")
+        #expect(
+            JSONValue.array([.string("G2"), .null, .string("G4")]).rLiteral
+                == "c(\"G2\", NA, \"G4\")")
+        #expect(
+            JSONValue.array([.bool(false), .null, .bool(true)]).rLiteral
+                == "c(FALSE, NA, TRUE)")
+        // Leading / trailing nulls, and more than one of them.
+        #expect(
+            JSONValue.array([.null, .int(95), .null, .int(5)]).rLiteral == "c(NA, 95, NA, 5)")
+        // A lone null, and an all-null array: c(NA) / c(NA, NA) are logical NA
+        // vectors, matching what R's own JSON readers produce.
+        #expect(JSONValue.array([.null]).rLiteral == "c(NA)")
+        #expect(JSONValue.array([.null, .null]).rLiteral == "c(NA, NA)")
+        // A null does not rescue a genuinely mixed array.
+        #expect(
+            JSONValue.array([.int(1), .null, .string("a")]).rLiteral == "list(1, NA, \"a\")")
     }
 
     @Test func objectsAreSortedNamedLists() {

--- a/changelog.d/delete-support-file-tool.md
+++ b/changelog.d/delete-support-file-tool.md
@@ -1,0 +1,13 @@
+### Added
+
+- **`delete_support_file` MCP tool.** Removes one non-graded support/data file from
+  an assignment's test setup. `author_script(tier: "support")` could create and
+  replace support files but never remove one, so retiring a helper module or a stale
+  fixture meant overwriting it with a stub — leaving a dead entry in the setup zip
+  that students could still download. The tool refuses graded rows (pointing at
+  `delete_suite_item` or the owning family/check) and the reserved setup members
+  (`test.properties.json`, `assignment.ipynb`, `solution.ipynb`), clears any
+  `graderOnlyFiles` / `datasets` mark naming the file, re-syncs the shared support
+  directory so student symlinks disappear, and re-runs validation — so a remaining
+  test that still sources the file fails loudly instead of at submission time.
+  Content catalog is now 52 tools.

--- a/changelog.d/r-na-pattern-family-cases.md
+++ b/changelog.d/r-na-pattern-family-cases.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **R pattern-family and notebook-check cases can express `NA`.** An authored JSON
+  `null` now renders as R's `NA` rather than `NULL`, and a null interleaved among
+  scalars no longer demotes the whole array to `list(...)` — `[60, null, 20]` renders
+  as `c(60, NA, 20)`, `["G2", null, "G4"]` as `c("G2", NA, "G4")`. Previously `NULL`
+  silently vanished inside `c()`, so an NA-bearing case handed the student's function
+  a list and failed with `'list' object cannot be coerced to type 'double'` before the
+  function was meaningfully exercised. This made the "NA in, NA out" half of a
+  function's contract unauthorable as a pattern family, forcing hand-written scripts.
+  Mixed-kind arrays still render as `list(...)`; a null does not rescue them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -590,7 +590,7 @@ refresh; an hourly reaper drops dead OAuth rows.
 
 Lets an agent author course content on an instructor's behalf. Gated by
 `MCP_MODE` (`off` / `read_only` / `read_write`); scopes are clamped to the
-mode ceiling. The catalog holds **51 tools** — `MCPToolCatalog.live` in
+mode ceiling. The catalog holds **52 tools** — `MCPToolCatalog.live` in
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift` is the source
 of truth — covering course/assignment/suite/notebook/solution reads, suite +
 pattern-family + notebook-check + script authoring, course sections and

--- a/docs/compliance/tool-inventory.md
+++ b/docs/compliance/tool-inventory.md
@@ -8,8 +8,8 @@ end and `mcp-student-data-audit-2026-07.md` for the full re-audit).
 This is a complete, one-row-per-tool inventory of the MCP capability surface,
 walked from the live registry (`MCPToolCatalog.live`,
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) down to each
-tool's handler. As of the 2026-07 refresh the content catalog registers
-**51 tools** (the table below plus the six-tool addendum), and a second,
+tool's handler. As of the 2026-07 refresh (plus `delete_support_file`) the content catalog
+registers **52 tools** (the table below plus the six-tool addendum), and a second,
 admin-only diagnostic surface (`AdminMCPToolCatalog.live`) registers
 **19 read-only tools** — inventoried in the addendum. The registries are the
 source of truth; a census re-count is required whenever either changes
@@ -50,7 +50,7 @@ source of truth; a census re-count is required whenever either changes
 | `validate_assignment` | `ValidateAssignmentTool.swift:36` | `assignmentPublicID` | course-enrol (`:82`) | enqueues validation run; reads `validationStatus` | passed/failed/no-runner |
 | `get_validation_result` | `GetValidationResultTool.swift:69` | `assignmentPublicID` | course-enrol (`:113`) | validation submission + its `APIResult` only | per-test outcomes (no student identity) |
 
-## Write tools (`content:write`) — 25
+## Write tools (`content:write`) — 26
 
 | Tool | Handler (`file`) | Resource arg | Authz | Writes / touches |
 |------|------------------|--------------|-------|------------------|
@@ -61,6 +61,7 @@ source of truth; a census re-count is required whenever either changes
 | `update_suite` | `UpdateSuiteTool.swift:46` | `assignmentPublicID` | course-enrol (`:116`) | `APITestSetup` manifest (suite metadata) |
 | `author_script` | `AuthorScriptTool.swift:58` | `assignmentPublicID` + `filename` | course-enrol (`:194`) | **verbatim file into setup zip** (escape hatch — see below) |
 | `delete_suite_item` | `DeleteSuiteItemTool.swift:49` | `assignmentPublicID` + item | course-enrol (`:103`) | `APITestSetup` manifest + zip |
+| `delete_support_file` | `DeleteSupportFileTool.swift:49` | `assignmentPublicID` + `filename` | course-enrol (`:110`) | `APITestSetup` manifest + zip |
 | `move_suite_item` | `MoveSuiteItemTool.swift:53` | `assignmentPublicID` + item | course-enrol (`:111`) | `APITestSetup` manifest (placement only) |
 | `create_pattern_family` | `CreatePatternFamilyTool.swift:131` | `assignmentPublicID` | course-enrol (`:312`) | `APITestSetup` manifest + generated scripts |
 | `update_pattern_family` | `UpdatePatternFamilyTool.swift:123` | `assignmentPublicID` | course-enrol (`:329`) | `APITestSetup` manifest + generated scripts |

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -66,6 +66,7 @@ The catalog:
 | `create_pattern_family` | `content:write` | Create a new pattern family: kind, function, cases (args/expected/hint), defaults (tier/points/`defaultHint`) |
 | `update_pattern_family` | `content:write` | Family defaults (tier/points/`defaultHint`) + per-case args/expected/hint (incl. per-student `$ref`s), enable/disable, append new cases (`addCases`), replace prerequisites (`dependsOn`) |
 | `delete_suite_item` | `content:write` | Remove a script, family (+ its cases), or notebook check from the suite |
+| `delete_support_file` | `content:write` | Remove a non-graded support/data file from the setup zip (graded rows and reserved members refused; clears any graderOnly / dataset mark) |
 | `author_notebook_check` | `content:write` | Create/replace a notebook check (DataFrame shape/columns/equality, figures, AST, …) |
 | `author_script` | `content:write` | Escape hatch: create/replace a hand-written test (prefer a pattern family / notebook check) or a non-graded support file |
 | `update_notebook` | `content:write` | Replace the starter notebook |


### PR DESCRIPTION
Two independent authoring gaps found while rewriting HLTH 230 Assignments 0 and 1 through the MCP surface. Both forced the same kind of workaround — hand-writing around a tool that couldn't express what was needed — and both are reviewable separately (one commit each).

---

## 1. `fix(r)`: JSON `null` renders as `NA`, so a case can express a missing value

An authored `null` rendered as R `NULL`. `NULL` is a zero-length object that *vanishes* inside `c()` — it is not a missing element; R's missing value is `NA`. Separately, `isHomogeneousScalarArray` treated null as non-scalar, so a single null demoted the whole array to `list(...)`.

| Authored | Before | After |
|---|---|---|
| `[60, null, 20]` | `list(60, NULL, 20)` | `c(60, NA, 20)` |
| `["G2", null, "G4"]` | `list("G2", NULL, "G4")` | `c("G2", NA, "G4")` |
| `[null]` | `list(NULL)` | `c(NA)` |
| `[1, null, "a"]` | `list(1, NULL, "a")` | `list(1, NA, "a")` (unchanged — still mixed) |

Together these made the "NA in, NA out" half of a function's contract **unauthorable as a pattern family**. Every such case died with:

```
error: 'list' object cannot be coerced to type 'double'
```

before the student's function was meaningfully exercised. On A1 all three functions had to fall back to hand-written `author_script` tests for their NA assertions.

Both changes are in `Sources/Core/JSONValue.swift`. Null becomes a *wildcard* in the homogeneity check, compatible with any scalar kind; all-null arrays stay atomic (`c(NA, NA)`, a logical NA vector — what R's own JSON readers produce). Arrays and objects still force `list(...)`. Python rendering is untouched (`null` → `None`).

**Testing.** Unit tests across numeric/character/logical interleaving, leading and trailing nulls, lone and all-null arrays, and the mixed-array negative case. A **rendered-source** assertion (`!source.contains("NULL")`) so the guarantee holds where Rscript is absent — the execution suite `guard`s out and passes vacuously there, which I confirmed locally. And end-to-end execution tests on CI's R image: passing when the function propagates NA, and **failing rather than erroring** when it drops the NA or substitutes `"unknown"`.

Two existing tests pinned the old behaviour and were updated with comments: `JSONValueRLiteralTests.scalars`, `AssignmentLanguageStrategyTests.literalDispatch`.

---

## 2. `feat(mcp)`: `delete_support_file`

`author_script(tier: "support")` could create and replace support files but never remove one. Retiring a helper or a stale fixture meant overwriting it with a stub, leaving a dead entry in the setup zip that students could still download. On A1, ten deleted BMI test scripts lingered in the zip with their goal-weight logic intact — content that assignment specifically must not carry.

The tool is deliberately narrow:

- **Graded rows refused**, pointing at `delete_suite_item` or the owning family/check, so a suite row is never left dangling over a missing file.
- **Reserved setup members refused** (`test.properties.json`, `assignment.ipynb`, `solution.ipynb`) — deleting one corrupts the setup rather than tidying it.
- **Manifest marks cleared**: any `graderOnlyFiles` / `datasets` entry naming the file goes with it, so a later file reusing the name can't silently inherit "withhold from students".
- **Shared support directory re-synced** (wiped and re-extracted), so student symlinks disappear instead of going stale.
- **Validation re-runs**, so a remaining test that still `source()`s the file fails loudly here rather than at submission time.

`GetSupportFilesTool.reservedNames` is promoted from private and reused for the remaining-count, so the number returned matches the list the caller reads next rather than two filters drifting apart.

**Testing.** 8 tests, mostly on the refusals — graded test, each reserved member, unknown filename, path separator — plus the happy path, the graderOnly-mark clearing, open-assignment closing, and count agreement with `get_support_files`.

---

## Docs

Content catalog is now **52 tools**. `docs/architecture.md`, `CLAUDE.md`, and `docs/compliance/tool-inventory.md` (row + both counts) are updated. **I left `docs/compliance/mcp-student-data-audit-2026-07.md` alone** — it is a dated audit snapshot, and rewriting its counts felt wrong. Flagging it because that package is the UW approval artifact: if a new write tool means the audit needs a formal re-count, that is a call for you, not a silent edit from me.

## Reviewer notes

- **The one semantic change beyond the bug:** if a personalization expression ever returned R `NULL`, it now renders `NA`. In practice the evaluator produces its own R literals (`preview_personalization` already returned `NA` correctly before this change), so `rLiteral` nulls come from *authored* JSON, where "missing value" is the intended reading.
- Existing NA-bearing content authored as hand-written scripts keeps working; nothing needs migrating. Those tests can be folded back into families opportunistically.
- Local: 241 CoreTests, 301 renderer/personalization tests, 34 MCP support/suite-tool tests. `scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh` (0 violations, 884 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcUNcQXrRbd6zJY9L5JgS5