### PR TITLE
Workbench: cover activity forwarding and tab-switch mounting in the browser check

### DIFF
--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -179,6 +179,20 @@ async function seed() {
   const assignmentID = (pubLoc.match(/\/instructor\/([^/]+)\/edit/) || [])[1];
   if (!assignmentID) throw new Error(`could not parse assignmentID from redirect: "${pubLoc}"`);
 
+  // Give the assignment a reference solution, so the workbench actually renders
+  // the Solution tab and the switching assertions are live rather than skipped.
+  // This is the same button the edit page's Files table offers.
+  csrf = await csrfFrom(instr, `/instructor/${assignmentID}/edit`);
+  await expectOK(
+    "create solution",
+    instr.post(`/instructor/${assignmentID}/create-solution`, {
+      form: { _csrf: csrf },
+      headers: { "x-csrf-token": csrf },
+      maxRedirects: 0,
+    }),
+    [302, 303]
+  );
+
   const storageState = await instr.storageState();
   await instr.dispose();
   return { setupID, assignmentID, storageState };
@@ -325,6 +339,75 @@ async function main() {
         `about:blank until its tab is selected, so a second Pyodide is only paid ` +
         `for by an author who asks for it.`
       );
+    }
+
+    // 5. Activity forwarding — the guard against being signed out mid-edit.
+    //
+    // `idle-logout.js` measures interaction with its OWN document, and it lives
+    // on the shell; every keystroke an author makes lands in a pane. Without the
+    // forwarder the shell sits apparently idle and signs the author out ~30
+    // minutes into a session. That is a bug you cannot notice in a smoke test
+    // that only checks the first minute, so assert the mechanism directly:
+    // a keystroke in a pane must raise `chickadee:activity` on the shell.
+    const sawActivity = await page.evaluate(async () => {
+      let seen = false;
+      const onActivity = () => { seen = true; };
+      window.addEventListener("chickadee:activity", onActivity);
+      const frame = document.getElementById("wb-edit-frame");
+      frame.contentWindow.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+      await new Promise((r) => setTimeout(r, 500));
+      window.removeEventListener("chickadee:activity", onActivity);
+      return seen;
+    });
+    console.log(`pane keystroke reached the shell as chickadee:activity = ${sawActivity}`);
+    if (!sawActivity) {
+      return fail(
+        "a keystroke in a pane did not reach the shell. embedded-activity.js is not " +
+        "forwarding, or workbench.js is not re-raising it — which means idle-logout.js " +
+        "on the shell will sign an author out while they are actively typing."
+      );
+    }
+
+    // 6. Lazy mount, then keep. Selecting the solution tab must mount it AND
+    //    leave the assignment mounted, so switching back is a CSS toggle rather
+    //    than a second cold kernel boot. This is the contract behind the
+    //    kernel-count decision; without it the feature's whole point is lost.
+    if (mounts.solutionPresent) {
+      await page.click("#wb-tab-solution");
+      await page.waitForTimeout(1500);
+      const afterSwitch = await page.evaluate(() => {
+        const a = document.getElementById("wb-notebook-assignment");
+        const s = document.getElementById("wb-notebook-solution");
+        return {
+          assignment: a.getAttribute("src"),
+          solution: s.getAttribute("src"),
+          assignmentHidden: a.hidden,
+          solutionHidden: s.hidden,
+        };
+      });
+      console.log(`after switch: solution=${afterSwitch.solution} assignmentStillMounted=${afterSwitch.assignment !== "about:blank"}`);
+      if (!afterSwitch.solution || !afterSwitch.solution.includes("file=solution")) {
+        return fail(`selecting the Solution tab did not mount it (src=${afterSwitch.solution})`);
+      }
+      if (afterSwitch.solutionHidden || !afterSwitch.assignmentHidden) {
+        return fail("tab switch did not swap which pane is visible");
+      }
+      // On a CI runner deviceMemory is usually unreported, so the keep-mounted
+      // branch is the one under test. Skip the assertion if the shell chose the
+      // low-memory path — that is a legitimate outcome, not a failure.
+      const twoKernels = await page.evaluate(
+        () => !window.ChickadeeWorkbench || window.ChickadeeWorkbench.allowsTwoKernels(navigator)
+      );
+      if (twoKernels && afterSwitch.assignment === "about:blank") {
+        return fail(
+          "switching tabs unmounted the assignment notebook on a device that can hold " +
+          "two kernels — switching back will pay a full cold boot, which is the cost " +
+          "this feature exists to remove."
+        );
+      }
+      if (!twoKernels) {
+        console.log("(low-memory device: unmount-on-switch is the expected branch)");
+      }
     }
 
     console.log("E2E OK — workbench isolation chain intact, panes wired as designed.");

