### PR TITLE
Assignment workbench: edit page and notebook editor side by side

### DIFF
--- a/Public/embedded-activity.js
+++ b/Public/embedded-activity.js
@@ -1,0 +1,82 @@
+// Public/embedded-activity.js
+//
+// Activity forwarder for pages rendered *into a pane* of the assignment
+// workbench (`workbench.leaf`).  Loaded by base.leaf only when the page context
+// carries `embedded`.
+//
+// Why this exists:
+//
+//   `idle-logout.js` is a client-side inactivity watchdog — institutional
+//   policy requires signing an idle user out after a fixed period, and the
+//   server can't do it alone because a user sitting on a page makes no
+//   requests.  It measures interaction with *its own document*.
+//
+//   The workbench composes two existing pages as same-origin iframes, so every
+//   keystroke an author makes lands in a pane document, not in the shell.  The
+//   shell holds the only watchdog (it is the only one of the three documents
+//   with a nav, and `idle-logout.js` bails out without the nav's logout form),
+//   and left to itself it would see a completely idle document and sign the
+//   author out roughly 30 minutes into an editing session.
+//
+//   So each pane forwards a throttled "someone is here" ping up to the shell,
+//   which re-dispatches it as `chickadee:activity` — the event `idle-logout.js`
+//   already listens for on behalf of the JupyterLite iframe.
+//
+// Note this is about the *client-side* watchdog only.  Server-side session life
+// is separately kept alive by notebook.js, which POSTs /session/keepalive on
+// editor activity; that runs unchanged inside the pane.
+//
+// Deliberately tiny and dependency-free: it must not assume ChickadeeUI, and it
+// must be a no-op when the page is somehow loaded top-level (a stale bookmark
+// to a `?embedded=1` URL), which is what the `window.parent === window` guard
+// below is for.
+
+(function () {
+    'use strict';
+
+    // Not in a frame — nothing to forward to.  A pane URL opened directly in a
+    // tab still renders; it just has no parent to notify.
+    if (window.parent === window) return;
+
+    // The watchdog is dormant when no idle ceiling is configured, so there is
+    // nothing worth forwarding.  Mirrors idle-logout.js's own early return.
+    var meta = document.querySelector('meta[name="session-idle-timeout-seconds"]');
+    var timeoutSeconds = meta ? parseInt(meta.getAttribute('content'), 10) || 0 : 0;
+    if (timeoutSeconds <= 0) return;
+
+    // Leading-edge throttle.  The shell only needs to know activity happened
+    // recently, not how many keystrokes there were, and postMessage on every
+    // keydown would be pure overhead in a document whose whole job is to host a
+    // text editor.  10s is far below any plausible idle ceiling.
+    var THROTTLE_MS = 10 * 1000;
+    var lastSent = 0;
+
+    function forwardActivity() {
+        var now = Date.now();
+        if (now - lastSent < THROTTLE_MS) return;
+        lastSent = now;
+        try {
+            // Explicit target origin rather than '*': this message is only ever
+            // meant for a Chickadee shell on the same origin, and '*' would leak
+            // the fact that someone is typing to any document that managed to
+            // frame this page.
+            window.parent.postMessage(
+                { source: 'chickadee', type: 'activity' },
+                window.location.origin
+            );
+        } catch (_) {
+            // Cross-origin parent, or a parent that went away mid-navigation.
+            // Nothing to do — the shell simply keeps its own idle timer.
+        }
+    }
+
+    ['keydown', 'pointerdown', 'wheel'].forEach(function (name) {
+        window.addEventListener(name, forwardActivity, { passive: true, capture: true });
+    });
+
+    // notebook.js raises this on the pane window for keystrokes that happen
+    // inside the *JupyterLite* iframe, whose own events never reach us.  Without
+    // this line, an author typing in notebook cells — the single most likely way
+    // to spend 30 minutes in the workbench — would look idle to the shell.
+    window.addEventListener('chickadee:activity', forwardActivity);
+}());

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1257,6 +1257,16 @@
     // server-side for course staff only (NotebookContext.canSaveToAssignment);
     // the endpoint re-checks the same permission, so this is convenience, not
     // the control.
+    // Post a same-origin note to the assignment-workbench shell when this page
+    // is one of its panes.  Silent no-op when the page is top-level, which is
+    // every other way it is reached.
+    function notifyWorkbench(type) {
+        if (window.parent === window) return;
+        try {
+            window.parent.postMessage({ source: 'chickadee', type: type }, window.location.origin);
+        } catch (_) { /* cross-origin or vanished parent */ }
+    }
+
     if (saveAssignmentBtn) {
         const saveFileKind = saveAssignmentBtn.dataset.fileKind === 'solution' ? 'solution' : 'assignment';
         // Which working copy the editor is showing. The endpoint writes the
@@ -1292,6 +1302,11 @@
                 }
                 const payload = await res.json();
                 setStatus('ok', payload.message || 'Saved to the assignment.');
+                // In an assignment-workbench pane, tell the shell: the save
+                // changed the files list and validation status that the edit
+                // pane beside us is rendering, so it is now stale.  No-op on
+                // the standalone page, which has no parent.
+                notifyWorkbench('notebook-saved');
             } catch (err) {
                 const msg = (err instanceof Error && err.message) ? err.message : String(err);
                 console.error('[notebook] Save-to-assignment error:', err);

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -832,6 +832,12 @@ code { font-family: var(--font-mono); font-size: .9em; }
     display: block;
 }
 
+/* The notebook page rendered into an assignment-workbench pane.  `100vh` here
+   is the *pane iframe's* height, not the window's, and the pane has no site nav
+   above it — so only the notebook's own toolbar row has to be subtracted, where
+   the standalone page also pays for the nav and course tabs. */
+.jl-frame-embedded { height: calc(100vh - 3rem); }
+
 /* ── Auth pages ──────────────────────────────────────── */
 
 .auth-box {

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -832,6 +832,20 @@ code { font-family: var(--font-mono); font-size: .9em; }
     display: block;
 }
 
