### PR TITLE
Author notebooks against the template, not against a rendering

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1259,6 +1259,10 @@
     // the control.
     if (saveAssignmentBtn) {
         const saveFileKind = saveAssignmentBtn.dataset.fileKind === 'solution' ? 'solution' : 'assignment';
+        // Which working copy the editor is showing. The endpoint writes the
+        // save back to this view's copy and discards the other, so a wrong
+        // value here would leave the author looking at stale bytes.
+        const saveViewMode = saveAssignmentBtn.dataset.viewMode === 'personalized' ? 'personalized' : 'template';
         const saveLabel = saveAssignmentBtn.textContent;
         saveAssignmentBtn.addEventListener('click', async () => {
             saveAssignmentBtn.disabled = true;
@@ -1272,7 +1276,7 @@
                 const notebook = await loadNotebookForSubmit();
                 setStatus('loading', 'Saving to the assignment…');
                 const res = await fetch(
-                    `/testsetups/${encodeURIComponent(setupID)}/notebook/save?file=${saveFileKind}`,
+                    `/testsetups/${encodeURIComponent(setupID)}/notebook/save?file=${saveFileKind}&view=${saveViewMode}`,
                     {
                         method: 'POST',
                         headers: {

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -71,15 +71,23 @@ Notebook
     <div class="notebook-toolbar">
         <span class="nb-status" id="nb-status" role="status" aria-live="polite" aria-atomic="true"></span>
         <div class="notebook-actions">
-            #if(showSubmit):
+            #if(isTemplateView):
+            <span class="nb-closed-notice">Editing the template &mdash; placeholders stand as written.</span>
+            #elseif(showSubmit):
             <button class="btn btn-primary" id="nb-submit">Submit</button>
             #elseif(isReadOnly):
             <span class="nb-closed-notice">This assignment is closed &mdash; view only.</span>
             #elseif(isClosed):
             <span class="nb-closed-notice">This assignment is closed to students &mdash; editable as course staff.</span>
             #endif
+            #if(viewToggleURL):
+            <a class="btn" href="#(viewToggleURL)">
+                #if(isTemplateView):View with values#else:Edit the template#endif
+            </a>
+            #endif
             #if(canSaveToAssignment):
             <button class="btn btn-primary" id="nb-save-assignment" data-file-kind="#(fileKind)"
+                    data-view-mode="#if(isTemplateView):template#else:personalized#endif"
                     title="Write what is in this editor back to the assignment for every student">
                 #if(fileKind == "solution"):Save solution#else:Save to assignment#endif
             </button>

--- a/Sources/APIServer/Routes/Web/AssignmentDraftHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentDraftHelpers.swift
@@ -158,15 +158,23 @@ func draftNotebookData(
     fileKind: NotebookFileKind,
     fallbackPath: String?
 ) -> Data? {
-    let workingCopyPath =
-        req.application.directory.publicDirectory
-        + "jupyterlite/files/"
-        + userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: fileKind)
-    if let data = try? Data(contentsOf: URL(fileURLWithPath: workingCopyPath)),
-        !data.isEmpty,
-        (try? JSONSerialization.jsonObject(with: data)) != nil
-    {
-        return data
+    // The template copy first: on a personalized assignment it is the view the
+    // author is actually working in, and it is the one holding `{{name}}`
+    // rather than one person's values — which is what a draft must carry
+    // forward.  On an assignment without personalization it simply does not
+    // exist, and this falls through to the copy it always read.
+    let candidatePaths = [NotebookViewMode.template, .personalized].map { viewMode in
+        req.application.directory.publicDirectory + "jupyterlite/files/"
+            + userNotebookWorkingCopyRelativePath(
+                setupID: setupID, userID: userID, fileKind: fileKind, viewMode: viewMode)
+    }
+    for path in candidatePaths {
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+            !data.isEmpty,
+            (try? JSONSerialization.jsonObject(with: data)) != nil
+        {
+            return data
+        }
     }
     guard let fallbackPath,
         let data = try? Data(contentsOf: URL(fileURLWithPath: fallbackPath)),

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -226,6 +226,15 @@ struct NotebookContext: Encodable {
     /// Which notebook is open — `"assignment"` or `"solution"`.  Labels the
     /// save button and rides along as the endpoint's `?file=` argument.
     let fileKind: String
+    /// True when the editor holds the author's *template* — `{{name}}` left
+    /// standing — rather than a rendering of it.  Staff default on an
+    /// assignment with personalization; never true for a student.  Drives the
+    /// header notice and the absence of Submit (a template does not run).
+    let isTemplateView: Bool
+    /// Link to the same notebook in the other view, or nil when there is
+    /// nothing to switch between (no placeholders, or the viewer is not
+    /// staff).  Rides `?view=` on the notebook page.
+    let viewToggleURL: String?
     /// Unix-epoch mtime (seconds) of the user's working-copy notebook file
     /// on disk at render time.  Embedded in the iframe as
     /// `data-working-copy-mtime`; `notebook.js` compares it against a

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -26,6 +26,7 @@ extension WebRoutes {
             var title: String?
             var submissionID: String?
             var file: String?
+            var view: String?
         }
         let user = try req.auth.require(APIUser.self)
         guard let userID = user.id else { throw Abort(.unauthorized) }
@@ -55,6 +56,9 @@ extension WebRoutes {
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == setupID)
             .first()
+        let viewMode = try await resolveNotebookViewMode(
+            req: req, setup: setup, assignment: assignment,
+            fileKind: fileKind, isStaff: isStaff, requested: query.view)
         // Treat an assignment as closed for read-only display whenever it is
         // not effectively open *for this user* — the per-user check honors a
         // deadline extension granted to the current student, so an extended
@@ -104,7 +108,8 @@ extension WebRoutes {
             assignment: assignment,
             assignmentTitle: assignmentTitle,
             isClosed: isClosed,
-            isStaff: isStaff
+            isStaff: isStaff,
+            viewMode: viewMode
         )
         if !requestedSubmissionID.isEmpty {
             return try await renderSubmissionNotebookView(
@@ -226,6 +231,10 @@ extension WebRoutes {
                 isReadOnly: args.isClosed,
                 canSaveToAssignment: false,
                 fileKind: NotebookFileKind.assignment.rawValue,
+                // A submission is a rendering by construction — it is the
+                // bytes a student ran — and has no template to switch to.
+                isTemplateView: false,
+                viewToggleURL: nil,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: submissionViewAbsPath),
                 currentUser: req.currentUserContext
             ))
@@ -242,6 +251,9 @@ extension WebRoutes {
         let userID = args.userID
         let assignment = args.assignment
         let userSlug = userID.uuidString.lowercased()
+        let viewMode = args.viewMode
+        let workingCopyPath = userNotebookWorkingCopyRelativePath(
+            setupID: setupID, userID: userID, fileKind: fileKind, viewMode: viewMode)
         if fileKind == .solution {
             let solutionData = try await solutionNotebookData(for: assignment, setup: setup, db: req.db)
             _ = try await ensureUserNotebookWorkingCopy(
@@ -249,29 +261,32 @@ extension WebRoutes {
                 setupID: setupID,
                 userID: userID,
                 fallbackSetup: setup,
-                relativePath: userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: fileKind),
-                defaultData: solutionData
+                relativePath: workingCopyPath,
+                defaultData: solutionData,
+                viewMode: viewMode
             )
         } else {
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
                 setupID: setupID,
                 userID: userID,
-                fallbackSetup: setup
+                fallbackSetup: setup,
+                relativePath: workingCopyPath,
+                viewMode: viewMode
             )
         }
-        let jupyterLiteNotebookPath = userNotebookWorkingCopyRelativePath(
-            setupID: setupID, userID: userID, fileKind: fileKind)
+        let jupyterLiteNotebookPath = workingCopyPath
         let encodedPath =
             jupyterLiteNotebookPath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
             ?? jupyterLiteNotebookPath
-        let workspaceID = "\(setupID)-\(userSlug)-\(fileKind.rawValue)"
+        // The workspace id carries the view mode so JupyterLite keeps a
+        // separate layout (and IndexedDB copy) per view — switching to the
+        // template must not surface the rendered copy from cache.
+        let workspaceID = "\(setupID)-\(userSlug)-\(fileKind.rawValue)-\(viewMode.rawValue)"
         let editorURL = "/jupyterlite/notebooks/index.html?workspace=\(workspaceID)&reset=&path=\(encodedPath)"
         let notebookURL =
-            switch fileKind {
-            case .assignment: "/testsetups/\(setupID)/notebook/source"
-            case .solution: "/testsetups/\(setupID)/notebook/source?file=solution"
-            }
+            "/testsetups/\(setupID)/notebook/source"
+            + "?file=\(fileKind.rawValue)&view=\(viewMode.rawValue)"
         let downloadURL: String? = {
             guard let assignment else { return nil }
             return switch fileKind {
@@ -301,6 +316,26 @@ extension WebRoutes {
                 user: args.user, courseID: setup.courseID, atLeast: .ta, db: req.db)
             canSaveToAssignment = denial == nil
         }
+        // Staff-only view switch, offered only where the two views differ — an
+        // assignment with no personalization reads identically in both, so the
+        // control would be noise.  Being *in* the template view already proves
+        // that (`resolveNotebookViewMode` only returns it for staff on a
+        // notebook with placeholders), so the short-circuit spares the common
+        // case a second read of the notebook.
+        let canSwitchViews: Bool
+        if viewMode == .template {
+            canSwitchViews = true
+        } else if args.isStaff {
+            canSwitchViews = await notebookHasPlaceholders(
+                req: req, setup: setup, assignment: assignment, fileKind: fileKind)
+        } else {
+            canSwitchViews = false
+        }
+        let otherView: NotebookViewMode = viewMode == .template ? .personalized : .template
+        let viewToggleURL: String? =
+            canSwitchViews
+            ? "/testsetups/\(setupID)/notebook?file=\(fileKind.rawValue)&view=\(otherView.rawValue)"
+            : nil
         return try await req.view.render(
             "notebook",
             NotebookContext(
@@ -311,11 +346,16 @@ extension WebRoutes {
                 downloadURL: downloadURL,
                 gradingMode: decodeManifestGradingMode(setup),
                 browserUnsupported: SupportedBrowserMatrix.assess(req).tier == .unsupported,
-                showSubmit: fileKind == .assignment && !args.isClosed,
+                // A template still holds `{{name}}`, which does not run and
+                // would fail every test, so Submit belongs to the rendered
+                // view only.  Staff who want to test-submit switch views.
+                showSubmit: fileKind == .assignment && !args.isClosed && viewMode == .personalized,
                 isClosed: args.isClosed,
                 isReadOnly: isReadOnly,
                 canSaveToAssignment: canSaveToAssignment,
                 fileKind: fileKind.rawValue,
+                isTemplateView: viewMode == .template,
+                viewToggleURL: viewToggleURL,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: workingCopyAbsPath),
                 currentUser: req.currentUserContext
             ))
@@ -336,6 +376,64 @@ extension WebRoutes {
         /// Staff author content in this editor, so they are never locked out
         /// of the assignment / solution notebook by the closed state.
         let isStaff: Bool
+        /// Which reading of the notebook to put in the editor — the author's
+        /// template or a per-viewer rendering.  Always `.personalized` for
+        /// students and for the submission-history view.
+        let viewMode: NotebookViewMode
+    }
+
+    /// Which reading of the notebook this request gets.
+    ///
+    /// Staff author these notebooks, so when there is a template to author —
+    /// the stored notebook still carries `{{name}}` — that is their default
+    /// view, and `?view=personalized` switches to the rendering for running
+    /// and test-submitting.
+    ///
+    /// Everything else resolves to `.personalized`, which is what keeps this
+    /// change confined to the case it is for:
+    /// - **Students**, always. A raw `{{name}}` cell is not valid Python or R;
+    ///   serving one would break the notebook and leak the class template.
+    ///   The requested view is ignored rather than honoured, so the template
+    ///   is not reachable by URL.
+    /// - **An assignment with no personalization**, for staff too. The two
+    ///   views are byte-identical there, so `.personalized` keeps the page
+    ///   exactly as it was — Submit included.
+    private func resolveNotebookViewMode(
+        req: Request,
+        setup: APITestSetup,
+        assignment: APIAssignment?,
+        fileKind: NotebookFileKind,
+        isStaff: Bool,
+        requested: String?
+    ) async throws -> NotebookViewMode {
+        guard isStaff else { return .personalized }
+        guard
+            await notebookHasPlaceholders(
+                req: req, setup: setup, assignment: assignment, fileKind: fileKind)
+        else {
+            return .personalized
+        }
+        return notebookViewMode(from: requested) ?? .template
+    }
+
+    /// Whether the stored notebook still carries `{{name}}` placeholders —
+    /// i.e. whether the template and rendered views of it actually differ.
+    /// Drives the staff view switch, which is pointless on an assignment
+    /// without personalization.  Unreadable bytes answer `false`: the switch
+    /// is an affordance, and a missing notebook has bigger problems.
+    private func notebookHasPlaceholders(
+        req: Request,
+        setup: APITestSetup,
+        assignment: APIAssignment?,
+        fileKind: NotebookFileKind
+    ) async -> Bool {
+        let data: Data? =
+            switch fileKind {
+            case .assignment: try? notebookData(for: setup)
+            case .solution: try? await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            }
+        guard let data else { return false }
+        return !NotebookSubstitution.placeholderNames(in: data).isEmpty
     }
 
     /// Decodes the manifest's `gradingMode` for the notebook template;
@@ -354,6 +452,7 @@ extension WebRoutes {
     func notebookSource(req: Request) async throws -> Response {
         struct NotebookSourceQuery: Content {
             var file: String?
+            var view: String?
             var submissionID: String?
         }
         let user = try req.auth.require(APIUser.self)
@@ -403,9 +502,23 @@ extension WebRoutes {
         }
 
         let fileKind = notebookFileKind(from: query.file)
+        // The reference solution is staff-only.  `notebookPage` has always
+        // guarded this, but the raw content endpoint did not, so any enrolled
+        // student could fetch the answer key as JSON by asking for
+        // `?file=solution` directly — the exact bypass the page's own comment
+        // warns about ("never serve the answer key to a student").
+        if fileKind == .solution, !isStaff {
+            throw Abort(.forbidden, reason: "The solution is only available to course staff.")
+        }
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == setupID)
             .first()
+        // Same resolution as the page, so the editor's frame and its content
+        // fetch never disagree about which copy is open — and so a student
+        // asking for `?view=template` by hand still gets their rendering.
+        let viewMode = try await resolveNotebookViewMode(
+            req: req, setup: setup, assignment: assignment,
+            fileKind: fileKind, isStaff: isStaff, requested: query.view)
         let defaultData: Data? =
             if fileKind == .solution {
                 try await solutionNotebookData(for: assignment, setup: setup, db: req.db)
@@ -418,8 +531,10 @@ extension WebRoutes {
             setupID: setupID,
             userID: userID,
             fallbackSetup: setup,
-            relativePath: userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: fileKind),
-            defaultData: defaultData
+            relativePath: userNotebookWorkingCopyRelativePath(
+                setupID: setupID, userID: userID, fileKind: fileKind, viewMode: viewMode),
+            defaultData: defaultData,
+            viewMode: viewMode
         )
 
         var headers = HTTPHeaders()

--- a/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
@@ -59,6 +59,7 @@ extension WebRoutes {
     func saveNotebookFromEditor(req: Request) async throws -> NotebookSaveResult {
         struct SaveQuery: Content {
             var file: String?
+            var view: String?
         }
 
         let user = try req.auth.require(APIUser.self)
@@ -77,7 +78,15 @@ extension WebRoutes {
         try await requireCourseWriteAccess(
             caller: user, courseID: setup.courseID, atLeast: .ta, db: req.db)
 
-        let fileKind = notebookFileKind(from: (try? req.query.decode(SaveQuery.self))?.file)
+        let saveQuery = try? req.query.decode(SaveQuery.self)
+        let fileKind = notebookFileKind(from: saveQuery?.file)
+        // Which of the caller's two working copies this save came from.  The
+        // page sends it explicitly, and only ever sends `template` when it is
+        // actually showing one, so the historic behaviour is the right default
+        // for a request that omits it.  Nothing security-relevant rides on
+        // this: it picks which working copy to refresh, while what gets
+        // *stored* is decided by the cell tags in the body.
+        let viewMode = notebookViewMode(from: saveQuery?.view) ?? .personalized
 
         guard let buffer = req.body.data, buffer.readableBytes > 0 else {
             throw Abort(.badRequest, reason: "The request body must be the notebook JSON.")
@@ -94,12 +103,19 @@ extension WebRoutes {
             .filter(\.$testSetupID == setupID)
             .first()
 
-        // The copy in the author's editor is a *rendering*: the server
-        // substituted their own values into every `{{name}}` placeholder before
+        // A save from the `.template` view is already template text — the
+        // author typed the `{{name}}` themselves — and its cells carry no
+        // personalization tag, so the restoration below is a no-op and their
+        // placeholders store verbatim. That is the whole point of that view.
+        //
+        // A save from the `.personalized` view is a *rendering*: the server
+        // substituted the author's own values into every placeholder before
         // handing it over. Storing that verbatim would replace the class's
-        // template with one person's data, so the personalized cells are
-        // restored from the notebook currently stored before anything is
-        // written. A no-op on an assignment without personalization.
+        // template with one person's data, so its tagged cells are restored
+        // from the notebook currently stored before anything is written.
+        //
+        // Running both through one path means neither view needs to be trusted
+        // to declare what it is holding: the cell tags are the evidence.
         let canonical = try await canonicalNotebookData(
             req: req, setup: setup, assignment: assignment, fileKind: fileKind)
         let toStore: Data
@@ -126,18 +142,25 @@ extension WebRoutes {
         // id, so it registers by hand (as `update_solution` does over MCP).
         await req.beginAssignmentContentEdit(setup: setup)
 
-        // The author's working copy keeps the *rendered* bytes they were
-        // editing — the same personalized view they had a second ago, and the
-        // one that actually runs — while the assignment stores the template.
+        // The author's working copy keeps exactly the bytes they were editing,
+        // in whichever view they were editing them: a template save leaves the
+        // placeholders they typed on screen, a personalized save leaves the
+        // rendering that actually runs.
         _ = try await ensureUserNotebookWorkingCopy(
             req: req,
             setupID: setupID,
             userID: userID,
             fallbackSetup: setup,
             relativePath: userNotebookWorkingCopyRelativePath(
-                setupID: setupID, userID: userID, fileKind: fileKind),
-            overwriteWith: asEdited
+                setupID: setupID, userID: userID, fileKind: fileKind, viewMode: viewMode),
+            overwriteWith: asEdited,
+            viewMode: viewMode
         )
+        // The counterpart view is now a rendering of superseded bytes, so drop
+        // it: switching views after a save must show the save, not the notebook
+        // as it stood before it.
+        await discardOtherNotebookViewCopy(
+            req: req, setupID: setupID, userID: userID, fileKind: fileKind, viewMode: viewMode)
 
         let outcome =
             switch fileKind {

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -15,6 +15,34 @@ import Fluent
 import Foundation
 import Vapor
 
+/// Which of the two readings of a notebook a working copy holds.
+///
+/// A notebook with personalization is two documents at once: the *template*
+/// the author writes (`patients = {{patients}}`) and the per-viewer
+/// *rendering* the server produces from it (`patients = [61, 47, ...]`).
+/// Both are legitimate views of the same file, and which one a request wants
+/// depends on what the viewer is doing rather than on who they are:
+///
+/// - `.personalized` — running and submitting.  This is what every student
+///   gets, always, and what staff get when they want to see the notebook as a
+///   student does.  Placeholders are replaced at seed time and the rewritten
+///   cells carry `NotebookSubstitution.fencedCellMetadataKey`.
+/// - `.template` — authoring.  Placeholders are left standing, so an author
+///   can read, edit, and write `{{name}}` directly.  Cells carry no
+///   personalization tag, which is what makes a save store the author's own
+///   text (`PersonalizedCellRestoration` has nothing to restore).
+///
+/// The two live in separate working-copy files, so switching between them
+/// costs nothing and neither view can clobber the other's edits.
+enum NotebookViewMode: String, Sendable {
+    case personalized
+    case template
+}
+
+func notebookViewMode(from rawValue: String?) -> NotebookViewMode? {
+    NotebookViewMode(rawValue: (rawValue ?? "").lowercased())
+}
+
 func userNotebookWorkingCopyRelativePath(setupID: String, userID: UUID) -> String {
     userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: .assignment)
 }
@@ -23,19 +51,28 @@ func notebookFileKind(from rawValue: String?) -> NotebookFileKind {
     NotebookFileKind(rawValue: (rawValue ?? "").lowercased()) ?? .assignment
 }
 
-private func userNotebookFilename(fileKind: NotebookFileKind) -> String {
-    switch fileKind {
-    case .assignment: return "assignment.ipynb"
-    case .solution: return "solution.ipynb"
+private func userNotebookFilename(fileKind: NotebookFileKind, viewMode: NotebookViewMode) -> String {
+    let stem =
+        switch fileKind {
+        case .assignment: "assignment"
+        case .solution: "solution"
+        }
+    switch viewMode {
+    // The rendered copy keeps the historical filename: every existing working
+    // copy on disk is one of these, and a student's path must not move.
+    case .personalized: return "\(stem).ipynb"
+    case .template: return "\(stem)-template.ipynb"
     }
 }
 
 func userNotebookWorkingCopyRelativePath(
     setupID: String,
     userID: UUID,
-    fileKind: NotebookFileKind
+    fileKind: NotebookFileKind,
+    viewMode: NotebookViewMode = .personalized
 ) -> String {
-    "users/\(userID.uuidString.lowercased())/\(setupID)/\(userNotebookFilename(fileKind: fileKind))"
+    "users/\(userID.uuidString.lowercased())/\(setupID)/"
+        + userNotebookFilename(fileKind: fileKind, viewMode: viewMode)
 }
 
 /// Whether `userID` has previously engaged with `assignment`: a durable
@@ -130,7 +167,8 @@ func ensureUserNotebookWorkingCopy(
     fallbackSetup: APITestSetup,
     relativePath: String? = nil,
     defaultData: Data? = nil,
-    overwriteWith: Data? = nil
+    overwriteWith: Data? = nil,
+    viewMode: NotebookViewMode = .personalized
 ) async throws -> Data {
     let fileManager = FileManager.default
     let resolvedRelativePath = relativePath ?? userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID)
@@ -169,17 +207,23 @@ func ensureUserNotebookWorkingCopy(
         return existingData
     }
 
-    let seedData =
-        if let defaultData {
-            defaultData
-        } else {
-            try await latestNotebookSubmissionData(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fallbackSetup: fallbackSetup
-            ).data
-        }
+    let seedData: Data
+    if let defaultData {
+        seedData = defaultData
+    } else if viewMode == .template, let starter = try? notebookData(for: fallbackSetup) {
+        // A template copy is a view of the *assignment*, not of this viewer's
+        // work, so it seeds from the stored starter.  Without this an author
+        // who had also submitted would open their own submission and save it
+        // over the class's starter.
+        seedData = starter
+    } else {
+        seedData = try await latestNotebookSubmissionData(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: fallbackSetup
+        ).data
+    }
 
     // Slice 1 + Slice 2 + Slice 4: substitute `{{name}}` placeholders in
     // the starter notebook.  Slice 5: the evaluator can now import
@@ -187,14 +231,24 @@ func ensureUserNotebookWorkingCopy(
     // `solution.py` from solution.ipynb).  Failures fall back to
     // un-substituted seedData; the editor's save-time check is the
     // primary gate.
-    let processedData = await applyNotebookSubstitutionsIfNeeded(
-        seedData: seedData,
-        setup: fallbackSetup,
-        userID: userID,
-        db: req.db,
-        supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setupID)/",
-        logger: req.logger
-    )
+    //
+    // A `.template` copy skips this by definition: leaving the placeholders
+    // standing is the whole point of that view, and it is what lets an author
+    // edit them (see `NotebookViewMode`).
+    let processedData =
+        switch viewMode {
+        case .personalized:
+            await applyNotebookSubstitutionsIfNeeded(
+                seedData: seedData,
+                setup: fallbackSetup,
+                userID: userID,
+                db: req.db,
+                supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setupID)/",
+                logger: req.logger
+            )
+        case .template:
+            seedData
+        }
 
     try await runBlocking(on: req) {
         try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
@@ -204,6 +258,45 @@ func ensureUserNotebookWorkingCopy(
     await writeDatasetFiles(req: req, setup: fallbackSetup, userID: userID, studentDir: workingCopyDir)
 
     return processedData
+}
+
+/// Discards `userID`'s working copy of `fileKind` in the view *other* than
+/// `viewMode`, so it is re-seeded from the stored notebook the next time it is
+/// opened.
+///
+/// The two views are separate files, and `ensureUserNotebookWorkingCopy`
+/// returns an existing copy untouched — which is what keeps an author's edits
+/// across visits, and also what would otherwise leave the counterpart showing
+/// pre-edit bytes forever. After a save, the counterpart is by definition
+/// stale: the stored notebook it was rendered from has just changed. Dropping
+/// it is safe because it holds no unsaved work that the save did not just
+/// supersede, and cheap because re-seeding is one read plus (for the rendered
+/// view) a substitution pass.
+///
+/// Best-effort: a copy that cannot be removed is a stale editor tab, not a
+/// failed save, so this never throws into the save path.
+func discardOtherNotebookViewCopy(
+    req: Request,
+    setupID: String,
+    userID: UUID,
+    fileKind: NotebookFileKind,
+    viewMode: NotebookViewMode
+) async {
+    let other: NotebookViewMode = viewMode == .template ? .personalized : .template
+    let path =
+        req.application.directory.publicDirectory + "jupyterlite/files/"
+        + userNotebookWorkingCopyRelativePath(
+            setupID: setupID, userID: userID, fileKind: fileKind, viewMode: other)
+    let fileManager = FileManager.default
+    guard fileManager.fileExists(atPath: path) else { return }
+    do {
+        try await runBlocking(on: req) {
+            try fileManager.removeItem(atPath: path)
+        }
+    } catch {
+        req.logger.warning(
+            "Could not discard the \(other.rawValue) working copy for setup \(setupID): \(error)")
+    }
 }
 
 /// Overwrites `userID`'s working copy with `starter` after applying the same

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -242,7 +242,8 @@ import VaporTesting
                     #expect(res.status == .ok)
                     let html = res.body.string
                     #expect(html.contains("data-setup-id=\"\(setupID)\""))
-                    #expect(html.contains("data-notebook-url=\"/testsetups/\(setupID)/notebook/source\""))
+                    #expect(
+                        html.contains("data-notebook-url=\"/testsetups/\(setupID)/notebook/source?file=assignment"))
                     #expect(html.contains("/jupyterlite/notebooks/index.html?workspace=\(setupID)-"))
                     #expect(html.contains("&amp;path=users/"))
                     // v0.4.153 cache-bust: the iframe is stamped with the
@@ -622,11 +623,13 @@ import VaporTesting
         setupID: String,
         cookie: String,
         file: String? = nil,
+        view: String? = nil,
         body: String,
         afterResponse: (TestingHTTPResponse) throws -> Void
     ) async throws {
         let (csrf, sessionCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
-        let query = file.map { "?file=\($0)" } ?? ""
+        let params = [file.map { "file=\($0)" }, view.map { "view=\($0)" }].compactMap { $0 }
+        let query = params.isEmpty ? "" : "?" + params.joined(separator: "&")
         try await app.asyncTest(
             .POST, "/testsetups/\(setupID)/notebook/save\(query)",
             beforeRequest: { req in
@@ -912,6 +915,259 @@ import VaporTesting
             let storedPath = try #require(
                 try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
             #expect(try String(contentsOfFile: storedPath, encoding: .utf8).contains("{{patients}}"))
+        }
+    }
+
+    // MARK: - Template vs rendered view (staff authoring)
+
+    /// Manifest with one personalized global, and the matching one-code-cell
+    /// template — the smallest fixture in which the two views differ.
+    private var personalizedManifest: String {
+        """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null,"globalVariables":[{"name":"patients","value":[{"name":"Maria","age":42}]}]}
+        """
+    }
+
+    @Test func notebookSourceServesTheTemplateToStaffAndTheRenderingToStudents() async throws {
+        try await withApp(app) { _ in
+            // The author's default view is the template: `{{patients}}` reaches
+            // the editor intact, which is what makes it editable. A student
+            // asking for the same notebook still gets their own rendering —
+            // a raw placeholder is not valid Python and would not run.
+            let setupID = "setup_nb_view_template"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(code: "patients = {{patients}}"),
+                manifest: personalizedManifest)
+            _ = try await insertAssignment(testSetupID: setupID, title: "Template Lab", isOpen: true)
+
+            let staffLogin = try await staffCookie(username: "notebook_view_staff")
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffLogin) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("{{patients}}"))
+                })
+
+            let studentLogin = try await loginAsStudent()
+            try await enroll(try await studentUser())
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentLogin) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("{{patients}}") == false)
+                    #expect(res.body.string.contains("Maria"))
+                })
+        }
+    }
+
+    @Test func notebookSourceRefusesATemplateViewToStudents() async throws {
+        try await withApp(app) { _ in
+            // The view is resolved from the caller's role, not from the URL:
+            // asking for `?view=template` as a student must not hand over the
+            // un-substituted notebook.
+            let setupID = "setup_nb_view_student_template"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(code: "patients = {{patients}}"),
+                manifest: personalizedManifest)
+            _ = try await insertAssignment(testSetupID: setupID, title: "Forced Lab", isOpen: true)
+
+            let studentLogin = try await loginAsStudent(username: "notebook_view_forcer")
+            try await enroll(
+                try #require(
+                    try await APIUser.query(on: app.db)
+                        .filter(\.$username == "notebook_view_forcer").first()))
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source?view=template",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentLogin) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("{{patients}}") == false)
+                })
+        }
+    }
+
+    @Test func notebookSourceRejectsSolutionFileForStudent() async throws {
+        try await withApp(app) { _ in
+            // The page route has always guarded the reference solution; the raw
+            // content endpoint did not, so `?file=solution` handed any enrolled
+            // student the answer key as JSON.
+            let setupID = "setup_nb_source_solution"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(markdown: "Starter"),
+                zipEntries: [
+                    ("assignment.ipynb", notebookJSON(markdown: "Starter")),
+                    ("solution.ipynb", notebookJSON(code: "answer = 42")),
+                ])
+            _ = try await insertAssignment(testSetupID: setupID, title: "Guarded Lab", isOpen: true)
+
+            let studentLogin = try await loginAsStudent(username: "notebook_source_peeker")
+            try await enroll(
+                try #require(
+                    try await APIUser.query(on: app.db)
+                        .filter(\.$username == "notebook_source_peeker").first()))
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source?file=solution",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentLogin) },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                    #expect(res.body.string.contains("answer = 42") == false)
+                })
+
+            let staffLogin = try await staffCookie(username: "notebook_source_owner")
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source?file=solution",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffLogin) },
+                afterResponse: { res in #expect(res.status == .ok) })
+        }
+    }
+
+    @Test func notebookPageOffersTheViewSwitchOnlyWhenPlaceholdersExist() async throws {
+        try await withApp(app) { _ in
+            // The switch is an affordance for a real difference: without
+            // placeholders the two views are the same bytes, so offering it
+            // would be noise.
+            let staffLogin = try await staffCookie(username: "notebook_view_switch_staff")
+
+            let personalizedID = "setup_nb_switch_yes"
+            _ = try await insertSetup(
+                id: personalizedID,
+                notebookJSON: notebookJSON(code: "patients = {{patients}}"),
+                manifest: personalizedManifest)
+            _ = try await insertAssignment(
+                testSetupID: personalizedID, title: "Switch Lab", isOpen: true)
+
+            // The switch is a link to the same notebook in the other view; the
+            // `?view=` on the content-fetch URL is not it, so match the href.
+            func toggleHref(_ setupID: String, to view: String) -> String {
+                #"href="/testsetups/\#(setupID)/notebook?file=assignment&amp;view=\#(view)""#
+            }
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(personalizedID)/notebook",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffLogin) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains(toggleHref(personalizedID, to: "personalized")))
+                    // Submit belongs to the rendered view — a template does not run.
+                    #expect(res.body.string.contains(#"id="nb-submit""#) == false)
+                })
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(personalizedID)/notebook?view=personalized",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffLogin) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains(toggleHref(personalizedID, to: "template")))
+                    #expect(res.body.string.contains(#"id="nb-submit""#))
+                })
+
+            let plainID = "setup_nb_switch_no"
+            _ = try await insertSetup(id: plainID, notebookJSON: notebookJSON(markdown: "Plain"))
+            _ = try await insertAssignment(testSetupID: plainID, title: "Plain Lab", isOpen: true)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(plainID)/notebook",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffLogin) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains(toggleHref(plainID, to: "template")) == false)
+                    #expect(res.body.string.contains(toggleHref(plainID, to: "personalized")) == false)
+                    // Nothing about a plain assignment changes for staff.
+                    #expect(res.body.string.contains(#"id="nb-submit""#))
+                })
+        }
+    }
+
+    @Test func saveNotebookFromEditorStoresHandAuthoredPlaceholders() async throws {
+        try await withApp(app) { _ in
+            // The point of the template view: an author types `{{name}}` into a
+            // cell and it is stored as written, rather than being treated as a
+            // rendering and reverted.
+            let cookie = try await staffCookie(username: "notebook_author_placeholder")
+
+            let setupID = "setup_nb_author_placeholder"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(code: "patients = {{patients}}"),
+                manifest: personalizedManifest)
+            _ = try await insertAssignment(testSetupID: setupID, title: "Authoring Lab", isOpen: false)
+
+            // Untagged, because a template copy is never substituted — this is
+            // exactly what the editor holds after the author edits it.
+            let authored = """
+                {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+                {"cell_type":"code","id":"cell-one","execution_count":null,"metadata":{},"outputs":[],\
+                "source":["patients = {{patients}}\\nfirst = {{patients}}[0]"]}]}
+                """
+
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, view: "template", body: authored
+            ) { res in
+                #expect(res.status == .ok)
+            }
+
+            let storedPath = try #require(
+                try await APITestSetup.find(setupID, on: app.db)?.notebookPath)
+            let stored = try String(contentsOfFile: storedPath, encoding: .utf8)
+            #expect(stored.contains("first = {{patients}}[0]"), "The authored placeholder must survive the save")
+        }
+    }
+
+    @Test func savingTheTemplateRefreshesTheRenderedView() async throws {
+        try await withApp(app) { _ in
+            // The two views are separate files and an existing working copy is
+            // returned untouched, so a template save has to invalidate the
+            // rendered copy — otherwise switching views after a save shows the
+            // notebook as it stood before it.
+            let cookie = try await staffCookie(username: "notebook_view_refresh")
+            let staff = try #require(
+                try await APIUser.query(on: app.db)
+                    .filter(\.$username == "notebook_view_refresh").first())
+            let staffID = try staff.requireID()
+
+            let setupID = "setup_nb_view_refresh"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(code: "patients = {{patients}}"),
+                manifest: personalizedManifest)
+            _ = try await insertAssignment(testSetupID: setupID, title: "Refresh Lab", isOpen: false)
+
+            // Seed the rendered copy, so there is a stale file to invalidate.
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source?view=personalized",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in #expect(res.body.string.contains("Maria")) })
+
+            let authored = """
+                {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+                {"cell_type":"code","id":"cell-one","execution_count":null,"metadata":{},"outputs":[],\
+                "source":["cohort = {{patients}}"]}]}
+                """
+            try await postNotebookSave(
+                setupID: setupID, cookie: cookie, view: "template", body: authored
+            ) { res in
+                #expect(res.status == .ok)
+            }
+
+            let renderedPath =
+                publicDir + "jupyterlite/files/"
+                + userNotebookWorkingCopyRelativePath(
+                    setupID: setupID, userID: staffID, fileKind: .assignment, viewMode: .personalized)
+            #expect(
+                FileManager.default.fileExists(atPath: renderedPath) == false,
+                "The stale rendered copy must be dropped so it reseeds from the saved template")
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook/source?view=personalized",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains("cohort = "))
+                    #expect(res.body.string.contains("Maria"))
+                })
         }
     }
 

