### PR TITLE
Edit assignment notebooks from the web: unlock the editor for staff, and save it back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,20 @@ name, due date, notebook uploads, and the validation enqueue. Dependencies
 accept `family:<id>` tokens which the server expands to concrete filenames
 before persistence; cycle detection runs on the authored graph.
 
+**The embedded editor writes back (`POST /testsetups/:id/notebook/save`).**
+JupyterLite keeps the live document in the browser, so authoring edits used to
+reach the server only via an upload on the new-assignment page or the MCP
+`update_notebook` / `update_solution` tools. Course staff (TA+) now get a
+"Save to assignment" button on the notebook page that POSTs the open notebook
+back through the same server-side steps those tools use —
+`AssignmentAuthoringService.writeAssignmentNotebook` for the starter, a fresh
+`kind == .validation` submission for the solution — plus the author's working
+copy so a reload shows the save, and the version snapshot every authoring write
+gets. It is a **live-edit** endpoint: like `PUT /suite` and unlike the MCP
+tools, it never changes visibility, so fixing a typo mid-lab does not close the
+assignment out from under students. Re-validation still runs (debounced for the
+starter, always for a solution, since the new solution *is* what validates).
+
 **Assignment vanity URLs (v0.4.71).** Each assignment gets a per-course
 unique slug. Student links prefer `/:courseCode/:assignmentSlug` routes while
 the canonical `/testsetups/:id/submit` handlers remain active for
@@ -394,6 +408,11 @@ GET  /results/:id                       — Browser-rendered result view
 GET  /instructor/:assignmentID/suite    — Author-facing view of the ordered suite list
 PUT  /instructor/:assignmentID/suite    — Persist drag-reorder, tier/points/displayName edits
 PUT  /instructor/:assignmentID/families — Save a pattern family (add/edit/delete)