+/* Width of the assignment workbench's left (edit) pane.  Declared here rather
+   than in the page block because every custom property must resolve from the
+   global sheet.  Layout only — no dark-mode mirror needed.  workbench.js
+   overwrites it on the shell element as the splitter is dragged; this value is
+   the pre-JS default, biased toward the notebook. */
+:root { --wb-left-width: 42%; }
+
+/* Full-bleed page body: drops the 900px cap and the gutters `.main` applies, for
+   pages that own the whole viewport rather than sitting in the reading column.
+   Set from base.leaf via the `fullBleed` context flag.  Lives here rather than
+   in a page <style> block because more than one page needs it, and `.main`
+   itself may only be overridden by a single page. */
+.main-fullbleed { max-width: 100%; padding: 0; margin: 0; }
+
 /* The notebook page rendered into an assignment-workbench pane.  `100vh` here
    is the *pane iframe's* height, not the window's, and the pane has no site nav
    above it — so only the notebook's own toolbar row has to be subtracted, where

--- a/Public/workbench.js
+++ b/Public/workbench.js
@@ -1,0 +1,274 @@
+// Public/workbench.js
+//
+// The assignment workbench shell: the instructor edit page in a left pane, the
+// notebook editor in a right pane, a draggable splitter between them, and a tab
+// strip that switches the right pane between the starter notebook and the
+// reference solution.
+//
+// The shell owns no assignment content — every pane is an iframe onto a page
+// that already existed.  What lives here is the composition: pane sizing, which
+// notebook is mounted, and the messages the panes send each other.
+//
+// Three things are load-bearing and easy to get wrong:
+//
+//   * **Pane floors.** The notebook page hides its own editor below 640px and
+//     shows "open on a larger screen".  A too-narrow notebook pane would
+//     therefore render that notice instead of the editor — so the splitter
+//     clamps the notebook pane at 720px and the edit pane at 380px, and below a
+//     viewport that can hold both the layout drops to one pane at a time.
+//
+//   * **Kernel count.** The solution iframe stays at about:blank until its tab
+//     is first selected, then stays mounted, so switching is instant after one
+//     boot.  On a device that reports low memory it is unmounted on switch
+//     instead — one kernel at a time, at the cost of a reboot per switch.
+//
+//   * **Idle logout.** The watchdog runs in this document, but every keystroke
+//     lands in a pane.  `embedded-activity.js` forwards activity up; this file
+//     re-raises it as `chickadee:activity`, which idle-logout.js listens for.
+//     Without that an author gets signed out mid-edit.
+
+(function () {
+    'use strict';
+
+    // Minimum widths, in px.  NOTEBOOK_MIN sits deliberately clear of the
+    // notebook page's own 640px small-screen cutoff.
+    var NOTEBOOK_MIN = 720;
+    var EDIT_MIN = 380;
+    // Splitter column width (.5rem) — kept in sync with .wb-splitter in
+    // workbench.leaf.  Only used for arithmetic, never for styling.
+    var SPLITTER_PX = 8;
+    // Below this the split is not honest: 720 + 380 + splitter.  Matches the
+    // media query in workbench.leaf.
+    var SINGLE_PANE_MAX = 1140;
+    var KEY_STEP_PX = 24;
+
+    /// Clamp a desired left-pane width so neither pane drops below its floor.
+    /// Pure arithmetic, exported for test: this is the rule that keeps the
+    /// notebook pane from rendering "open on a larger screen".
+    ///
+    /// When the viewport cannot satisfy both floors at once the edit pane
+    /// yields — the notebook is the pane with the hard rendering cliff, so it
+    /// is the one that must keep its width.
+    function clampLeftWidth(desiredPx, totalPx) {
+        var maxLeft = totalPx - SPLITTER_PX - NOTEBOOK_MIN;
+        if (maxLeft < EDIT_MIN) return Math.max(0, maxLeft);
+        if (desiredPx < EDIT_MIN) return EDIT_MIN;
+        if (desiredPx > maxLeft) return maxLeft;
+        return desiredPx;
+    }
+
+    /// Whether this device should hold two Pyodide kernels at once.
+    /// `navigator.deviceMemory` is GB rounded to a power of two and is absent
+    /// on Firefox/Safari — absent means "no evidence of a problem", so we keep
+    /// both mounted, matching notebook-preflight.js's own conservative read.
+    function allowsTwoKernels(nav) {
+        var dm = (nav && typeof nav.deviceMemory === 'number') ? nav.deviceMemory : null;
+        if (dm === null) return true;
+        return dm > 4;
+    }
+
+    // Exported for the unit tests, which exercise the arithmetic and the
+    // policy without a DOM.
+    var api = { clampLeftWidth: clampLeftWidth, allowsTwoKernels: allowsTwoKernels };
+    if (typeof window !== 'undefined') window.ChickadeeWorkbench = api;
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+
+    if (typeof document === 'undefined') return;
+    var shell = document.getElementById('wb-shell');
+    if (!shell) return;
+
+    var body = shell.querySelector('.wb-body');
+    var splitter = document.getElementById('wb-splitter');
+    var editFrame = document.getElementById('wb-edit-frame');
+    var staleChip = document.getElementById('wb-stale-chip');
+    var singleEditBtn = document.getElementById('wb-single-edit');
+    var assignmentID = shell.getAttribute('data-assignment-id') || '';
+    var storageKey = 'chickadee-workbench-split:' + assignmentID;
+
+    var tabs = Array.prototype.slice.call(shell.querySelectorAll('.wb-tab'));
+    var panes = {};
+    tabs.forEach(function (tab) {
+        var name = tab.getAttribute('data-wb-pane');
+        panes[name] = document.getElementById(tab.getAttribute('aria-controls'));
+    });
+    var activePane = 'assignment';
+
+    // ── Splitter ──────────────────────────────────────────────────────────
+
+    function applyLeftWidth(px) {
+        var total = body ? body.clientWidth : 0;
+        if (!total) return;
+        var clamped = clampLeftWidth(px, total);
+        shell.style.setProperty('--wb-left-width', clamped + 'px');
+        if (splitter) {
+            splitter.setAttribute('aria-valuenow', String(Math.round((clamped / total) * 100)));
+        }
+        return clamped;
+    }
+
+    function currentLeftWidth() {
+        var pane = shell.querySelector('.wb-pane-edit');
+        return pane ? pane.getBoundingClientRect().width : EDIT_MIN;
+    }
+
+    function persist(px) {
+        try { window.localStorage.setItem(storageKey, String(Math.round(px))); } catch (_) { /* private mode */ }
+    }
+
+    function restore() {
+        var saved = null;
+        try { saved = window.localStorage.getItem(storageKey); } catch (_) { /* private mode */ }
+        var px = saved ? parseInt(saved, 10) : NaN;
+        if (!isNaN(px) && px > 0) applyLeftWidth(px);
+    }
+
+    if (splitter && body) {
+        var dragging = false;
+
+        splitter.addEventListener('pointerdown', function (e) {
+            dragging = true;
+            try { splitter.setPointerCapture(e.pointerId); } catch (_) { /* not supported */ }
+            e.preventDefault();
+        });
+
+        splitter.addEventListener('pointermove', function (e) {
+            if (!dragging) return;
+            applyLeftWidth(e.clientX - body.getBoundingClientRect().left);
+        });
+
+        function endDrag() {
+            if (!dragging) return;
+            dragging = false;
+            persist(currentLeftWidth());
+        }
+        splitter.addEventListener('pointerup', endDrag);
+        splitter.addEventListener('pointercancel', endDrag);
+
+        // Keyboard: the splitter is a real control, not a mouse-only affordance.
+        splitter.addEventListener('keydown', function (e) {
+            var width = currentLeftWidth();
+            var total = body.clientWidth;
+            var next = null;
+            if (e.key === 'ArrowLeft') next = width - KEY_STEP_PX;
+            else if (e.key === 'ArrowRight') next = width + KEY_STEP_PX;
+            else if (e.key === 'Home') next = EDIT_MIN;
+            else if (e.key === 'End') next = total - SPLITTER_PX - NOTEBOOK_MIN;
+            if (next === null) return;
+            e.preventDefault();
+            persist(applyLeftWidth(next));
+        });
+
+        // A window resize can invalidate a stored width — re-clamp against the
+        // new viewport rather than leaving a pane under its floor.
+        window.addEventListener('resize', function () {
+            applyLeftWidth(currentLeftWidth());
+        });
+
+        restore();
+    }
+
+    // ── Notebook tabs ─────────────────────────────────────────────────────
+
+    function mount(pane) {
+        var frame = panes[pane];
+        if (!frame) return;
+        var wanted = frame.getAttribute('data-wb-src');
+        if (wanted && frame.getAttribute('src') !== wanted) frame.setAttribute('src', wanted);
+    }
+
+    function unmount(pane) {
+        var frame = panes[pane];
+        if (frame) frame.setAttribute('src', 'about:blank');
+    }
+
+    function selectPane(name) {
+        if (!panes[name]) return;
+        var previous = activePane;
+        activePane = name;
+
+        tabs.forEach(function (tab) {
+            var isActive = tab.getAttribute('data-wb-pane') === name;
+            tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+            // Roving tabindex: one stop for the whole strip.
+            tab.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+        Object.keys(panes).forEach(function (key) {
+            if (panes[key]) panes[key].hidden = (key !== name);
+        });
+
+        mount(name);
+        // Reclaim the hidden pane's kernel only where memory is tight; the
+        // default is to keep it warm so the next switch costs nothing.
+        if (previous !== name && !allowsTwoKernels(navigator)) unmount(previous);
+
+        // Whatever made the chip appear applied to the notebook the author was
+        // looking at; a fresh mount is current by construction.
+        if (staleChip) staleChip.hidden = true;
+    }
+
+    tabs.forEach(function (tab, index) {
+        tab.addEventListener('click', function () {
+            selectPane(tab.getAttribute('data-wb-pane'));
+        });
+        tab.addEventListener('keydown', function (e) {
+            var delta = e.key === 'ArrowRight' ? 1 : (e.key === 'ArrowLeft' ? -1 : 0);
+            if (!delta) return;
+            e.preventDefault();
+            var next = tabs[(index + delta + tabs.length) % tabs.length];
+            next.focus();
+            selectPane(next.getAttribute('data-wb-pane'));
+        });
+    });
+
+    // ── Single-pane fallback (narrow desktop windows) ──────────────────────
+
+    function syncSinglePane() {
+        var single = window.innerWidth <= SINGLE_PANE_MAX;
+        if (singleEditBtn) singleEditBtn.hidden = !single;
+        if (!single) shell.setAttribute('data-wb-single', 'notebook');
+    }
+    if (singleEditBtn) {
+        singleEditBtn.addEventListener('click', function () {
+            var showingEdit = shell.getAttribute('data-wb-single') === 'edit';
+            shell.setAttribute('data-wb-single', showingEdit ? 'notebook' : 'edit');
+            singleEditBtn.textContent = showingEdit ? 'Editor' : 'Notebook';
+        });
+    }
+    window.addEventListener('resize', syncSinglePane);
+    syncSinglePane();
+
+    // ── Pane messaging ────────────────────────────────────────────────────
+
+    window.addEventListener('message', function (event) {
+        // Same-origin only.  These messages move session-liveness and reload
+        // signals; a framed third party must not be able to forge them.
+        if (event.origin !== window.location.origin) return;
+        var data = event.data;
+        if (!data || data.source !== 'chickadee') return;
+
+        if (data.type === 'activity') {
+            // Re-raise for idle-logout.js, which is listening on this window.
+            try { window.dispatchEvent(new CustomEvent('chickadee:activity')); } catch (_) { /* ignore */ }
+            return;
+        }
+
+        if (data.type === 'notebook-saved') {
+            // The save changed the assignment's files and validation status,
+            // both of which the left pane renders.  Reloading it is safe — it
+            // holds no kernel and no unsaved state that is not already POSTed.
+            if (editFrame) editFrame.contentWindow.location.reload();
+            return;
+        }
+
+        if (data.type === 'inputs-changed') {
+            // Personalization changed, so what the notebook is showing is now a
+            // rendering of stale values.  Deliberately advisory: reloading the
+            // pane restarts the kernel and drops the author's live state, so
+            // the author decides when to pay that.
+            if (staleChip) {
+                staleChip.textContent = 'Inputs changed — reload the notebook to see new values';
+                staleChip.hidden = false;
+            }
+        }
+    });
+}());

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -72,7 +72,13 @@
                     title="Save assignment metadata (name, due date, notebooks) and re-validate. Suite edits are saved live as you make them.">
                 Save &amp; Validate
             </button>