--- a/changelog.d/workbench-interaction-smoke.md
+++ b/changelog.d/workbench-interaction-smoke.md
@@ -1,0 +1,23 @@
+### Added
+
+- **The workbench smoke check now covers the two interactive behaviours that had
+  no browser coverage.** It asserts that a keystroke inside a pane reaches the
+  shell as `chickadee:activity` — the chain that stops the idle watchdog from
+  signing an author out while they are actively typing, a bug that otherwise
+  only shows up half an hour into a session — and that selecting the Solution
+  tab mounts it while leaving the assignment notebook mounted, so switching back
+  is a pane toggle rather than a second cold kernel boot. The seeded assignment
+  now gets a reference solution so the Solution tab actually renders; without it
+  those assertions were unreachable.
+
+  Both were verified by falsification: disabling the activity forwarder and
+  forcing unmount-on-switch each fail the check with the matching diagnostic.
+
+### Changed
+
+- **`docs/ci-flakiness.md` records the first chromium sighting of the grading
+  hang.** Family 2 is documented as webkit-only, and the note that "chromium
+  passes 12/12" is what makes a chromium hang look like a genuine regression.
+  One was observed (and did not reproduce on rerun), so the doc now says it is
+  rarer on chromium rather than absent. The gate policy is deliberately
+  unchanged — chromium stays at hard zero so a recurrence is loud.

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -120,6 +120,23 @@ Webkit: `hangs<=1/12` tolerated on `pull_request` runs with a loud
 zero, so the probe remains the regression guard a real fix must turn green
 and the ambient rate stays measured rather than silently absorbed.
 
+**First chromium sighting (2026-08-04, PR #1261, run 30867456697).**
+`grading-probe (chromium)` reported `hangs=1/12` while
+`grading-probe (webkit)` passed in the same run — the inverse of the
+pattern above, and the first time chromium has shown this. It did not
+reproduce: a rerun of the same commit passed 12/12 on both engines. The
+PR's diff could not reach the grading path (its only notebook.js change
+sits inside `if (saveAssignmentBtn)`, a staff-only button the probe's
+student session never renders), so this reads as the same ambient rate
+rather than a regression.
+
+Recorded because the sentence above — chromium passes 12/12 — is what
+makes a chromium hang look like a real regression to the next person who
+hits one. It is rarer than webkit's, not impossible. The gate policy is
+deliberately unchanged: chromium stays at hard zero, so a second sighting
+is loud rather than absorbed. If it recurs, that is the signal to treat
+chromium as in-family and go after the shared root cause.
+
 **Root cause** remains the exec-hang investigation's to close — continue
 from the probe's `grading breadcrumbs:` per-phase timings on a hung
 iteration.


### PR DESCRIPTION
Follow-up to #1260 / #1261. Closes the last two gaps in browser coverage for the workbench, and corrects a claim in the flake docs.

## Two behaviours that had no browser coverage

Both fail in ways a first-minute smoke test would not notice, which is exactly why they needed asserting.

**Activity forwarding** is the guard against being signed out mid-edit. `idle-logout.js` measures interaction with its *own* document and lives on the shell, while every keystroke an author makes lands in a pane. Without the forwarder the shell sits apparently idle and expires the session roughly thirty minutes in. The check now dispatches a keystroke into a pane and asserts the shell raises `chickadee:activity`.

**Tab-switch mounting** is the contract behind the kernel-count decision I flagged as a judgment call on #1260: the solution pane mounts lazily, then stays mounted, so switching back is a pane toggle rather than a second cold boot. The check asserts both frames hold a real `src` after a switch — and skips that assertion on a device reporting low memory, where unmount-on-switch is the correct branch.

## The seeding bug this surfaced

The seeded assignment had no reference solution, so the workbench omitted the Solution tab entirely and the switching assertions were **unreachable** — they would have passed while testing nothing. Seeding now calls `POST /instructor/:id/create-solution`, the same button the edit page's Files table offers.

## Verified by falsification, not by a green run

- Disabling the activity forwarder → fails on the keystroke assertion.
- Forcing unmount-on-switch → fails on the mounting assertion.

Each with the diagnostic that names the consequence, not just the mismatch. Restored and re-verified green afterwards:

```
shell crossOriginIsolated = true
left pane: isolated=true bodyLen=31646
notebook pane: isolated=true SharedArrayBuffer=true
mounts: assignment=...file=assignment&embedded=1 solution=about:blank
pane keystroke reached the shell as chickadee:activity = true
after switch: solution=...file=solution&embedded=1 assignmentStillMounted=true
E2E OK
```

## Flake-doc correction

`docs/ci-flakiness.md` documents the grading hang as WebKit-only and states Chromium passes 12/12. On #1261, `grading-probe (chromium)` reported `hangs=1/12` while `grading-probe (webkit)` passed — the inverse of the documented pattern. It did not reproduce on rerun, and that PR's diff could not reach the grading path, so it reads as the same ambient rate.

Recorded because that "chromium passes 12/12" sentence is precisely what makes a Chromium hang look like a real regression to whoever hits the next one — it cost me a diagnosis cycle. The gate policy is **deliberately unchanged**: Chromium stays at hard zero, so a second sighting is loud rather than absorbed.

## Remaining manual-only items

For the record, what is still not automated after this: dark mode, splitter drag at the viewport extremes (the arithmetic is unit-tested, the DOM wiring is not), and the `inputs-changed` chip appearing after a left-pane save. None are silent-failure classes the way the isolation chain and idle logout were.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj)_