### PR TITLE
Workbench: template/rendered view switch, on a single notebook iframe

### DIFF
--- a/Public/workbench.js
+++ b/Public/workbench.js
@@ -5,9 +5,9 @@
 // strip that switches the right pane between the starter notebook and the
 // reference solution.
 //
-// The shell owns no assignment content — every pane is an iframe onto a page
+// The shell owns no assignment content — each pane is an iframe onto a page
 // that already existed.  What lives here is the composition: pane sizing, which
-// notebook is mounted, and the messages the panes send each other.
+// notebook is loaded, and the messages the panes send each other.
 //
 // Three things are load-bearing and easy to get wrong:
 //
@@ -17,10 +17,13 @@
 //     clamps the notebook pane at 720px and the edit pane at 380px, and below a
 //     viewport that can hold both the layout drops to one pane at a time.
 //
-//   * **Kernel count.** The solution iframe stays at about:blank until its tab
-//     is first selected, then stays mounted, so switching is instant after one
-//     boot.  On a device that reports low memory it is unmounted on switch
-//     instead — one kernel at a time, at the cost of a reboot per switch.
+//   * **One notebook document, always.** The tabs and the view switch change
+//     the single iframe's src; they are destinations, not panes. An iframe per
+//     (file, view) would mean a Pyodide kernel per combination — up to four —
+//     and bounding that needs an eviction policy, which is a lot of machinery
+//     for a secondary interaction. The workbench exists to put the edit page
+//     and *a* notebook on screen together, and that holds with one. The cost is
+//     honest and accepted: switching notebooks re-boots the kernel.
 //
 //   * **Idle logout.** The watchdog runs in this document, but every keystroke
 //     lands in a pane.  `embedded-activity.js` forwards activity up; this file
@@ -57,14 +60,24 @@
         return desiredPx;
     }
 
-    /// Whether this device should hold two Pyodide kernels at once.
-    /// `navigator.deviceMemory` is GB rounded to a power of two and is absent
-    /// on Firefox/Safari — absent means "no evidence of a problem", so we keep
-    /// both mounted, matching notebook-preflight.js's own conservative read.
-    function allowsTwoKernels(nav) {
-        var dm = (nav && typeof nav.deviceMemory === 'number') ? nav.deviceMemory : null;
-        if (dm === null) return true;
-        return dm > 4;
+    /// Resolve which notebook URL a (file, view) selection should load.
+    ///
+    /// Falls back to the rendered view when the requested reading does not
+    /// exist for that file — the server only publishes a `template` entry for a
+    /// notebook that actually carries placeholders, so switching to Solution
+    /// while viewing the Assignment's template lands exactly there. Returning
+    /// the fallback (rather than nothing) is what keeps a tab click from being
+    /// silently ignored.
+    ///
+    /// Pure, so the fallback is testable without a DOM.
+    function resolvePane(urls, file, view) {
+        var key = file + ':' + view;
+        if (urls[key]) return { key: key, file: file, view: view, url: urls[key] };
+        var fallback = file + ':personalized';
+        if (urls[fallback]) {
+            return { key: fallback, file: file, view: 'personalized', url: urls[fallback] };
+        }
+        return null;
     }
 
     /// Toggle the edit pane between collapsed and its last expanded width.
@@ -88,7 +101,7 @@
     // policy without a DOM.
     var api = {
         clampLeftWidth: clampLeftWidth,
-        allowsTwoKernels: allowsTwoKernels,
+        resolvePane: resolvePane,
         toggleCollapse: toggleCollapse
     };
     if (typeof window !== 'undefined') window.ChickadeeWorkbench = api;
@@ -107,12 +120,30 @@
     var storageKey = 'chickadee-workbench-split:' + assignmentID;
 
     var tabs = Array.prototype.slice.call(shell.querySelectorAll('.wb-tab'));
-    var panes = {};
-    tabs.forEach(function (tab) {
-        var name = tab.getAttribute('data-wb-pane');
-        panes[name] = document.getElementById(tab.getAttribute('aria-controls'));
-    });
-    var activePane = 'assignment';
+    var viewButtons = Array.prototype.slice.call(shell.querySelectorAll('.wb-view'));
+    var viewSwitch = document.getElementById('wb-viewswitch');
+
+    // The single notebook document, and the destinations its tabs can send it
+    // to. There is one iframe, so there is one kernel — switching notebooks
+    // costs a boot, and nothing here has to manage a pool.
+    var notebookFrame = document.getElementById('wb-notebook');
+    // Carried on a data-attribute rather than a <script> island: it is a small
+    // map the shell reads once, and the style guard ratchets inline script
+    // down, not up.
+    var paneURLs = {};
+    try {
+        paneURLs = JSON.parse(shell.getAttribute('data-wb-pane-urls') || '{}');
+    } catch (_) {
+        paneURLs = {};
+    }
+
+    var activeFile = 'assignment';
+    var activeView = 'personalized';
+
+    function hasTemplate(file) {
+        if (!viewSwitch) return false;
+        return viewSwitch.getAttribute('data-' + file + '-has-template') === '1';
+    }
 
     // ── Splitter ──────────────────────────────────────────────────────────
 
@@ -224,48 +255,45 @@
         restore();
     }
 
-    // ── Notebook tabs ─────────────────────────────────────────────────────
+    // ── Notebook selection: which file, and which reading of it ────────────
 