+            #if(!embedded):
+            <!-- Absent when this page IS the workbench's left pane: the pane
+                 must not offer a link to the surface containing it. -->
+            <a class="btn" href="/instructor/#(assignmentID)/workbench"
+               title="Edit this assignment beside the notebook editor">Workbench</a>
             <a class="btn" href="/instructor">Cancel</a>
+            #endif
         </div>
     </div>
 

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -24,6 +24,15 @@
     <script src="/chickadee-ui.js?v=#appVersion()"></script>
 </head>
 <body>
+<!-- Site chrome — the nav, the colour bar, and the course tabs.  Suppressed
+     when `embedded` is set, i.e. when this page is being rendered *into a pane*
+     of the assignment workbench (`workbench.leaf`) rather than as a top-level
+     document.  The workbench composes two existing pages as same-origin
+     iframes, and three stacked copies of the nav inside one viewport is both
+     noise and a duplicate set of landmarks for a screen reader.  `embedded` is
+     absent from every other page context, and a missing Leaf variable is
+     falsy, so those pages render exactly as before. -->
+#if(!embedded):
 <a class="skip-link" href="#main-content">Skip to main content</a>
 <nav class="nav">
     <a class="nav-brand" href="/">
@@ -110,12 +119,22 @@
     #endfor
 </nav>
 #endif
+#endif
 <main class="main" id="main-content">
     #import("content")
 </main>
 <script src="/app.js?v=#appVersion()"></script>
 #if(currentUser):
+#if(embedded):
+<!-- An embedded pane has no nav, so it has no logout form and `idle-logout.js`
+     would bail out on its own.  Load the forwarder instead: the idle watchdog
+     lives on the workbench shell, but every keystroke happens down here in a
+     pane, so without this the shell would sit "idle" and sign the author out
+     mid-edit. -->
+<script src="/embedded-activity.js?v=#appVersion()"></script>
+#else:
 <script src="/idle-logout.js?v=#appVersion()"></script>
+#endif
 #endif
 <script>
 // All multipart/form-data uploads bypass the hidden _csrf body field because

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -120,7 +120,7 @@
 </nav>
 #endif
 #endif
-<main class="main" id="main-content">
+<main class="main#if(fullBleed): main-fullbleed#endif" id="main-content">
     #import("content")
 </main>
 <script src="/app.js?v=#appVersion()"></script>

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -10,6 +10,13 @@ Notebook
    hairline top margin and no bottom margin. */
 .main { max-width: 100%; padding: 0 1rem; margin: .5rem auto 0; }
 
+#if(embedded):
+/* Rendered into a workbench pane: no site nav above us and no page scroll, so
+   trim the gutter to match.  The editor's own height comes from the
+   `.jl-frame-embedded` modifier in styles.css. */
+.main { padding: 0 .5rem; margin: 0 auto; }
+#endif
+
 /* Closed-assignment "view only" notice + fallback/small-screen text. */
 .nb-closed-notice { color: var(--gray-600); font-size: var(--text-base); }
 .nb-notice-title { margin: .2rem 0 .5rem; }
@@ -134,7 +141,7 @@ Notebook
      notebook.js skips the mount entirely, so the iframe stays about:blank. -->
 <iframe
     id="jl-frame"
