### PR TITLE
Workbench: wire cross-pane notifications, add pane collapse, and check the isolation chain in a browser

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -80,7 +80,7 @@ jobs:
           # the assets the editor actually loads and the middlewares that isolate
           # them. Over-matching is safe (it just runs the smoke); under-matching
           # is the dangerous direction.
-          pattern='^(Public/notebook[^/]*\.js|Public/browser-runner\.js|Public/grading-worker\.js|Public/pyodide-worker\.js|Public/assignment-validate\.js|Public/freeze-watchdog-worker\.js|Public/jupyterlite/|Public/pyodide/|Public/vendor/|Sources/APIServer/Middleware/COEPMiddleware\.swift|Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware\.swift|Sources/APIServer/Middleware/EditorEngineDetection\.swift|Sources/APIServer/Middleware/JupyterLiteConfigFlagMiddleware\.swift|Sources/APIServer/Middleware/CrossOriginIsolationHeaders\.swift|Sources/APIServer/Middleware/SecurityHeadersMiddleware\.swift|Sources/APIServer/Middleware/EditorAssetFastPathMiddleware\.swift|Sources/APIServer/Bootstrap/AppMiddleware\.swift|Sources/APIServer/Configuration/SecurityConfig\.swift|Tools/jupyterlite/|Tools/editor-smoke-test/|\.github/workflows/editor-smoke\.yml)'
+          pattern='^(Public/notebook[^/]*\.js|Public/browser-runner\.js|Public/grading-worker\.js|Public/pyodide-worker\.js|Public/assignment-validate\.js|Public/freeze-watchdog-worker\.js|Public/workbench\.js|Public/embedded-activity\.js|Public/jupyterlite/|Public/pyodide/|Public/vendor/|Resources/Views/workbench\.leaf|Resources/Views/notebook\.leaf|Resources/Views/base\.leaf|Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes\.swift|Sources/APIServer/Middleware/COEPMiddleware\.swift|Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware\.swift|Sources/APIServer/Middleware/EditorEngineDetection\.swift|Sources/APIServer/Middleware/JupyterLiteConfigFlagMiddleware\.swift|Sources/APIServer/Middleware/CrossOriginIsolationHeaders\.swift|Sources/APIServer/Middleware/SecurityHeadersMiddleware\.swift|Sources/APIServer/Middleware/EditorAssetFastPathMiddleware\.swift|Sources/APIServer/Bootstrap/AppMiddleware\.swift|Sources/APIServer/Configuration/SecurityConfig\.swift|Tools/jupyterlite/|Tools/editor-smoke-test/|\.github/workflows/editor-smoke\.yml)'
           # Use a here-string, NOT `echo "$changed" | grep -qE`: with a large
           # changed-file list (e.g. a full JupyterLite bundle re-vendor) grep -q
           # matches early and closes the pipe, echo takes SIGPIPE, and the
@@ -187,6 +187,30 @@ jobs:
           fi
           echo "::warning::FLAKE RETRY: webkit notebook-page e2e failed (rc=${rc}) — known exec-hang class (docs/ci-flakiness.md Families 2+3). Retrying once; a second failure fails the gate."
           SMOKE_BROWSER="$ENGINE" SMOKE_CHECK=notebook-page-check.mjs Tools/editor-smoke-test/run-smoke.sh
+
+      # The assignment workbench nests the notebook page one frame deeper than
+      # anything else, and cross-origin isolation is a property of the WHOLE
+      # ancestor chain. COEPMiddlewareTests pins the headers; only a real browser
+      # can confirm the isolation those headers are meant to produce survives two
+      # levels of framing. Without this, a broken chain is silent: the kernel
+      # still boots, just on the service-worker comlink transport instead of
+      # SharedArrayBuffer. Cheaper than the notebook-page e2e — it asserts the
+      # frames and their isolation, and does not wait for a kernel or a submit.
+      - name: Run workbench isolation-chain e2e (${{ matrix.browser }})
+        shell: bash
+        env:
+          ENGINE: ${{ matrix.browser }}
+        run: |
+          set -uo pipefail
+          if SMOKE_BROWSER="$ENGINE" SMOKE_CHECK=workbench-check.mjs Tools/editor-smoke-test/run-smoke.sh; then
+            exit 0
+          fi
+          rc=$?
+          if [ "$ENGINE" != "webkit" ]; then
+            exit "$rc"
+          fi
+          echo "::warning::FLAKE RETRY: webkit workbench e2e failed (rc=${rc}) — same flake class as the notebook-page e2e. Retrying once; a second failure fails the gate."
+          SMOKE_BROWSER="$ENGINE" SMOKE_CHECK=workbench-check.mjs Tools/editor-smoke-test/run-smoke.sh
 
   # Always-running required status. Green when the smoke passed OR was skipped
   # (no editor-relevant changes), red only when the smoke actually failed — so

--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -262,6 +262,40 @@
         return finish;
     }
 