+
+# Notebook authoring from the embedded editor (course staff, TA+)
+POST /testsetups/:id/notebook/save      — Write the notebook open in JupyterLite
+                                          back to the assignment
+                                          (?file=assignment|solution)
 ```
 
 Web routes (Leaf-rendered, session auth required) live under `/` and handle

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -20,6 +20,8 @@
     const submitBtn  = document.getElementById('nb-submit');
     const resultsEl  = document.getElementById('nb-results');
     const uploadFile = document.getElementById('nb-upload-file');
+    // Course-staff authoring control; absent for students (see notebook.leaf).
+    const saveAssignmentBtn = document.getElementById('nb-save-assignment');
     const setupID     = frame ? frame.dataset.setupId : null;
     const gradingMode = frame ? frame.dataset.gradingMode : null;
     // Closed-assignment read-only mode.  Plumbed from the server via
@@ -1245,6 +1247,56 @@
         if (!nbRes.ok) return null;
         const notebook = await nbRes.json();
         return looksLikeNotebook(notebook) ? notebook : null;
+    }
+
+    // -------------------------------------------------------------------------
+    // 2b. "Save to assignment" — course staff authoring
+    // -------------------------------------------------------------------------
+    // JupyterLite keeps the live document in the browser, so authoring edits
+    // reach the server only when something POSTs them. The button is rendered
+    // server-side for course staff only (NotebookContext.canSaveToAssignment);
+    // the endpoint re-checks the same permission, so this is convenience, not
+    // the control.
+    if (saveAssignmentBtn) {
+        const saveFileKind = saveAssignmentBtn.dataset.fileKind === 'solution' ? 'solution' : 'assignment';
+        const saveLabel = saveAssignmentBtn.textContent;
+        saveAssignmentBtn.addEventListener('click', async () => {
+            saveAssignmentBtn.disabled = true;
+            saveAssignmentBtn.textContent = 'Saving…';
+            clearResults();
+            setStatus('loading', 'Capturing notebook…');
+            try {
+                // Same capture chain the Submit button uses (live frame →
+                // server snapshot → visible DOM → contents API), so a save
+                // never silently stores stale bytes when the editor is slow.
+                const notebook = await loadNotebookForSubmit();
+                setStatus('loading', 'Saving to the assignment…');
+                const res = await fetch(
+                    `/testsetups/${encodeURIComponent(setupID)}/notebook/save?file=${saveFileKind}`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'content-type': 'application/json',
+                            'x-csrf-token': ChickadeeUI.getCsrfToken()
+                        },
+                        body: JSON.stringify(notebook)
+                    });
+                if (!res.ok) {
+                    let reason = '';
+                    try { reason = (await res.json()).reason || ''; } catch (_) { /* non-JSON error */ }
+                    throw new Error(reason || `Save failed (${res.status})`);
+                }
+                const payload = await res.json();
+                setStatus('ok', payload.message || 'Saved to the assignment.');
+            } catch (err) {
+                const msg = (err instanceof Error && err.message) ? err.message : String(err);
+                console.error('[notebook] Save-to-assignment error:', err);
+                setStatus('error', `Could not save: ${msg}`);
+            } finally {
+                saveAssignmentBtn.disabled = false;
+                saveAssignmentBtn.textContent = saveLabel;
+            }
+        });
     }
 
     // ── Editor command bridge (jupyter-iframe-commands) ──────────────

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -78,6 +78,12 @@ Notebook
             #elseif(isClosed):
             <span class="nb-closed-notice">This assignment is closed to students &mdash; editable as course staff.</span>
             #endif
+            #if(canSaveToAssignment):
+            <button class="btn btn-primary" id="nb-save-assignment" data-file-kind="#(fileKind)"
+                    title="Write what is in this editor back to the assignment for every student">
+                #if(fileKind == "solution"):Save solution#else:Save to assignment#endif
+            </button>
+            #endif
             #if(downloadURL):
             <a class="btn"
                href="#(downloadURL)"

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -73,8 +73,10 @@ Notebook
         <div class="notebook-actions">
             #if(showSubmit):
             <button class="btn btn-primary" id="nb-submit">Submit</button>
-            #elseif(isClosed):
+            #elseif(isReadOnly):
             <span class="nb-closed-notice">This assignment is closed &mdash; view only.</span>
+            #elseif(isClosed):
+            <span class="nb-closed-notice">This assignment is closed to students &mdash; editable as course staff.</span>
             #endif
             #if(downloadURL):
             <a class="btn"
@@ -126,7 +128,7 @@ Notebook
     data-notebook-url="#(notebookURL)"
     data-editor-url="#(jupyterLiteEditorURL)"
     data-working-copy-mtime="#(workingCopyMtime)"
-    data-read-only="#(isClosed)"
+    data-read-only="#(isReadOnly)"
     src="about:blank"
     loading="eager">
 </iframe>

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -206,11 +206,17 @@ struct NotebookContext: Encodable {
     let browserUnsupported: Bool
     let showSubmit: Bool
     /// True when the assignment is closed (deadline passed without an active
-    /// override, or explicitly closed by the instructor).  The Leaf template
-    /// surfaces a "view only" notice and `notebook.js` reads this via the
-    /// iframe's `data-read-only` attribute to lock cell editing and run
-    /// shortcuts inside JupyterLite.
+    /// override, or explicitly closed by the instructor).  Drives the
+    /// submission affordances and the header notice.
     let isClosed: Bool
+    /// True when the editor itself must be locked: `notebook.js` reads this via
+    /// the iframe's `data-read-only` attribute to disable cell editing and run
+    /// shortcuts inside JupyterLite.  A closed assignment is read-only for
+    /// students, but *not* for course staff — they author the starter and
+    /// solution notebooks in this editor, and an assignment is closed for the
+    /// whole time it is being written (creation, cloning, and every save return
+    /// it to `.closed`).  Submission stays gated by `isClosed` for everyone.
+    let isReadOnly: Bool
     /// Unix-epoch mtime (seconds) of the user's working-copy notebook file
     /// on disk at render time.  Embedded in the iframe as
     /// `data-working-copy-mtime`; `notebook.js` compares it against a

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -217,6 +217,15 @@ struct NotebookContext: Encodable {
     /// whole time it is being written (creation, cloning, and every save return
     /// it to `.closed`).  Submission stays gated by `isClosed` for everyone.
     let isReadOnly: Bool
+    /// True when the viewer may write what they are editing back to the
+    /// assignment — course staff (TA+) on a non-archived course, viewing the
+    /// starter or solution notebook (never a past submission).  Renders the
+    /// "Save to assignment" button, which POSTs to
+    /// `/testsetups/:id/notebook/save`.
+    let canSaveToAssignment: Bool
+    /// Which notebook is open — `"assignment"` or `"solution"`.  Labels the
+    /// save button and rides along as the endpoint's `?file=` argument.
+    let fileKind: String
     /// Unix-epoch mtime (seconds) of the user's working-copy notebook file
     /// on disk at render time.  Embedded in the iframe as
     /// `data-working-copy-mtime`; `notebook.js` compares it against a

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -221,8 +221,11 @@ extension WebRoutes {
                 // A past submission is a record, not a working document: it
                 // stays locked on exactly the same terms as before the staff
                 // authoring bypass below (which is scoped to the assignment /
-                // solution notebooks).
+                // solution notebooks), and it is never savable back to the
+                // assignment.
                 isReadOnly: args.isClosed,
+                canSaveToAssignment: false,
+                fileKind: NotebookFileKind.assignment.rawValue,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: submissionViewAbsPath),
                 currentUser: req.currentUserContext
             ))
@@ -288,6 +291,16 @@ extension WebRoutes {
         // which they are being written.  Submission stays gated separately —
         // `showSubmit` still follows `isClosed` for everyone.
         let isReadOnly = args.isClosed && !args.isStaff
+        // Staff can write the open notebook back to the assignment
+        // (`POST /testsetups/:id/notebook/save`).  Mirrors that endpoint's own
+        // gate — TA+ on a course that isn't archived — so the button is absent
+        // rather than failing when the course is read-only.
+        var canSaveToAssignment = false
+        if args.isStaff {
+            let denial = try await evaluateCourseWrite(
+                user: args.user, courseID: setup.courseID, atLeast: .ta, db: req.db)
+            canSaveToAssignment = denial == nil
+        }
         return try await req.view.render(
             "notebook",
             NotebookContext(
@@ -301,6 +314,8 @@ extension WebRoutes {
                 showSubmit: fileKind == .assignment && !args.isClosed,
                 isClosed: args.isClosed,
                 isReadOnly: isReadOnly,
+                canSaveToAssignment: canSaveToAssignment,
+                fileKind: fileKind.rawValue,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: workingCopyAbsPath),
                 currentUser: req.currentUserContext
             ))

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -39,17 +39,17 @@ extension WebRoutes {
 
         let query = try req.query.decode(NotebookQuery.self)
         let fileKind = notebookFileKind(from: query.file)
+        // Staff-ness is per-course (#417 Slice G — was the global
+        // `user.isInstructor`). It gates two things here: who may see the
+        // reference solution at all, and who keeps an editable editor on a
+        // closed assignment.
+        let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
         // The reference solution is staff-only. The student notebook route is
         // reachable by any enrolled student (and now, read-only, for closed
         // assignments), so guard the solution view here rather than relying on
         // the absence of a UI link — never serve the answer key to a student.
-        if fileKind == .solution {
-            // The reference solution is staff-only, scoped to this setup's
-            // course (#417 Slice G — was the global `user.isInstructor`).
-            let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
-            if !isStaff {
-                throw Abort(.forbidden, reason: "The solution is only available to course staff.")
-            }
+        if fileKind == .solution, !isStaff {
+            throw Abort(.forbidden, reason: "The solution is only available to course staff.")
         }
         let queryTitle = (query.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let assignment = try await APIAssignment.query(on: req.db)
@@ -103,7 +103,8 @@ extension WebRoutes {
             userID: userID,
             assignment: assignment,
             assignmentTitle: assignmentTitle,
-            isClosed: isClosed
+            isClosed: isClosed,
+            isStaff: isStaff
         )
         if !requestedSubmissionID.isEmpty {
             return try await renderSubmissionNotebookView(
@@ -217,6 +218,11 @@ extension WebRoutes {
                 browserUnsupported: SupportedBrowserMatrix.assess(req).tier == .unsupported,
                 showSubmit: false,  // read-only view
                 isClosed: args.isClosed,
+                // A past submission is a record, not a working document: it
+                // stays locked on exactly the same terms as before the staff
+                // authoring bypass below (which is scoped to the assignment /
+                // solution notebooks).
+                isReadOnly: args.isClosed,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: submissionViewAbsPath),
                 currentUser: req.currentUserContext
             ))
@@ -274,6 +280,14 @@ extension WebRoutes {
         let workingCopyAbsPath =
             req.application.directory.publicDirectory
             + "jupyterlite/files/" + jupyterLiteNotebookPath
+        // Course staff are the authors of these two notebooks, so the closed
+        // state never locks their editor.  Saving an assignment returns it to
+        // `.closed` (the close-on-save contract) and a freshly created or
+        // cloned assignment starts closed, so the old blanket lock made the
+        // starter and solution notebooks uneditable for exactly the window in
+        // which they are being written.  Submission stays gated separately —
+        // `showSubmit` still follows `isClosed` for everyone.
+        let isReadOnly = args.isClosed && !args.isStaff
         return try await req.view.render(
             "notebook",
             NotebookContext(
@@ -286,6 +300,7 @@ extension WebRoutes {
                 browserUnsupported: SupportedBrowserMatrix.assess(req).tier == .unsupported,
                 showSubmit: fileKind == .assignment && !args.isClosed,
                 isClosed: args.isClosed,
+                isReadOnly: isReadOnly,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: workingCopyAbsPath),
                 currentUser: req.currentUserContext
             ))
@@ -302,6 +317,10 @@ extension WebRoutes {
         let assignment: APIAssignment?
         let assignmentTitle: String
         let isClosed: Bool
+        /// Whether the viewer is staff (TA+ or admin) of this setup's course.
+        /// Staff author content in this editor, so they are never locked out
+        /// of the assignment / solution notebook by the closed state.
+        let isStaff: Bool
     }
 
     /// Decodes the manifest's `gradingMode` for the notebook template;

--- a/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
@@ -1,0 +1,300 @@
+// APIServer/Routes/Web/WebRoutes+NotebookSave.swift
+//
+// POST /testsetups/:testSetupID/notebook/save?file=assignment|solution
+//
+// Persists what course staff are editing in the embedded JupyterLite editor
+// back to the assignment.  Before this, the editor was a scratchpad: JupyterLite
+// keeps its live document in the browser's IndexedDB, the on-disk working copy
+// under `jupyterlite/files/users/…` was only ever *seeded* by the server, and
+// the only ways to change an assignment's notebooks were an upload on the
+// new-assignment page or the MCP `update_notebook` / `update_solution` tools.
+//
+// This is the web sibling of those two tools and deliberately reuses their
+// server-side steps, so the browser and the agent can't drift:
+//
+//   - starter notebook → `AssignmentAuthoringService.writeAssignmentNotebook`
+//     (the same normalization + flat-file write the editor Save path uses),
+//     then the debounced `scheduleValidationAfterSuiteEdit`.
+//   - reference solution → a fresh `kind == .validation` submission via
+//     `enqueueRunnerValidationSubmission`, linked as the assignment's
+//     validation submission — the same storage the "Save & Validate" button
+//     and `update_solution` use, because that submission *is* where an
+//     assignment's solution lives.
+//
+// Two deliberate differences from the MCP tools:
+//
+//   - **Visibility is never changed.** The MCP write tools close an open
+//     assignment; the web live-edit endpoints (`PUT /suite`, `PUT /families`)
+//     deliberately do not, because pulling an assignment out from under a lab
+//     in progress is worse than the risk being guarded against — neither
+//     notebook changes what the suite grades.  This is a live-edit endpoint, so
+//     it follows the live-edit rule.  The `Save & Validate` button on the edit
+//     page still closes, as it always has.
+//   - **The author's working copy is written too**, so a reload of the editor
+//     (which reseeds from disk when the server's copy is newer) shows what was
+//     saved, and so the new-assignment draft flow — which reads the working
+//     copy via `draftNotebookData` — sees the edit on a setup that has no
+//     assignment row yet.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension WebRoutes {
+
+    /// JSON result of a notebook save, rendered by `notebook.js` in the page's
+    /// status line.
+    struct NotebookSaveResult: Content {
+        let saved: Bool
+        let fileKind: String
+        let cellCount: Int
+        let validationStatus: String?
+        let message: String
+    }
+
+    // MARK: - POST /testsetups/:testSetupID/notebook/save
+
+    @Sendable
+    func saveNotebookFromEditor(req: Request) async throws -> NotebookSaveResult {
+        struct SaveQuery: Content {
+            var file: String?
+        }
+
+        let user = try req.auth.require(APIUser.self)
+        guard let userID = user.id else { throw Abort(.unauthorized) }
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let setup = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        // The same gate every other authoring write goes through: TA+ in this
+        // setup's *own* course (admin bypass), archived courses refused.
+        // Notebook/solution edits are `.ta` content work — see the role-floor
+        // convention on `evaluateCourseWrite`.
+        try await requireCourseWriteAccess(
+            caller: user, courseID: setup.courseID, atLeast: .ta, db: req.db)
+
+        let fileKind = notebookFileKind(from: (try? req.query.decode(SaveQuery.self))?.file)
+
+        guard let buffer = req.body.data, buffer.readableBytes > 0 else {
+            throw Abort(.badRequest, reason: "The request body must be the notebook JSON.")
+        }
+        let raw = Data(buffer.readableBytesView)
+        guard let cellCount = notebookCellCount(fromRaw: raw) else {
+            throw Abort(
+                .badRequest,
+                reason: "That does not look like a notebook — expected .ipynb JSON with a \"cells\" array.")
+        }
+        let asEdited = normalizeNotebookForJupyterLite(raw)
+
+        let assignment = try await APIAssignment.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .first()
+
+        // The copy in the author's editor is a *rendering*: the server
+        // substituted their own values into every `{{name}}` placeholder before
+        // handing it over. Storing that verbatim would replace the class's
+        // template with one person's data, so the personalized cells are
+        // restored from the notebook currently stored before anything is
+        // written. A no-op on an assignment without personalization.
+        let canonical = try await canonicalNotebookData(
+            req: req, setup: setup, assignment: assignment, fileKind: fileKind)
+        let toStore: Data
+        switch PersonalizedCellRestoration.restoreTemplates(in: asEdited, canonical: canonical) {
+        case .restored(let restored):
+            toStore = restored
+        case .unmatched(let placeholders):
+            throw Abort(
+                .conflict,
+                reason: """
+                    This copy has per-student values substituted into it, and the \
+                    original \(placeholders.map { "{{\($0)}}" }.joined(separator: ", ")) \
+                    placeholder cells could not be matched to the stored notebook — \
+                    saving would replace them with one student's values. Reset this \
+                    notebook to the current starter, redo the edit without moving the \
+                    personalized cells, and save again.
+                    """)
+        }
+
+        // Content-versioning seam: seeds the pre-edit baseline and registers the
+        // setup so `AssignmentVersionCaptureMiddleware` snapshots this save.
+        // The parameterized write helpers do this from
+        // `loadAssignmentAndSetupForWrite`; this handler reaches its setup by
+        // id, so it registers by hand (as `update_solution` does over MCP).
+        await req.beginAssignmentContentEdit(setup: setup)
+
+        // The author's working copy keeps the *rendered* bytes they were
+        // editing — the same personalized view they had a second ago, and the
+        // one that actually runs — while the assignment stores the template.
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            relativePath: userNotebookWorkingCopyRelativePath(
+                setupID: setupID, userID: userID, fileKind: fileKind),
+            overwriteWith: asEdited
+        )
+
+        let outcome =
+            switch fileKind {
+            case .assignment:
+                try await persistStarterNotebook(
+                    req: req, setup: setup, assignment: assignment, normalized: toStore)
+            case .solution:
+                try await persistSolutionNotebook(
+                    req: req, setup: setup, assignment: assignment, normalized: toStore,
+                    submitterUserID: userID)
+            }
+
+        let validationLabel = outcome.validationStatus ?? "none"
+        req.logger.info(
+            "notebook_editor_save setup=\(setupID) file=\(fileKind.rawValue) cells=\(cellCount) author=\(userID.uuidString) validation=\(validationLabel)"
+        )
+
+        return NotebookSaveResult(
+            saved: true,
+            fileKind: fileKind.rawValue,
+            cellCount: cellCount,
+            validationStatus: outcome.validationStatus,
+            message: outcome.message
+        )
+    }
+
+    /// The notebook currently stored for `fileKind` — the one still carrying
+    /// `{{name}}` templates — or nil when there is nothing stored yet (a draft
+    /// whose solution has never been saved). Same resolution the notebook page
+    /// itself seeds working copies from, so the two always agree on what the
+    /// canonical bytes are.
+    private func canonicalNotebookData(
+        req: Request,
+        setup: APITestSetup,
+        assignment: APIAssignment?,
+        fileKind: NotebookFileKind
+    ) async throws -> Data? {
+        switch fileKind {
+        case .assignment:
+            return try? notebookData(for: setup)
+        case .solution:
+            return try? await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+        }
+    }
+
+    /// What one save did, in the two fields the page reports.
+    private struct NotebookSaveOutcome {
+        let validationStatus: String?
+        let message: String
+    }
+
+    /// Starter-notebook save: rewrite the setup's flat notebook (the bytes every
+    /// student's copy is seeded from), then let the debounced validation helper
+    /// re-check the suite against the existing solution.
+    private func persistStarterNotebook(
+        req: Request,
+        setup: APITestSetup,
+        assignment: APIAssignment?,
+        normalized: Data
+    ) async throws -> NotebookSaveOutcome {
+        do {
+            try await AssignmentAuthoringService.writeAssignmentNotebook(
+                setup: setup,
+                notebookData: normalized,
+                setupsDirectory: req.application.testSetupsDirectory,
+                on: req.db)
+        } catch let error as AssignmentAuthoringError {
+            throw Abort(.internalServerError, reason: "Could not write the notebook: \(error)")
+        }
+
+        guard let assignment else {
+            // A setup with no assignment row is a new-assignment draft; there is
+            // nothing to validate until it is published.
+            return NotebookSaveOutcome(
+                validationStatus: nil, message: "Notebook saved to the draft.")
+        }
+        // Debounced + best-effort, exactly as after a live suite edit: a no-op
+        // when a validation is already pending or no solution exists yet.
+        await scheduleValidationAfterSuiteEdit(req: req, assignment: assignment)
+        return NotebookSaveOutcome(
+            validationStatus: assignment.validationStatus,
+            message: validationSuffixed("Starter notebook saved.", status: assignment.validationStatus))
+    }
+
+    /// Solution save: an assignment's reference solution *is* its latest
+    /// `kind == .validation` submission, so storing one is what persists the
+    /// edit — and re-running validation against the new answer key is the point
+    /// of saving it.
+    private func persistSolutionNotebook(
+        req: Request,
+        setup: APITestSetup,
+        assignment: APIAssignment?,
+        normalized: Data,
+        submitterUserID: UUID
+    ) async throws -> NotebookSaveOutcome {
+        guard let assignment else {
+            // Draft: the new-assignment page resolves its solution from the
+            // draft path (with the working copy, already written above, taking
+            // precedence), so write that and stop.
+            let draftPath = draftSolutionNotebookPath(
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id ?? "")
+            _ = try ensureDraftNotebookDirectory(
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id ?? "")
+            try normalized.write(to: URL(fileURLWithPath: draftPath))
+            return NotebookSaveOutcome(
+                validationStatus: nil, message: "Solution saved to the draft.")
+        }
+
+        let submissionID = try await enqueueRunnerValidationSubmission(
+            req: req,
+            setupID: assignment.testSetupID,
+            solutionNotebookData: normalized,
+            filename: "solution.ipynb",
+            submitterUserID: submitterUserID)
+        assignment.validationSubmissionID = submissionID
+
+        // Report "no-runner" rather than a `pending` that nothing can claim —
+        // the same pre-check `enqueueValidationForEditedAssignment` runs on the
+        // Save & Validate path. The submission row is still stored (it is the
+        // solution), so it validates on its own once a runner comes up.
+        let requirementSpec = try await loadAssignmentRequirementSpec(
+            assignment: assignment, on: req.db)
+        let hasEligibleRunner = try await ensureCompatibleValidationRunnerAvailability(
+            req: req, requirements: requirementSpec)
+        assignment.validationStatus = hasEligibleRunner ? "pending" : "no-runner"
+        try await assignment.save(on: req.db)
+
+        return NotebookSaveOutcome(
+            validationStatus: assignment.validationStatus,
+            message: validationSuffixed("Solution saved.", status: assignment.validationStatus))
+    }
+
+    /// Appends the one-clause explanation of what validation is doing now, so
+    /// the editor's status line answers "and then what?" without a second look
+    /// at the dashboard.
+    private func validationSuffixed(_ lead: String, status: String?) -> String {
+        switch status {
+        case "pending":
+            return "\(lead) Re-validating against the current test suite."
+        case "no-runner":
+            return "\(lead) No compatible runner is available, so validation is still queued."
+        default:
+            return lead
+        }
+    }
+}
+
+/// Number of cells in `raw`, or nil when it is not notebook-shaped JSON (an
+/// object carrying a `cells` array).  The web mirror of the MCP tools'
+/// `validateNotebookShape` guard: the same rejection, one step earlier, so a
+/// stray POST can never overwrite a notebook with something that isn't one.
+func notebookCellCount(fromRaw raw: Data) -> Int? {
+    guard
+        let object = try? JSONSerialization.jsonObject(with: raw) as? [String: Any],
+        let cells = object["cells"] as? [Any]
+    else {
+        return nil
+    }
+    return cells.count
+}

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -24,6 +24,9 @@ struct WebRoutes: RouteCollection {
         routes.get("testsetups", ":testSetupID", "history", use: submissionHistoryPage)
         routes.get("testsetups", ":testSetupID", "notebook", use: notebookPage)
         routes.get("testsetups", ":testSetupID", "notebook", "source", use: notebookSource)
+        // Course-staff-only: persist what the author is editing in JupyterLite
+        // back to the assignment (WebRoutes+NotebookSave.swift).
+        routes.post("testsetups", ":testSetupID", "notebook", "save", use: saveNotebookFromEditor)
         routes.post("testsetups", ":testSetupID", "reset-notebook", use: resetOwnNotebook)
         routes.post("testsetups", ":testSetupID", "reveal-secret", use: spendSecretRevealToken)
         // Slip days (#1228): explicit confirmation page + the spend POST.

--- a/Sources/APIServer/Services/NotebookSubstitution.swift
+++ b/Sources/APIServer/Services/NotebookSubstitution.swift
@@ -124,15 +124,24 @@ enum NotebookSubstitution {
             guard let cellType = cell["cell_type"] as? String, cellType == "code" else {
                 continue
             }
-            let source = readCellSource(cell)
-            let nsSource = source as NSString
-            let range = NSRange(location: 0, length: nsSource.length)
-            placeholderRegex.enumerateMatches(in: source, options: [], range: range) { match, _, _ in
-                guard let match, match.numberOfRanges >= 2 else { return }
-                let nameRange = match.range(at: 1)
-                if nameRange.location != NSNotFound {
-                    found.insert(nsSource.substring(with: nameRange))
-                }
+            found.formUnion(placeholderNames(inSource: readCellSource(cell)))
+        }
+        return found.sorted()
+    }
+
+    /// Returns the placeholder names appearing in one cell's source text.
+    /// Same scan as `placeholderNames(in:)`, one cell at a time — used by
+    /// `PersonalizedCellRestoration` to confirm a canonical cell really is the
+    /// template a rendered cell came from.  Deduplicated and sorted.
+    static func placeholderNames(inSource source: String) -> [String] {
+        let nsSource = source as NSString
+        let range = NSRange(location: 0, length: nsSource.length)
+        var found = Set<String>()
+        placeholderRegex.enumerateMatches(in: source, options: [], range: range) { match, _, _ in
+            guard let match, match.numberOfRanges >= 2 else { return }
+            let nameRange = match.range(at: 1)
+            if nameRange.location != NSNotFound {
+                found.insert(nsSource.substring(with: nameRange))
             }
         }
         return found.sorted()

--- a/Sources/APIServer/Services/PersonalizedCellRestoration.swift
+++ b/Sources/APIServer/Services/PersonalizedCellRestoration.swift
@@ -1,0 +1,156 @@
+// APIServer/Services/PersonalizedCellRestoration.swift
+//
+// Turns a *rendered* notebook back into the *template* it was rendered from,
+// for the cells the server personalized.
+//
+// Every working copy handed to a viewer — students and staff alike — has its
+// `{{name}}` placeholders replaced with that viewer's values, and each rewritten
+// cell is tagged `metadata.chickadee_personalized` (NotebookSubstitution). That
+// is right for reading and running, and wrong for authoring: writing an author's
+// copy straight back would replace `patients = {{patients}}` in the assignment's
+// notebook with one person's literal patient list, silently ending
+// personalization for the whole class.
+//
+// So the save path (WebRoutes+NotebookSave) runs the incoming notebook through
+// here first. Only tagged cells are touched, and each is restored from the
+// canonical notebook's own text — never reconstructed — so this can add nothing
+// the author did not already have. A tagged cell that cannot be matched to the
+// canonical notebook is reported instead of guessed at: refusing a save is
+// recoverable, quietly baking a student's values into the class template is not.
+//
+// An assignment with no personalization has no tagged cells, so the whole thing
+// is one dictionary lookup and the input is returned untouched.
+
+import Foundation
+
+enum PersonalizedCellRestoration {
+
+    /// The result of restoring one notebook.
+    enum Outcome: Equatable {
+        /// The notebook is safe to store: either it had no personalized cells,
+        /// or every one of them was restored from the canonical notebook.
+        case restored(Data)
+        /// At least one personalized cell could not be matched to the canonical
+        /// notebook; the names are the placeholders whose templates would have
+        /// been lost. Nothing should be written.
+        case unmatched(placeholders: [String])
+    }
+
+    /// Restores the `{{name}}` template text in every cell of `incoming` that
+    /// carries the personalization tag, taking the text from `canonical` — the
+    /// notebook currently stored for the assignment, which still holds the
+    /// templates.
+    ///
+    /// Cells are matched by nbformat cell `id` first. When the incoming cell has
+    /// no id (a notebook authored before nbformat 4.5), the canonical cell at
+    /// the same index is accepted *only* if it is a code cell that actually
+    /// carries the placeholders the tag names — a check strong enough that a
+    /// coincidental index collision cannot pass it.
+    static func restoreTemplates(in incoming: Data, canonical: Data?) -> Outcome {
+        guard
+            var notebook = (try? JSONSerialization.jsonObject(with: incoming)) as? [String: Any],
+            var cells = notebook["cells"] as? [[String: Any]]
+        else {
+            // Not notebook-shaped: the caller has already rejected that, so
+            // there is nothing here to restore.
+            return .restored(incoming)
+        }
+
+        let taggedIndexes = cells.indices.filter { !taggedPlaceholders(in: cells[$0]).isEmpty }
+        guard !taggedIndexes.isEmpty else { return .restored(incoming) }
+
+        guard
+            let canonical,
+            let canonicalNotebook = (try? JSONSerialization.jsonObject(with: canonical)) as? [String: Any],
+            let canonicalCells = canonicalNotebook["cells"] as? [[String: Any]]
+        else {
+            // No stored template to restore from — every tagged cell is at risk.
+            return .unmatched(
+                placeholders: Set(taggedIndexes.flatMap { taggedPlaceholders(in: cells[$0]) }).sorted())
+        }
+
+        var canonicalByID: [String: [String: Any]] = [:]
+        for cell in canonicalCells {
+            if let id = cell["id"] as? String, !id.isEmpty {
+                canonicalByID[id] = cell
+            }
+        }
+
+        var unmatched = Set<String>()
+        for index in taggedIndexes {
+            let names = taggedPlaceholders(in: cells[index])
+            guard
+                let template = templateCell(
+                    for: cells[index], at: index, names: names,
+                    canonicalByID: canonicalByID, canonicalCells: canonicalCells)
+            else {
+                unmatched.formUnion(names)
+                continue
+            }
+            cells[index] = restoring(cells[index], toSourceOf: template)
+        }
+
+        guard unmatched.isEmpty else { return .unmatched(placeholders: unmatched.sorted()) }
+
+        notebook["cells"] = cells
+        guard let encoded = try? JSONSerialization.data(withJSONObject: notebook) else {
+            return .restored(incoming)
+        }
+        return .restored(encoded)
+    }
+
+    // MARK: - Private helpers
+
+    /// The placeholder names a cell was personalized for, or `[]` when the cell
+    /// carries no personalization tag.
+    private static func taggedPlaceholders(in cell: [String: Any]) -> [String] {
+        guard
+            let metadata = cell["metadata"] as? [String: Any],
+            let tag = metadata[NotebookSubstitution.fencedCellMetadataKey] as? String
+        else {
+            return []
+        }
+        return tag.split(separator: ",").map(String.init).filter { !$0.isEmpty }
+    }
+
+    /// The canonical cell `cell` was rendered from: same id, or — for a notebook
+    /// with no cell ids — the same position, provided that cell really is the
+    /// template for `names`.
+    private static func templateCell(
+        for cell: [String: Any],
+        at index: Int,
+        names: [String],
+        canonicalByID: [String: [String: Any]],
+        canonicalCells: [[String: Any]]
+    ) -> [String: Any]? {
+        if let id = cell["id"] as? String, !id.isEmpty {
+            return canonicalByID[id]
+        }
+        guard canonicalCells.indices.contains(index) else { return nil }
+        let candidate = canonicalCells[index]
+        guard (candidate["cell_type"] as? String) == "code" else { return nil }
+        let carried = Set(NotebookSubstitution.placeholderNames(inSource: cellSource(candidate)))
+        guard carried.isSuperset(of: names) else { return nil }
+        return candidate
+    }
+
+    /// `cell` with the template's source text and without the personalization
+    /// tag — everything else the author changed (outputs, other metadata, cell
+    /// type) is left exactly as they left it.
+    private static func restoring(_ cell: [String: Any], toSourceOf template: [String: Any]) -> [String: Any] {
+        var restored = cell
+        restored["source"] = template["source"]
+        if var metadata = restored["metadata"] as? [String: Any] {
+            metadata.removeValue(forKey: NotebookSubstitution.fencedCellMetadataKey)
+            restored["metadata"] = metadata
+        }
+        return restored
+    }
+
+    /// nbformat allows `source` to be a string or an array of strings.
+    private static func cellSource(_ cell: [String: Any]) -> String {
+        if let source = cell["source"] as? String { return source }
+        if let source = cell["source"] as? [String] { return source.joined() }
+        return ""
+    }
+}

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -613,6 +613,336 @@ import VaporTesting
         }
     }
 
+    // MARK: - POST /testsetups/:id/notebook/save
+
+    /// Drives the editor's "Save to assignment" endpoint with `body` as the
+    /// notebook JSON, mirroring what `notebook.js` sends (JSON body + the CSRF
+    /// token in a header).
+    private func postNotebookSave(
+        setupID: String,
+        cookie: String,
+        file: String? = nil,
+        body: String,
+        afterResponse: (TestingHTTPResponse) throws -> Void
+    ) async throws {
+        let (csrf, sessionCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
+        let query = file.map { "?file=\($0)" } ?? ""
+        try await app.asyncTest(
+            .POST, "/testsetups/\(setupID)/notebook/save\(query)",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                req.headers.add(name: "x-csrf-token", value: csrf)
+                req.headers.contentType = .json
+                req.body = ByteBufferAllocator().buffer(string: body)
+            },
+            afterResponse: afterResponse)
+    }
+
+    private func staffCookie(username: String) async throws -> String {
+        let cookie = try await loginUser(
+            username: username, password: "testpassword", role: "instructor", on: app)
+        let staff = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == username).first())
+        try await enroll(staff)
+        return cookie
+    }
+
+    @Test func saveNotebookFromEditorReplacesTheStarterNotebook() async throws {
+        try await withApp(app) { _ in
+            // The editing loop this closes: JupyterLite holds the live document
+            // in the browser, so an authoring edit reached the server nowhere
+            // before this endpoint. A staff save must land in the setup's flat
+            // notebook — the bytes every student's working copy is seeded from —
+            // and in the author's own working copy, so a reload shows the save.
+            let cookie = try await staffCookie(username: "notebook_save_starter")
+            let staff = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "notebook_save_starter").first())
+
+            let setupID = "setup_nb_save_starter"
+            let setup = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Original"))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Authoring Lab", isOpen: false)
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, body: notebookJSON(markdown: "Edited in the editor")
+            ) { res in
+                #expect(res.status == .ok)
+                let body = res.body.string
+                #expect(body.contains("\"saved\":true"))
+                #expect(body.contains("\"cellCount\":1"))
+            }
+
+            let storedPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            let stored = try String(contentsOfFile: storedPath, encoding: .utf8)
+            #expect(stored.contains("Edited in the editor"))
+            #expect(stored.contains("Original") == false)
+
+            let workingCopy = try String(
+                contentsOfFile: workingCopyPath(setupID: setupID, userID: try staff.requireID()),
+                encoding: .utf8)
+            #expect(workingCopy.contains("Edited in the editor"))
+            _ = setup
+        }
+    }
+
+    @Test func saveNotebookFromEditorLeavesAnOpenAssignmentOpen() async throws {
+        try await withApp(app) { _ in
+            // Unlike the MCP write tools (and the page's Save & Validate
+            // button), this live-edit endpoint never changes visibility:
+            // yanking an open lab out from under students mid-session to fix a
+            // typo in the starter notebook is worse than the risk, and neither
+            // notebook changes what the suite grades.
+            let cookie = try await staffCookie(username: "notebook_save_openstate")
+
+            let setupID = "setup_nb_save_openstate"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Original"))
+            _ = try await insertAssignment(
+                testSetupID: setupID, title: "Live Lab", dueAt: Date(timeIntervalSinceNow: 3600),
+                isOpen: true)
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, body: notebookJSON(markdown: "Typo fixed")
+            ) { res in
+                #expect(res.status == .ok)
+            }
+
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db).filter(\.$testSetupID == setupID).first())
+            #expect(assignment.visibility == .open, "A starter-notebook save must not close an open lab")
+        }
+    }
+
+    @Test func saveNotebookFromEditorStoresSolutionAsValidationSubmission() async throws {
+        try await withApp(app) { _ in
+            // An assignment's reference solution IS its latest validation
+            // submission (that is what `loadExistingSolution` reads and what the
+            // Save & Validate path writes), so storing one is what persists a
+            // solution edit — and re-validating against the new answer key is
+            // the point of saving it.
+            let cookie = try await staffCookie(username: "notebook_save_solution")
+
+            let setupID = "setup_nb_save_solution"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(markdown: "Assignment"),
+                zipEntries: [
+                    ("assignment.ipynb", notebookJSON(markdown: "Assignment")),
+                    ("solution.ipynb", notebookJSON(markdown: "Old solution")),
+                ])
+            _ = try await insertAssignment(testSetupID: setupID, title: "Solution Lab", isOpen: false)
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, file: "solution",
+                body: notebookJSON(markdown: "New reference solution")
+            ) { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("\"fileKind\":\"solution\""))
+            }
+
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db).filter(\.$testSetupID == setupID).first())
+            let validationID = try #require(assignment.validationSubmissionID)
+            let submission = try #require(try await APISubmission.find(validationID, on: app.db))
+            #expect(submission.kind == APISubmission.Kind.validation)
+            let stored = try String(contentsOfFile: submission.zipPath, encoding: .utf8)
+            #expect(stored.contains("New reference solution"))
+
+            // And the starter notebook is untouched — a solution save must never
+            // overwrite what students open.
+            let starterPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            #expect(try String(contentsOfFile: starterPath, encoding: .utf8).contains("Assignment"))
+        }
+    }
+
+    @Test func saveNotebookFromEditorWritesDraftSetupWithNoAssignmentRow() async throws {
+        try await withApp(app) { _ in
+            // The new-assignment page edits a draft setup that has no assignment
+            // row yet, and reads it back through `draftNotebookData` (working
+            // copy first). A save there must persist without trying to validate
+            // an assignment that does not exist.
+            let cookie = try await staffCookie(username: "notebook_save_draft")
+            let staff = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "notebook_save_draft").first())
+
+            let setupID = "setup_nb_save_draft"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Draft starter"))
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, body: notebookJSON(markdown: "Draft edited")
+            ) { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("draft"))
+            }
+
+            let workingCopy = try String(
+                contentsOfFile: workingCopyPath(setupID: setupID, userID: try staff.requireID()),
+                encoding: .utf8)
+            #expect(workingCopy.contains("Draft edited"))
+        }
+    }
+
+    @Test func saveNotebookFromEditorRejectsAStudent() async throws {
+        try await withApp(app) { _ in
+            // The button is staff-only in the template; the endpoint is what
+            // actually enforces it. A student POSTing directly must be refused
+            // before anything is written.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_save_student"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Original"))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Student Lab", isOpen: true)
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, body: notebookJSON(markdown: "Student rewrite")
+            ) { res in
+                #expect(res.status == .forbidden)
+            }
+
+            let storedPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            #expect(try String(contentsOfFile: storedPath, encoding: .utf8).contains("Original"))
+        }
+    }
+
+    @Test func saveNotebookFromEditorRejectsNonNotebookJSON() async throws {
+        try await withApp(app) { _ in
+            // A body that isn't notebook-shaped must be refused rather than
+            // stored: the flat notebook is what every student is seeded from,
+            // so a stray POST cannot be allowed to replace it with junk.
+            let cookie = try await staffCookie(username: "notebook_save_badjson")
+
+            let setupID = "setup_nb_save_badjson"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Original"))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Guard Lab", isOpen: false)
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, body: #"{"not":"a notebook"}"#
+            ) { res in
+                #expect(res.status == .badRequest)
+            }
+
+            let storedPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            #expect(try String(contentsOfFile: storedPath, encoding: .utf8).contains("Original"))
+        }
+    }
+
+    @Test func saveNotebookFromEditorRestoresPersonalizationTemplates() async throws {
+        try await withApp(app) { _ in
+            // Every working copy is a *rendering*: the server substitutes the
+            // viewer's own values into `{{name}}` and tags the cell. Saving that
+            // verbatim would replace the class's template with one person's
+            // data, so the tagged cells must be restored from the stored
+            // notebook before anything is written.
+            let cookie = try await staffCookie(username: "notebook_save_personalized")
+
+            let setupID = "setup_nb_save_personalized"
+            let manifest = """
+                {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null,"globalVariables":[{"name":"patients","value":[{"name":"Maria","age":42}]}]}
+                """
+            // The stored template, with a cell id so the restore has an exact
+            // match (what JupyterLite writes for nbformat 4.5).
+            let template = """
+                {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+                {"cell_type":"code","id":"cell-one","execution_count":null,"metadata":{},"outputs":[],"source":["patients = {{patients}}"]}]}
+                """
+            _ = try await insertSetup(id: setupID, notebookJSON: template, manifest: manifest)
+            _ = try await insertAssignment(testSetupID: setupID, title: "Personalized Lab", isOpen: false)
+
+            // What the editor holds after the author edited the *rendered* copy:
+            // the substituted literal, tagged as personalized.
+            let rendered = """
+                {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+                {"cell_type":"code","id":"cell-one","execution_count":null,\
+                "metadata":{"chickadee_personalized":"patients"},"outputs":[],\
+                "source":["patients = [{'name': 'Maria', 'age': 42}]"]}]}
+                """
+
+            try await postNotebookSave(setupID: setupID, cookie: cookie, body: rendered) { res in
+                #expect(res.status == .ok)
+            }
+
+            let storedPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            let stored = try String(contentsOfFile: storedPath, encoding: .utf8)
+            #expect(
+                stored.contains("{{patients}}"),
+                "The stored notebook must keep its personalization template")
+            #expect(
+                stored.contains("Maria") == false,
+                "One viewer's substituted values must never reach the class template")
+        }
+    }
+
+    @Test func saveNotebookFromEditorRefusesUnmatchablePersonalizedCell() async throws {
+        try await withApp(app) { _ in
+            // A personalized cell that can't be matched back to the stored
+            // notebook (here: an id that isn't in it) is refused rather than
+            // guessed at — a rejected save is recoverable, a template quietly
+            // replaced by one student's data is not.
+            let cookie = try await staffCookie(username: "notebook_save_unmatched")
+
+            let setupID = "setup_nb_save_unmatched"
+            let manifest = """
+                {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null,"globalVariables":[{"name":"patients","value":[{"name":"Maria","age":42}]}]}
+                """
+            let template = """
+                {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+                {"cell_type":"code","id":"cell-one","execution_count":null,"metadata":{},"outputs":[],"source":["patients = {{patients}}"]}]}
+                """
+            _ = try await insertSetup(id: setupID, notebookJSON: template, manifest: manifest)
+            _ = try await insertAssignment(testSetupID: setupID, title: "Unmatched Lab", isOpen: false)
+
+            let rendered = """
+                {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+                {"cell_type":"markdown","id":"intro","metadata":{},"source":["Intro"]},\
+                {"cell_type":"code","id":"cell-moved","execution_count":null,\
+                "metadata":{"chickadee_personalized":"patients"},"outputs":[],\
+                "source":["patients = [{'name': 'Maria', 'age': 42}]"]}]}
+                """
+
+            try await postNotebookSave(setupID: setupID, cookie: cookie, body: rendered) { res in
+                #expect(res.status == .conflict)
+                #expect(res.body.string.contains("{{patients}}"))
+            }
+
+            let storedPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            #expect(try String(contentsOfFile: storedPath, encoding: .utf8).contains("{{patients}}"))
+        }
+    }
+
+    @Test func notebookPageRendersSaveButtonForStaffOnly() async throws {
+        try await withApp(app) { _ in
+            // The authoring control is rendered server-side, so a student never
+            // receives the markup for it.
+            let staffLogin = try await staffCookie(username: "notebook_save_button_staff")
+            let setupID = "setup_nb_save_button"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Button"))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Button Lab", isOpen: true)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffLogin) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains(#"id="nb-save-assignment""#))
+                })
+
+            let studentLogin = try await loginAsStudent()
+            let student = try await studentUser()
+            try await enroll(student)
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentLogin) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains(#"id="nb-save-assignment""#) == false)
+                })
+        }
+    }
+
     @Test func notebookPageNotYetOpenAssignmentRedirectsToDashboard() async throws {
         try await withApp(app) { _ in
             // A student following a pre-posted link to an assignment whose open

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -528,6 +528,91 @@ import VaporTesting
         }
     }
 
+    @Test func notebookPageClosedAssignmentStaysEditableForCourseStaff() async throws {
+        try await withApp(app) { _ in
+            // Course staff author the starter notebook in this editor, and an
+            // assignment is closed for the whole window in which it is being
+            // written (creation, cloning, and every save return it to closed).
+            // The closed state must therefore never lock the editor for staff:
+            // the iframe stays editable and the "view only" notice is replaced
+            // by the staff-editable one.  Submission stays closed for everyone.
+            let cookie = try await loginUser(
+                username: "notebook_staff_closed", password: "testpassword", role: "instructor", on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "notebook_staff_closed").first())
+            try await enroll(instructor)
+
+            let setupID = "setup_nb_closed_staff"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Authoring"))
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Draft Lab",
+                dueAt: nil,  // never published — a freshly created assignment
+                isOpen: false
+            )
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains(#"data-read-only="false""#),
+                        "Course staff must keep an EDITABLE notebook on a closed assignment")
+                    #expect(
+                        html.contains("This assignment is closed &mdash; view only.") == false,
+                        "Staff must not see the student view-only notice")
+                    #expect(
+                        html.contains("editable as course staff"),
+                        "Staff must see the staff-editable notice instead")
+                    #expect(
+                        html.contains(#"id="nb-submit""#) == false,
+                        "Submission stays gated by the closed state, for staff too")
+                })
+        }
+    }
+
+    @Test func notebookPageClosedAssignmentSolutionStaysEditableForCourseStaff() async throws {
+        try await withApp(app) { _ in
+            // Same contract for the reference solution: it is authored on a
+            // closed assignment, so ?file=solution must render editable too.
+            let cookie = try await loginUser(
+                username: "notebook_staff_solution", password: "testpassword", role: "instructor", on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "notebook_staff_solution").first())
+            try await enroll(instructor)
+
+            let setupID = "setup_nb_closed_staff_solution"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(markdown: "Assignment"),
+                zipEntries: [
+                    ("assignment.ipynb", notebookJSON(markdown: "Assignment")),
+                    ("solution.ipynb", notebookJSON(markdown: "Reference solution")),
+                ]
+            )
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Closed Solution Lab",
+                dueAt: Date(timeIntervalSinceNow: -3600),  // deadline passed
+                isOpen: false
+            )
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook?file=solution",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains(#"data-read-only="false""#))
+                })
+        }
+    }
+
     @Test func notebookPageNotYetOpenAssignmentRedirectsToDashboard() async throws {
         try await withApp(app) { _ in
             // A student following a pre-posted link to an assignment whose open

--- a/changelog.d/instructor-edit-closed-assignment.md
+++ b/changelog.d/instructor-edit-closed-assignment.md
@@ -1,3 +1,18 @@
+### Added
+
+- **"Save to assignment" in the notebook editor.** Course staff (TA+) can now
+  write the notebook they are editing in the embedded JupyterLite editor back to
+  the assignment, from the browser — the starter notebook and the reference
+  solution both. Previously JupyterLite kept the live document in the browser
+  and the only ways to change an assignment's notebooks were an upload on the
+  new-assignment page or the MCP `update_notebook` / `update_solution` tools;
+  the editor's Edit button was effectively a scratchpad. The new endpoint
+  (`POST /testsetups/:id/notebook/save`) reuses those tools' server-side steps,
+  is versioned like every other authoring write, and re-runs validation — but,
+  matching the other live-edit endpoints rather than the MCP tools, it never
+  changes the assignment's visibility, so fixing a starter notebook mid-lab does
+  not close the assignment out from under students.
+
 ### Fixed
 
 - **Course staff can edit an assignment's notebooks while it is closed.** The

--- a/changelog.d/instructor-edit-closed-assignment.md
+++ b/changelog.d/instructor-edit-closed-assignment.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Course staff can edit an assignment's notebooks while it is closed.** The
+  notebook editor locked itself read-only ("This assignment is closed — view
+  only") for everyone on a closed assignment, including the staff authoring it —
+  and an assignment is closed for exactly the window in which it is being
+  written, since creating, cloning, or saving one returns it to closed. Staff
+  (TA+ or admin in the assignment's course) now keep an editable starter and
+  solution notebook regardless of the closed state; students are unaffected, and
+  submission stays gated by the closed state for everyone.


### PR DESCRIPTION
Two commits: unlock the editor for course staff on a closed assignment, then give it somewhere to save to.

## 1. The editor was locked for the people authoring it

Opening a starter or solution notebook from `/instructor/:id/edit` showed **"This assignment is closed — view only"** and locked JupyterLite, because the notebook page derived the editor lock straight from the closed state:

```swift
isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db))
...
data-read-only="#(isClosed)"
```

`AssignmentVisibility.submissionGate(isStaff:)` treats `.preview` as open for staff, but `.closed` is closed for everyone. And a closed assignment is precisely the state content is written in: creating or cloning one starts it `.closed`, and every `Save & Validate` returns it to `.closed` (`PublishedAssignmentRoutes+SaveEdit.swift:105`). The editor was locked for the whole authoring window.

`NotebookContext` now carries `isReadOnly` separately from `isClosed`; for the assignment/solution branch that is `isClosed && !isStaff`, using the same per-course `isCourseStaff` check that already gates the solution view. Students are unaffected, `showSubmit` still follows `isClosed` for everyone, and a past-submission view stays locked as before.

## 2. …and it had nowhere to save to

JupyterLite keeps the live document in the browser. The on-disk working copy under `jupyterlite/files/users/…` was only ever *seeded* by the server, `JupyterLiteContentsRoutes` is GET-only, and `notebook.js` POSTed only to `runner-submit` / `browser-failover` / `session/keepalive`. The only ways to change an assignment's notebooks were an upload on the new-assignment page or the MCP `update_notebook` / `update_solution` tools — so the Edit button was a scratchpad.

New: **`POST /testsetups/:id/notebook/save?file=assignment|solution`**, plus a "Save to assignment" button rendered for course staff (TA+, non-archived course; the endpoint re-checks via `requireCourseWriteAccess`). It reuses the MCP tools' server-side steps so the two paths can't drift:

| | starter notebook | reference solution |
|---|---|---|
| stored by | `AssignmentAuthoringService.writeAssignmentNotebook` | a fresh `kind == .validation` submission, linked to the assignment |
| re-validation | `scheduleValidationAfterSuiteEdit` (debounced) | always — the new solution *is* what validates |

It also refreshes the author's working copy (so a reload shows the save) and registers the setup with `beginAssignmentContentEdit`, so the save is versioned like every other authoring write.

**One deliberate difference from the MCP tools: visibility never changes.** The MCP write tools close an open assignment; the web live-edit endpoints (`PUT /suite`, `PUT /families`) deliberately do not, and this is a live-edit endpoint. Pulling an open lab out from under students to fix a typo in a starter notebook is worse than the risk being guarded against — neither notebook changes what the suite grades. The `Save & Validate` button still closes, as it always has.

## Personalization safety (the part worth reviewing closely)

Every working copy is a *rendering*: `ensureUserNotebookWorkingCopy` substitutes the viewer's own values into each `{{name}}` and tags the cell `metadata.chickadee_personalized`. Storing an author's copy verbatim would replace `patients = {{patients}}` in the class template with one person's patient list — silently ending personalization for everyone.

`PersonalizedCellRestoration` (new service) puts the template text back before anything is written:

- Only tagged cells are touched; an assignment without personalization takes a one-lookup no-op path.
- Text comes from the canonical notebook itself, never reconstructed — this can add nothing the author didn't already have.
- Cells match by nbformat cell `id`; with no id, the same index is accepted **only** if that canonical cell really carries the placeholders the tag names.
- A tagged cell that can't be matched is **refused** (409, naming the placeholders) rather than guessed at. A rejected save is recoverable; a template quietly replaced by one student's data is not.

The author's own working copy keeps the rendered bytes they were editing — the view that actually runs — while the assignment stores the template.

## Tests

`Tests/APITests/NotebookWebRoutesTests.swift`, 39/39 green (11 new):

- staff keep an editable iframe on a closed assignment (starter and `?file=solution`); the four existing student read-only cases unchanged
- a save replaces the setup's flat notebook and the author's working copy
- a save leaves an **open** assignment open
- a solution save lands as a linked validation submission and does not touch the starter
- a draft setup with no assignment row saves without trying to validate
- a student POSTing directly gets 403; non-notebook JSON gets 400; in both cases the stored notebook is untouched
- personalization templates survive a save; an unmatchable personalized cell 409s and changes nothing
- the save button renders for staff and is absent for students

Also green locally: `Notebook|Personaliz|AssignmentVersion|Substitution` (448 tests / 74 suites), the 135 `.mjs` frontend tests, `scripts/lint.sh`, `scripts/swiftlint.sh` (0 violations), `scripts/check-styles.sh`.

## Known limit, not addressed here

`draftNotebookData` reads the working copy first, so publishing a *draft* that uses personalization can still pick up substituted bytes. That predates this PR (seeded draft copies were already substituted) and is unchanged by it — say the word if you want it closed too.