-    class="jl-frame"
+    class="jl-frame#if(embedded): jl-frame-embedded#endif"
     title="Notebook editor"
     data-setup-id="#(testSetupID)"
     data-grading-mode="#(gradingMode)"

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -1,0 +1,170 @@
+#extend("base"):
+#export("title"):
+#(assignmentTitle) — Workbench
+#endexport
+#export("content"):
+<style>
+/* The workbench owns the viewport: the panes scroll internally, the page never
+   does.  The reading-column cap is dropped by `fullBleed` on the context, which
+   adds `.main-fullbleed` in base.leaf. */
+.wb-shell {
+    display: flex;
+    flex-direction: column;
+    /* dvh, not vh: mobile browsers shrink the visual viewport when chrome
+       appears, and vh would leave the bottom of the editor under it. */
+    height: 100dvh;
+}
+
+.wb-bar {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    flex: 0 0 auto;
+    padding: .4rem .75rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-muted);
+}
+.wb-title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.wb-bar-spacer { flex: 1; }
+
+/* Three columns: left pane, splitter, right pane.  min-height:0 on the body
+   and min-width:0 on the panes are what let the grid children actually shrink
+   — without them a grid item's automatic minimum size is its content, and the
+   iframes would push the layout wider than the viewport. */
+.wb-body {
+    flex: 1;
+    display: grid;
+    grid-template-columns: var(--wb-left-width) auto 1fr;
+    min-height: 0;
+}
+.wb-pane {
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+.wb-pane-frame {
+    flex: 1;
+    width: 100%;
+    border: 0;
+    display: block;
+    min-height: 0;
+}
+
+.wb-splitter {
+    width: .5rem;
+    cursor: col-resize;
+    border: 0;
+    padding: 0;
+    background: var(--border);
+    /* Widen the grab area beyond the visible line without widening the column. */
+    box-shadow: 0 0 0 .25rem transparent;
+}
+.wb-splitter:hover,
+.wb-splitter:focus-visible { background: var(--health-teal); }
+
+.wb-panehead {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    flex: 0 0 auto;
+    padding: .3rem .5rem;
+    border-bottom: 1px solid var(--border);
+}
+.wb-tab[aria-selected="true"] {
+    background: var(--health-teal);
+    color: var(--surface);
+}
+/* Set by workbench.js when a left-pane edit invalidates what the notebook is
+   showing.  Advisory only — reloading the pane would restart the kernel and
+   discard the author's live state, so the author chooses when. */
+.wb-stale-chip {
+    font-size: var(--text-sm);
+    color: var(--gray-700);
+}
+
+/* Below the point where an honest split is possible (720px notebook floor +
+   380px edit floor + the splitter), collapse to one pane at a time.  The
+   notebook page hides its own editor under 640px, so a too-narrow pane would
+   render "open on a larger screen" instead of the editor — the failure this
+   breakpoint exists to prevent. */
+@media (max-width: 1140px) {
+    .wb-body { grid-template-columns: 1fr; }
+    .wb-splitter { display: none; }
+    .wb-shell[data-wb-single="edit"] .wb-pane-notebook { display: none; }
+    .wb-shell[data-wb-single="notebook"] .wb-pane-edit { display: none; }
+}
+</style>
+<div class="wb-shell"
+     id="wb-shell"
+     data-assignment-id="#(assignmentID)"
+     data-setup-id="#(testSetupID)"
+     data-wb-single="notebook">
+    <div class="wb-bar">
+        <h1 class="wb-title">#(assignmentTitle)</h1>
+        <span class="wb-bar-spacer"></span>
+        <button class="btn action-btn" type="button" id="wb-single-edit" hidden>Editor</button>
+        <a class="btn action-btn" href="#(standaloneEditURL)">Full-width editor</a>
+    </div>
+    <div class="wb-body">
+        <section class="wb-pane wb-pane-edit" aria-label="Assignment editor">
+            <iframe class="wb-pane-frame"
+                    id="wb-edit-frame"
+                    title="Assignment editor"
+                    src="#(editPanelURL)"></iframe>
+        </section>
+        <button class="wb-splitter"
+                id="wb-splitter"
+                type="button"
+                role="separator"
+                aria-orientation="vertical"
+                aria-label="Resize panes"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow="42"></button>
+        <section class="wb-pane wb-pane-notebook" aria-label="Notebook editor">
+            <div class="wb-panehead" role="tablist" aria-label="Notebook">
+                <button class="btn action-btn wb-tab" type="button" role="tab"
+                        id="wb-tab-assignment" data-wb-pane="assignment"
+                        aria-selected="true" aria-controls="wb-notebook-assignment">Assignment</button>
+                #if(solutionNotebookURL):
+                <button class="btn action-btn wb-tab" type="button" role="tab"
+                        id="wb-tab-solution" data-wb-pane="solution" tabindex="-1"
+                        aria-selected="false" aria-controls="wb-notebook-solution">Solution</button>
+                #endif
+                <span class="wb-bar-spacer"></span>
+                <span class="wb-stale-chip" id="wb-stale-chip" role="status" hidden></span>
+            </div>
+            <!-- Both notebook panes are real iframes, but only the assignment one
+                 carries a src at load.  The solution's stays about:blank until the
+                 tab is first selected, so the second Pyodide kernel is only paid
+                 for by an author who actually asks for it; after that both stay
+                 mounted and switching is a CSS toggle rather than a cold boot.
+                 workbench.js unmounts on switch instead when the device reports
+                 low memory. -->
+            <iframe class="wb-pane-frame"
+                    id="wb-notebook-assignment"
+                    title="Assignment notebook"
+                    data-wb-src="#(assignmentNotebookURL)"
+                    src="#(assignmentNotebookURL)"></iframe>
+            #if(solutionNotebookURL):
+            <iframe class="wb-pane-frame"
+                    id="wb-notebook-solution"
+                    title="Solution notebook"
+                    data-wb-src="#(solutionNotebookURL)"
+                    src="about:blank"
+                    hidden></iframe>
+            #endif
+        </section>
+    </div>
+</div>
+<script src="/workbench.js?v=#appVersion()"></script>
+#endexport
+#endextend

--- a/Sources/APIServer/Middleware/COEPMiddleware.swift
+++ b/Sources/APIServer/Middleware/COEPMiddleware.swift
@@ -73,13 +73,46 @@ struct COEPMiddleware: AsyncMiddleware {
         let last = parts.last ?? ""
 
         // Instructor validate page — loads assignment-validate.js (Pyodide).
-        // Matched by last path component to avoid affecting /instructor/:id/edit
-        // and other instructor pages that load CDN resources.
+        // Matched by last path component rather than a prefix so it does not
+        // sweep in the rest of /instructor/*, which has no need of isolation.
+        // (The historic reason given here — that those pages load CDN
+        // resources — no longer holds: the CSP is `'self'`-only and every
+        // browser library is vendored same-origin.  The narrow match is still
+        // right, just not for that reason.)
         if last == "validate" { return true }
 
         // Student notebook editor page (/testsetups/:id/notebook), gated.
         if isolateNotebook, parts.count == 3, parts[0] == "testsetups", last == "notebook" {
             return true
+        }
+
+        // Assignment workbench (/instructor/:assignmentID/workbench) and its
+        // left pane (…/workbench/panel).
+        //
+        // Both need the headers, and the reason is the whole point of this
+        // block: cross-origin isolation is a property of the *entire ancestor
+        // chain*.  The workbench nests the notebook page one level deeper than
+        // it has ever been nested, so
+        //
+        //   • without isolation on the shell, the notebook iframe cannot be
+        //     isolated either, `crossOriginIsolated` goes false inside it, and
+        //     every Chrome/Firefox author silently drops off the
+        //     SharedArrayBuffer path onto the service-worker comlink transport
+        //     (docs/notebook-editor-kernel-boot.md) — a performance and
+        //     reliability regression with no error message; and
+        //   • under `require-corp` a nested document must itself send
+        //     `require-corp` or the browser refuses to load it outright
+        //     (`ERR_BLOCKED_BY_RESPONSE.CoepFrameResourceNeedsCoepHeader`), so
+        //     the *left* pane needs them too even though it runs no Python.
+        //
+        // Gated on the same flag as the notebook page: the panes and their
+        // shell must agree, and the unit-test seam has to be able to turn the
+        // whole thing off in one place.  WebKit is exempted by the caller, which
+        // is what keeps Safari's comlink path working — there it is simply
+        // "no isolation anywhere in the chain", which is equally consistent.
+        if isolateNotebook, parts.count >= 3, parts[0] == "instructor" {
+            if parts.count == 3, last == "workbench" { return true }
+            if parts.count == 4, parts[2] == "workbench", last == "panel" { return true }
         }
 
         return false

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -82,6 +82,30 @@ struct NewAssignmentNotebookContext: Encodable {
     let editURL: String
 }
 
+/// The assignment workbench shell (`workbench.leaf`).  Deliberately thin: the
+/// shell renders no assignment content, only the frame around two iframes that
+/// each load an existing page.  Everything here is either an identifier the
+/// page JS keys on or a URL for one of those iframes.
+struct AssignmentWorkbenchContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let assignmentID: String
+    let testSetupID: String
+    let assignmentTitle: String
+    /// Left pane — the edit page in embedded mode.
+    let editPanelURL: String
+    /// Right pane, "Assignment" tab.
+    let assignmentNotebookURL: String
+    /// Right pane, "Solution" tab.  `nil` when the assignment has no reference
+    /// solution yet, in which case the tab is absent rather than disabled —
+    /// matching how the edit page omits `solutionNotebookEditURL`.
+    let solutionNotebookURL: String?
+    /// Escape hatch back to the full-width single-page editor.
+    let standaloneEditURL: String
+    /// Drops `.main`'s reading-column cap and gutters — the workbench sizes
+    /// itself to the viewport and scrolls inside its panes.
+    let fullBleed: Bool = true
+}
+
 struct EditAssignmentContext: Encodable {
     let currentUser: CurrentUserContext?
     let assignmentID: String

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -152,4 +152,11 @@ struct EditAssignmentContext: Encodable {
     let timeLimitSeconds: Int
     let notice: String?
     let error: String?
+    /// True when this page is being rendered into the left pane of the
+    /// assignment workbench (`GET /instructor/:assignmentID/workbench/panel`)
+    /// rather than as the standalone edit page.  `base.leaf` reads it to
+    /// suppress the site chrome, and the template reads it to drop the
+    /// "Open workbench" link (the workbench must not link to itself).
+    /// `nil` on the standalone `/edit` render.
+    let embedded: Bool?
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -573,6 +573,23 @@ struct InstructorDashboardRoutes: RouteCollection {
 
     @Sendable
     func editPage(req: Request) async throws -> View {
+        let ctx = try await makeEditAssignmentContext(req: req, embedded: false)
+        return try await req.view.render("assignment-edit", ctx)
+    }
+
+    /// Builds the edit page's context.
+    ///
+    /// Factored out of `editPage` so the assignment workbench's left pane
+    /// (`GET /instructor/:assignmentID/workbench/panel`,
+    /// `InstructorWorkbenchRoutes`) renders the *same* page from the *same*
+    /// 26-field construction rather than a copy of it that would drift.  The
+    /// only difference between the two callers is `embedded`, which suppresses
+    /// the site chrome — the staff gate, the query overrides, and every
+    /// derived field are identical.
+    func makeEditAssignmentContext(
+        req: Request,
+        embedded: Bool
+    ) async throws -> EditAssignmentContext {
         let (assignment, setup) = try await loadAssignmentAndSetupForStaffRead(req)
         let idStr = assignment.publicID
 
@@ -614,7 +631,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             let checkData = (try? enc.encode(props.notebookChecks)) ?? Data("[]".utf8)
             return String(data: checkData, encoding: .utf8) ?? "[]"
         }()
-        let ctx = EditAssignmentContext(
+        return EditAssignmentContext(
             currentUser: req.currentUserContext,
             assignmentID: idStr,
             testSetupID: assignment.testSetupID,
@@ -646,8 +663,9 @@ struct InstructorDashboardRoutes: RouteCollection {
             timeLimitSeconds: manifest?.timeLimitSeconds ?? 10,
             notice: q?.notice,
             error: q?.error,
-            embedded: nil
+            // nil rather than `false` on the standalone page so its rendered
+            // HTML is byte-identical to before the workbench existed.
+            embedded: embedded ? true : nil
         )
-        return try await req.view.render("assignment-edit", ctx)
     }
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -645,7 +645,8 @@ struct InstructorDashboardRoutes: RouteCollection {
             secretRevealEnabled: assignment.secretRevealEnabled == true,
             timeLimitSeconds: manifest?.timeLimitSeconds ?? 10,
             notice: q?.notice,
-            error: q?.error
+            error: q?.error,
+            embedded: nil
         )
         return try await req.view.render("assignment-edit", ctx)
     }

--- a/Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
@@ -1,0 +1,111 @@
+// APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
+//
+//   GET /instructor/:assignmentID/workbench        → workbench.leaf (the shell)
+//   GET /instructor/:assignmentID/workbench/panel  → assignment-edit.leaf (embedded)
+//
+// The assignment workbench puts the instructor edit page and the notebook
+// editor side by side, so an author can read and change variables, suite
+// entries and deadlines while a Pyodide kernel boots or a validation run
+// finishes.  Before it, every hop between the two cost a full editor cold
+// boot, and switching from the starter notebook to the reference solution
+// cost a third.
+//
+// The shell renders no assignment content of its own.  It composes two
+// *existing* pages as same-origin iframes:
+//
+//   left  → /instructor/:assignmentID/workbench/panel   (this file)
+//   right → /testsetups/:testSetupID/notebook?file=…&embedded=1
+//           (`WebRoutes+Notebook.swift`, unchanged apart from the flag)
+//
+// Composing rather than merging is deliberate, for two independent reasons:
+//
+//   1. A merged Leaf template is not available to us.  `assignment-edit.leaf`
+//      already carries one inline `#extend`, and LeafKit 1.14.2 fails at render
+//      with `extend only supports one or two parameters` as soon as a template
+//      that size carries a second one — so the decomposition a merge would need
+//      is exactly the shape that is broken.
+//   2. `notebook.js` is a single-instance IIFE bound to the element `#jl-frame`,
+//      with global state for the freeze watchdog, kernel diagnostics and
+//      IndexedDB eviction.  Two notebooks as two *documents* needs no change to
+//      it at all; two `#jl-frame`s in one document would need it rewritten.
+//
+// See `InstructorWorkbenchRoutes+COEP` note in `COEPMiddleware`: both routes
+// here must be cross-origin isolated, or the nested editor iframe silently
+// loses `SharedArrayBuffer` and the kernel drops onto the service-worker
+// transport the codebase deliberately moved off.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+struct InstructorWorkbenchRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        // Registered under the same `/instructor` group as the rest of the
+        // authoring surface, so `ActiveCourseStaffMiddleware` applies; the
+        // per-resource gate is `loadAssignmentAndSetupForStaffRead` inside
+        // each handler.
+        let r = routes.grouped("instructor")
+        r.get(":assignmentID", "workbench", use: workbenchPage)
+        r.get(":assignmentID", "workbench", "panel", use: workbenchPanel)
+    }
+
+    // MARK: - GET /instructor/:assignmentID/workbench
+
+    @Sendable
+    func workbenchPage(req: Request) async throws -> View {
+        let (assignment, setup) = try await loadAssignmentAndSetupForStaffRead(req)
+        let setupID = assignment.testSetupID
+
+        // Whether there is a solution to offer a tab for.  Resolved exactly the
+        // way the edit page's Files table resolves it — same helper, same
+        // fallback — so the workbench can never advertise a solution tab the
+        // edit page says does not exist, or vice versa.
+        let existingSolutionName = try await existingSolutionFilename(req: req, assignment: assignment)
+        let draftSolutionPath = draftSolutionNotebookPath(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        let hasDraftSolution = FileManager.default.fileExists(atPath: draftSolutionPath)
+        let hasSolution =
+            existingSolutionName != nil
+            || assignment.validationStatus == "passed"
+            || assignment.validationSubmissionID != nil
+            || hasDraftSolution
+
+        let title = assignment.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let ctx = AssignmentWorkbenchContext(
+            currentUser: req.currentUserContext,
+            assignmentID: assignment.publicID,
+            testSetupID: setupID,
+            assignmentTitle: title.isEmpty ? "Assignment" : title,
+            editPanelURL: "/instructor/\(assignment.publicID)/workbench/panel",
+            assignmentNotebookURL: notebookPaneURL(setupID: setupID, file: "assignment"),
+            solutionNotebookURL: hasSolution
+                ? notebookPaneURL(setupID: setupID, file: "solution")
+                : nil,
+            standaloneEditURL: "/instructor/\(assignment.publicID)/edit"
+        )
+        _ = setup  // loaded for the staff gate; the shell needs nothing from it
+        return try await req.view.render("workbench", ctx)
+    }
+
+    // MARK: - GET /instructor/:assignmentID/workbench/panel
+
+    /// The workbench's left pane: the ordinary edit page, rendered without the
+    /// site chrome.  Deliberately a distinct path rather than `/edit?embedded=1`
+    /// — `COEPMiddleware` matches on path components, so this keeps the
+    /// isolation rule a one-liner and leaves the public `/edit` page's headers
+    /// exactly as they were.
+    @Sendable
+    func workbenchPanel(req: Request) async throws -> View {
+        let ctx = try await InstructorDashboardRoutes().makeEditAssignmentContext(
+            req: req, embedded: true)
+        return try await req.view.render("assignment-edit", ctx)
+    }
+
+    /// URL of one notebook pane.  `embedded=1` drops the site chrome; every
+    /// access decision on that page (the staff-only solution guard, the closed
+    /// gate, `canSaveToAssignment`) is made without reference to it.
+    private func notebookPaneURL(setupID: String, file: String) -> String {
+        "/testsetups/\(setupID)/notebook?file=\(file)&embedded=1"
+    }
+}

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -244,6 +244,12 @@ struct NotebookContext: Encodable {
     /// copy could not be stat'd.
     let workingCopyMtime: Int
     let currentUser: CurrentUserContext?
+    /// True when this page is being rendered into a pane of the assignment
+    /// workbench rather than as a top-level document.  `base.leaf` reads it to
+    /// suppress the site chrome (nav, colour bar, course tabs); the notebook
+    /// page reads it to let the editor iframe fill the pane.  `nil` on every
+    /// standalone render, which is what keeps the existing page byte-identical.
+    let embedded: Bool?
 }
 
 // MARK: - Submission history page

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -27,6 +27,10 @@ extension WebRoutes {
             var submissionID: String?
             var file: String?
             var view: String?
+            /// `?embedded=1` from the workbench shell.  Decoded as `Bool` —
+            /// Vapor's form decoder already accepts `1` / `true` — so there is
+            /// no truthiness helper to keep in sync.
+            var embedded: Bool?
         }
         let user = try req.auth.require(APIUser.self)
         guard let userID = user.id else { throw Abort(.unauthorized) }
@@ -109,7 +113,13 @@ extension WebRoutes {
             assignmentTitle: assignmentTitle,
             isClosed: isClosed,
             isStaff: isStaff,
-            viewMode: viewMode
+            viewMode: viewMode,
+            // `?embedded=1` is a rendering hint from the workbench shell, not a
+            // permission: every gate above (solution-is-staff-only, the closed
+            // gate, `canSaveToAssignment`) has already been decided without
+            // reference to it, so a student appending it to the URL gains
+            // nothing beyond a page with no nav bar.
+            embedded: query.embedded == true ? true : nil
         )
         if !requestedSubmissionID.isEmpty {
             return try await renderSubmissionNotebookView(
@@ -236,7 +246,8 @@ extension WebRoutes {
                 isTemplateView: false,
                 viewToggleURL: nil,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: submissionViewAbsPath),
-                currentUser: req.currentUserContext
+                currentUser: req.currentUserContext,
+                embedded: args.embedded
             ))
     }
 
@@ -357,7 +368,8 @@ extension WebRoutes {
                 isTemplateView: viewMode == .template,
                 viewToggleURL: viewToggleURL,
                 workingCopyMtime: workingCopyMtimeEpoch(absolutePath: workingCopyAbsPath),
-                currentUser: req.currentUserContext
+                currentUser: req.currentUserContext,
+                embedded: args.embedded
             ))
     }
 