--- a/changelog.d/author-notebook-templates.md
+++ b/changelog.d/author-notebook-templates.md
@@ -1,0 +1,25 @@
+### Added
+
+- **Course staff author notebooks against the template, not a rendering.** A
+  notebook with personalization is two documents: the template the author
+  writes (`patients = {{patients}}`) and the per-viewer rendering the server
+  produces from it. Staff only ever saw the second one — their own values,
+  substituted in — so the placeholders were not visible, not editable, and
+  edits to a substituted cell were silently reverted on save (correctly: the
+  alternative was baking one person's values into the class template). Staff
+  opening the starter or the solution now get the template by default, with
+  `{{name}}` standing as written; typing a placeholder into a cell stores it
+  verbatim. The two views are separate working copies, so a "View with values"
+  switch in the editor toolbar moves between them without either clobbering the
+  other's edits, and Submit stays on the rendered view — a template does not
+  run. Nothing changes for students, who always get their rendering, or for an
+  assignment with no personalization, where the two views are identical bytes.
+
+### Fixed
+
+- **The reference solution was reachable by any enrolled student through
+  `/testsetups/:id/notebook/source?file=solution`.** The notebook *page* has
+  always gated the solution to course staff — with a comment warning against
+  relying on the absence of a UI link — but the raw content endpoint behind it
+  never applied the same check, so a student who guessed the query parameter was
+  served the answer key as JSON. It now enforces the same staff gate.


### PR DESCRIPTION
A notebook with personalization is two documents at once: the **template** the
author writes (`patients = {{patients}}`) and the per-viewer **rendering** the
server produces from it (`patients = [61, 47, ...]`). Staff only ever got the
second one. The placeholders were invisible, so they could not be hand-authored,
and an edit to a substituted cell was silently dropped on save — correctly,
since the alternative was baking one person's values into the class template,
but the author had no way to see why their change had vanished.

`NotebookViewMode` splits the two readings.

**Template view (the staff default).** Substitution is skipped at seed time, so
`{{name}}` reaches the editor intact and stores verbatim. This falls out of the
existing safety net rather than bypassing it: a template copy carries no
`chickadee_personalized` cell tags, so `PersonalizedCellRestoration` has nothing
to restore and the author's own text survives. Both views run through the same
save path — the cell tags are the evidence, so neither view has to be trusted to
declare what it is holding.

**Rendered view, one click away.** The toolbar carries a "View with values" /
"Edit the template" switch. Submit lives on the rendered view only, since a
template does not run. The two views are separate working-copy files, so neither
clobbers the other's edits; a save discards the counterpart so switching after a
save shows the save rather than the pre-edit bytes. `draftNotebookData` prefers
the template copy for the same reason — a draft must carry the template forward,
not one person's values.

**Confined to the case it is for.** Students always resolve to `.personalized`,
and the requested view is *ignored* rather than honoured, so the template is not
reachable by URL. An assignment with no placeholders also resolves to
`.personalized` for staff: the two views are identical bytes there, so the page
is unchanged — Submit included — and the switch is not rendered at all.

### Also fixes a solution leak

`notebookPage` has always gated `?file=solution` to course staff, with a comment
warning against relying on the absence of a UI link. The raw `/notebook/source`
endpoint behind it never applied that check, so any enrolled student could fetch
the reference solution as JSON by guessing the query parameter. It now enforces
the same gate. Found while wiring the view switch through both routes; it is
independent of the rest of this change.

### Testing

`swift test --filter NotebookWebRoutesTests` — 45 pass, including six new cases:
the template/rendering split across staff and students, a student's `?view=template`
being refused, the solution gate on `/notebook/source`, the switch appearing only
where the views differ, a hand-authored placeholder surviving a save, and the
rendered copy refreshing after a template save. The wider adjacent sweep
(`Notebook|Draft|Assignment|Personaliz`) is 773 tests in 118 suites, green.
`scripts/lint.sh`, `scripts/swiftlint.sh --strict`, and `scripts/check-styles.sh`
are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zZwkZSNVXkYMmc269dKp1


---
_Generated by [Claude Code](https://claude.ai/code/session_014zZwkZSNVXkYMmc269dKp1)_