-    function mount(pane) {
-        var frame = panes[pane];
-        if (!frame) return;
-        var wanted = frame.getAttribute('data-wb-src');
-        if (wanted && frame.getAttribute('src') !== wanted) frame.setAttribute('src', wanted);
-    }
-
-    function unmount(pane) {
-        var frame = panes[pane];
-        if (frame) frame.setAttribute('src', 'about:blank');
-    }
-
-    function selectPane(name) {
-        if (!panes[name]) return;
-        var previous = activePane;
-        activePane = name;
+    function selectPane(file, view) {
+        var pane = resolvePane(paneURLs, file, view);
+        if (!pane || !notebookFrame) return;
+        activeFile = pane.file;
+        activeView = pane.view;
 
         tabs.forEach(function (tab) {
-            var isActive = tab.getAttribute('data-wb-pane') === name;
+            var isActive = tab.getAttribute('data-wb-file') === pane.file;
             tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
             // Roving tabindex: one stop for the whole strip.
             tab.setAttribute('tabindex', isActive ? '0' : '-1');
         });
-        Object.keys(panes).forEach(function (key) {
-            if (panes[key]) panes[key].hidden = (key !== name);
+        viewButtons.forEach(function (btn) {
+            btn.setAttribute(
+                'aria-pressed',
+                btn.getAttribute('data-wb-view') === pane.view ? 'true' : 'false');
         });
+        // The control only makes sense where the two readings differ.
+        if (viewSwitch) viewSwitch.hidden = !hasTemplate(pane.file);
 
-        mount(name);
-        // Reclaim the hidden pane's kernel only where memory is tight; the
-        // default is to keep it warm so the next switch costs nothing.
-        if (previous !== name && !allowsTwoKernels(navigator)) unmount(previous);
+        notebookFrame.setAttribute('data-wb-file', pane.file);
+        notebookFrame.setAttribute('data-wb-view', pane.view);
+        // Guarded: re-setting src to the value it already holds is a reload in
+        // some browsers, which would throw away a kernel that is already
+        // booting just because the author clicked the tab they are on.
+        if (notebookFrame.getAttribute('src') !== pane.url) {
+            notebookFrame.setAttribute('src', pane.url);
+        }
 
         // Whatever made the chip appear applied to the notebook the author was
-        // looking at; a fresh mount is current by construction.
+        // looking at; a fresh load is current by construction.
         if (staleChip) staleChip.hidden = true;
     }
 
     tabs.forEach(function (tab, index) {
         tab.addEventListener('click', function () {
-            selectPane(tab.getAttribute('data-wb-pane'));
+            selectPane(tab.getAttribute('data-wb-file'), activeView);
         });
         tab.addEventListener('keydown', function (e) {
             var delta = e.key === 'ArrowRight' ? 1 : (e.key === 'ArrowLeft' ? -1 : 0);
@@ -273,9 +301,20 @@
             e.preventDefault();
             var next = tabs[(index + delta + tabs.length) % tabs.length];
             next.focus();
-            selectPane(next.getAttribute('data-wb-pane'));
+            selectPane(next.getAttribute('data-wb-file'), activeView);
         });
     });
+
+    viewButtons.forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            selectPane(activeFile, btn.getAttribute('data-wb-view'));
+        });
+    });
+
+    // The template already loaded the assignment's rendered view, so only the
+    // view control needs syncing — show it when this notebook has a template
+    // worth switching to.
+    if (viewSwitch) viewSwitch.hidden = !hasTemplate(activeFile);
 
     // ── Single-pane fallback (narrow desktop windows) ──────────────────────
 

--- a/Public/workbench.js
+++ b/Public/workbench.js
@@ -60,6 +60,23 @@
         return desiredPx;
     }
 
+    /// The only URL shape this shell is ever allowed to point a notebook frame
+    /// at: a same-origin absolute path to the embedded notebook page.
+    ///
+    /// The destinations arrive as DOM text (a data-attribute the server
+    /// rendered), and the sink is an iframe `src` — a `javascript:` URL there
+    /// is script execution in this page's origin. Today the server builds that
+    /// map from its own `setup_…` identifiers so nothing hostile can reach it,
+    /// but nothing in *this* file enforced that, and the distance between "is
+    /// not attacker-controlled" and "cannot be" is the whole bug class.
+    /// Anchored at both ends, scheme-relative `//host` excluded by the second
+    /// character check.
+    var SAFE_PANE_URL = /^\/testsetups\/[A-Za-z0-9_.-]+\/notebook\?[A-Za-z0-9_=&%.-]*$/;
+
+    function safePaneURL(url) {
+        return (typeof url === 'string' && SAFE_PANE_URL.test(url)) ? url : null;
+    }
+
     /// Resolve which notebook URL a (file, view) selection should load.
     ///
     /// Falls back to the rendered view when the requested reading does not
@@ -70,12 +87,15 @@
     /// silently ignored.
     ///
     /// Pure, so the fallback is testable without a DOM.