@@ -380,6 +392,11 @@ extension WebRoutes {
         /// template or a per-viewer rendering.  Always `.personalized` for
         /// students and for the submission-history view.
         let viewMode: NotebookViewMode
+        /// True when this render is a pane of the assignment workbench.
+        /// Purely presentational — it suppresses the site chrome and lets the
+        /// editor iframe fill the pane.  `nil` (not `false`) when absent, so
+        /// the standalone page's HTML is unchanged.
+        let embedded: Bool?
     }
 
     /// Which reading of the notebook this request gets.

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -62,6 +62,10 @@ func routes(_ app: Application) throws {
     let instructor = app.grouped(
         sessionAuth, ActiveCourseStaffMiddleware(), NavCourseContextMiddleware(), csrf)
     try instructor.register(collection: InstructorDashboardRoutes())
+    // Side-by-side authoring surface: the edit page and the notebook editor as
+    // two panes.  Composes the pages registered above and below rather than
+    // adding content of its own.
+    try instructor.register(collection: InstructorWorkbenchRoutes())
     try instructor.register(collection: DraftAssignmentRoutes())
     try instructor.register(collection: PublishedAssignmentRoutes())
     try instructor.register(collection: CourseAdminRoutes())

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -15,6 +15,9 @@ import VaporTesting
 
         app.get("testsetups", ":testSetupID", "notebook") { _ in "notebook" }
         app.get("instructor", ":assignmentID", "validate") { _ in "validate" }
+        app.get("instructor", ":assignmentID", "workbench") { _ in "workbench" }
+        app.get("instructor", ":assignmentID", "workbench", "panel") { _ in "panel" }
+        app.get("instructor", ":assignmentID", "edit") { _ in "edit" }
         app.get("jupyterlite", "notebooks", "index.html") { _ in "iframe" }
         app.get("grading-worker.js") { _ in "// grading worker" }
         app.get("freeze-watchdog-worker.js") { _ in "// freeze worker" }
@@ -208,6 +211,67 @@ import VaporTesting
                 headers: ["User-Agent": Self.safariUA]
             ) { res async in
                 #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+            }
+        }
+    }
+
+    // MARK: - Assignment workbench: the whole ancestor chain must be isolated
+
+    // Cross-origin isolation is a property of the entire frame chain, and the
+    // workbench nests the notebook page one level deeper than it has ever been
+    // nested.  If the shell is not isolated, the notebook iframe cannot be
+    // either — `crossOriginIsolated` goes false inside it and the kernel
+    // silently drops off SharedArrayBuffer onto the service-worker transport,
+    // with no error anywhere.  And under `require-corp` a nested document that
+    // does not itself send `require-corp` is refused outright, so the left pane
+    // needs the headers even though it runs no Python.
+    //
+    // These two tests are the guard on that: they are the only place the
+    // requirement is stated executably.
+
+    @Test(arguments: [
+        "/instructor/assignment_123/workbench",
+        "/instructor/assignment_123/workbench/panel",
+    ])
+    func workbenchChainIsIsolatedForChrome(path: String) async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            try await app.testing().test(
+                .GET, path, headers: ["User-Agent": Self.chromeUA]
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
+                #expect(variesOnUserAgent(res), "Isolation varies by engine, so the response must Vary")
+            }
+        }
+    }
+
+    @Test(arguments: [
+        "/instructor/assignment_123/workbench",
+        "/instructor/assignment_123/workbench/panel",
+    ])
+    func workbenchChainIsNotIsolatedForWebKit(path: String) async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            try await app.testing().test(
+                .GET, path, headers: ["User-Agent": Self.safariUA]
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+            }
+        }
+    }
+
+    /// The regression that matters most: the workbench rule must not widen to
+    /// the rest of `/instructor/*`.  The standalone edit page is reached by
+    /// every instructor on every assignment and has no business being isolated.
+    @Test func plainEditPageStaysUnisolated() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            try await app.testing().test(
+                .GET, "/instructor/assignment_123/edit", headers: ["User-Agent": Self.chromeUA]
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
             }
         }