+    // Tell the assignment-workbench shell that something on this page changed
+    // in a way the *other* pane cares about.
+    //
+    // The workbench composes the edit page and the notebook editor as two
+    // same-origin iframes; neither pane can see the other, so a save in one has
+    // to be announced. Lives here rather than in each pane's own script because
+    // three pages need the identical guard, and getting the guard wrong is what
+    // would leak these notes to a hostile framer.
+    //
+    // A no-op on a standalone page — every one of these pages is reachable
+    // directly, and there `window.parent === window`.
+    //
+    // Recognised types:
+    //   'notebook-saved'  — a notebook was written back to the assignment, so
+    //                       the edit pane's files list / validation state is stale.
+    //   'inputs-changed'  — global or section inputs changed, so what the
+    //                       notebook pane is rendering is a substitution of
+    //                       stale values.
+    function notifyWorkbench(type) {
+        if (typeof window === 'undefined' || window.parent === window) return;
+        try {
+            // An explicit target origin, never '*': these are same-origin notes
+            // to our own shell, and '*' would hand them to any document that
+            // managed to frame this page.
+            window.parent.postMessage(
+                { source: 'chickadee', type: type },
+                window.location.origin
+            );
+        } catch (_) {
+            // Cross-origin parent, or one that went away mid-navigation. The
+            // panes stay correct on their own; only the cross-pane hint is lost.
+        }
+    }
+
     var root = typeof window !== 'undefined' ? window : globalThis;
     root.ChickadeeUI = {
         escapeHtml: escapeHtml,
@@ -270,6 +304,7 @@
         setStatus: setStatus,
         extractErrorMessage: extractErrorMessage,
         fetchJSON: fetchJSON,
+        notifyWorkbench: notifyWorkbench,
         renderSparkline: renderSparkline,
         accordion: {
             CARET_HTML: CARET_HTML,

--- a/Public/global-inputs-editor.js
+++ b/Public/global-inputs-editor.js
@@ -50,6 +50,11 @@
                 body: JSON.stringify(payload)
             }).then(function (r) {
                 if (r.ok) {
+                    // Global inputs feed personalization, so a notebook open in
+                    // the workbench's other pane is now a rendering of stale
+                    // values.  The shell raises an advisory chip rather than
+                    // reloading that pane, which would restart the kernel.
+                    ChickadeeUI.notifyWorkbench('inputs-changed');
                     return r.json().then(function (body) {
                         var warns = body && body.warnings;
                         if (warns && warns.length) {

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1257,16 +1257,6 @@
     // server-side for course staff only (NotebookContext.canSaveToAssignment);
     // the endpoint re-checks the same permission, so this is convenience, not
     // the control.
-    // Post a same-origin note to the assignment-workbench shell when this page
-    // is one of its panes.  Silent no-op when the page is top-level, which is
-    // every other way it is reached.
-    function notifyWorkbench(type) {
-        if (window.parent === window) return;
-        try {
-            window.parent.postMessage({ source: 'chickadee', type: type }, window.location.origin);
-        } catch (_) { /* cross-origin or vanished parent */ }
-    }
-
     if (saveAssignmentBtn) {
         const saveFileKind = saveAssignmentBtn.dataset.fileKind === 'solution' ? 'solution' : 'assignment';
         // Which working copy the editor is showing. The endpoint writes the
@@ -1306,7 +1296,7 @@
                 // changed the files list and validation status that the edit
                 // pane beside us is rendering, so it is now stale.  No-op on
                 // the standalone page, which has no parent.
-                notifyWorkbench('notebook-saved');
+                ChickadeeUI.notifyWorkbench('notebook-saved');
             } catch (err) {
                 const msg = (err instanceof Error && err.message) ? err.message : String(err);
                 console.error('[notebook] Save-to-assignment error:', err);

--- a/Public/section-inputs-editor.js
+++ b/Public/section-inputs-editor.js
@@ -44,6 +44,10 @@
                         throw new Error('section-vars save failed: HTTP ' + r.status + ' ' + t.slice(0, 200));
                     });
                 }
+                // Section variables feed personalization the same way global
+                // inputs do, so a notebook open in the workbench's other pane is
+                // now rendering stale values.  Advisory only — see the shell.
+                ChickadeeUI.notifyWorkbench('inputs-changed');
             }).catch(function (err) {
                 console.error('section-vars auto-save failed:', err);
             });

--- a/Public/workbench.js
+++ b/Public/workbench.js
@@ -67,9 +67,30 @@
         return dm > 4;
     }
 
+    /// Toggle the edit pane between collapsed and its last expanded width.
+    ///
+    /// Kept as a pure transition on an explicit state object because the bug
+    /// this shape prevents is a real one: collapsing while already collapsed
+    /// must not overwrite the remembered width with 0, or the pane can never be
+    /// restored and the author is left with no way back to the editor short of
+    /// dragging the splitter out from the edge.
+    ///
+    /// `state` is `{ collapsed, width, restoreWidth }`; the return is the same
+    /// shape.
+    function toggleCollapse(state) {
+        if (state.collapsed) {
+            return { collapsed: false, width: state.restoreWidth, restoreWidth: state.restoreWidth };
+        }
+        return { collapsed: true, width: 0, restoreWidth: state.width };
+    }
+
     // Exported for the unit tests, which exercise the arithmetic and the
     // policy without a DOM.
-    var api = { clampLeftWidth: clampLeftWidth, allowsTwoKernels: allowsTwoKernels };
+    var api = {
+        clampLeftWidth: clampLeftWidth,
+        allowsTwoKernels: allowsTwoKernels,
+        toggleCollapse: toggleCollapse
+    };
     if (typeof window !== 'undefined') window.ChickadeeWorkbench = api;
     if (typeof module !== 'undefined' && module.exports) module.exports = api;
 
@@ -122,6 +143,34 @@
         if (!isNaN(px) && px > 0) applyLeftWidth(px);
     }
 