+    /// A destination that does not match `SAFE_PANE_URL` is treated as absent,
+    /// not as a pane with a bad URL — so a malformed entry falls through to the
+    /// rendered view or to nothing, and never reaches an iframe.
     function resolvePane(urls, file, view) {
-        var key = file + ':' + view;
-        if (urls[key]) return { key: key, file: file, view: view, url: urls[key] };
-        var fallback = file + ':personalized';
-        if (urls[fallback]) {
-            return { key: fallback, file: file, view: 'personalized', url: urls[fallback] };
+        var exact = safePaneURL(urls[file + ':' + view]);
+        if (exact) return { key: file + ':' + view, file: file, view: view, url: exact };
+        var fallback = safePaneURL(urls[file + ':personalized']);
+        if (fallback) {
+            return { key: file + ':personalized', file: file, view: 'personalized', url: fallback };
         }
         return null;
     }
@@ -279,11 +299,18 @@
 
         notebookFrame.setAttribute('data-wb-file', pane.file);
         notebookFrame.setAttribute('data-wb-view', pane.view);
-        // Guarded: re-setting src to the value it already holds is a reload in
-        // some browsers, which would throw away a kernel that is already
-        // booting just because the author clicked the tab they are on.
-        if (notebookFrame.getAttribute('src') !== pane.url) {
-            notebookFrame.setAttribute('src', pane.url);
+        // Re-validated at the sink rather than trusting that resolvePane already
+        // did it: this is the line where a `javascript:` URL would become script
+        // execution in this origin, so the check belongs where the damage would
+        // happen, not one call up.
+        //
+        // Also guarded on inequality: re-setting src to the value it already
+        // holds is a reload in some browsers, which would throw away a kernel
+        // that is already booting just because the author clicked the tab they
+        // are already on.
+        var nextURL = safePaneURL(pane.url);
+        if (nextURL && notebookFrame.getAttribute('src') !== nextURL) {
+            notebookFrame.setAttribute('src', nextURL);
         }
 
         // Whatever made the chip appear applied to the notebook the author was

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -88,9 +88,15 @@ Notebook
             <span class="nb-closed-notice">This assignment is closed to students &mdash; editable as course staff.</span>
             #endif
             #if(viewToggleURL):
+            #if(!embedded):
+            <!-- Suppressed in a workbench pane: the workbench has its own
+                 template/values control, so this would be a second one for the
+                 same thing — and `viewToggleURL` carries no `embedded=1`, so
+                 following it would load the fully-chromed page into the pane. -->
             <a class="btn" href="#(viewToggleURL)">
                 #if(isTemplateView):View with values#else:Edit the template#endif
             </a>
+            #endif
             #endif
             #if(canSaveToAssignment):
             <button class="btn btn-primary" id="nb-save-assignment" data-file-kind="#(fileKind)"

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -105,10 +105,19 @@
     color: var(--gray-700);
 }
 
-/* Collapsed edit pane: the notebook takes the full width.  The splitter stays
-   put so the pane can be dragged back out, and the toolbar button is the
-   primary way back. */
-.wb-shell[data-wb-collapsed="edit"] .wb-pane-edit { display: none; }
+/* Collapsed edit pane: the notebook takes the full width.
+   The grid must be re-declared to a single column, not just have the edit pane
+   hidden.  `display: none` removes an item from the grid entirely, so with the
+   three-column template still in force the splitter would take column 1 and the
+   notebook column 2 — which is `auto`, i.e. sized to content, leaving the
+   notebook pane narrow enough that the embedded notebook page renders its
+   "Open on a larger screen" notice instead of the editor.  That is the exact
+   failure the 720px floor exists to prevent, arriving by a different route.
+   Hiding the splitter too means the toolbar toggle is the way back, which is
+   what the button is for. */
+.wb-shell[data-wb-collapsed="edit"] .wb-body { grid-template-columns: 1fr; }
+.wb-shell[data-wb-collapsed="edit"] .wb-pane-edit,
+.wb-shell[data-wb-collapsed="edit"] .wb-splitter { display: none; }
 
 /* Below the point where an honest split is possible (720px notebook floor +
    380px edit floor + the splitter), collapse to one pane at a time.  The

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -78,7 +78,22 @@
     padding: .3rem .5rem;
     border-bottom: 1px solid var(--border);
 }
-.wb-tab[aria-selected="true"] {
+.wb-tabstrip,
+.wb-viewswitch {
+    display: flex;
+    align-items: center;
+    gap: .25rem;
+}
+/* A visible seam between the two axes: which notebook (tabs) and which reading
+   of it (view switch) are independent choices, and reading them as one strip of
+   four buttons would misrepresent that. */
+.wb-viewswitch {
+    margin-left: .5rem;
+    padding-left: .5rem;
+    border-left: 1px solid var(--border);
+}
+.wb-tab[aria-selected="true"],
+.wb-view[aria-pressed="true"] {
     background: var(--health-teal);
     color: var(--surface);
 }
@@ -111,7 +126,8 @@
      id="wb-shell"
      data-assignment-id="#(assignmentID)"
      data-setup-id="#(testSetupID)"
-     data-wb-single="notebook">
+     data-wb-single="notebook"
+     data-wb-pane-urls="#(notebookPaneURLsJSON)">
     <div class="wb-bar">
         <h1 class="wb-title">#(assignmentTitle)</h1>
         <span class="wb-bar-spacer"></span>
@@ -138,38 +154,54 @@
                 aria-valuemax="100"
                 aria-valuenow="42"></button>
         <section class="wb-pane wb-pane-notebook" aria-label="Notebook editor">
-            <div class="wb-panehead" role="tablist" aria-label="Notebook">
-                <button class="btn action-btn wb-tab" type="button" role="tab"
-                        id="wb-tab-assignment" data-wb-pane="assignment"
-                        aria-selected="true" aria-controls="wb-notebook-assignment">Assignment</button>
-                #if(solutionNotebookURL):
-                <button class="btn action-btn wb-tab" type="button" role="tab"
-                        id="wb-tab-solution" data-wb-pane="solution" tabindex="-1"
-                        aria-selected="false" aria-controls="wb-notebook-solution">Solution</button>
-                #endif
+            <div class="wb-panehead">
+                <div class="wb-tabstrip" role="tablist" aria-label="Notebook">
+                    <button class="btn action-btn wb-tab" type="button" role="tab"
+                            id="wb-tab-assignment" data-wb-file="assignment"
+                            aria-selected="true">Assignment</button>
+                    #if(hasSolution):
+                    <button class="btn action-btn wb-tab" type="button" role="tab"
+                            id="wb-tab-solution" data-wb-file="solution" tabindex="-1"
+                            aria-selected="false">Solution</button>
+                    #endif
+                </div>
+                <!-- The view control is a second, independent axis: which reading
+                     of the selected notebook to show.  Rendered only when the
+                     active file actually has placeholders — otherwise the two
+                     readings are byte-identical and the control is noise.
+                     workbench.js hides it when the selected file has no template. -->
+                <div class="wb-viewswitch" id="wb-viewswitch" role="group"
+                     aria-label="Notebook view"
+                     data-assignment-has-template="#if(assignmentHasTemplateView):1#else:0#endif"
+                     data-solution-has-template="#if(solutionHasTemplateView):1#else:0#endif"
+                     hidden>
+                    <button class="btn action-btn wb-view" type="button"
+                            data-wb-view="personalized" aria-pressed="true"
+                            title="The notebook as a student sees it, with values substituted">With values</button>
+                    <button class="btn action-btn wb-view" type="button"
+                            data-wb-view="template" aria-pressed="false"
+                            title="The authored template, with placeholders left standing">Template</button>
+                </div>
                 <span class="wb-bar-spacer"></span>
                 <span class="wb-stale-chip" id="wb-stale-chip" role="status" hidden></span>
             </div>
-            <!-- Both notebook panes are real iframes, but only the assignment one
-                 carries a src at load.  The solution's stays about:blank until the
-                 tab is first selected, so the second Pyodide kernel is only paid
-                 for by an author who actually asks for it; after that both stay
-                 mounted and switching is a CSS toggle rather than a cold boot.
-                 workbench.js unmounts on switch instead when the device reports
-                 low memory. -->
+            <!-- ONE notebook iframe.  The tabs and the view switch change its
+                 src; they do not each get their own live document.
+                 Two files times two views is four combinations, and a live
+                 iframe per combination means a live Pyodide kernel per
+                 combination — so keeping them all mounted would need an
+                 eviction policy to bound memory, which is a lot of machinery
+                 for a secondary interaction.  The workbench's actual purpose is
+                 having the edit page and *a* notebook on screen together, and
+                 that holds however many notebooks are mounted.  So: one kernel,
+                 always, and switching notebooks costs a boot.
+                 The URL for each (file, view) is in the lookup table below. -->
             <iframe class="wb-pane-frame"
-                    id="wb-notebook-assignment"
-                    title="Assignment notebook"
-                    data-wb-src="#(assignmentNotebookURL)"
-                    src="#(assignmentNotebookURL)"></iframe>
-            #if(solutionNotebookURL):
-            <iframe class="wb-pane-frame"
-                    id="wb-notebook-solution"
-                    title="Solution notebook"
-                    data-wb-src="#(solutionNotebookURL)"
-                    src="about:blank"
-                    hidden></iframe>
-            #endif
+                    id="wb-notebook"
+                    title="Notebook"
+                    data-wb-file="assignment"
+                    data-wb-view="personalized"
+                    src="#(initialNotebookURL)"></iframe>
         </section>
     </div>
 </div>

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -83,7 +83,7 @@ struct NewAssignmentNotebookContext: Encodable {
 }
 
 /// The assignment workbench shell (`workbench.leaf`).  Deliberately thin: the
-/// shell renders no assignment content, only the frame around two iframes that
+/// shell renders no assignment content, only the frame around iframes that
 /// each load an existing page.  Everything here is either an identifier the
 /// page JS keys on or a URL for one of those iframes.
 struct AssignmentWorkbenchContext: Encodable {
@@ -93,12 +93,29 @@ struct AssignmentWorkbenchContext: Encodable {
     let assignmentTitle: String
     /// Left pane — the edit page in embedded mode.
     let editPanelURL: String
-    /// Right pane, "Assignment" tab.
-    let assignmentNotebookURL: String
-    /// Right pane, "Solution" tab.  `nil` when the assignment has no reference
-    /// solution yet, in which case the tab is absent rather than disabled —
-    /// matching how the edit page omits `solutionNotebookEditURL`.
-    let solutionNotebookURL: String?
+    /// The notebook the single right-hand iframe loads at page load: the
+    /// assignment, rendered.
+    let initialNotebookURL: String
+    /// `{"<file>:<view>": "<url>"}` for every combination that exists, as a
+    /// JSON object the page embeds and the tab handlers look up.  A lookup
+    /// table rather than one iframe per entry: there is only ever one notebook
+    /// document alive, so these are destinations, not panes.
+    ///
+    /// `view=` is always explicit in each URL — `resolveNotebookViewMode`
+    /// defaults staff to the template on a notebook that carries placeholders,
+    /// so omitting it would make "Assignment" mean the template on a
+    /// personalized lab and the rendering on every other one.
+    let notebookPaneURLsJSON: String
+    /// True when the assignment has a reference solution.  `false` omits the
+    /// Solution tab rather than disabling it — matching how the edit page
+    /// omits `solutionNotebookEditURL`.
+    let hasSolution: Bool
+    /// Per-file: whether the stored notebook still carries `{{name}}`, i.e.
+    /// whether its template and rendered views actually differ.  When they do
+    /// not, the two panes would be byte-identical and the view control is
+    /// noise, so it is not rendered.
+    let assignmentHasTemplateView: Bool
+    let solutionHasTemplateView: Bool
     /// Escape hatch back to the full-width single-page editor.
     let standaloneEditURL: String
     /// Drops `.main`'s reading-column cap and gutters — the workbench sizes

--- a/Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
@@ -71,6 +71,42 @@ struct InstructorWorkbenchRoutes: RouteCollection {
             || assignment.validationSubmissionID != nil
             || hasDraftSolution
 
+        // Whether each notebook still carries `{{name}}` — i.e. whether its
+        // template and its rendering are actually different documents. When
+        // they are not, offering a view switch would just be two tabs onto
+        // identical bytes, so the control is omitted per file.
+        let assignmentHasTemplate = hasPlaceholders(try? notebookData(for: setup))
+        // Not folded into an `&&`: the right-hand side of `&&` is a
+        // non-async autoclosure, so the await has to stand on its own.
+        var solutionHasTemplate = false
+        if hasSolution {
+            let solutionData = try? await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            solutionHasTemplate = hasPlaceholders(solutionData)
+        }
+
+        // Every (file, view) the tabs can reach.  A `template` entry exists only
+        // where the notebook actually carries placeholders — otherwise the two
+        // readings are byte-identical and switching between them is a kernel
+        // reboot for no change.
+        var urls: [String: String] = [
+            "assignment:personalized": notebookPaneURL(setupID: setupID, file: "assignment", view: "personalized")
+        ]
+        if assignmentHasTemplate {
+            urls["assignment:template"] = notebookPaneURL(
+                setupID: setupID, file: "assignment", view: "template")
+        }
+        if hasSolution {
+            urls["solution:personalized"] = notebookPaneURL(
+                setupID: setupID, file: "solution", view: "personalized")
+            if solutionHasTemplate {
+                urls["solution:template"] = notebookPaneURL(
+                    setupID: setupID, file: "solution", view: "template")
+            }
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let urlsJSON = String(data: (try? encoder.encode(urls)) ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+
         let title = assignment.title.trimmingCharacters(in: .whitespacesAndNewlines)
         let ctx = AssignmentWorkbenchContext(
             currentUser: req.currentUserContext,
@@ -78,14 +114,22 @@ struct InstructorWorkbenchRoutes: RouteCollection {
             testSetupID: setupID,
             assignmentTitle: title.isEmpty ? "Assignment" : title,
             editPanelURL: "/instructor/\(assignment.publicID)/workbench/panel",
-            assignmentNotebookURL: notebookPaneURL(setupID: setupID, file: "assignment"),
-            solutionNotebookURL: hasSolution
-                ? notebookPaneURL(setupID: setupID, file: "solution")
-                : nil,
+            initialNotebookURL: urls["assignment:personalized"] ?? "",
+            notebookPaneURLsJSON: urlsJSON,
+            hasSolution: hasSolution,
+            assignmentHasTemplateView: assignmentHasTemplate,
+            solutionHasTemplateView: solutionHasTemplate,
             standaloneEditURL: "/instructor/\(assignment.publicID)/edit"
         )
-        _ = setup  // loaded for the staff gate; the shell needs nothing from it
         return try await req.view.render("workbench", ctx)
+    }
+
+    /// True when the notebook still holds `{{name}}` placeholders.  Unreadable
+    /// bytes answer `false`: the view switch is an affordance, and a missing
+    /// notebook has bigger problems — the same reading `notebookPage` takes.
+    private func hasPlaceholders(_ data: Data?) -> Bool {
+        guard let data else { return false }
+        return !NotebookSubstitution.placeholderNames(in: data).isEmpty
     }
 
     // MARK: - GET /instructor/:assignmentID/workbench/panel
@@ -105,7 +149,14 @@ struct InstructorWorkbenchRoutes: RouteCollection {
     /// URL of one notebook pane.  `embedded=1` drops the site chrome; every
     /// access decision on that page (the staff-only solution guard, the closed
     /// gate, `canSaveToAssignment`) is made without reference to it.
-    private func notebookPaneURL(setupID: String, file: String) -> String {
-        "/testsetups/\(setupID)/notebook?file=\(file)&embedded=1"
+    ///
+    /// `view=` is always sent explicitly.  `resolveNotebookViewMode` defaults
+    /// staff to `.template` on a notebook that carries placeholders, so leaving
+    /// it off would silently make a pane's identity depend on the assignment's
+    /// content — the "Assignment" tab would show the template on a personalized
+    /// lab and the rendering on every other one.  It is still resolved
+    /// server-side, so a student who forges one gets their own rendering.
+    private func notebookPaneURL(setupID: String, file: String, view: String) -> String {
+        "/testsetups/\(setupID)/notebook?file=\(file)&view=\(view)&embedded=1"
     }
 }

--- a/Tests/APITests/InstructorWorkbenchRoutesTests.swift
+++ b/Tests/APITests/InstructorWorkbenchRoutesTests.swift
@@ -39,10 +39,20 @@ import VaporTesting
                     #expect(res.status == .ok)
                     let html = res.body.string
                     #expect(html.contains("/instructor/\(assignment.publicID)/workbench/panel"))
-                    #expect(html.contains("/testsetups/setup_wb1/notebook?file=assignment&amp;embedded=1"))
+                    // `view=` is always explicit: the server defaults staff to
+                    // the template on a notebook with placeholders, so an
+                    // omitted `view=` would make the Assignment tab mean
+                    // different things on different assignments.
+                    #expect(html.contains("file=assignment&amp;view=personalized&amp;embedded=1"))
                     // `validationStatus == "passed"` means a reference solution
                     // exists, so the solution tab is offered.
-                    #expect(html.contains("/testsetups/setup_wb1/notebook?file=solution&amp;embedded=1"))
+                    // The destination table rides a data-attribute, so Leaf
+                    // HTML-escapes it: quotes become &quot; and & becomes &amp;.
+                    #expect(html.contains("solution:personalized"))
+                    #expect(html.contains("file=solution&amp;view=personalized&amp;embedded=1"))
+                    // One notebook document, not one per destination: the tabs
+                    // repoint a single iframe, so exactly one is rendered.
+                    #expect(html.contains("id=\"wb-notebook\""))
                     #expect(html.contains("Workbench Lab"))
                 })
         }

--- a/Tests/BrowserRunnerJSTests/workbench.test.mjs
+++ b/Tests/BrowserRunnerJSTests/workbench.test.mjs
@@ -1,5 +1,5 @@
-// Unit tests for the assignment workbench shell's pane arithmetic and
-// kernel-count policy.
+// Unit tests for the assignment workbench shell's pure logic: the splitter
+// clamp, which notebook a tab click resolves to, and the collapse toggle.
 //
 // The clamp is the load-bearing piece. The notebook page hides its own editor
 // below 640px and shows "open on a larger screen" instead — so a splitter that
@@ -68,19 +68,37 @@ test('clampLeftWidth: a viewport narrower than the notebook floor clamps to zero
   assert.equal(Workbench.clampLeftWidth(0, 100), 0);
 });
 
-test('allowsTwoKernels: an unknown deviceMemory is not treated as low', () => {
-  // Firefox and Safari do not expose deviceMemory. Absent evidence must not
-  // downgrade those authors to a kernel reboot on every tab switch.
-  assert.equal(Workbench.allowsTwoKernels({}), true);
-  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: undefined }), true);
-  assert.equal(Workbench.allowsTwoKernels(null), true);
+// The server publishes a `template` destination only for a notebook that
+// actually carries {{placeholders}}. These fixtures model an assignment that
+// has one and a solution that does not.
+const URLS = {
+  'assignment:personalized': '/n?file=assignment&view=personalized',
+  'assignment:template': '/n?file=assignment&view=template',
+  'solution:personalized': '/n?file=solution&view=personalized',
+};
+
+test('resolvePane: returns the exact destination when it exists', () => {
+  const p = Workbench.resolvePane(URLS, 'assignment', 'template');
+  assert.equal(p.key, 'assignment:template');
+  assert.equal(p.view, 'template');
+  assert.equal(p.url, URLS['assignment:template']);
 });
 
-test('allowsTwoKernels: low-memory devices hold one kernel at a time', () => {
-  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 2 }), false);
-  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 4 }), false);
-  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 8 }), true);
-  assert.equal(Workbench.allowsTwoKernels({ deviceMemory: 16 }), true);
+test('resolvePane: falls back to the rendered view rather than doing nothing', () => {
+  // Reachable by a normal click: view the assignment's template, then hit the
+  // Solution tab. The solution has no template, and silently ignoring the click
+  // would leave the author on the wrong notebook with the wrong tab lit.
+  const p = Workbench.resolvePane(URLS, 'solution', 'template');
+  assert.equal(p.view, 'personalized');
+  assert.equal(p.key, 'solution:personalized');
+});
+
+test('resolvePane: reports nothing for a file that has no destinations', () => {
+  // An assignment with no reference solution renders no Solution tab, so this
+  // is unreachable by clicking — but returning null rather than a broken URL is
+  // what keeps it that way if the markup and the table ever disagree.
+  assert.equal(Workbench.resolvePane(URLS, 'nosuchfile', 'personalized'), null);
+  assert.equal(Workbench.resolvePane({}, 'assignment', 'personalized'), null);
 });
 
 test('toggleCollapse: collapsing remembers the width to come back to', () => {

--- a/Tests/BrowserRunnerJSTests/workbench.test.mjs
+++ b/Tests/BrowserRunnerJSTests/workbench.test.mjs
@@ -71,10 +71,14 @@ test('clampLeftWidth: a viewport narrower than the notebook floor clamps to zero
 // The server publishes a `template` destination only for a notebook that
 // actually carries {{placeholders}}. These fixtures model an assignment that
 // has one and a solution that does not.
+// Real-shaped paths, not placeholders: resolvePane only accepts URLs matching
+// the embedded notebook-page shape, so a toy path here would be rejected and
+// the tests would be exercising the reject path by accident.
+const NB = '/testsetups/setup_abc123/notebook';
 const URLS = {
-  'assignment:personalized': '/n?file=assignment&view=personalized',
-  'assignment:template': '/n?file=assignment&view=template',
-  'solution:personalized': '/n?file=solution&view=personalized',
+  'assignment:personalized': NB + '?file=assignment&view=personalized&embedded=1',
+  'assignment:template': NB + '?file=assignment&view=template&embedded=1',
+  'solution:personalized': NB + '?file=solution&view=personalized&embedded=1',
 };
 
 test('resolvePane: returns the exact destination when it exists', () => {
@@ -91,6 +95,32 @@ test('resolvePane: falls back to the rendered view rather than doing nothing', (
   const p = Workbench.resolvePane(URLS, 'solution', 'template');
   assert.equal(p.view, 'personalized');
   assert.equal(p.key, 'solution:personalized');
+});
+
+test('resolvePane: refuses a destination that is not a notebook-page path', () => {
+  // The destination map arrives as DOM text and the sink is an iframe src, so a
+  // javascript: URL there would be script execution in this origin. The server
+  // never produces one — the point is that this file no longer depends on that.
+  const hostile = {
+    'assignment:personalized': 'javascript:alert(1)',
+    'assignment:template': '//evil.example/steal',
+    'solution:personalized': 'https://evil.example/steal',
+  };
+  assert.equal(Workbench.resolvePane(hostile, 'assignment', 'personalized'), null);
+  assert.equal(Workbench.resolvePane(hostile, 'assignment', 'template'), null);
+  assert.equal(Workbench.resolvePane(hostile, 'solution', 'personalized'), null);
+});
+
+test('resolvePane: a bad entry falls through rather than being served', () => {
+  // A malformed template entry must degrade to the rendered view, not hand the
+  // caller a pane whose URL will be rejected later and leave the frame blank.
+  const mixed = {
+    'assignment:personalized': '/testsetups/setup_1/notebook?file=assignment&view=personalized',
+    'assignment:template': 'javascript:alert(1)',
+  };
+  const p = Workbench.resolvePane(mixed, 'assignment', 'template');
+  assert.equal(p.view, 'personalized');
+  assert.equal(p.url, mixed['assignment:personalized']);
 });
 
 test('resolvePane: reports nothing for a file that has no destinations', () => {

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -27,9 +27,13 @@
 //   2. the LEFT pane loaded a real edit page — i.e. was not COEP-refused;
 //   3. the NESTED notebook iframe is cross-origin isolated and has
 //      SharedArrayBuffer — the property the whole chain exists to preserve;
-//   4. the notebook pane mounts the assignment notebook and leaves the solution
-//      pane unmounted until asked (the lazy-mount contract that keeps a second
-//      Pyodide off the page until an author actually wants it).
+//   4. there is exactly ONE notebook iframe — the tabs and the view switch
+//      repoint it rather than each owning a live document, so there is one
+//      Pyodide kernel however many notebooks the assignment has;
+//   5. a keystroke in a pane reaches the shell as `chickadee:activity`, the
+//      chain that stops the idle watchdog signing an author out mid-edit;
+//   6. the view switch appears on a notebook that carries placeholders and
+//      repoints to `view=template`, and the tabs repoint to the other file.
 //
 // WebKit is expected NON-isolated at every level — it needs the comlink path —
 // so there the assertion is inverted, exactly as in notebook-page-check.mjs.
@@ -100,6 +104,20 @@ async function buildSetupZip() {
       metadata: { kernelspec: { name: "python", display_name: "Python" } },
       cells: [
         { cell_type: "code", source: ["x = 1\n"], metadata: {}, outputs: [], execution_count: null },
+        // A personalization placeholder, deliberately: without one the server
+        // reports no template view, the switch is (correctly) not rendered, and
+        // the assertion below would be skipped — passing while testing nothing.
+        //
+        // It must be a CODE cell. `NotebookSubstitution.placeholderNames(in:)`
+        // scans `cell_type == "code"` only, so a `{{name}}` in markdown is
+        // invisible to the whole personalization pipeline.
+        {
+          cell_type: "code",
+          source: ["dataset_name = '{{dataset_name}}'\n"],
+          metadata: {},
+          outputs: [],
+          execution_count: null,
+        },
       ],
     })
   );
@@ -279,7 +297,7 @@ async function main() {
     await page.waitForFunction(
       () => {
         const l = document.getElementById("wb-edit-frame");
-        const n = document.getElementById("wb-notebook-assignment");
+        const n = document.getElementById("wb-notebook");
         return l && n && l.contentWindow && n.contentWindow;
       },
       { timeout: FRAME_SETTLE_MS }
@@ -319,26 +337,31 @@ async function main() {
       return fail("nested notebook pane is isolated but has no SharedArrayBuffer");
     }
 
-    // 4. Lazy mount: the assignment notebook is mounted, the solution is not.
+    // 4. Exactly one notebook document.
+    //
+    //    The tabs and the view switch repoint a single iframe. Asserting the
+    //    count — not just that the right one is loaded — is what keeps a future
+    //    change from quietly reintroducing an iframe per destination, which is
+    //    an iframe per Pyodide kernel.
     const mounts = await page.evaluate(() => {
-      const a = document.getElementById("wb-notebook-assignment");
-      const s = document.getElementById("wb-notebook-solution");
+      const frames = document.querySelectorAll("#wb-notebook, .wb-notebook-pane");
+      const f = document.getElementById("wb-notebook");
       return {
-        assignment: a ? a.getAttribute("src") : null,
-        solutionPresent: !!s,
-        solution: s ? s.getAttribute("src") : null,
+        count: frames.length,
+        src: f ? f.getAttribute("src") : null,
+        solutionPresent: !!document.getElementById("wb-tab-solution"),
       };
     });
-    console.log(`mounts: assignment=${mounts.assignment} solution=${mounts.solution}`);
-    if (!mounts.assignment || !mounts.assignment.includes("file=assignment")) {
-      return fail(`assignment notebook pane is not mounted (src=${mounts.assignment})`);
-    }
-    if (mounts.solutionPresent && mounts.solution !== "about:blank") {
+    console.log(`notebook frames=${mounts.count} src=${mounts.src}`);
+    if (mounts.count !== 1) {
       return fail(
-        `solution pane mounted eagerly (src=${mounts.solution}); it must stay at ` +
-        `about:blank until its tab is selected, so a second Pyodide is only paid ` +
-        `for by an author who asks for it.`
+        `expected exactly one notebook iframe, found ${mounts.count}. Each live ` +
+        `notebook document holds a Pyodide kernel, so one per destination is one ` +
+        `kernel per destination.`
       );
+    }
+    if (!mounts.src || !mounts.src.includes("file=assignment")) {
+      return fail(`the notebook iframe is not showing the assignment (src=${mounts.src})`);
     }
 
     // 5. Activity forwarding — the guard against being signed out mid-edit.
@@ -368,45 +391,60 @@ async function main() {
       );
     }
 
-    // 6. Lazy mount, then keep. Selecting the solution tab must mount it AND
-    //    leave the assignment mounted, so switching back is a CSS toggle rather
-    //    than a second cold kernel boot. This is the contract behind the
-    //    kernel-count decision; without it the feature's whole point is lost.
+    // 6a. The view switch, asserted while the ASSIGNMENT is selected.
+    //
+    //     Order matters and cost me a run: the seeded solution has no
+    //     placeholders, so checking this after selecting Solution finds the
+    //     control correctly hidden and proves nothing. The seeded assignment
+    //     carries `{{dataset_name}}` precisely so this path is live.
+    const viewSwitchVisible = await page.evaluate(() => {
+      const v = document.getElementById("wb-viewswitch");
+      return {
+        present: !!v,
+        visible: !!v && !v.hidden,
+        flag: v ? v.getAttribute("data-assignment-has-template") : null,
+      };
+    });
+    console.log(
+      `view switch: present=${viewSwitchVisible.present} visible=${viewSwitchVisible.visible} ` +
+      `assignmentHasTemplate=${viewSwitchVisible.flag}`);
+    if (!viewSwitchVisible.visible) {
+      return fail(
+        "the view switch is not showing on an assignment whose notebook carries " +
+        "{{dataset_name}}. Either the server did not detect the placeholder " +
+        "(assignmentHasTemplateView) or workbench.js is not un-hiding the control."
+      );
+    }
+    await page.click('#wb-viewswitch .wb-view[data-wb-view="template"]');
+    await page.waitForTimeout(1000);
+    const afterView = await page.evaluate(() => {
+      const f = document.getElementById("wb-notebook");
+      return { src: f.getAttribute("src"), view: f.getAttribute("data-wb-view") };
+    });
+    console.log(`after view switch: src=${afterView.src}`);
+    if (!afterView.src || !afterView.src.includes("view=template")) {
+      return fail(`the view switch did not repoint the notebook (src=${afterView.src})`);
+    }
+
+    // 6b. Tab and view switching drive the ONE notebook iframe.
+    //
+    //    There is a single notebook document, so what is asserted is that the
+    //    controls change where it points — not that a pool of frames is being
+    //    managed. Selecting Solution must repoint it at the solution; the view
+    //    switch must repoint it at the template of whatever file is selected.
     if (mounts.solutionPresent) {
       await page.click("#wb-tab-solution");
-      await page.waitForTimeout(1500);
-      const afterSwitch = await page.evaluate(() => {
-        const a = document.getElementById("wb-notebook-assignment");
-        const s = document.getElementById("wb-notebook-solution");
-        return {
-          assignment: a.getAttribute("src"),
-          solution: s.getAttribute("src"),
-          assignmentHidden: a.hidden,
-          solutionHidden: s.hidden,
-        };
+      await page.waitForTimeout(1000);
+      const afterTab = await page.evaluate(() => {
+        const f = document.getElementById("wb-notebook");
+        return { src: f.getAttribute("src"), file: f.getAttribute("data-wb-file") };
       });
-      console.log(`after switch: solution=${afterSwitch.solution} assignmentStillMounted=${afterSwitch.assignment !== "about:blank"}`);
-      if (!afterSwitch.solution || !afterSwitch.solution.includes("file=solution")) {
-        return fail(`selecting the Solution tab did not mount it (src=${afterSwitch.solution})`);
+      console.log(`after tab switch: src=${afterTab.src}`);
+      if (!afterTab.src || !afterTab.src.includes("file=solution")) {
+        return fail(`selecting the Solution tab did not repoint the notebook (src=${afterTab.src})`);
       }
-      if (afterSwitch.solutionHidden || !afterSwitch.assignmentHidden) {
-        return fail("tab switch did not swap which pane is visible");
-      }
-      // On a CI runner deviceMemory is usually unreported, so the keep-mounted
-      // branch is the one under test. Skip the assertion if the shell chose the
-      // low-memory path — that is a legitimate outcome, not a failure.
-      const twoKernels = await page.evaluate(
-        () => !window.ChickadeeWorkbench || window.ChickadeeWorkbench.allowsTwoKernels(navigator)
-      );
-      if (twoKernels && afterSwitch.assignment === "about:blank") {
-        return fail(
-          "switching tabs unmounted the assignment notebook on a device that can hold " +
-          "two kernels — switching back will pay a full cold boot, which is the cost " +
-          "this feature exists to remove."
-        );
-      }
-      if (!twoKernels) {
-        console.log("(low-memory device: unmount-on-switch is the expected branch)");
+      if (afterTab.file !== "solution") {
+        return fail(`notebook frame still reports file=${afterTab.file} after selecting Solution`);
       }
     }
 

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -448,6 +448,46 @@ async function main() {
       }
     }
 
+    // 7. Collapsing the editor must give the notebook the FULL width.
+    //
+    //    This is a regression guard for a real bug, found by screenshotting
+    //    rather than by any test: hiding the edit pane with `display: none`
+    //    removes it from the grid, so with a three-column template still in
+    //    force the notebook landed in the `auto` column and sized to content.
+    //    It ended up ~380px wide, and the embedded notebook page — which hides
+    //    its editor below 640px — rendered "Open on a larger screen" instead of
+    //    the notebook. Collapsing to see MORE notebook showed none of it.
+    //
+    //    Unit tests could not see this; `toggleCollapse` was correct, the CSS
+    //    was not. So the assertion is on the rendered geometry.
+    await page.click("#wb-collapse-edit");
+    await page.waitForTimeout(800);
+    const collapsed = await page.evaluate(() => {
+      const pane = document.querySelector(".wb-pane-notebook");
+      const edit = document.querySelector(".wb-pane-edit");
+      return {
+        notebookWidth: pane ? pane.getBoundingClientRect().width : 0,
+        editVisible: edit ? edit.getBoundingClientRect().width > 0 : false,
+        viewport: window.innerWidth,
+      };
+    });
+    console.log(
+      `collapsed: notebook=${Math.round(collapsed.notebookWidth)}px of ${collapsed.viewport}px ` +
+      `viewport, editVisible=${collapsed.editVisible}`);
+    if (collapsed.editVisible) {
+      return fail("collapsing the editor left it visible");
+    }
+    // Full width, allowing for scrollbars/rounding — not merely "wider than the
+    // 720px floor", because the point of collapsing is to get everything.
+    if (collapsed.notebookWidth < collapsed.viewport - 40) {
+      return fail(
+        `collapsing the editor left the notebook only ${Math.round(collapsed.notebookWidth)}px ` +
+        `of a ${collapsed.viewport}px viewport. The edit pane is hidden but the grid still ` +
+        `reserves its columns, so the notebook is being sized to content — below 640px it ` +
+        `will render "Open on a larger screen" instead of the editor.`
+      );
+    }
+
     console.log("E2E OK — workbench isolation chain intact, panes wired as designed.");
     process.exit(0);
   } catch (e) {

--- a/changelog.d/workbench-pane-url-guard.md
+++ b/changelog.d/workbench-pane-url-guard.md
@@ -1,0 +1,11 @@
+### Security
+
+- **The workbench validates a notebook destination before pointing a frame at
+  it.** The tab destinations reach the page as DOM text and the sink is an
+  iframe `src`, where a `javascript:` URL would be script execution in
+  Chickadee's own origin. The server builds that map from its own test-setup
+  identifiers, so nothing hostile could reach it — but the page did not enforce
+  that, and the gap between "is not attacker-controlled" and "cannot be" is the
+  whole bug class. Destinations are now accepted only if they match the
+  same-origin notebook-page path shape, checked both where a click is resolved
+  and again at the assignment itself. Flagged by CodeQL.

--- a/changelog.d/workbench-template-view.md
+++ b/changelog.d/workbench-template-view.md
@@ -1,0 +1,26 @@
+### Added
+
+- **The workbench can switch between a notebook's template and its rendering.**
+  On an assignment whose notebook carries `{{placeholders}}`, the notebook pane
+  gains a Template / With values control beside the Assignment / Solution tabs,
+  so an author can compare what they wrote against what a student sees without
+  leaving the page. The control is rendered per file and only where the two
+  readings actually differ — on a notebook without placeholders they are
+  byte-identical, and switching would be a kernel reboot for no change.
+
+  Pane URLs now always carry an explicit `view=`. The server defaults staff to
+  the template on a personalized notebook, so omitting it made the "Assignment"
+  tab mean the template on one assignment and the rendering on another.
+
+### Changed
+
+- **The workbench holds one notebook document, not one per destination.** The
+  tabs and the view switch repoint a single iframe. Previously each notebook got
+  its own live iframe so switching was instant; with the view axis that would
+  have been up to four simultaneous Pyodide kernels and an eviction policy to
+  bound them — a lot of machinery for a secondary interaction. The workbench
+  exists to put the edit page and *a* notebook on screen together, which holds
+  with one. The accepted cost: switching notebooks re-boots the kernel.
+
+  The browser check now asserts the iframe count directly, so reintroducing a
+  frame per destination fails rather than passing quietly.

--- a/changelog.d/workbench-ui-pass.md
+++ b/changelog.d/workbench-ui-pass.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **Collapsing the workbench editor now actually gives the notebook the window.**
+  Hiding the edit pane removed it from the grid without re-declaring the
+  columns, so the notebook landed in the content-sized column and shrank to
+  roughly 300px — narrow enough that the embedded notebook page rendered its
+  "Open on a larger screen" notice. Collapsing the editor to see more of the
+  notebook showed none of it. Found by screenshotting the real page; the
+  collapse unit tests were correct and could not see it, so the browser check
+  now asserts the rendered width.
+
+- **The workbench no longer shows two template/values controls.** The embedded
+  notebook page rendered its own view-toggle link beside the workbench's, and
+  that link carries no `embedded=1` — following it would have loaded the fully
+  chromed page inside the pane. The page's own toggle is suppressed when it is
+  a workbench pane; the workbench's control is the one that works there.


### PR DESCRIPTION
Adds the second axis to the workbench's notebook pane — which *reading* of the selected notebook to show — and simplifies the pane model while doing it.

## The feature

On an assignment whose notebook carries `{{placeholders}}`, a **Template / With values** control sits beside the Assignment / Solution tabs. An author can compare what they wrote against what a student sees without leaving the page.

The control is per file and appears **only where the two readings actually differ**. On a notebook without placeholders they are byte-identical, so switching would be a kernel reboot for no change; the server reports this per file using the same placeholder scan the notebook page already uses.

Pane URLs now always carry an explicit `view=`. `resolveNotebookViewMode` defaults staff to the template on a notebook with placeholders, so leaving it off made the "Assignment" tab mean the template on a personalized lab and the rendering on every other one — the tab's meaning depended on the content behind it.

## The simplification (the more important half)

Each notebook used to get its own live iframe so switching was instant. Two files × two views is four combinations, and a live iframe is a live Pyodide kernel — so my first pass kept that model and added an LRU with a mount cap and eviction tests to bound memory.

Reaching for a cache to manage complexity the change had just introduced was the signal the design was wrong. The workbench exists to put the edit page and *a* notebook on screen together, and that holds with one document however many notebooks the assignment has.

**Now: one iframe.** The tabs and the view switch repoint it. One kernel, always. The accepted cost is that switching notebooks re-boots the kernel (~10–30s), where previously a second visit was instant.

Deleted: the mount cap, the eviction policy, the `deviceMemory` low-memory branch, and their tests. What remains is `resolvePane` — where a click lands — including the fallback to the rendered view when the target file has no template, which is reached by viewing a template and then switching files.

## Testing

Verified against a real server in Chromium; every path below is live, not skipped:

```
notebook frames=1 src=...file=assignment&view=personalized&embedded=1
pane keystroke reached the shell as chickadee:activity = true
view switch: present=true visible=true assignmentHasTemplate=1
after view switch: src=...file=assignment&view=template&embedded=1
after tab switch:  src=...file=solution&view=personalized&embedded=1
E2E OK
```

That last line is the `resolvePane` fallback working live: switching from the assignment's *template* to Solution, which has no template, correctly lands on `view=personalized`.

The check now asserts the **iframe count** directly, so reintroducing a frame per destination fails rather than passing quietly.

## Two fixture bugs worth naming

The smoke fixture needed a placeholder, and my first attempt put it in a **markdown** cell. `NotebookSubstitution.placeholderNames(in:)` scans `cell_type == "code"` only, so the server correctly reported no template view, the control was correctly hidden, and the new assertion was **skipped** — passing while testing nothing. Moved to a code cell.

That is the same trap as the Solution tab in #1262. Twice now an assertion I added was unreachable because the fixture did not produce the condition it tested, and in both cases a green run looked like proof. The iframe-count assertion is partly a response to that: it fails on the *absence* of the right structure rather than only on a wrong value.

Unit tests: 151/151 JS. `InstructorWorkbenchRoutesTests` 7/7. `check-styles`, `eslint`, `swiftlint --strict` clean.

One guard caught something real: `check-styles.sh` ratchets inline `<script>` lines downward, and my JSON island added five. Moved the URL map to a `data-` attribute, which is more consistent with the other `data-wb-*` on that element anyway.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj)_