--- a/Tests/APITests/InstructorWorkbenchRoutesTests.swift
+++ b/Tests/APITests/InstructorWorkbenchRoutesTests.swift
@@ -1,0 +1,189 @@
+// Tests/APITests/InstructorWorkbenchRoutesTests.swift
+//
+// The assignment workbench: a shell page that composes the instructor edit page
+// and the notebook editor as two same-origin iframe panes.
+//
+// What these tests are really pinning is that the shell *reuses* rather than
+// reimplements.  The left pane is the ordinary edit page rendered from the same
+// context builder, so the risk is not that it looks wrong — it is that it
+// silently stops rendering (the LeafKit multi-`#extend` failure this page's
+// design exists to avoid) or that the chrome suppression leaks into the
+// standalone page.
+//
+// The isolation headers these routes also need live in COEPMiddlewareTests.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct InstructorWorkbenchRoutesTests {
+
+    // MARK: - Shell
+
+    @Test func workbenchShellReferencesBothPanes() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "setup_wb1", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb1", title: "Workbench Lab", isOpen: false,
+                validationStatus: "passed", on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/workbench",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("/instructor/\(assignment.publicID)/workbench/panel"))
+                    #expect(html.contains("/testsetups/setup_wb1/notebook?file=assignment&amp;embedded=1"))
+                    // `validationStatus == "passed"` means a reference solution
+                    // exists, so the solution tab is offered.
+                    #expect(html.contains("/testsetups/setup_wb1/notebook?file=solution&amp;embedded=1"))
+                    #expect(html.contains("Workbench Lab"))
+                })
+        }
+    }
+
+    /// No solution yet → the tab is *absent*, not disabled, mirroring how the
+    /// edit page omits `solutionNotebookEditURL` entirely.
+    @Test func workbenchOmitsSolutionTabWhenThereIsNoSolution() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "setup_wb2", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb2", title: "No Solution Yet", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/workbench",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("file=assignment"))
+                    #expect(!html.contains("file=solution"))
+                    #expect(!html.contains("wb-tab-solution"))
+                })
+        }
+    }
+
+    // MARK: - Left pane
+
+    /// The pane must render the *whole* edit page — this is the assertion that
+    /// would fail if `assignment-edit.leaf` ever hit the LeafKit extend bug, and
+    /// the reason the workbench composes by iframe instead of merging templates.
+    @Test func panelRendersTheEditPageWithoutSiteChrome() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "setup_wb3", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb3", title: "Panel Lab", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/workbench/panel",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    // The real editor is present …
+                    #expect(html.contains("suite-sections"))
+                    #expect(html.contains("global-inputs-block"))
+                    #expect(html.contains("notebook-files-table"))
+                    #expect(html.contains("Panel Lab"))
+                    // … the site chrome is not …
+                    #expect(!html.contains("<nav class=\"nav\""))
+                    #expect(!html.contains("skip-link"))
+                    #expect(!html.contains("/idle-logout.js"))
+                    #expect(html.contains("/embedded-activity.js"))
+                    // … and the pane does not link to the surface containing it.
+                    #expect(!html.contains("/workbench\""))
+                })
+        }
+    }
+
+    /// The standalone edit page is the control: same template, chrome intact,
+    /// plus the entry point into the workbench.
+    @Test func standaloneEditPageKeepsChromeAndOffersTheWorkbench() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "setup_wb4", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb4", title: "Standalone Lab", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/edit",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("<nav class=\"nav\""))
+                    #expect(html.contains("/idle-logout.js"))
+                    #expect(!html.contains("/embedded-activity.js"))
+                    #expect(html.contains("/instructor/\(assignment.publicID)/workbench"))
+                })
+        }
+    }
+
+    // MARK: - Access control
+
+    /// Both routes sit behind the same per-course staff gate as the rest of the
+    /// authoring surface.  A student in the course is not staff, and the
+    /// workbench must not become a way around that.
+    @Test func studentsCannotReachTheWorkbench() async throws {
+        try await withAssignmentRoutesApp { app in
+            let studentCookie = try await arLoginAsStudent(on: app)
+            let student = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "teststudent").first())
+            try await arEnrollStudentInTestCourse(student, on: app)
+
+            try await arInsertSetup(id: "setup_wb5", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb5", title: "Gated Lab", isOpen: true, on: app)
+
+            for path in [
+                "/instructor/\(assignment.publicID)/workbench",
+                "/instructor/\(assignment.publicID)/workbench/panel",
+            ] {
+                try await app.asyncTest(
+                    .GET, path,
+                    beforeRequest: { req in req.headers.add(name: .cookie, value: studentCookie) },
+                    afterResponse: { res in
+                        #expect(
+                            res.status != .ok,
+                            "A student reached \(path) — the staff gate is not applied")
+                    })
+            }
+        }
+    }
+
+    @Test func unauthenticatedVisitorsAreNotServedTheWorkbench() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "setup_wb6", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb6", title: "Anon Lab", isOpen: false, on: app)
+            _ = cookie
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/workbench",
+                afterResponse: { res in
+                    #expect(res.status != .ok)
+                })
+        }
+    }
+
+    @Test func unknownAssignmentIsNotFound() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/nosuch/workbench",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .notFound)
+                })
+        }
+    }
+}

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -222,6 +222,80 @@ import VaporTesting
         }
     }
 
