### PR TITLE
feat(personalization): let variable_equality families use a per-student expected

### DIFF
--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -213,7 +213,8 @@ struct UpdatePatternFamilyTool: ContentTool {
                             "type": .string("string"),
                             "description": .string(
                                 "Per-student expected: name of a global/section = expression resolved for the "
-                                    + "student's seed (boundary_equality only). Empty string clears it."),
+                                    + "student's seed (boundary_equality, approximate_equality, "
+                                    + "unordered_equality, and variable_equality). Empty string clears it."),
                         ]),
                         "hint": .object([
                             "type": .string("string"),

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer+VariableEquality.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer+VariableEquality.swift
@@ -17,7 +17,8 @@ func renderVariableEquality(
     family: PatternFamily,
     case c: PatternCase,
     sectionVariables: [FamilyVariable],
-    specHash: String
+    specHash: String,
+    perStudentNames: Set<String> = []
 ) -> String {
     // Section + family variables are declared as module-level globals in
     // the generated test.  `variableEquality` is checking a STUDENT-module
@@ -37,11 +38,21 @@ func renderVariableEquality(
     }()
     let nameLiteral = "\"" + escapeForPythonStringLiteral(variableName) + "\""
 
+    // A per-student `expectedVarRef` is bound at grading time from
+    // `_ck_inputs.py`; see personalizationPreambleForCase.  Note the variable
+    // NAME (args[0]) stays a baked literal — only the expected VALUE
+    // personalizes, which is why the validator still rejects arg refs here.
+    // With no per-student refs the preamble is "" and `expectedExpression`
+    // returns the same literal as before, so existing families render
+    // byte-identically and their spec_hash / TestSetupCache keys don't churn.
+    let preamble = personalizationPreambleForCase(c, perStudentNames: perStudentNames)
+    let preambleBlock = preamble.isEmpty ? "" : preamble + "\n\n"
+
     return """
         \(generatedCaseHeader(family: family, case: c, specHash: specHash))
 
-        variable_name = \(nameLiteral)
-        expected      = \(c.expected.pythonLiteral)
+        \(preambleBlock)variable_name = \(nameLiteral)
+        expected      = \(expectedExpression(for: c))
 
         _MISSING = object()
         actual = getattr(student_module, variable_name, _MISSING)

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -101,11 +101,11 @@ private func validateFamilyVariablesAndArgRefs(
             }
             // Per-student arg refs are bound by the generated case's
             // personalization preamble, which only the equality kinds emit.
-            if isPerStudent, !kindSupportsPerStudentRefs(family.kind) {
+            if isPerStudent, !kindSupportsPerStudentArgRefs(family.kind) {
                 throw Abort(
                     .unprocessableEntity,
                     reason:
-                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in \(perStudentCapableKindsDescription) families for now."
+                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in \(perStudentArgCapableKindsDescription) families for now."
                 )
             }
         }
@@ -119,23 +119,26 @@ private func validateFamilyVariablesAndArgRefs(
                         "Pattern family '\(family.id)': case '\(c.key)' expected reference '$\(eref)' must name a per-student input (a global or section `=` expression)."
                 )
             }
-            guard kindSupportsPerStudentRefs(family.kind) else {
+            guard kindSupportsPerStudentExpected(family.kind) else {
                 throw Abort(
                     .unprocessableEntity,
                     reason:
-                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in \(perStudentCapableKindsDescription) families for now."
+                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in \(perStudentExpectedCapableKindsDescription) families for now."
                 )
             }
         }
     }
 }
 
-/// Whether a kind's generated cases bind per-student `_ck_inputs` (so `$name`
-/// arg refs and `expectedVarRef` resolve at grading time).  Extend as renderers
-/// gain the personalization preamble (`personalizationPreambleForCase`).  An
-/// exhaustive switch — a new `PatternKind` must opt in or out here explicitly,
-/// and `perStudentCapableKindsDescription` below must name the same set.
-private func kindSupportsPerStudentRefs(_ kind: PatternKind) -> Bool {
+/// Whether a kind's generated cases can bind a per-student `$name` ARG ref.
+/// Only the function-calling equality kinds can: they build a call from
+/// `args`, so a bound name reaches the student's function.  `variableEquality`
+/// cannot — its `args[0]` is the *name* of the variable to inspect, baked into
+/// the script as a literal, so an arg ref there would be silently ignored
+/// rather than personalizing anything.  An exhaustive switch — a new
+/// `PatternKind` must opt in or out explicitly, and
+/// `perStudentArgCapableKindsDescription` must name the same set.
+private func kindSupportsPerStudentArgRefs(_ kind: PatternKind) -> Bool {
     switch kind {
     case .boundaryEquality, .approximateEquality, .unorderedEquality: return true
     case .variableEquality, .returnTypeCheck, .exceptionExpected,
@@ -144,10 +147,31 @@ private func kindSupportsPerStudentRefs(_ kind: PatternKind) -> Bool {
     }
 }
 
+/// Whether a kind's generated cases can bind a per-student EXPECTED value.
+/// This is a strictly weaker requirement than an arg ref: the case only needs
+/// to emit the personalization preamble and read `expected` from it, which
+/// every equality-shaped kind does.  `variableEquality` qualifies — "this
+/// student's `sd_systolic` equals this student's expected value" is the
+/// simplest personalization there is, and withholding it forced authors to
+/// reshape a variable exercise into a function purely to get a per-student
+/// answer.  Extend as renderers gain the preamble
+/// (`personalizationPreambleForCase` / `rPersonalizationPreambleForCase`).
+private func kindSupportsPerStudentExpected(_ kind: PatternKind) -> Bool {
+    switch kind {
+    case .boundaryEquality, .approximateEquality, .unorderedEquality, .variableEquality:
+        return true
+    case .returnTypeCheck, .exceptionExpected, .performanceThreshold, .stdoutEquality:
+        return false
+    }
+}
+
 /// Human-readable list of the kinds `kindSupportsPerStudentRefs` allows, for
 /// validation error messages.  Keep in lockstep with the switch above.
-private let perStudentCapableKindsDescription =
+private let perStudentArgCapableKindsDescription =
     "boundary_equality, approximate_equality, and unordered_equality"
+
+private let perStudentExpectedCapableKindsDescription =
+    "boundary_equality, approximate_equality, unordered_equality, and variable_equality"
 
 /// Validates the family `id`, `functionName`, and `paramNames` fields
 /// — the structural header of one `PatternFamily` before its cases are

--- a/Sources/APIServer/Utilities/PatternKindHandler.swift
+++ b/Sources/APIServer/Utilities/PatternKindHandler.swift
@@ -137,7 +137,9 @@ struct VariableEqualityKind: PatternKindHandler {
         sectionVariables: [FamilyVariable], specHash: String,
         perStudentNames: Set<String>
     ) -> String {
-        renderVariableEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
+        renderVariableEquality(
+            family: family, case: c, sectionVariables: sectionVariables, specHash: specHash,
+            perStudentNames: perStudentNames)
     }
 
     func validateCase(family: PatternFamily, case c: PatternCase) throws {

--- a/Tests/APITests/PatternFamilyRendererRTests.swift
+++ b/Tests/APITests/PatternFamilyRendererRTests.swift
@@ -439,4 +439,53 @@ import Testing
         proc.waitUntilExit()
         #expect(proc.terminationStatus == 0, "expected 7 delivered via _ck_inputs.R")
     }
+
+    /// The same end-to-end path for variable_equality: a per-student expected
+    /// against a module-level variable, with no function involved. This is the
+    /// shape a recap exercise takes ("your sd_systolic equals your value"), and
+    /// it was rejected outright before.
+    @Test func variableEqualityPerStudentExpectedRunsForReal() throws {
+        guard Self.hasRscript else { return }
+        let c = PatternCase(
+            key: "01", label: "sd_systolic", args: [.string("sd_systolic")], expected: .null,
+            expectedVarRef: "sd_expected")
+        let fam = PatternFamily(
+            id: "sd", name: "SD", kind: .variableEquality, functionName: "",
+            paramNames: [], cases: [c])
+        let script = try #require(
+            renderPatternFamily(fam, perStudentNames: ["sd_expected"], language: .r).first)
+        #expect(script.source.contains("_ck_inputs.R"), "must bind the per-student value")
+
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("ck-rvar-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        try Self.canonicalRuntime().write(
+            to: dir.appendingPathComponent("test_runtime.R"), atomically: true, encoding: .utf8)
+        try AssignmentLanguage.r.renderInputsFile(["sd_expected": "9.5"]).write(
+            to: dir.appendingPathComponent("_ck_inputs.R"), atomically: true, encoding: .utf8)
+        let scriptURL = dir.appendingPathComponent(script.filename)
+        try script.source.write(to: scriptURL, atomically: true, encoding: .utf8)
+
+        func runWith(_ submission: String) throws -> Int32 {
+            try submission.write(
+                to: dir.appendingPathComponent("solution.R"), atomically: true, encoding: .utf8)
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            proc.arguments = ["Rscript", scriptURL.path]
+            proc.currentDirectoryURL = dir
+            proc.standardOutput = Pipe()
+            proc.standardError = Pipe()
+            try proc.run()
+            proc.waitUntilExit()
+            return proc.terminationStatus
+        }
+
+        // Matches this student's personalized value.
+        #expect(try runWith("sd_systolic <- 9.5\n") == 0)
+        // Another student's answer must not pass.
+        #expect(try runWith("sd_systolic <- 8.1\n") == 1)
+        // Undefined is a clean failure, not an error.
+        #expect(try runWith("other <- 9.5\n") == 1)
+    }
 }

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -556,6 +556,100 @@ import Vapor
         }
     }
 
+    // MARK: - Personalization for variableEquality
+
+    private func perStudentVariableFamily() -> PatternFamily {
+        let c = PatternCase(
+            key: "01", label: "sd_systolic", args: [.string("sd_systolic")], expected: .null,
+            expectedVarRef: "sd_expected")
+        return PatternFamily(
+            id: "sd", name: "Standard deviation", kind: .variableEquality,
+            functionName: "", paramNames: [], cases: [c])
+    }
+
+    /// The simplest personalization there is — "this student's variable equals
+    /// this student's value". Previously rejected, which forced an author to
+    /// reshape a variable exercise into a function purely to get a per-student
+    /// answer.
+    @Test func variableEqualityEmitsPerStudentPreambleAndExpectedRef() throws {
+        let scripts = renderPatternFamily(
+            perStudentVariableFamily(), perStudentNames: ["sd_expected"])
+        let src = try #require(scripts.first).source
+        try pfAssertValidPythonSyntax(src, label: "sd_01")
+        #expect(src.contains("_ck_inputs.py"))
+        #expect(src.contains(#"sd_expected = _ck["sd_expected"]"#))
+        #expect(src.contains("Personalization input"))  // fails closed when missing
+        // Expected is the bare per-student ref; the variable NAME stays literal.
+        #expect(src.contains("expected      = sd_expected"))
+        #expect(src.contains(#"variable_name = "sd_systolic""#))
+        #expect(!src.contains("expected      = None"))
+    }
+
+    /// A family with no per-student refs must render exactly as before — the
+    /// preamble is "" and the expected is the same baked literal. Generated
+    /// bytes feed spec_hash / TestSetupCache keys, so any drift here would
+    /// invalidate every existing variable_equality family's cache.
+    @Test func variableEqualityWithoutRefsIsByteIdentical() throws {
+        let c = PatternCase(
+            key: "01", label: "answer", args: [.string("answer")], expected: .int(42))
+        let family = PatternFamily(
+            id: "ans", name: "Answer", kind: .variableEquality,
+            functionName: "", paramNames: [], cases: [c])
+        // Rendered with and without a per-student name in scope: neither case
+        // references one, so both must be identical, and neither may carry a
+        // preamble.
+        let bare = try #require(renderPatternFamily(family).first).source
+        let withNames = try #require(
+            renderPatternFamily(family, perStudentNames: ["unrelated"]).first
+        ).source
+        #expect(bare == withNames)
+        #expect(!bare.contains("_ck_inputs.py"))
+        #expect(bare.contains("expected      = 42"))
+    }
+
+    /// An arg ref stays rejected for this kind: args[0] is the *name* of the
+    /// variable to inspect and is baked in as a literal, so a bound value
+    /// would be silently ignored rather than personalizing anything.
+    @Test func variableEqualityStillRejectsPerStudentArgRefs() throws {
+        // args[0] is a valid literal name, so the kind's own structural check
+        // passes and the per-student arg-ref gate is what rejects this.
+        let c = PatternCase(
+            key: "01", label: "X", args: [.string("sd_systolic")], expected: .int(1),
+            argVarRefs: ["which_var"])
+        let family = PatternFamily(
+            id: "v", name: "V", kind: .variableEquality,
+            functionName: "", paramNames: ["name"], cases: [c])
+        #expect {
+            try validatePatternFamilies(
+                [family], testSuites: [], perStudentExpressionNames: ["which_var"])
+        } throws: { error in
+            #expect(
+                "\(error)".contains(
+                    "only supported in boundary_equality, approximate_equality, and unordered_equality"
+                ))
+            return true
+        }
+    }
+
+    /// A kind with no preamble at all still refuses a per-student expected,
+    /// and the message names the wider expected-capable set.
+    @Test func unsupportedKindStillRejectsPerStudentExpected() throws {
+        let c = PatternCase(
+            key: "01", label: "X", args: [.null], expected: .string("int"),
+            expectedVarRef: "t_expected")
+        let family = PatternFamily(
+            id: "rt", name: "RT", kind: .returnTypeCheck,
+            functionName: "f", paramNames: ["x"], cases: [c])
+        #expect {
+            try validatePatternFamilies(
+                [family], testSuites: [], perStudentExpressionNames: ["t_expected"])
+        } throws: { error in
+            #expect("\(error)".contains("uses a per-student expected"))
+            #expect("\(error)".contains("and variable_equality"))
+            return true
+        }
+    }
+
     // MARK: - Personalization for approximateEquality (Slice E)
 
     private func perStudentApproxFamily() -> PatternFamily {

--- a/changelog.d/variable-equality-personalization.md
+++ b/changelog.d/variable-equality-personalization.md
@@ -1,0 +1,16 @@
+### Added
+
+- **`variable_equality` pattern families support a per-student `expectedVarRef`.**
+  "This student's `sd_systolic` equals this student's value" is the simplest
+  personalization there is, but it was rejected outright — so an author who wanted a
+  per-student answer for a variable exercise had to reshape it into a function first,
+  purely to satisfy the grader. The R renderer already had the plumbing; the Python
+  one never emitted the personalization preamble and baked the expected in as a
+  literal. Both now bind the value from `_ck_inputs`, and the validator's single
+  per-student gate is split in two: `kindSupportsPerStudentArgRefs` (unchanged — a
+  bound `$name` must reach a called function) and `kindSupportsPerStudentExpected`
+  (now including `variable_equality`). Arg refs stay rejected for
+  `variable_equality`, whose `args[0]` is the variable *name* and is baked in as a
+  literal — a ref there would be silently ignored rather than personalizing anything.
+  Families with no per-student refs render byte-identically, so existing `spec_hash`
+  / `TestSetupCache` keys do not churn.

--- a/docs/personalization-pattern-families.md
+++ b/docs/personalization-pattern-families.md
@@ -203,9 +203,27 @@ So the feature's strongest wins are for **worker-graded** assignments and for
   family case), not just the notebook.
 
 Since the initial `.boundaryEquality`-only MVP, per-student refs have expanded
-to `.approximateEquality` and `.unorderedEquality` — the supported set is the
-`kindSupportsPerStudentRefs` allowlist in `PatternFamilyValidator.swift`
-(the equality kinds; the remaining kinds are future work).
+to `.approximateEquality` and `.unorderedEquality`. The gate is now **two**
+allowlists in `PatternFamilyValidator.swift`, because arg refs and expected
+refs are different requirements:
+
+- `kindSupportsPerStudentArgRefs` — `.boundaryEquality`,
+  `.approximateEquality`, `.unorderedEquality`. A bound `$name` has to reach
+  the student's function, so only the function-calling kinds qualify.
+- `kindSupportsPerStudentExpected` — those three **plus
+  `.variableEquality`**. A per-student *expected* is strictly weaker: the case
+  only needs the personalization preamble and to read `expected` from it.
+  `.variableEquality` gets this because "this student's `sd_systolic` equals
+  this student's value" is the simplest personalization there is; withholding
+  it forced authors to reshape a variable exercise into a function purely to
+  obtain a per-student answer.
+
+`.variableEquality` deliberately stays out of the *arg* list: its `args[0]` is
+the **name** of the variable to inspect, baked into the generated script as a
+literal, so an arg ref there would be silently ignored rather than
+personalizing anything. The remaining kinds (`returnTypeCheck`,
+`exceptionExpected`, `performanceThreshold`, `stdoutEquality`) emit no
+preamble and remain future work.
 
 ## Open questions
 


### PR DESCRIPTION
## Why

"This student's `sd_systolic` equals this student's value" is the simplest personalization the platform can express, and it was rejected outright:

```
case '01' uses a per-student expected, which is only supported in
boundary_equality, approximate_equality, and unordered_equality families for now.
```

The practical cost: an author who wanted a per-student answer for a **variable** exercise had to reshape it into a **function** first — purely to satisfy the grader, not because the exercise wanted to be a function. That's what blocked personalizing HLTH 230 A0's recap, where eight of nine graded items are module-level variables.

## What was actually blocking it

Two small gaps, not a design constraint:

- **R was already done.** `renderRPatternCase` builds its prelude — header + variables + personalization preamble — uniformly for *every* kind, and `rVariableEqualityCase` already used `rExpectedExpression(for:)`. Only the validator refused it.
- **Python was the gap.** `renderVariableEquality` never emitted the preamble and baked the expected in via `c.expected.pythonLiteral`. It now takes `perStudentNames`, emits the preamble, and uses `expectedExpression(for:)`. `VariableEqualityKind.render` was already *handed* `perStudentNames` and dropped it on the floor — that's now threaded through.

## The validator split

The single `kindSupportsPerStudentRefs` gate conflated two different requirements, so it's now two:

| Predicate | Kinds | Why |
|---|---|---|
| `kindSupportsPerStudentArgRefs` | boundary, approximate, unordered | A bound `$name` must reach the student's **function**, so only function-calling kinds qualify. **Unchanged.** |
| `kindSupportsPerStudentExpected` | those three **+ `variableEquality`** | Strictly weaker: the case only needs the preamble and to read `expected` from it. |

`variableEquality` deliberately stays **out** of the arg list. Its `args[0]` is the *name* of the variable to inspect, baked into the script as a literal — an arg ref there would be silently ignored rather than personalizing anything. Rejecting it is honest; accepting it would be a trap that looks like it works. There's a test pinning that refusal.

## Compatibility

Families with no per-student refs render **byte-identically**: the preamble is `""` and `expectedExpression` returns the same literal as before. Generated bytes feed `spec_hash` / `TestSetupCache` keys, so this matters — `variableEqualityWithoutRefsIsByteIdentical` asserts it directly by rendering with and without an unrelated per-student name in scope and comparing sources.

## Testing

- `variableEqualityEmitsPerStudentPreambleAndExpectedRef` — Python: binds from `_ck_inputs`, `expected` is the bare ref, variable **name** stays literal, fails closed when the value is missing.
- `variableEqualityWithoutRefsIsByteIdentical` — the no-churn guarantee above.
- `variableEqualityStillRejectsPerStudentArgRefs` — the deliberate refusal. (First draft of this test was wrong: I passed `.null` for `args[0]`, so the kind's own structural check fired first and the assertion passed for the wrong reason. Fixed to use a valid literal name so the per-student gate is genuinely what rejects it.)
- `unsupportedKindStillRejectsPerStudentExpected` — `returnTypeCheck` still refused, message names the wider set.
- `variableEqualityPerStudentExpectedRunsForReal` — R, end-to-end against the real runtime: the student's own value passes, another student's answer fails, undefined fails cleanly rather than erroring.

Local: 247 tests across the pattern-family / validator / MCP-tool / catalog-sync suites. `format.sh`, `lint.sh`, `swiftlint.sh` (0 violations, 884 files) clean.

## Notes

- `update_pattern_family`'s `expectedVarRef` description said "(boundary_equality only)" — stale even before this change, since approximate and unordered were already supported. Now accurate.
- `docs/personalization-pattern-families.md` documents the two-allowlist split and why `variableEquality` is in one and not the other.
- Branch note: the previous PR from this branch merged and the remote branch was auto-deleted, so this is restarted from the latest `main` under the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcUNcQXrRbd6zJY9L5JgS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcUNcQXrRbd6zJY9L5JgS5)_