+    // ── Collapse ──────────────────────────────────────────────────────────
+
+    var collapseState = { collapsed: false, width: 0, restoreWidth: 0 };
+
+    function applyCollapse() {
+        shell.setAttribute('data-wb-collapsed', collapseState.collapsed ? 'edit' : '');
+        if (collapseBtn) {
+            collapseBtn.setAttribute('aria-expanded', collapseState.collapsed ? 'false' : 'true');
+            collapseBtn.textContent = collapseState.collapsed ? 'Show editor' : 'Hide editor';
+        }
+        if (collapseState.collapsed) {
+            shell.style.setProperty('--wb-left-width', '0px');
+            if (splitter) splitter.setAttribute('aria-valuenow', '0');
+        } else {
+            applyLeftWidth(collapseState.restoreWidth || EDIT_MIN);
+        }
+    }
+
+    function doToggleCollapse() {
+        collapseState.width = collapseState.collapsed ? collapseState.width : currentLeftWidth();
+        collapseState = toggleCollapse(collapseState);
+        applyCollapse();
+        if (!collapseState.collapsed) persist(currentLeftWidth());
+    }
+
+    var collapseBtn = document.getElementById('wb-collapse-edit');
+    if (collapseBtn) collapseBtn.addEventListener('click', doToggleCollapse);
+
     if (splitter && body) {
         var dragging = false;
 
@@ -148,6 +197,11 @@
         splitter.addEventListener('keydown', function (e) {
             var width = currentLeftWidth();
             var total = body.clientWidth;
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                doToggleCollapse();
+                return;
+            }
             var next = null;
             if (e.key === 'ArrowLeft') next = width - KEY_STEP_PX;
             else if (e.key === 'ArrowRight') next = width + KEY_STEP_PX;
@@ -155,6 +209,9 @@
             else if (e.key === 'End') next = total - SPLITTER_PX - NOTEBOOK_MIN;
             if (next === null) return;
             e.preventDefault();
+            // Any explicit sizing means the pane is no longer collapsed.
+            collapseState.collapsed = false;
+            shell.setAttribute('data-wb-collapsed', '');
             persist(applyLeftWidth(next));
         });
 

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -90,6 +90,11 @@
     color: var(--gray-700);
 }
 