+    // MARK: - Embedded mode (assignment workbench panes)
+
+    /// `?embedded=1` renders the same page without the site chrome, so the
+    /// notebook can be composed into a workbench pane without three stacked
+    /// copies of the nav.  Asserted against the *same* setup in both modes so
+    /// the only difference under test is the flag.
+    @Test func notebookPageEmbeddedDropsSiteChromeButKeepsEditor() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_embedded"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Embedded seed"))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Embedded Lab")
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("<nav class=\"nav\""), "Standalone page keeps the site nav")
+                    #expect(html.contains("/idle-logout.js"))
+                    #expect(!html.contains("jl-frame-embedded"))
+                })
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook?embedded=1",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    // Chrome gone …
+                    #expect(!html.contains("<nav class=\"nav\""), "Embedded pane must not render the site nav")
+                    #expect(!html.contains("skip-link"))
+                    // … watchdog swapped for the forwarder (the shell owns the
+                    // idle timer; the pane only reports activity to it) …
+                    #expect(!html.contains("/idle-logout.js"))
+                    #expect(html.contains("/embedded-activity.js"))
+                    // … and the editor itself is untouched, now pane-height.
+                    #expect(html.contains("data-setup-id=\"\(setupID)\""))
+                    #expect(html.contains("jl-frame-embedded"))
+                })
+        }
+    }
+
+    /// `embedded` is a rendering hint, never a permission.  A student who
+    /// appends it to a solution URL gets the same 403 as without it — the
+    /// staff-only guard runs before the flag is ever consulted.
+    @Test func embeddedFlagGrantsNoAccessToTheSolution() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_embedded_sol"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Seed"))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Embedded Solution Guard")
+
+            for path in [
+                "/testsetups/\(setupID)/notebook?file=solution&embedded=1",
+                "/testsetups/\(setupID)/notebook/source?file=solution&embedded=1",
+            ] {
+                try await app.asyncTest(
+                    .GET, path,
+                    beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                    afterResponse: { res in
+                        #expect(res.status == .forbidden, "Expected 403 for \(path)")
+                    })
+            }
+        }
+    }
+
     @Test func notebookPageSeedsWorkingCopyAndRendersEditorFrame() async throws {
         try await withApp(app) { _ in
             let cookie = try await loginAsStudent()

--- a/Tests/BrowserRunnerJSTests/workbench.test.mjs
+++ b/Tests/BrowserRunnerJSTests/workbench.test.mjs
@@ -1,0 +1,84 @@
+// Unit tests for the assignment workbench shell's pane arithmetic and
+// kernel-count policy.
+//
+// The clamp is the load-bearing piece. The notebook page hides its own editor
+// below 640px and shows "open on a larger screen" instead — so a splitter that
+// lets the notebook pane get too narrow does not merely look cramped, it
+// replaces the editor with a notice. These tests pin the floor from both drag
+// directions and at viewports too small to honour both floors at once.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const Workbench = require('../../Public/workbench.js');
+
+const NOTEBOOK_MIN = 720;
+const EDIT_MIN = 380;
+const SPLITTER = 8;
+
+// A roomy desktop: 1920 - 8 - 720 = 1192px of headroom for the edit pane.
+const WIDE = 1920;
+
+test('clampLeftWidth: leaves a comfortable width untouched', () => {
+  assert.equal(Workbench.clampLeftWidth(600, WIDE), 600);
+});
+
+test('clampLeftWidth: dragging left stops at the edit-pane floor', () => {
+  assert.equal(Workbench.clampLeftWidth(100, WIDE), EDIT_MIN);
+  assert.equal(Workbench.clampLeftWidth(0, WIDE), EDIT_MIN);
+  assert.equal(Workbench.clampLeftWidth(-500, WIDE), EDIT_MIN);
+});
+
+test('clampLeftWidth: dragging right never starves the notebook pane', () => {
+  const maxLeft = WIDE - SPLITTER - NOTEBOOK_MIN;
+  assert.equal(Workbench.clampLeftWidth(WIDE, WIDE), maxLeft);
+  assert.equal(Workbench.clampLeftWidth(maxLeft + 1, WIDE), maxLeft);
+  assert.equal(Workbench.clampLeftWidth(999999, WIDE), maxLeft);
+});
+
+test('clampLeftWidth: the notebook pane keeps its floor at every drag position', () => {
+  // Sweep the whole range at both a wide and a marginal viewport and assert the
+  // invariant directly, rather than trusting the two endpoint cases above.
+  for (const total of [WIDE, 1440, 1280, 1140]) {
+    for (let desired = -200; desired <= total + 200; desired += 17) {
+      const left = Workbench.clampLeftWidth(desired, total);
+      const notebook = total - SPLITTER - left;
+      assert.ok(
+        notebook >= NOTEBOOK_MIN,
+        `notebook pane ${notebook}px < ${NOTEBOOK_MIN}px (total=${total}, desired=${desired})`,
+      );
+    }
+  }
+});
+
+test('clampLeftWidth: when both floors cannot fit, the edit pane yields', () => {
+  // 900px cannot hold 720 + 8 + 380. The notebook is the pane with the hard
+  // rendering cliff, so it keeps its width and the edit pane gives up the rest.
+  const total = 900;
+  const left = Workbench.clampLeftWidth(500, total);
+  assert.ok(left < EDIT_MIN, 'edit pane should yield below its own floor');
+  assert.equal(left, total - SPLITTER - NOTEBOOK_MIN);
+  assert.ok(left >= 0, 'clamp must never return a negative width');
+});
+
+test('clampLeftWidth: a viewport narrower than the notebook floor clamps to zero, not negative', () => {
+  assert.equal(Workbench.clampLeftWidth(300, 500), 0);
+  assert.equal(Workbench.clampLeftWidth(0, 100), 0);
+});
+
+test('allowsTwoKernels: an unknown deviceMemory is not treated as low', () => {
+  // Firefox and Safari do not expose deviceMemory. Absent evidence must not
+  // downgrade those authors to a kernel reboot on every tab switch.
+  assert.equal(Workbench.allowsTwoKernels({}), true);
+  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: undefined }), true);
+  assert.equal(Workbench.allowsTwoKernels(null), true);
+});
+
+test('allowsTwoKernels: low-memory devices hold one kernel at a time', () => {
+  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 2 }), false);
+  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 4 }), false);
+  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 8 }), true);
+  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 16 }), true);
+});

--- a/changelog.d/assignment-workbench.md
+++ b/changelog.d/assignment-workbench.md
@@ -1,0 +1,35 @@
+### Added
+
+- **Assignment workbench — the edit page and the notebook editor, side by side.**
+  A new instructor surface at `/instructor/:assignmentID/workbench` puts the
+  assignment editor in a left pane and the embedded JupyterLite editor in a
+  right pane, with a tab strip that switches the notebook pane between the
+  starter notebook and the reference solution. Authors can read and change
+  global inputs, section variables, suite entries and deadlines while a Pyodide
+  kernel boots or a validation run finishes, instead of paying a full editor
+  cold boot on every hop between the two pages. Reached from a "Workbench"
+  button on the edit page; the standalone `/edit` and
+  `/testsetups/:id/notebook` pages are unchanged and remain the default.
+
+  The shell renders no assignment content of its own — it composes the two
+  existing pages as same-origin iframes, so the suite editor, inputs editors and
+  `notebook.js` all run unmodified. The solution pane stays unmounted until its
+  tab is first selected, then stays warm, so switching costs one kernel boot
+  rather than one per switch; a device reporting low memory keeps a single
+  kernel and reboots on switch instead. The splitter is drag- and
+  keyboard-operable and clamps so the notebook pane can never fall under the
+  width at which it would replace the editor with its "open on a larger screen"
+  notice; below a viewport that can hold both panes honestly, the layout falls
+  back to one pane at a time.
+
+### Fixed
+
+- **Cross-origin isolation now covers the whole editor frame chain.** Isolation
+  is a property of every ancestor, so nesting the notebook page inside another
+  page requires the outer documents to carry `COOP`/`COEP` as well. Without it
+  the editor iframe would lose `SharedArrayBuffer` and silently fall back to the
+  service-worker kernel transport on Chrome and Firefox — and, under
+  `require-corp`, the sibling pane would have been refused outright. The
+  workbench routes are isolated on the same terms as the notebook page,
+  including the WebKit exemption that keeps Safari on its comlink path. Plain
+  `/instructor/*` pages are unaffected.


### PR DESCRIPTION
Adds `GET /instructor/:assignmentID/workbench` — the assignment editor in a left pane, the embedded JupyterLite editor in a right pane, and a tab strip switching the notebook pane between the starter notebook and the reference solution.

Today an author ping-pongs between `/instructor/:id/edit` and `/testsetups/:id/notebook`, and every hop costs a full Pyodide cold boot. The two things that have to be reconciled — variables and suite entries on one page, notebook cells on the other — are never on screen together, and reaching the solution is a third navigation and a third boot.

The existing `/edit` and `/testsetups/:id/notebook` pages are unchanged and remain the default. The workbench is opt-in from a **Workbench** button on the edit page.

## How it is built

The shell renders no assignment content. It composes the two existing pages as same-origin iframes, so the suite editor, the inputs editors and `notebook.js` all run unmodified.

Composition rather than a merged template is forced by two independent constraints:

- `assignment-edit.leaf` already carries one inline `#extend`, and LeafKit 1.14.2 fails at render with `extend only supports one or two parameters` on a second one in a template that size — the decomposition a merge would need is exactly the broken shape (documented in `CLAUDE.md`).
- `notebook.js` is a 2460-line single-instance IIFE bound to `#jl-frame`, with global state for the freeze watchdog, kernel diagnostics and IndexedDB eviction. Two notebooks as two *documents* needs none of that touched.

The left pane is the ordinary edit page rendered from the **same** context builder — `editPage`'s body was factored out as `makeEditAssignmentContext(req:embedded:)` so the two routes cannot drift. It is served on its own path rather than `/edit?embedded=1` so the COEP rule stays a path match and the public edit page's headers are untouched.

## The part most worth reviewing: cross-origin isolation

Isolation is a property of the **entire ancestor chain**, and the workbench nests the notebook page a level deeper than it has ever been nested. Two consequences, both silent if missed:

- Without `COOP`/`COEP` on the shell, `crossOriginIsolated` goes false inside the notebook iframe and every Chrome/Firefox author drops off `SharedArrayBuffer` onto the service-worker kernel transport the codebase deliberately moved away from — no error anywhere.
- Under `require-corp`, a nested document that does not itself send `require-corp` is refused outright (`ERR_BLOCKED_BY_RESPONSE.CoepFrameResourceNeedsCoepHeader`), so the **left** pane needs the headers even though it runs no Python.

Both routes are isolated on the same terms as the notebook page, WebKit exemption included (Safari stays on comlink — there it is consistently "no isolation anywhere in the chain"). Plain `/instructor/*` is unaffected, which `COEPMiddlewareTests` pins explicitly.

I also corrected a stale comment in `COEPMiddleware` claiming instructor pages load CDN resources — the CSP has been `'self'`-only since the vendoring work. The narrow path match is still right, just not for that reason.

## Kernel count

The solution pane stays at `about:blank` until its tab is first selected, then stays mounted — so switching costs one kernel boot rather than one per switch. A device reporting low `deviceMemory` keeps a single kernel and unmounts on switch instead. Flipping to strictly-one-kernel is a one-constant change if preferred.

## Desktop layout

The failure mode designed against is concrete: `notebook.leaf` hides its editor below 640px and shows "open on a larger screen", so a too-narrow notebook pane would render that notice *instead of the editor*.

- Notebook pane floor 720px, edit pane floor 380px; the splitter clamps to both, and when the viewport cannot satisfy both the edit pane yields (the notebook is the pane with the cliff).
- Below 1140px the layout drops to one pane at a time rather than faking a split.
- Splitter is a real `role="separator"` control: arrows step it, Home/End snap to the floors.

## Also fixed: idle logout

Surfaced while building this. `idle-logout.js` measures interaction with *its own* document; in the workbench every keystroke lands in a pane iframe, so the shell would look idle and sign the author out roughly 30 minutes into a session. Panes already bail out of the watchdog (it needs the nav's logout form) and now load a new `embedded-activity.js`, which forwards throttled same-origin activity pings the shell re-raises as `chickadee:activity`. Server-side session life was never at risk — `notebook.js` already posts `/session/keepalive` on editor activity.

## Testing

- `InstructorWorkbenchRoutesTests` (new, 7) — both routes render for staff; students and anonymous visitors are refused; the panel renders the *full* edit page with chrome suppressed and no self-link; the standalone page keeps its chrome; the solution tab is absent rather than disabled when there is no solution. The "panel renders the full edit page" case is the executable guard against the LeafKit failure.
- `COEPMiddlewareTests` (+5) — the isolation chain for Chrome/Firefox, its absence for WebKit, and that plain `/edit` stays unisolated.
- `NotebookWebRoutesTests` (+2) — `?embedded=1` drops chrome and keeps the editor, and grants no access: a student asking for `?file=solution&embedded=1` still gets 403 on both the page and the raw source endpoint.
- `workbench.test.mjs` (new, 8) — the splitter clamp swept across the full drag range at four viewport widths asserting the notebook floor directly, plus the low-memory kernel policy.

109 Swift tests across the affected suites pass. `format.sh`, `lint.sh`, `swiftlint.sh --strict`, `check-styles.sh` (incl. css-vars + design-tokens) and `eslint.sh` all green.

**Not yet done — this is why it is a draft.** The manual desktop pass in the plan is unrun: confirming `crossOriginIsolated === true` inside the nested notebook iframe on real Chrome, that the solution tab boots once and switches instantly thereafter, that a "Save to assignment" refreshes the left pane without closing the assignment, splitter behaviour at both extremes, dark mode, and the idle-timeout case. Render tests prove templates resolve; they do not exercise page JS or real browser isolation.

## Out of scope

Validation-results and template/rendered-view panes (the tab strip is built to take more entries), any change to the standalone pages, and mobile/tablet side-by-side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj)_