+/* Collapsed edit pane: the notebook takes the full width.  The splitter stays
+   put so the pane can be dragged back out, and the toolbar button is the
+   primary way back. */
+.wb-shell[data-wb-collapsed="edit"] .wb-pane-edit { display: none; }
+
 /* Below the point where an honest split is possible (720px notebook floor +
    380px edit floor + the splitter), collapse to one pane at a time.  The
    notebook page hides its own editor under 640px, so a too-narrow pane would
@@ -110,6 +115,9 @@
     <div class="wb-bar">
         <h1 class="wb-title">#(assignmentTitle)</h1>
         <span class="wb-bar-spacer"></span>
+        <button class="btn action-btn" type="button" id="wb-collapse-edit"
+                aria-controls="wb-edit-frame" aria-expanded="true"
+                title="Give the notebook the full width">Hide editor</button>
         <button class="btn action-btn" type="button" id="wb-single-edit" hidden>Editor</button>
         <a class="btn action-btn" href="#(standaloneEditURL)">Full-width editor</a>
     </div>

--- a/Tests/BrowserRunnerJSTests/notify-workbench.test.mjs
+++ b/Tests/BrowserRunnerJSTests/notify-workbench.test.mjs
@@ -1,0 +1,78 @@
+// Unit tests for ChickadeeUI.notifyWorkbench — the cross-pane notification the
+// assignment workbench's shell listens for.
+//
+// Three pages call it (the notebook editor, the global-inputs editor, the
+// section-inputs editor) and every one of them is also reachable directly as a
+// top-level page. Two properties matter and neither is visible by reading a
+// single call site: it must be silent when there is no shell above it, and it
+// must never broadcast to '*' — these are same-origin notes about what an
+// instructor is editing, and a wildcard target would hand them to any document
+// that managed to frame the page.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+
+/// Loads chickadee-ui.js against a stub window whose `parent` we control, and
+/// records every postMessage the module makes.
+function load({ framed }) {
+  const posted = [];
+  const window = {
+    location: { origin: 'https://chickadee.example' },
+    document: { querySelector: () => null },
+  };
+  window.parent = framed ? { postMessage: (data, origin) => posted.push({ data, origin }) } : window;
+
+  const context = vm.createContext({ window, document: window.document, globalThis: {} });
+  vm.runInContext(source, context);
+  return { ui: window.ChickadeeUI, posted };
+}
+
+test('notifyWorkbench: posts to the shell when the page is a workbench pane', () => {
+  const { ui, posted } = load({ framed: true });
+  ui.notifyWorkbench('notebook-saved');
+
+  assert.equal(posted.length, 1);
+  // Field-by-field rather than deepEqual: the payload is constructed inside the
+  // vm realm, so its prototype is not this realm's Object.prototype.
+  assert.equal(posted[0].data.source, 'chickadee');
+  assert.equal(posted[0].data.type, 'notebook-saved');
+});
+
+test('notifyWorkbench: targets this origin explicitly, never a wildcard', () => {
+  const { ui, posted } = load({ framed: true });
+  ui.notifyWorkbench('inputs-changed');
+
+  assert.equal(posted[0].origin, 'https://chickadee.example');
+  assert.notEqual(posted[0].origin, '*');
+});
+
+test('notifyWorkbench: is a no-op on a standalone page', () => {
+  // window.parent === window is how every one of these pages loads when opened
+  // directly. Posting there would be harmless but wasteful; the real point is
+  // that the standalone pages behave identically to before the workbench.
+  const { ui, posted } = load({ framed: false });
+  ui.notifyWorkbench('notebook-saved');
+  ui.notifyWorkbench('inputs-changed');
+
+  assert.equal(posted.length, 0);
+});
+
+test('notifyWorkbench: a throwing parent does not propagate', () => {
+  // A parent that navigated away mid-save throws on postMessage. The pane's own
+  // save already succeeded, so losing the cross-pane hint must not surface as
+  // an error in the caller's success path.
+  const window = {
+    location: { origin: 'https://chickadee.example' },
+    document: { querySelector: () => null },
+  };
+  window.parent = { postMessage: () => { throw new Error('parent is gone'); } };
+  const context = vm.createContext({ window, document: window.document, globalThis: {} });
+  vm.runInContext(source, context);
+
+  assert.doesNotThrow(() => window.ChickadeeUI.notifyWorkbench('notebook-saved'));
+});

--- a/Tests/BrowserRunnerJSTests/workbench.test.mjs
+++ b/Tests/BrowserRunnerJSTests/workbench.test.mjs
@@ -82,3 +82,31 @@ test('allowsTwoKernels: low-memory devices hold one kernel at a time', () => {
   assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 8 }), true);
   assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 16 }), true);
 });
+
+test('toggleCollapse: collapsing remembers the width to come back to', () => {
+  const collapsed = Workbench.toggleCollapse({ collapsed: false, width: 640, restoreWidth: 0 });
+  assert.deepEqual(collapsed, { collapsed: true, width: 0, restoreWidth: 640 });
+
+  const expanded = Workbench.toggleCollapse(collapsed);
+  assert.deepEqual(expanded, { collapsed: false, width: 640, restoreWidth: 640 });
+});
+
+test('toggleCollapse: collapsing twice does not lose the restore width', () => {
+  // The failure this guards: a second collapse capturing the already-collapsed
+  // width of 0 would leave the pane unrestorable, with no way back to the
+  // editor short of dragging the splitter off the edge.
+  let state = { collapsed: false, width: 500, restoreWidth: 0 };
+  state = Workbench.toggleCollapse(state);
+  state = Workbench.toggleCollapse(state); // expand
+  state = Workbench.toggleCollapse(state); // collapse again
+  assert.equal(state.collapsed, true);
+  assert.equal(state.restoreWidth, 500);
+
+  state = Workbench.toggleCollapse(state);
+  assert.equal(state.width, 500, 'restoring must return the original width, not 0');
+});
+
+test('toggleCollapse: round-trips back to the starting state', () => {
+  const start = { collapsed: false, width: 420, restoreWidth: 420 };
+  assert.deepEqual(Workbench.toggleCollapse(Workbench.toggleCollapse(start)), start);
+});

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -1,0 +1,340 @@
+// workbench-check.mjs
+//
+// END-TO-END check of the assignment workbench (`/instructor/:id/workbench`) —
+// the surface that nests the JupyterLite editor one frame deeper than anything
+// before it.
+//
+// This exists because that nesting introduced a failure mode no unit test can
+// see. Cross-origin isolation is a property of the ENTIRE ancestor chain, so
+// the workbench shell and its left pane must both carry COOP/COEP or:
+//
+//   * `crossOriginIsolated` goes false inside the notebook iframe, the kernel
+//     silently drops off SharedArrayBuffer onto the service-worker comlink
+//     transport, and NOTHING reports an error — the editor still boots, just
+//     on the path the codebase deliberately moved away from; or
+//   * under `require-corp` the browser refuses the left pane outright
+//     (ERR_BLOCKED_BY_RESPONSE.CoepFrameResourceNeedsCoepHeader) and the author
+//     gets an empty pane where the editor should be.
+//
+// COEPMiddlewareTests pins the *headers*. Only a real browser can confirm the
+// isolation those headers are supposed to produce actually survives two levels
+// of framing, which is what this check does. It is the automated form of what
+// was otherwise a manual "open DevTools in the nested iframe" step.
+//
+// Asserts, as the instructor who authors the assignment:
+//
+//   1. the workbench shell is cross-origin isolated (chromium/firefox);
+//   2. the LEFT pane loaded a real edit page — i.e. was not COEP-refused;
+//   3. the NESTED notebook iframe is cross-origin isolated and has
+//      SharedArrayBuffer — the property the whole chain exists to preserve;
+//   4. the notebook pane mounts the assignment notebook and leaves the solution
+//      pane unmounted until asked (the lazy-mount contract that keeps a second
+//      Pyodide off the page until an author actually wants it).
+//
+// WebKit is expected NON-isolated at every level — it needs the comlink path —
+// so there the assertion is inverted, exactly as in notebook-page-check.mjs.
+//
+// Usage:   node workbench-check.mjs <baseURL>
+// Exit 0 = healthy; exit 1 = broken (details printed).
+
+import { chromium, webkit, firefox } from "playwright";
+import { request as pwRequest } from "playwright";
+import JSZip from "jszip";
+
+const BROWSERS = { chromium, webkit, firefox };
+const browserName = process.env.SMOKE_BROWSER || "chromium";
+const browserType = BROWSERS[browserName] || chromium;
+
+const baseURL = (process.argv[2] || process.env.BASE_URL || "http://127.0.0.1:8099").replace(/\/$/, "");
+
+const STAMP = Date.now().toString(36);
+const INSTRUCTOR = { username: `e2e_wb_instr_${STAMP}`, password: "instructor-pw-123" };
+const COURSE = { code: `WB${STAMP}`.slice(0, 12), name: "E2E Workbench Course" };
+
+const PAGE_LOAD_MS = 30_000;
+// The shell loads two documents, one of which boots a Pyodide kernel. We do not
+// wait for the kernel here — notebook-page-check.mjs already proves kernels boot
+// — but the frames themselves have to settle.
+const FRAME_SETTLE_MS = parseInt(process.env.SMOKE_FRAME_MS || "60000", 10);
+
+function fail(reason, extra) {
+  console.log(`E2E FAIL — ${reason}`);
+  if (extra) console.log(extra);
+  process.exit(1);
+}
+
+function extractCsrf(html) {
+  let m = html.match(/name=['"]_csrf['"][^>]*\svalue=['"]([^'"]+)['"]/i);
+  if (m) return m[1];
+  m = html.match(/\svalue=['"]([^'"]+)['"][^>]*name=['"]_csrf['"]/i);
+  if (m) return m[1];
+  m = html.match(/<meta\s+name=['"]csrf-token['"]\s+content=['"]([^'"]+)['"]/i);
+  if (m) return m[1];
+  return null;
+}
+
+async function csrfFrom(ctx, path) {
+  const res = await ctx.get(path);
+  const token = extractCsrf(await res.text());
+  if (!token) throw new Error(`could not find CSRF token on ${path} (status ${res.status()})`);
+  return token;
+}
+
+async function expectOK(label, resPromise, okStatuses) {
+  const res = await resPromise;
+  if (!okStatuses.includes(res.status())) {
+    let body = "";
+    try { body = (await res.text()).slice(0, 400); } catch { /* ignore */ }
+    throw new Error(`${label}: unexpected status ${res.status()} (wanted ${okStatuses.join("/")})\n${body}`);
+  }
+  return res;
+}
+
+async function buildSetupZip() {
+  const zip = new JSZip();
+  zip.file(
+    "assignment.ipynb",
+    JSON.stringify({
+      nbformat: 4,
+      nbformat_minor: 5,
+      metadata: { kernelspec: { name: "python", display_name: "Python" } },
+      cells: [
+        { cell_type: "code", source: ["x = 1\n"], metadata: {}, outputs: [], execution_count: null },
+      ],
+    })
+  );
+  zip.file("test_public.py", 'print("public test ok")\n');
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+const MANIFEST = JSON.stringify({
+  schemaVersion: 1,
+  gradingMode: "browser",
+  requiredFiles: [],
+  testSuites: [{ tier: "public", script: "test_public.py" }],
+  timeLimitSeconds: 10,
+  makefile: null,
+});
+
+// --- Seed via the real HTTP API ------------------------------------------
+//
+// Unlike notebook-page-check.mjs we stay signed in as the INSTRUCTOR: the
+// workbench is staff-only, and it is the authoring surface, so the instructor
+// session is the one under test. We also have to publish an assignment — the
+// workbench keys off the assignment's public ID, not the bare test setup.
+async function seed() {
+  const instr = await pwRequest.newContext({ baseURL });
+
+  let csrf = await csrfFrom(instr, "/register");
+  await expectOK(
+    "register instructor",
+    instr.post("/register", { form: { username: INSTRUCTOR.username, password: INSTRUCTOR.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]
+  );
+
+  csrf = await csrfFrom(instr, "/admin/courses/new");
+  const courseRes = await expectOK(
+    "create course",
+    instr.post("/admin/courses", { form: { code: COURSE.code, name: COURSE.name, _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]
+  );
+  const loc = courseRes.headers()["location"] || "";
+  const courseID = (loc.match(/\/admin\/courses\/([0-9a-fA-F-]{36})/) || [])[1];
+  if (!courseID) throw new Error(`could not parse courseID from redirect: "${loc}"`);
+  await expectOK(
+    "set enrollment auto",
+    instr.post(`/courses/${courseID}/enrollment-mode`, { form: { enrollmentMode: "auto", _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]
+  );
+
+  const zipBuf = await buildSetupZip();
+  csrf = await csrfFrom(instr, "/");
+  const setupRes = await expectOK(
+    "upload test setup",
+    instr.post("/api/v1/testsetups", {
+      multipart: {
+        manifest: MANIFEST,
+        courseID,
+        files: { name: "setup.zip", mimeType: "application/zip", buffer: zipBuf },
+      },
+      headers: { "x-csrf-token": csrf },
+    }),
+    [200, 201]
+  );
+  const setupID = JSON.parse(await setupRes.text()).testSetupID;
+  if (!setupID) throw new Error("no testSetupID in upload response");
+
+  // Publish the assignment; the redirect carries its public ID.
+  csrf = await csrfFrom(instr, "/instructor");
+  const pubRes = await expectOK(
+    "publish assignment",
+    instr.post("/instructor", {
+      form: { testSetupID: setupID, title: "Workbench E2E Lab", _csrf: csrf },
+      headers: { "x-csrf-token": csrf },
+      maxRedirects: 0,
+    }),
+    [302, 303]
+  );
+  const pubLoc = pubRes.headers()["location"] || "";
+  const assignmentID = (pubLoc.match(/\/instructor\/([^/]+)\/edit/) || [])[1];
+  if (!assignmentID) throw new Error(`could not parse assignmentID from redirect: "${pubLoc}"`);
+
+  const storageState = await instr.storageState();
+  await instr.dispose();
+  return { setupID, assignmentID, storageState };
+}
+
+/// Read `crossOriginIsolated` inside a specific frame, by URL substring.
+///
+/// A missing frame is itself a diagnosis, and the most likely one: when a
+/// document is refused under `require-corp` the navigation never commits, so
+/// the iframe is still sitting on about:blank rather than holding an error
+/// page. Verified by removing the panel's COEP match and watching this fire.
+async function isolationOf(page, urlPart, label) {
+  const frame = page.frames().find((f) => f.url().includes(urlPart));
+  if (!frame) {
+    const seen = page.frames().map((f) => f.url() || "(blank)").join("\n  ");
+    throw new Error(
+      `${label}: no frame ever committed "${urlPart}". The usual cause is that ` +
+      `the browser refused the document under COEP require-corp ` +
+      `(ERR_BLOCKED_BY_RESPONSE.CoepFrameResourceNeedsCoepHeader) because it ` +
+      `did not send require-corp itself — check COEPMiddleware.needsCOEP.\n` +
+      `Frames seen:\n  ${seen}`
+    );
+  }
+  return frame.evaluate(() => ({
+    isolated: globalThis.crossOriginIsolated === true,
+    sab: typeof SharedArrayBuffer === "function",
+    // A COEP-refused document is replaced by an error page, which has no body
+    // text from our template. Length is a cheap proxy for "real document".
+    bodyLen: (document.body && document.body.textContent || "").length,
+  }));
+}
+
+async function main() {
+  console.log(`Browser engine: ${browserName}`);
+  // WebKit deadlocks on the SharedArrayBuffer kernel transport, so it is served
+  // NON-isolated on purpose — at every level of the chain, consistently.
+  const expectIsolated = browserName !== "webkit";
+  console.log(`Expecting cross-origin isolation = ${expectIsolated}`);
+
+  let seeded;
+  try {
+    seeded = await seed();
+  } catch (e) {
+    return fail(`seeding failed: ${(e && e.message) || e}`);
+  }
+
+  const workbenchURL = `${baseURL}/instructor/${seeded.assignmentID}/workbench`;
+  console.log(`Seeded assignment ${seeded.assignmentID}; opening ${workbenchURL}`);
+
+  const launchOptions =
+    browserName === "chromium"
+      ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
+      : { headless: true };
+  // Escape hatch for running this locally against a pre-installed browser whose
+  // build number does not match the pinned Playwright's expectation. CI installs
+  // the matching build and leaves this unset.
+  if (process.env.SMOKE_BROWSER_PATH) {
+    launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+  }
+  const browser = await browserType.launch(launchOptions);
+  const context = await browser.newContext({ storageState: seeded.storageState });
+  const page = await context.newPage();
+
+  const consoleErrors = [];
+  page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text()); });
+
+  try {
+    const res = await page.goto(workbenchURL, { waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
+    if (!res || !res.ok()) {
+      return fail(`workbench page did not load (status ${res && res.status()})`);
+    }
+
+    // 1. The shell itself.
+    const shellIsolated = await page.evaluate(() => globalThis.crossOriginIsolated === true);
+    console.log(`shell crossOriginIsolated = ${shellIsolated}`);
+    if (shellIsolated !== expectIsolated) {
+      return fail(
+        `workbench shell isolation is ${shellIsolated}, expected ${expectIsolated}. ` +
+        `COEPMiddleware.needsCOEP is not matching /instructor/:id/workbench.`
+      );
+    }
+
+    // Give both panes a chance to commit their navigations.
+    await page.waitForFunction(
+      () => {
+        const l = document.getElementById("wb-edit-frame");
+        const n = document.getElementById("wb-notebook-assignment");
+        return l && n && l.contentWindow && n.contentWindow;
+      },
+      { timeout: FRAME_SETTLE_MS }
+    );
+    await page.waitForTimeout(2000);
+
+    // 2. The left pane must be a REAL edit page. If COEP refused it, the frame
+    //    exists but holds a browser error document.
+    const left = await isolationOf(page, "/workbench/panel", "left pane");
+    console.log(`left pane: isolated=${left.isolated} bodyLen=${left.bodyLen}`);
+    if (left.bodyLen < 100) {
+      return fail(
+        "the left pane is empty — the edit page was almost certainly refused by COEP " +
+        "(ERR_BLOCKED_BY_RESPONSE.CoepFrameResourceNeedsCoepHeader). " +
+        "/instructor/:id/workbench/panel needs the same isolation headers as the shell."
+      );
+    }
+    const leftHasEditor = await page
+      .frames()
+      .find((f) => f.url().includes("/workbench/panel"))
+      .evaluate(() => !!document.getElementById("suite-sections"));
+    if (!leftHasEditor) {
+      return fail("the left pane loaded but is not the assignment editor (no #suite-sections)");
+    }
+
+    // 3. The nested notebook page — the reason this check exists.
+    const nb = await isolationOf(page, "/notebook", "notebook pane");
+    console.log(`notebook pane: isolated=${nb.isolated} SharedArrayBuffer=${nb.sab}`);
+    if (nb.isolated !== expectIsolated) {
+      return fail(
+        `NESTED notebook pane isolation is ${nb.isolated}, expected ${expectIsolated}. ` +
+        `This is the silent failure: the kernel still boots, but on the ` +
+        `service-worker comlink transport instead of SharedArrayBuffer.`
+      );
+    }
+    if (expectIsolated && !nb.sab) {
+      return fail("nested notebook pane is isolated but has no SharedArrayBuffer");
+    }
+
+    // 4. Lazy mount: the assignment notebook is mounted, the solution is not.
+    const mounts = await page.evaluate(() => {
+      const a = document.getElementById("wb-notebook-assignment");
+      const s = document.getElementById("wb-notebook-solution");
+      return {
+        assignment: a ? a.getAttribute("src") : null,
+        solutionPresent: !!s,
+        solution: s ? s.getAttribute("src") : null,
+      };
+    });
+    console.log(`mounts: assignment=${mounts.assignment} solution=${mounts.solution}`);
+    if (!mounts.assignment || !mounts.assignment.includes("file=assignment")) {
+      return fail(`assignment notebook pane is not mounted (src=${mounts.assignment})`);
+    }
+    if (mounts.solutionPresent && mounts.solution !== "about:blank") {
+      return fail(
+        `solution pane mounted eagerly (src=${mounts.solution}); it must stay at ` +
+        `about:blank until its tab is selected, so a second Pyodide is only paid ` +
+        `for by an author who asks for it.`
+      );
+    }
+
+    console.log("E2E OK — workbench isolation chain intact, panes wired as designed.");
+    process.exit(0);
+  } catch (e) {
+    return fail(`workbench check threw: ${(e && e.message) || e}`, consoleErrors.join("\n"));
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+}
+
+main().catch((e) => fail(`unexpected: ${(e && e.stack) || e}`));

--- a/changelog.d/workbench-isolation-smoke.md
+++ b/changelog.d/workbench-isolation-smoke.md
@@ -1,0 +1,19 @@
+### Added
+
+- **The workbench's cross-origin-isolation chain is now checked in a real
+  browser.** `Tools/editor-smoke-test/workbench-check.mjs` seeds an assignment
+  through the real HTTP API, opens the workbench as its instructor, and asserts
+  the shell, the left pane, and the *nested* notebook iframe are each isolated
+  (inverted for WebKit, which runs the comlink path deliberately), that the
+  nested frame really has `SharedArrayBuffer`, and that the solution pane stays
+  unmounted until asked for. Runs in the editor-smoke matrix on both engines.
+
+  Unit tests can only pin the response headers. Whether the isolation those
+  headers are meant to produce actually survives two levels of framing is a
+  browser question, and getting it wrong is silent — the kernel still boots,
+  just on the slower service-worker transport, with no error reported anywhere.
+  The check was verified by removing each half of the isolation rule in turn and
+  confirming it fails with the matching diagnostic.
+
+  The editor-smoke path filter now also covers the workbench route, template and
+  scripts, so a change to any of them runs the smoke rather than skipping it.

--- a/changelog.d/workbench-pane-wiring.md
+++ b/changelog.d/workbench-pane-wiring.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- **Editing inputs in the workbench now warns that the notebook is stale.** The
+  assignment workbench's shell already knew how to raise a "reload the notebook"
+  chip when global inputs or section variables changed, but nothing sent the
+  message — so saving an input silently left the notebook pane rendering a
+  substitution of the old values, which is the confusion the chip exists to
+  prevent. The two inputs editors now announce their saves. The notice is
+  deliberately advisory rather than an automatic reload: reloading that pane
+  restarts the Python kernel and discards the author's live state, so the author
+  chooses when to pay for it.
+
+### Added
+
+- **Collapse the workbench's editor pane.** A "Hide editor" toggle in the
+  workbench toolbar (and `Enter`/`Space` on the splitter) gives the notebook the
+  full window and restores the pane to its previous width. Previously the only
+  way to widen the notebook was to drag the splitter to its stop, which matters
+  most on a 1280–1440px laptop where the split leaves the notebook near its
+  minimum.
+
+### Changed
+
+- **`ChickadeeUI.notifyWorkbench`** replaces the private copy in `notebook.js`
+  as the one place a page tells the workbench shell that something the other
+  pane depends on has changed. Three pages send these notes and each is also
+  reachable as a standalone page, so the guards — silent when there is no shell
+  above, and an explicit target origin rather than a wildcard — are now written
+  and tested once instead of per caller.


### PR DESCRIPTION
Follow-up to #1260. Finishes the two pieces of the workbench shell that were designed but not built, and closes the one verification gap I flagged on #1260 as needing a human.

## 1. The `inputs-changed` message had a receiver and no sender

`workbench.js` handled it and raised the "reload the notebook" chip, but neither inputs editor ever posted it — so the chip was unreachable. Saving a global input or a section variable silently left the notebook pane rendering a substitution of the *old* values, which is precisely the confusion the chip exists to prevent. Both editors now announce their saves.

The notice stays **advisory** rather than reloading the notebook pane: that reload restarts the Python kernel and drops whatever the author has in flight, so the author decides when to pay for it.

`notifyWorkbench` moves out of `notebook.js` into `ChickadeeUI` rather than becoming a third copy of the same guard. Three pages send these notes and every one is also reachable standalone, so the two properties that matter are stated and tested once: silent when there is no shell above it, and an explicit target origin — never `'*'`, which would hand notes about what an instructor is editing to any document that managed to frame the page.

## 2. Pane collapse

A "Hide editor" toggle in the toolbar, plus `Enter`/`Space` on the splitter, give the notebook the full window and restore the pane to its previous width. Previously the only way to widen the notebook was dragging the splitter to its stop — which matters most on a 1280–1440px laptop where the split already leaves the notebook near its minimum.

The toggle is a pure state transition specifically so the stranding case is covered by test: collapsing twice would otherwise capture the already-collapsed width of `0` as the restore width, leaving no way back to the editor short of dragging the splitter off the edge.

## 3. The isolation chain, checked in a real browser

On #1260 I said confirming `crossOriginIsolated` inside the nested iframe needed a human with DevTools. It didn't — the editor-smoke harness already drives real browsers against a real server, so this is now automated.

`Tools/editor-smoke-test/workbench-check.mjs` seeds an assignment through the real HTTP API, opens the workbench as its instructor, and asserts:

1. the shell is cross-origin isolated;
2. the left pane loaded a real edit page — i.e. was not COEP-refused;
3. the **nested** notebook iframe is isolated **and has `SharedArrayBuffer`** — the property the whole chain exists to preserve;
4. the solution pane is still at `about:blank` — the lazy-mount contract that keeps a second Pyodide off the page until an author asks for it.

WebKit is asserted non-isolated at every level, since it runs the comlink path deliberately.

This matters because the failure is **silent**: if the chain breaks the kernel still boots, just on the service-worker transport, with nothing logged. `COEPMiddlewareTests` can only pin the headers; whether the isolation survives two levels of framing is a browser question.

**Verified by falsification, not by assuming it works.** Removing the shell's isolation rule fails it on the shell assertion; removing only the panel's fails it on the left pane — each with the matching diagnostic. Actual local run against a real server:

```
shell crossOriginIsolated = true
left pane: isolated=true bodyLen=31733
notebook pane: isolated=true SharedArrayBuffer=true
mounts: assignment=/testsetups/setup_.../notebook?file=assignment&embedded=1 solution=null
E2E OK — workbench isolation chain intact, panes wired as designed.
```

The left-pane failure turned out to manifest as a frame that *never commits* rather than one holding an error document, so the diagnostic names that cause explicitly.

The editor-smoke path filter now also covers the workbench route, template and scripts — it already covered `COEPMiddleware` and the harness, but a change to `InstructorWorkbenchRoutes` or `workbench.leaf` would have skipped the smoke, and under-matching is the dangerous direction.

## Testing

- `notify-workbench.test.mjs` (new, 4) — posts when framed; explicit origin, never `'*'`; no-op standalone; a parent that throws mid-save does not propagate into the caller's success path.
- `workbench.test.mjs` (+3) — collapse remembers the width, double-collapse does not lose it, the toggle round-trips.
- `workbench-check.mjs` (new) — the browser e2e above, wired into the editor-smoke matrix on both engines with the same webkit retry the notebook-page e2e uses.
- 150/150 JS tests under CI's exact invocation; `check-styles.sh` and `eslint.sh` clean.

One test needed a fix worth noting: `deepStrictEqual` rejects the payload because it is constructed inside the `vm` realm and so does not carry this realm's `Object.prototype`. Asserted field-by-field instead.

**Still draft** until CI confirms the new smoke step passes on **WebKit** — there is no WebKit build in my environment, so that engine's path is the one thing here I have reasoned about but not run. Chromium is verified locally end-to-end.