### PR TITLE
Workbench: cut the chrome back, one Save, Files table drives the notebook pane

### DIFF
--- a/.github/actions/browser-probe-setup/action.yml
+++ b/.github/actions/browser-probe-setup/action.yml
@@ -32,39 +32,73 @@ runs:
     # the mangled-symbol reason documented in swift-tests.yml. On a hit,
     # building the server product is near-no-op; on a miss it builds cold.
     - name: Restore build artifacts
+      id: shared-build-cache
       uses: actions/cache/restore@v5
       with:
         path: .build
         key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
+    # Fallback cache, owned by the probes, used only when the shared key missed.
+    #
+    # The shared key is written by `build` in swift-tests.yml — a different
+    # workflow, so `needs:` cannot order a probe after it. On any PR touching
+    # Sources/** or Tests/** the key is new, and whether a probe hits it is a
+    # race against that build finishing. Losing the race means a cold Swift
+    # build (~16 min of a 50 min budget), and losing it *repeatedly* is what
+    # made re-running a probe on the same commit cost the same 16 minutes every
+    # time — nothing the probes did ever populated a key they could read back.
+    #
+    # This one they own: same exact-match discipline (no restore-keys prefix
+    # fallback, which would build incrementally over a mismatched tree), same
+    # source hash, different namespace. Deliberately NOT the shared key: a probe
+    # that won that race would publish a `.build` holding only
+    # chickadee-server, and the swift-tests jobs restoring it would have to
+    # rebuild the test targets — trading their time for ours.
+    - name: Restore/save probe build cache
+      if: steps.shared-build-cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v5
+      with:
+        path: .build
+        key: ${{ runner.os }}-probebuild-v1-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+
     - name: Build chickadee-server
       shell: bash
       run: swift build --product chickadee-server
 
-    # apt against archive.ubuntu.com is the least reliable thing in this action:
-    # it is an unauthenticated plain-HTTP fetch of ~40 packages from a mirror we
-    # do not control, and when it is unreachable the step fails with exit 100 and
-    # takes the whole probe with it — a red required gate caused by an Ubuntu
-    # mirror. Retry the network-bound half a few times with a short backoff.
-    # `npm ci` stays outside the loop: it hits a different registry, and a
-    # genuine lockfile problem should fail once and clearly, not three times.
+    # Node and npm are baked into the swift-ci image, so the normal path here is
+    # to install nothing. The apt fallback stays for two cases that are real:
+    # a caller still on the plain mirror, and the window where this action runs
+    # before mirror-images.yml has republished swift-ci with a Dockerfile change.
+    # Deleting it outright would make those a hard failure instead of a slow path.
+    #
+    # apt against archive.ubuntu.com is the least reliable thing in this action —
+    # an unauthenticated plain-HTTP fetch of ~40 packages from a mirror we do not
+    # control — so when it does run it retries. On 2026-08-04 it was unreachable,
+    # the step exited 100, and the required editor-smoke gate went red because of
+    # an Ubuntu mirror. `npm ci` stays outside the loop: it hits a different
+    # registry, and a genuine lockfile problem should fail once and clearly.
     - name: Install Node and npm dependencies
       shell: bash
       working-directory: ${{ inputs.node-project }}
       run: |
         set -eu
-        for attempt in 1 2 3; do
-          if apt-get update -qq \
-            && apt-get install -y --no-install-recommends nodejs npm curl ca-certificates; then
-            break
-          fi
-          if [ "$attempt" = 3 ]; then
-            echo "::error::apt-get failed 3 times — archive.ubuntu.com is likely unreachable."
-            exit 1
-          fi
-          echo "::warning::apt-get attempt ${attempt} failed; retrying in $((attempt * 15))s"
-          sleep $((attempt * 15))
-        done
+        if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+          echo "node $(node --version) and npm $(npm --version) already present — skipping apt"
+        else
+          echo "::warning::node/npm missing from the image; falling back to apt-get"
+          for attempt in 1 2 3; do
+            if apt-get update -qq \
+              && apt-get install -y --no-install-recommends nodejs npm curl ca-certificates; then
+              break
+            fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::apt-get failed 3 times — archive.ubuntu.com is likely unreachable."
+              exit 1
+            fi
+            echo "::warning::apt-get attempt ${attempt} failed; retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+        fi
         npm ci
 
     # The engine download (~150 MB) is the slow, network-dependent part of

--- a/.github/actions/browser-probe-setup/action.yml
+++ b/.github/actions/browser-probe-setup/action.yml
@@ -41,13 +41,30 @@ runs:
       shell: bash
       run: swift build --product chickadee-server
 
+    # apt against archive.ubuntu.com is the least reliable thing in this action:
+    # it is an unauthenticated plain-HTTP fetch of ~40 packages from a mirror we
+    # do not control, and when it is unreachable the step fails with exit 100 and
+    # takes the whole probe with it — a red required gate caused by an Ubuntu
+    # mirror. Retry the network-bound half a few times with a short backoff.
+    # `npm ci` stays outside the loop: it hits a different registry, and a
+    # genuine lockfile problem should fail once and clearly, not three times.
     - name: Install Node and npm dependencies
       shell: bash
       working-directory: ${{ inputs.node-project }}
       run: |
-        set -eux
-        apt-get update -qq
-        apt-get install -y --no-install-recommends nodejs npm curl ca-certificates
+        set -eu
+        for attempt in 1 2 3; do
+          if apt-get update -qq \
+            && apt-get install -y --no-install-recommends nodejs npm curl ca-certificates; then
+            break
+          fi
+          if [ "$attempt" = 3 ]; then
+            echo "::error::apt-get failed 3 times — archive.ubuntu.com is likely unreachable."
+            exit 1
+          fi
+          echo "::warning::apt-get attempt ${attempt} failed; retrying in $((attempt * 15))s"
+          sleep $((attempt * 15))
+        done
         npm ci
 
     # The engine download (~150 MB) is the slow, network-dependent part of

--- a/.github/docker/ci-image/Dockerfile
+++ b/.github/docker/ci-image/Dockerfile
@@ -28,7 +28,16 @@ FROM ${BASE_IMAGE}
 #             and a shipped feature's grading path has zero CI coverage
 # python3-pandas / python3-matplotlib — NotebookCheckRuntimeState tests that
 #             exercise dataframe/plot check kinds against a real interpreter
+# nodejs/npm/ca-certificates — the browser probe jobs (editor smoke, exec-hang,
+#             grading-hang, lifecycle, reset, bridge, visual) run the
+#             Playwright harness in Tools/editor-smoke-test. They used to
+#             apt-get these at job start, which is the same 20-40 s per job the
+#             rest of this image exists to remove — and on 2026-08-04 it was
+#             worse than slow: archive.ubuntu.com was unreachable, the step
+#             exited 100, every probe skipped its tests, and the required
+#             editor-smoke gate went red because of an Ubuntu mirror.
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends file python3 zip unzip curl \
         r-base python3-pandas python3-matplotlib \
+        nodejs npm ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/editor-exec-probe.yml
+++ b/.github/workflows/editor-exec-probe.yml
@@ -47,7 +47,17 @@ concurrency:
 jobs:
   exec-probe:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 50, not 30: `browser-probe-setup` cold-builds chickadee-server whenever the
+    # shared build cache misses, and it MISSES on every PR that touches
+    # Sources/** or Tests/** — the cache key hashes both, and the job that
+    # populates it (`build` in swift-tests.yml) is a different workflow, so
+    # `needs:` cannot order this job after it.  Measured on PR #1264: the setup
+    # step alone took 23.2 min on a run that passed and 29.0 min on one that was
+    # killed, against a 30 min budget.  That is 85-97% of the ceiling spent
+    # before the first test runs, so the old value only ever worked on a cache
+    # hit and failed as a *timeout*, which GitHub reports as `cancelled` and the
+    # gate correctly treats as a failure.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/editor-exec-probe.yml
+++ b/.github/workflows/editor-exec-probe.yml
@@ -65,7 +65,11 @@ jobs:
     # Same Swift image as the other jobs so the cached server binary runs and the
     # vended Public/pyodide it serves is the exact build CI ships.
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -100,7 +100,17 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.editor == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 50, not 30: `browser-probe-setup` cold-builds chickadee-server whenever the
+    # shared build cache misses, and it MISSES on every PR that touches
+    # Sources/** or Tests/** — the cache key hashes both, and the job that
+    # populates it (`build` in swift-tests.yml) is a different workflow, so
+    # `needs:` cannot order this job after it.  Measured on PR #1264: the setup
+    # step alone took 23.2 min on a run that passed and 29.0 min on one that was
+    # killed, against a 30 min budget.  That is 85-97% of the ceiling spent
+    # before the first test runs, so the old value only ever worked on a cache
+    # hit and failed as a *timeout*, which GitHub reports as `cancelled` and the
+    # gate correctly treats as a failure.
+    timeout-minutes: 50
     # Run the editor against BOTH engines we ship to: Chromium (Chrome/Edge) and
     # WebKit (the engine behind Safari — every Safari-class editor bug we have
     # shipped was invisible to a Chromium-only check). fail-fast:false so one

--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -123,7 +123,11 @@ jobs:
     # (dynamically linked against this image's Swift runtime) actually runs, and
     # so the vended Public/pyodide it serves is the exact build CI ships.
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/grading-hang-probe.yml
+++ b/.github/workflows/grading-hang-probe.yml
@@ -65,7 +65,11 @@ jobs:
     # Same Swift image as the other editor jobs so the cached server binary runs
     # and the vended Public/pyodide it serves is the exact build CI ships.
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/grading-hang-probe.yml
+++ b/.github/workflows/grading-hang-probe.yml
@@ -50,7 +50,14 @@ concurrency:
 jobs:
   grading-probe:
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    # 75, not 50: this job pays the same cold `browser-probe-setup` build as the
+    # other probes (23-29 min when the shared cache misses, which it does on any
+    # PR touching Sources/** or Tests/**) and THEN runs 12 grading iterations per
+    # engine on top.  On PR #1264 the webkit leg ran the full 50 min and was
+    # killed before finishing, while chromium — which happened to get a warm
+    # cache — completed the same 12 iterations comfortably.  The old budget was
+    # sized for the warm path only.
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -50,7 +50,15 @@ concurrency:
 jobs:
   mirror:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 60, not 30: the derived-image build apt-installs a heavy set (r-base,
+    # python3-pandas, python3-matplotlib, and now nodejs/npm's ~40-package
+    # tree) from archive.ubuntu.com, behind a 5-attempt retry loop. On
+    # 2026-08-04, with that mirror flaking, the build step alone ran 29.3 min
+    # of the 30 and was killed — mirroring the base took 0.5 min, so the whole
+    # budget goes to the build. This job is weekly/on-demand, not a per-PR hot
+    # path, so a longer ceiling costs little; a timeout costs a stale CI image
+    # for everyone until someone notices.
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/notebook-bridge-probe.yml
+++ b/.github/workflows/notebook-bridge-probe.yml
@@ -55,7 +55,11 @@ jobs:
       matrix:
         browser: [chromium, webkit]
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notebook-bridge-probe.yml
+++ b/.github/workflows/notebook-bridge-probe.yml
@@ -39,7 +39,17 @@ concurrency:
 jobs:
   bridge:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 50, not 30: `browser-probe-setup` cold-builds chickadee-server whenever the
+    # shared build cache misses, and it MISSES on every PR that touches
+    # Sources/** or Tests/** — the cache key hashes both, and the job that
+    # populates it (`build` in swift-tests.yml) is a different workflow, so
+    # `needs:` cannot order this job after it.  Measured on PR #1264: the setup
+    # step alone took 23.2 min on a run that passed and 29.0 min on one that was
+    # killed, against a 30 min budget.  That is 85-97% of the ceiling spent
+    # before the first test runs, so the old value only ever worked on a cache
+    # hit and failed as a *timeout*, which GitHub reports as `cancelled` and the
+    # gate correctly treats as a failure.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/notebook-lifecycle-probe.yml
+++ b/.github/workflows/notebook-lifecycle-probe.yml
@@ -51,7 +51,11 @@ jobs:
       matrix:
         browser: [chromium, webkit]
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notebook-lifecycle-probe.yml
+++ b/.github/workflows/notebook-lifecycle-probe.yml
@@ -35,7 +35,17 @@ concurrency:
 jobs:
   lifecycle:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 50, not 30: `browser-probe-setup` cold-builds chickadee-server whenever the
+    # shared build cache misses, and it MISSES on every PR that touches
+    # Sources/** or Tests/** — the cache key hashes both, and the job that
+    # populates it (`build` in swift-tests.yml) is a different workflow, so
+    # `needs:` cannot order this job after it.  Measured on PR #1264: the setup
+    # step alone took 23.2 min on a run that passed and 29.0 min on one that was
+    # killed, against a 30 min budget.  That is 85-97% of the ceiling spent
+    # before the first test runs, so the old value only ever worked on a cache
+    # hit and failed as a *timeout*, which GitHub reports as `cancelled` and the
+    # gate correctly treats as a failure.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/notebook-reset-probe.yml
+++ b/.github/workflows/notebook-reset-probe.yml
@@ -51,7 +51,11 @@ jobs:
       matrix:
         browser: [chromium, webkit]
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/notebook-reset-probe.yml
+++ b/.github/workflows/notebook-reset-probe.yml
@@ -35,7 +35,17 @@ concurrency:
 jobs:
   reset:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 50, not 30: `browser-probe-setup` cold-builds chickadee-server whenever the
+    # shared build cache misses, and it MISSES on every PR that touches
+    # Sources/** or Tests/** — the cache key hashes both, and the job that
+    # populates it (`build` in swift-tests.yml) is a different workflow, so
+    # `needs:` cannot order this job after it.  Measured on PR #1264: the setup
+    # step alone took 23.2 min on a run that passed and 29.0 min on one that was
+    # killed, against a 30 min budget.  That is 85-97% of the ceiling spent
+    # before the first test runs, so the old value only ever worked on a cache
+    # hit and failed as a *timeout*, which GitHub reports as `cancelled` and the
+    # gate correctly treats as a failure.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -52,7 +52,11 @@ jobs:
     # links against the right runtime, and so font rendering is stable across
     # runs (the captures pin DejaVu, shipped in this image).
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci, not the plain mirror: it bakes in nodejs/npm (and the rest of
+      # the test packages), so the probe harness does not apt-get them at job
+      # start. Toolchain-identical to the mirror, so the shared .build cache
+      # keys still match — see .github/docker/ci-image/Dockerfile.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -37,7 +37,17 @@ concurrency:
 jobs:
   visual:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 50, not 30: `browser-probe-setup` cold-builds chickadee-server whenever the
+    # shared build cache misses, and it MISSES on every PR that touches
+    # Sources/** or Tests/** — the cache key hashes both, and the job that
+    # populates it (`build` in swift-tests.yml) is a different workflow, so
+    # `needs:` cannot order this job after it.  Measured on PR #1264: the setup
+    # step alone took 23.2 min on a run that passed and 29.0 min on one that was
+    # killed, against a 30 min budget.  That is 85-97% of the ceiling spent
+    # before the first test runs, so the old value only ever worked on a cache
+    # hit and failed as a *timeout*, which GitHub reports as `cancelled` and the
+    # gate correctly treats as a failure.
+    timeout-minutes: 50
     # Same swift image as the other browser jobs so the cached server binary
     # links against the right runtime, and so font rendering is stable across
     # runs (the captures pin DejaVu, shipped in this image).

--- a/Public/embedded-pane.js
+++ b/Public/embedded-pane.js
@@ -1,0 +1,88 @@
+// Public/embedded-pane.js
+//
+// The pane half of the assignment workbench's cross-pane wiring. Loaded by
+// base.leaf only when a page is rendered *into* a workbench pane.
+//
+// Two jobs, both of which exist because a pane cannot see its sibling:
+//
+//   1. **Opening a notebook.** The left pane's Files table is the only place
+//      that lists an assignment's notebooks, so it is the only place that
+//      chooses which one is open. Its Edit buttons are ordinary links — they
+//      still navigate on the standalone page — and here they are intercepted
+//      and turned into a request to the shell.
+//
+//   2. **Saving.** The workbench has one Save button. It asks each pane to save
+//      itself and waits for both replies, so a pane must answer even when it
+//      has nothing to save; staying silent would leave the button disabled
+//      forever.
+//
+// Deliberately separate from `embedded-activity.js`: that file forwards
+// keystrokes so the idle watchdog does not sign an author out, and it must keep
+// working even if this wiring is ever removed.
+
+(function () {
+    'use strict';
+
+    if (window.parent === window) return;
+
+    function post(type, extra) {
+        var payload = { source: 'chickadee', type: type };
+        if (extra) {
+            Object.keys(extra).forEach(function (k) { payload[k] = extra[k]; });
+        }
+        try {
+            // Explicit origin, never '*': these messages describe what an
+            // instructor is editing.
+            window.parent.postMessage(payload, window.location.origin);
+        } catch (_) { /* parent gone mid-navigation */ }
+    }
+
+    // --- 1. Files-table Edit buttons open into the notebook pane -------------
+
+    document.addEventListener('click', function (e) {
+        var el = e.target.closest && e.target.closest('[data-wb-file]');
+        if (!el) return;
+        // preventDefault, not a href removal: on the standalone page this
+        // listener never runs (no parent), so the link keeps working there.
+        e.preventDefault();
+        post('open-notebook', { file: el.getAttribute('data-wb-file') });
+    });
+
+    // --- 2. Answer the shell's Save ------------------------------------------
+
+    // The notebook page exposes `window.chickadeeSaveToAssignment` — the POST to
+    // /notebook/save, resolving true/false. Deliberately NOT
+    // `chickadeeSaveNotebook`, which despite the name only flushes cells to
+    // JupyterLite's local storage and would report a save that never reached
+    // the server. A pane with neither still replies `ok`, because "nothing to
+    // save" is a success, and silence would leave the shell's button disabled.
+    function performSave() {
+        if (typeof window.chickadeeSaveToAssignment === 'function') {
+            Promise.resolve()
+                .then(function () { return window.chickadeeSaveToAssignment(); })
+                .then(function (ok) { post('save-result', { ok: ok !== false }); })
+                .catch(function () { post('save-result', { ok: false }); });
+            return;
+        }
+
+        var form = document.querySelector('form[action$="/edit/save"]');
+        if (form) {
+            // The form posts and the pane navigates to the redirect target,
+            // which re-renders this same page. Reply before submitting: once
+            // the navigation starts this document is going away, and a reply
+            // sent after that never arrives.
+            post('save-result', { ok: true });
+            form.requestSubmit ? form.requestSubmit() : form.submit();
+            return;
+        }
+
+        post('save-result', { ok: true });
+    }
+
+    window.addEventListener('message', function (event) {
+        if (event.origin !== window.location.origin) return;
+        var data = event.data;
+        if (!data || data.source !== 'chickadee' || data.type !== 'save') return;
+        performSave();
+    });
+}());

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1264,7 +1264,13 @@
         // value here would leave the author looking at stale bytes.
         const saveViewMode = saveAssignmentBtn.dataset.viewMode === 'personalized' ? 'personalized' : 'template';
         const saveLabel = saveAssignmentBtn.textContent;
-        saveAssignmentBtn.addEventListener('click', async () => {
+
+        // Named, and exposed below, so the assignment workbench's single Save
+        // button can run exactly this — the same request, status line and
+        // error handling — instead of synthesising a click on a hidden button.
+        // Resolves true on success, false on failure; never throws, because the
+        // shell is waiting on it to re-enable its button.
+        async function saveToAssignment() {
             saveAssignmentBtn.disabled = true;
             saveAssignmentBtn.textContent = 'Saving…';
             clearResults();
@@ -1297,15 +1303,20 @@
                 // pane beside us is rendering, so it is now stale.  No-op on
                 // the standalone page, which has no parent.
                 ChickadeeUI.notifyWorkbench('notebook-saved');
+                return true;
             } catch (err) {
                 const msg = (err instanceof Error && err.message) ? err.message : String(err);
                 console.error('[notebook] Save-to-assignment error:', err);
                 setStatus('error', `Could not save: ${msg}`);
+                return false;
             } finally {
                 saveAssignmentBtn.disabled = false;
                 saveAssignmentBtn.textContent = saveLabel;
             }
-        });
+        }
+
+        saveAssignmentBtn.addEventListener('click', saveToAssignment);
+        window.chickadeeSaveToAssignment = saveToAssignment;
     }
 
     // ── Editor command bridge (jupyter-iframe-commands) ──────────────

--- a/Public/workbench.js
+++ b/Public/workbench.js
@@ -17,8 +17,9 @@
 //     clamps the notebook pane at 720px and the edit pane at 380px, and below a
 //     viewport that can hold both the layout drops to one pane at a time.
 //
-//   * **One notebook document, always.** The tabs and the view switch change
-//     the single iframe's src; they are destinations, not panes. An iframe per
+//   * **One notebook document, always.** The Files table and the view switch
+//     change the single iframe's src; they are destinations, not panes. An
+//     iframe per
 //     (file, view) would mean a Pyodide kernel per combination — up to four —
 //     and bounding that needs an eviction policy, which is a lot of machinery
 //     for a secondary interaction. The workbench exists to put the edit page
@@ -100,29 +101,11 @@
         return null;
     }
 
-    /// Toggle the edit pane between collapsed and its last expanded width.
-    ///
-    /// Kept as a pure transition on an explicit state object because the bug
-    /// this shape prevents is a real one: collapsing while already collapsed
-    /// must not overwrite the remembered width with 0, or the pane can never be
-    /// restored and the author is left with no way back to the editor short of
-    /// dragging the splitter out from the edge.
-    ///
-    /// `state` is `{ collapsed, width, restoreWidth }`; the return is the same
-    /// shape.
-    function toggleCollapse(state) {
-        if (state.collapsed) {
-            return { collapsed: false, width: state.restoreWidth, restoreWidth: state.restoreWidth };
-        }
-        return { collapsed: true, width: 0, restoreWidth: state.width };
-    }
-
     // Exported for the unit tests, which exercise the arithmetic and the
     // policy without a DOM.
     var api = {
         clampLeftWidth: clampLeftWidth,
-        resolvePane: resolvePane,
-        toggleCollapse: toggleCollapse
+        resolvePane: resolvePane
     };
     if (typeof window !== 'undefined') window.ChickadeeWorkbench = api;
     if (typeof module !== 'undefined' && module.exports) module.exports = api;
@@ -139,13 +122,15 @@
     var assignmentID = shell.getAttribute('data-assignment-id') || '';
     var storageKey = 'chickadee-workbench-split:' + assignmentID;
 
-    var tabs = Array.prototype.slice.call(shell.querySelectorAll('.wb-tab'));
+    // Which notebook is open is a label here, not a control: the choosing
+    // happens in the left pane's Files table, which already lists the files.
+    var openFileLabel = document.getElementById('wb-openfile');
     var viewButtons = Array.prototype.slice.call(shell.querySelectorAll('.wb-view'));
     var viewSwitch = document.getElementById('wb-viewswitch');
 
-    // The single notebook document, and the destinations its tabs can send it
-    // to. There is one iframe, so there is one kernel — switching notebooks
-    // costs a boot, and nothing here has to manage a pool.
+    // The single notebook document, and every destination it can be sent to.
+    // There is one iframe, so there is one kernel — switching notebooks costs a
+    // boot, and nothing here has to manage a pool.
     var notebookFrame = document.getElementById('wb-notebook');
     // Carried on a data-attribute rather than a <script> island: it is a small
     // map the shell reads once, and the style guard ratchets inline script
@@ -194,34 +179,6 @@
         if (!isNaN(px) && px > 0) applyLeftWidth(px);
     }
 
-    // ── Collapse ──────────────────────────────────────────────────────────
-
-    var collapseState = { collapsed: false, width: 0, restoreWidth: 0 };
-
-    function applyCollapse() {
-        shell.setAttribute('data-wb-collapsed', collapseState.collapsed ? 'edit' : '');
-        if (collapseBtn) {
-            collapseBtn.setAttribute('aria-expanded', collapseState.collapsed ? 'false' : 'true');
-            collapseBtn.textContent = collapseState.collapsed ? 'Show editor' : 'Hide editor';
-        }
-        if (collapseState.collapsed) {
-            shell.style.setProperty('--wb-left-width', '0px');
-            if (splitter) splitter.setAttribute('aria-valuenow', '0');
-        } else {
-            applyLeftWidth(collapseState.restoreWidth || EDIT_MIN);
-        }
-    }
-
-    function doToggleCollapse() {
-        collapseState.width = collapseState.collapsed ? collapseState.width : currentLeftWidth();
-        collapseState = toggleCollapse(collapseState);
-        applyCollapse();
-        if (!collapseState.collapsed) persist(currentLeftWidth());
-    }
-
-    var collapseBtn = document.getElementById('wb-collapse-edit');
-    if (collapseBtn) collapseBtn.addEventListener('click', doToggleCollapse);
-
     if (splitter && body) {
         var dragging = false;
 
@@ -248,11 +205,6 @@
         splitter.addEventListener('keydown', function (e) {
             var width = currentLeftWidth();
             var total = body.clientWidth;
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                doToggleCollapse();
-                return;
-            }
             var next = null;
             if (e.key === 'ArrowLeft') next = width - KEY_STEP_PX;
             else if (e.key === 'ArrowRight') next = width + KEY_STEP_PX;
@@ -260,9 +212,6 @@
             else if (e.key === 'End') next = total - SPLITTER_PX - NOTEBOOK_MIN;
             if (next === null) return;
             e.preventDefault();
-            // Any explicit sizing means the pane is no longer collapsed.
-            collapseState.collapsed = false;
-            shell.setAttribute('data-wb-collapsed', '');
             persist(applyLeftWidth(next));
         });
 
@@ -283,12 +232,9 @@
         activeFile = pane.file;
         activeView = pane.view;
 
-        tabs.forEach(function (tab) {
-            var isActive = tab.getAttribute('data-wb-file') === pane.file;
-            tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
-            // Roving tabindex: one stop for the whole strip.
-            tab.setAttribute('tabindex', isActive ? '0' : '-1');
-        });
+        if (openFileLabel) {
+            openFileLabel.textContent = pane.file === 'solution' ? 'Solution' : 'Assignment';
+        }
         viewButtons.forEach(function (btn) {
             btn.setAttribute(
                 'aria-pressed',
@@ -317,20 +263,6 @@
         // looking at; a fresh load is current by construction.
         if (staleChip) staleChip.hidden = true;
     }
-
-    tabs.forEach(function (tab, index) {
-        tab.addEventListener('click', function () {
-            selectPane(tab.getAttribute('data-wb-file'), activeView);
-        });
-        tab.addEventListener('keydown', function (e) {
-            var delta = e.key === 'ArrowRight' ? 1 : (e.key === 'ArrowLeft' ? -1 : 0);
-            if (!delta) return;
-            e.preventDefault();
-            var next = tabs[(index + delta + tabs.length) % tabs.length];
-            next.focus();
-            selectPane(next.getAttribute('data-wb-file'), activeView);
-        });
-    });
 
     viewButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
@@ -392,6 +324,72 @@
                 staleChip.textContent = 'Inputs changed — reload the notebook to see new values';
                 staleChip.hidden = false;
             }
+            return;
+        }
+
+        if (data.type === 'open-notebook') {
+            // The left pane's Files table is the only place that chooses which
+            // notebook is open.  `data.file` selects a destination from a
+            // server-rendered table, never a URL, so an unrecognised value
+            // resolves to nothing rather than navigating anywhere.
+            selectPane(data.file === 'solution' ? 'solution' : 'assignment', activeView);
+            return;
+        }
+
+        if (data.type === 'save-result') {
+            pendingSaves -= 1;
+            if (!data.ok) saveFailed = true;
+            if (pendingSaves <= 0) finishSave();
         }
     });
+
+    // ── Save ──────────────────────────────────────────────────────────────
+    //
+    // One button for what used to be two: it saves the notebook that is open
+    // and the assignment's details, then re-validates.
+    //
+    // It deliberately does NOT close the assignment.  The workbench is a
+    // live-edit surface — `PUT /suite`, `PUT /families` and
+    // `POST /notebook/save` all write without touching visibility — and
+    // closing on save would mean fixing a typo pulls a lab out from under the
+    // students sitting in it.  The standalone `/edit` page keeps
+    // close-on-save; the difference rides on the `liveEdit` field only the
+    // embedded form sends.
+
+    var saveBtn = document.getElementById('wb-save');
+    var saveStatus = document.getElementById('wb-save-status');
+    var pendingSaves = 0;
+    var saveFailed = false;
+
+    function finishSave() {
+        pendingSaves = 0;
+        if (saveBtn) saveBtn.disabled = false;
+        if (saveStatus) {
+            saveStatus.textContent = saveFailed ? 'Save failed — see the pane for details' : 'Saved';
+        }
+    }
+
+    if (saveBtn) {
+        saveBtn.addEventListener('click', function () {
+            saveFailed = false;
+            saveBtn.disabled = true;
+            if (saveStatus) saveStatus.textContent = 'Saving…';
+            // Both panes are asked, and each replies. A pane with nothing to
+            // save still replies, so the button always comes back — silence
+            // would leave it disabled forever.
+            pendingSaves = 0;
+            [notebookFrame, editFrame].forEach(function (frame) {
+                if (!frame || !frame.contentWindow) return;
+                pendingSaves += 1;
+                try {
+                    frame.contentWindow.postMessage(
+                        { source: 'chickadee', type: 'save' }, window.location.origin);
+                } catch (_) {
+                    pendingSaves -= 1;
+                    saveFailed = true;
+                }
+            });
+            if (pendingSaves <= 0) finishSave();
+        });
+    }
 }());

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -68,10 +68,21 @@
         </div>
 
         <div class="editor-actions">
+            #if(embedded):
+            <!-- The workbench has one Save in its top bar which submits this
+                 form for us, so a second button here would be the same action
+                 twice.  `liveEdit` is what makes that Save leave the
+                 assignment's visibility alone: the workbench is a live-edit
+                 surface, and closing on save would pull a lab out from under
+                 the students in it.  This page standalone keeps close-on-save,
+                 because it does not send the field. -->
+            <input type="hidden" name="liveEdit" value="1">
+            #else:
             <button class="btn btn-primary" type="submit"
                     title="Save assignment metadata (name, due date, notebooks) and re-validate. Suite edits are saved live as you make them.">
                 Save &amp; Validate
             </button>
+            #endif
             #if(!embedded):
             <!-- Absent when this page IS the workbench's left pane: the pane
                  must not offer a link to the surface containing it. -->
@@ -107,7 +118,8 @@
                         <a href="#(currentAssignmentURL)"><code id="assignment-notebook-name">#(currentAssignmentFile)</code></a>
                     </td>
                     <td class="time">
-                        <a class="btn action-btn" id="assignment-notebook-edit-btn" href="#(assignmentNotebookEditURL)">Edit</a>
+                        <a class="btn action-btn" id="assignment-notebook-edit-btn"
+                           data-wb-file="assignment" href="#(assignmentNotebookEditURL)">Edit</a>
                     </td>
                 </tr>
                 <tr>
@@ -121,7 +133,8 @@
                     </td>
                     <td class="time">
                         #if(solutionNotebookEditURL):
-                        <a class="btn action-btn" id="solution-notebook-edit-btn" href="#(solutionNotebookEditURL)">Edit</a>
+                        <a class="btn action-btn" id="solution-notebook-edit-btn"
+                           data-wb-file="solution" href="#(solutionNotebookEditURL)">Edit</a>
                         #else:
                         <form method="post" action="/instructor/#(assignmentID)/create-solution" class="inline-form">
                             #csrfFormField()

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -382,7 +382,7 @@
                                 onclick="copyAssignmentURL(this, '#(item.assignment.vanityURL)')">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
                         </button>
-                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/edit"
+                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/workbench"
                            title="Edit assignment" aria-label="Edit assignment"
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
@@ -423,7 +423,7 @@
                                 onclick="copyAssignmentURL(this, '#(item.assignment.vanityURL)')">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
                         </button>
-                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/edit"
+                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/workbench"
                            title="Edit assignment" aria-label="Edit assignment"
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
@@ -464,7 +464,7 @@
                                 onclick="copyAssignmentURL(this, '#(item.assignment.vanityURL)')">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
                         </button>
-                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/edit"
+                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/workbench"
                            title="Edit assignment" aria-label="Edit assignment"
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
@@ -779,7 +779,7 @@
                                 onclick="copyAssignmentURL(this, '#(item.assignment.vanityURL)')">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
                         </button>
-                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/edit"
+                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/workbench"
                            title="Edit assignment" aria-label="Edit assignment"
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
@@ -811,7 +811,7 @@
                                 onclick="copyAssignmentURL(this, '#(item.assignment.vanityURL)')">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
                         </button>
-                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/edit"
+                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/workbench"
                            title="Edit assignment" aria-label="Edit assignment"
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
@@ -837,7 +837,7 @@
                     </div>
                     #else:
                     <div class="row-actions-tight">
-                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/edit"
+                        <a class="btn action-btn" href="/instructor/#(item.assignment.assignmentID)/workbench"
                            title="Edit assignment" aria-label="Edit assignment"
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -132,6 +132,9 @@
      pane, so without this the shell would sit "idle" and sign the author out
      mid-edit. -->
 <script src="/embedded-activity.js?v=#appVersion()"></script>
+<!-- Cross-pane wiring: Files-table Edit opens into the notebook pane, and the
+     workbench's single Save is answered here. -->
+<script src="/embedded-pane.js?v=#appVersion()"></script>
 #else:
 <script src="/idle-logout.js?v=#appVersion()"></script>
 #endif

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -99,16 +99,26 @@ Notebook
             #endif
             #endif
             #if(canSaveToAssignment):
-            <button class="btn btn-primary" id="nb-save-assignment" data-file-kind="#(fileKind)"
+            <!-- Present but hidden in a workbench pane: the workbench's single
+                 Save calls the function notebook.js binds here, so the element
+                 must exist — but a second visible Save button would be the same
+                 action twice. -->
+            <button class="btn btn-primary" id="nb-save-assignment" #if(embedded):hidden#endif data-file-kind="#(fileKind)"
                     data-view-mode="#if(isTemplateView):template#else:personalized#endif"
                     title="Write what is in this editor back to the assignment for every student">
                 #if(fileKind == "solution"):Save solution#else:Save to assignment#endif
             </button>
             #endif
             #if(downloadURL):
+            #if(!embedded):
+            <!-- Suppressed in a workbench pane: the left pane's Files table
+                 already links the file, so this is a second route to the same
+                 download.  Kept on the standalone page, where it is the only
+                 one. -->
             <a class="btn"
                href="#(downloadURL)"
                download>Download</a>
+            #endif
             #endif
         </div>
     </div>

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -24,15 +24,17 @@
     border-bottom: 1px solid var(--border);
     background: var(--surface-muted);
 }
-.wb-title {
-    font-size: var(--text-base);
-    font-weight: 600;
-    margin: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
 .wb-bar-spacer { flex: 1; }
+.wb-save-status {
+    font-size: var(--text-sm);
+    color: var(--gray-700);
+}
+/* Which notebook the pane is showing.  A label, not a control — the choosing
+   happens in the left pane's Files table. */
+.wb-openfile {
+    font-size: var(--text-sm);
+    font-weight: 600;
+}
 
 /* Three columns: left pane, splitter, right pane.  min-height:0 on the body
    and min-width:0 on the panes are what let the grid children actually shrink
@@ -78,21 +80,14 @@
     padding: .3rem .5rem;
     border-bottom: 1px solid var(--border);
 }
-.wb-tabstrip,
 .wb-viewswitch {
     display: flex;
     align-items: center;
     gap: .25rem;
-}
-/* A visible seam between the two axes: which notebook (tabs) and which reading
-   of it (view switch) are independent choices, and reading them as one strip of
-   four buttons would misrepresent that. */
-.wb-viewswitch {
     margin-left: .5rem;
     padding-left: .5rem;
     border-left: 1px solid var(--border);
 }
-.wb-tab[aria-selected="true"],
 .wb-view[aria-pressed="true"] {
     background: var(--health-teal);
     color: var(--surface);
@@ -104,20 +99,6 @@
     font-size: var(--text-sm);
     color: var(--gray-700);
 }
-
-/* Collapsed edit pane: the notebook takes the full width.
-   The grid must be re-declared to a single column, not just have the edit pane
-   hidden.  `display: none` removes an item from the grid entirely, so with the
-   three-column template still in force the splitter would take column 1 and the
-   notebook column 2 — which is `auto`, i.e. sized to content, leaving the
-   notebook pane narrow enough that the embedded notebook page renders its
-   "Open on a larger screen" notice instead of the editor.  That is the exact
-   failure the 720px floor exists to prevent, arriving by a different route.
-   Hiding the splitter too means the toolbar toggle is the way back, which is
-   what the button is for. */
-.wb-shell[data-wb-collapsed="edit"] .wb-body { grid-template-columns: 1fr; }
-.wb-shell[data-wb-collapsed="edit"] .wb-pane-edit,
-.wb-shell[data-wb-collapsed="edit"] .wb-splitter { display: none; }
 
 /* Below the point where an honest split is possible (720px notebook floor +
    380px edit floor + the splitter), collapse to one pane at a time.  The
@@ -137,14 +118,17 @@
      data-setup-id="#(testSetupID)"
      data-wb-single="notebook"
      data-wb-pane-urls="#(notebookPaneURLsJSON)">
+    <!-- The bar carries one control.  The assignment's name, its files, and its
+         suite all live in the left pane, so repeating any of them up here was
+         chrome for its own sake.  `#wb-single-edit` is the exception: below
+         1140px the panes stack and it is the only way back to the editor, so it
+         appears only at that width. -->
     <div class="wb-bar">
-        <h1 class="wb-title">#(assignmentTitle)</h1>
         <span class="wb-bar-spacer"></span>
-        <button class="btn action-btn" type="button" id="wb-collapse-edit"
-                aria-controls="wb-edit-frame" aria-expanded="true"
-                title="Give the notebook the full width">Hide editor</button>
+        <span class="wb-save-status" id="wb-save-status" role="status"></span>
         <button class="btn action-btn" type="button" id="wb-single-edit" hidden>Editor</button>
-        <a class="btn action-btn" href="#(standaloneEditURL)">Full-width editor</a>
+        <button class="btn btn-primary" type="button" id="wb-save"
+                title="Save the open notebook and the assignment's details, then re-validate">Save</button>
     </div>
     <div class="wb-body">
         <section class="wb-pane wb-pane-edit" aria-label="Assignment editor">
@@ -164,21 +148,15 @@
                 aria-valuenow="42"></button>
         <section class="wb-pane wb-pane-notebook" aria-label="Notebook editor">
             <div class="wb-panehead">
-                <div class="wb-tabstrip" role="tablist" aria-label="Notebook">
-                    <button class="btn action-btn wb-tab" type="button" role="tab"
-                            id="wb-tab-assignment" data-wb-file="assignment"
-                            aria-selected="true">Assignment</button>
-                    #if(hasSolution):
-                    <button class="btn action-btn wb-tab" type="button" role="tab"
-                            id="wb-tab-solution" data-wb-file="solution" tabindex="-1"
-                            aria-selected="false">Solution</button>
-                    #endif
-                </div>
-                <!-- The view control is a second, independent axis: which reading
-                     of the selected notebook to show.  Rendered only when the
-                     active file actually has placeholders — otherwise the two
-                     readings are byte-identical and the control is noise.
-                     workbench.js hides it when the selected file has no template. -->
+                <!-- Which notebook is open is chosen in the left pane's Files
+                     table, which already lists them: one place names the files,
+                     and its Edit button opens one here.  A tab strip up here was
+                     a second control for the same job.
+                     What remains is the view control — a different question
+                     (which reading of the open notebook), rendered only when the
+                     file actually has placeholders, since otherwise the two
+                     readings are byte-identical. -->
+                <span class="wb-openfile" id="wb-openfile">Assignment</span>
                 <div class="wb-viewswitch" id="wb-viewswitch" role="group"
                      aria-label="Notebook view"
                      data-assignment-has-template="#if(assignmentHasTemplateView):1#else:0#endif"

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -102,7 +102,18 @@ extension PublishedAssignmentRoutes {
         }
         // Editing returns the assignment to closed (re-validation gates the
         // re-open / re-preview), matching the close-on-save contract.
-        assignment.visibility = .closed
+        //
+        // Except from the assignment workbench, which sets `liveEdit`.  That
+        // surface writes live — `PUT /suite`, `PUT /families` and
+        // `POST /notebook/save` all change content without touching visibility
+        // — and closing there would mean fixing a typo pulls a lab out from
+        // under the students sitting in it.  Re-validation still runs either
+        // way; the only difference is whether students lose access while it
+        // does.  This is a contract, not a permission: the caller already holds
+        // TA+ write access to this course, checked above.
+        if !form.liveEdit {
+            assignment.visibility = .closed
+        }
 
         // Only when it actually moved: the Save button posts the whole form on
         // every content edit, so auditing unconditionally would bury the real
@@ -133,6 +144,9 @@ extension PublishedAssignmentRoutes {
         let assignmentNotebookFile: File?
         let solutionNotebookFile: File?
         let gradeObjectID: String?
+        /// Set by the assignment workbench's embedded form.  Suppresses the
+        /// close-on-save below; see the comment at that call site.
+        let liveEdit: Bool
     }
 
     fileprivate struct ResolvedSolution {
@@ -149,6 +163,7 @@ extension PublishedAssignmentRoutes {
             var assignmentNotebookFile: File?
             var solutionNotebookFile: File?
             var gradeObjectID: String?
+            var liveEdit: String?
         }
 
         guard let body = try? req.content.decode(SaveBody.self) else {
@@ -164,7 +179,8 @@ extension PublishedAssignmentRoutes {
             startsAtRaw: try multipartTextField(named: ["startsAt"], from: req) ?? body.startsAt,
             assignmentNotebookFile: body.assignmentNotebookFile,
             solutionNotebookFile: body.solutionNotebookFile,
-            gradeObjectID: try multipartTextField(named: ["gradeObjectID"], from: req) ?? body.gradeObjectID
+            gradeObjectID: try multipartTextField(named: ["gradeObjectID"], from: req) ?? body.gradeObjectID,
+            liveEdit: (try multipartTextField(named: ["liveEdit"], from: req) ?? body.liveEdit) != nil
         )
     }
 

--- a/Tests/APITests/InstructorWorkbenchRoutesTests.swift
+++ b/Tests/APITests/InstructorWorkbenchRoutesTests.swift
@@ -50,9 +50,15 @@ import VaporTesting
                     // HTML-escapes it: quotes become &quot; and & becomes &amp;.
                     #expect(html.contains("solution:personalized"))
                     #expect(html.contains("file=solution&amp;view=personalized&amp;embedded=1"))
-                    // One notebook document, not one per destination: the tabs
-                    // repoint a single iframe, so exactly one is rendered.
+                    // One notebook document, not one per destination: the Files
+                    // table repoints a single iframe.
                     #expect(html.contains("id=\"wb-notebook\""))
+                    // The chrome the review asked for: one Save, and none of
+                    // the controls the left pane already provides.
+                    #expect(html.contains("id=\"wb-save\""))
+                    #expect(!html.contains("wb-tab-solution"))
+                    #expect(!html.contains("wb-collapse-edit"))
+                    #expect(!html.contains("Full-width editor"))
                     #expect(html.contains("Workbench Lab"))
                 })
         }
@@ -75,7 +81,6 @@ import VaporTesting
                     let html = res.body.string
                     #expect(html.contains("file=assignment"))
                     #expect(!html.contains("file=solution"))
-                    #expect(!html.contains("wb-tab-solution"))
                 })
         }
     }
@@ -110,6 +115,19 @@ import VaporTesting
                     #expect(html.contains("/embedded-activity.js"))
                     // … and the pane does not link to the surface containing it.
                     #expect(!html.contains("/workbench\""))
+                    // The Files table's Edit buttons are what open a notebook
+                    // in the other pane, so they must carry the marker
+                    // embedded-pane.js keys on.
+                    #expect(html.contains("data-wb-file=\"assignment\""))
+                    // Only the assignment marker: this fixture has no reference
+                    // solution, so that row renders "Create solution" instead of
+                    // an Edit button.  The solution marker is covered by the
+                    // browser check, which seeds one.
+                    // One Save lives in the shell; a second here would be the
+                    // same action twice.  `liveEdit` is what stops that Save
+                    // closing the assignment.
+                    #expect(!html.contains("Save &amp; Validate"))
+                    #expect(html.contains("name=\"liveEdit\""))
                 })
         }
     }
@@ -133,7 +151,102 @@ import VaporTesting
                     #expect(html.contains("/idle-logout.js"))
                     #expect(!html.contains("/embedded-activity.js"))
                     #expect(html.contains("/instructor/\(assignment.publicID)/workbench"))
+                    // Standalone keeps its own Save, and does NOT send
+                    // `liveEdit` — so it still closes on save, as it always has.
+                    #expect(html.contains("Save &amp; Validate"))
+                    #expect(!html.contains("name=\"liveEdit\""))
                 })
+        }
+    }
+
+    // MARK: - close-on-save, and the workbench's opt-out
+    //
+    // The pair below governs student-facing state, so it is pinned in both
+    // directions rather than only the new one.
+    //
+    // The standalone edit page has always closed an assignment on save, so
+    // re-validation gates re-opening.  The workbench must not: it is a
+    // live-edit surface (`PUT /suite`, `PUT /families` and
+    // `POST /notebook/save` all write without touching visibility), and
+    // closing there would pull a lab out from under the students sitting in
+    // it.  The whole difference is one form field, which is exactly the kind
+    // of thing that regresses without anyone noticing.
+    //
+    // These need the full multipart body — the handler returns early without a
+    // notebook, a solution and a non-empty suite, long before it reaches the
+    // visibility line.
+
+    private func saveBody(csrf: String, boundary: String, liveEdit: Bool) -> ByteBuffer {
+        let notebook = """
+            {"cells":[{"cell_type":"code","source":["x = 1\\n"],"metadata":{},"outputs":[],\
+            "execution_count":null}],"metadata":{},"nbformat":4,"nbformat_minor":5}
+            """
+        var fields: [(String, String)] = [
+            ("_csrf", csrf),
+            ("assignmentName", "Visibility Probe"),
+            ("dueAt", ""),
+        ]
+        if liveEdit { fields.append(("liveEdit", "1")) }
+        return arMultipartBody(
+            boundary: boundary,
+            fields: fields,
+            files: [
+                ("assignmentNotebookFile", "assignment.ipynb", "application/json", Data(notebook.utf8)),
+                ("solutionNotebookFile", "solution.ipynb", "application/json", Data(notebook.utf8)),
+            ]
+        )
+    }
+
+    private func visibilityAfterSave(
+        liveEdit: Bool, setupID: String, on app: Application
+    ) async throws
+        -> AssignmentVisibility
+    {
+        let cookie = try await arLoginAsInstructor(on: app)
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+        try await arInsertSetup(
+            id: setupID,
+            manifest: """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],\
+                "timeLimitSeconds":10,"makefile":null}
+                """,
+            on: app)
+        let assignment = try await arInsertAssignment(
+            testSetupID: setupID, title: "Visibility Probe", isOpen: true, on: app)
+        assignment.visibility = .open
+        try await assignment.save(on: app.db)
+
+        let boundary = "wbboundary\(setupID)"
+        try await app.asyncTest(
+            .POST, "/instructor/\(assignment.publicID)/edit/save",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                req.headers.contentType = .init(
+                    type: "multipart", subType: "form-data",
+                    parameters: ["boundary": boundary])
+                req.body = saveBody(csrf: csrf, boundary: boundary, liveEdit: liveEdit)
+            },
+            afterResponse: { _ in })
+
+        let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+        return reloaded.visibility
+    }
+
+    @Test func saveWithoutLiveEditClosesTheAssignment() async throws {
+        try await withAssignmentRoutesApp { app in
+            let visibility = try await visibilityAfterSave(
+                liveEdit: false, setupID: "setup_vis_closed", on: app)
+            #expect(visibility == .closed, "The standalone edit page must keep close-on-save")
+        }
+    }
+
+    @Test func saveWithLiveEditLeavesTheAssignmentOpen() async throws {
+        try await withAssignmentRoutesApp { app in
+            let visibility = try await visibilityAfterSave(
+                liveEdit: true, setupID: "setup_vis_open", on: app)
+            #expect(
+                visibility == .open,
+                "A workbench save must not close a lab that students are working in")
         }
     }
 

--- a/Tests/BrowserRunnerJSTests/workbench.test.mjs
+++ b/Tests/BrowserRunnerJSTests/workbench.test.mjs
@@ -1,5 +1,5 @@
 // Unit tests for the assignment workbench shell's pure logic: the splitter
-// clamp, which notebook a tab click resolves to, and the collapse toggle.
+// clamp, and which notebook a Files-table click resolves to.
 //
 // The clamp is the load-bearing piece. The notebook page hides its own editor
 // below 640px and shows "open on a larger screen" instead — so a splitter that
@@ -129,32 +129,4 @@ test('resolvePane: reports nothing for a file that has no destinations', () => {
   // what keeps it that way if the markup and the table ever disagree.
   assert.equal(Workbench.resolvePane(URLS, 'nosuchfile', 'personalized'), null);
   assert.equal(Workbench.resolvePane({}, 'assignment', 'personalized'), null);
-});
-
-test('toggleCollapse: collapsing remembers the width to come back to', () => {
-  const collapsed = Workbench.toggleCollapse({ collapsed: false, width: 640, restoreWidth: 0 });
-  assert.deepEqual(collapsed, { collapsed: true, width: 0, restoreWidth: 640 });
-
-  const expanded = Workbench.toggleCollapse(collapsed);
-  assert.deepEqual(expanded, { collapsed: false, width: 640, restoreWidth: 640 });
-});
-
-test('toggleCollapse: collapsing twice does not lose the restore width', () => {
-  // The failure this guards: a second collapse capturing the already-collapsed
-  // width of 0 would leave the pane unrestorable, with no way back to the
-  // editor short of dragging the splitter off the edge.
-  let state = { collapsed: false, width: 500, restoreWidth: 0 };
-  state = Workbench.toggleCollapse(state);
-  state = Workbench.toggleCollapse(state); // expand
-  state = Workbench.toggleCollapse(state); // collapse again
-  assert.equal(state.collapsed, true);
-  assert.equal(state.restoreWidth, 500);
-
-  state = Workbench.toggleCollapse(state);
-  assert.equal(state.width, 500, 'restoring must return the original width, not 0');
-});
-
-test('toggleCollapse: round-trips back to the starting state', () => {
-  const start = { collapsed: false, width: 420, restoreWidth: 420 };
-  assert.deepEqual(Workbench.toggleCollapse(Workbench.toggleCollapse(start)), start);
 });

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -160,12 +160,20 @@ async function seed() {
   // from the student dashboard once the assignment is open.)
   const instrDash = await instr.get("/instructor");
   const instrHtml = await instrDash.text();
-  const publicID = (instrHtml.match(/\/instructor\/([A-Za-z0-9]+)\/edit/) || [])[1];
+  // The dashboard's per-assignment link is the only place the publicID appears
+  // in this markup, so this scrape is load-bearing. It accepts both targets
+  // because that link has moved once already — it pointed at `/edit` until the
+  // workbench became the authoring surface — and a probe that hard-codes one
+  // spelling fails with "could not find publicID" rather than anything that
+  // points at the rename.
+  const publicID =
+    (instrHtml.match(/\/instructor\/([A-Za-z0-9]+)\/(?:workbench|edit)/) || [])[1];
   if (!publicID) {
     const markers = {
       finalURL: instrDash.url(),
       hasNoAssignments: instrHtml.includes("No assignments"),
       hasEditLink: instrHtml.includes("/edit"),
+      hasWorkbenchLink: instrHtml.includes("/workbench"),
       len: instrHtml.length,
     };
     throw new Error(`could not find publicID on /instructor markers=${JSON.stringify(markers)}:\n` + instrHtml.slice(0, 3500));

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -349,7 +349,12 @@ async function main() {
       return {
         count: frames.length,
         src: f ? f.getAttribute("src") : null,
-        solutionPresent: !!document.getElementById("wb-tab-solution"),
+        // Deliberately NOT a lookup in this document. The solution is now
+        // reached from the left pane's Files table, so its presence is a fact
+        // about that pane — and keying off a shell element that no longer
+        // exists is exactly how the assertion below would skip silently while
+        // looking like it passed.
+        solutionPresent: null,
       };
     });
     console.log(`notebook frames=${mounts.count} src=${mounts.src}`);
@@ -426,66 +431,46 @@ async function main() {
       return fail(`the view switch did not repoint the notebook (src=${afterView.src})`);
     }
 
-    // 6b. Tab and view switching drive the ONE notebook iframe.
+    // 6b. The left pane's Files table drives the notebook pane.
     //
-    //    There is a single notebook document, so what is asserted is that the
-    //    controls change where it points — not that a pool of frames is being
-    //    managed. Selecting Solution must repoint it at the solution; the view
-    //    switch must repoint it at the template of whatever file is selected.
-    if (mounts.solutionPresent) {
-      await page.click("#wb-tab-solution");
-      await page.waitForTimeout(1000);
-      const afterTab = await page.evaluate(() => {
+    //     Two things are asserted, and the second is the one that was a live
+    //     bug: those Edit links carry no `embedded=1`, so before this wiring a
+    //     click navigated the LEFT pane into a fully-chromed notebook page and
+    //     the assignment editor vanished from the workbench.
+    const panelFrame = page.frames().find((f) => f.url().includes("/workbench/panel"));
+    const hasSolutionEdit = await panelFrame.evaluate(
+      () => !!document.getElementById("solution-notebook-edit-btn"));
+    // Asserted, not assumed: the seed creates a solution, so a missing button
+    // means the wiring or the seed broke — not that this case does not apply.
+    if (!hasSolutionEdit) {
+      return fail(
+        "the left pane has no solution Edit button, so the Files-table switching " +
+        "assertion below would silently skip. The seed creates a solution.");
+    }
+    {
+      await panelFrame.click("#solution-notebook-edit-btn");
+      await page.waitForTimeout(1200);
+
+      const afterOpen = await page.evaluate(() => {
         const f = document.getElementById("wb-notebook");
         return { src: f.getAttribute("src"), file: f.getAttribute("data-wb-file") };
       });
-      console.log(`after tab switch: src=${afterTab.src}`);
-      if (!afterTab.src || !afterTab.src.includes("file=solution")) {
-        return fail(`selecting the Solution tab did not repoint the notebook (src=${afterTab.src})`);
+      console.log(`after Files-table open: src=${afterOpen.src}`);
+      if (!afterOpen.src || !afterOpen.src.includes("file=solution")) {
+        return fail(
+          `clicking the Files table's solution Edit did not repoint the notebook ` +
+          `(src=${afterOpen.src})`);
       }
-      if (afterTab.file !== "solution") {
-        return fail(`notebook frame still reports file=${afterTab.file} after selecting Solution`);
-      }
-    }
 
-    // 7. Collapsing the editor must give the notebook the FULL width.
-    //
-    //    This is a regression guard for a real bug, found by screenshotting
-    //    rather than by any test: hiding the edit pane with `display: none`
-    //    removes it from the grid, so with a three-column template still in
-    //    force the notebook landed in the `auto` column and sized to content.
-    //    It ended up ~380px wide, and the embedded notebook page — which hides
-    //    its editor below 640px — rendered "Open on a larger screen" instead of
-    //    the notebook. Collapsing to see MORE notebook showed none of it.
-    //
-    //    Unit tests could not see this; `toggleCollapse` was correct, the CSS
-    //    was not. So the assertion is on the rendered geometry.
-    await page.click("#wb-collapse-edit");
-    await page.waitForTimeout(800);
-    const collapsed = await page.evaluate(() => {
-      const pane = document.querySelector(".wb-pane-notebook");
-      const edit = document.querySelector(".wb-pane-edit");
-      return {
-        notebookWidth: pane ? pane.getBoundingClientRect().width : 0,
-        editVisible: edit ? edit.getBoundingClientRect().width > 0 : false,
-        viewport: window.innerWidth,
-      };
-    });
-    console.log(
-      `collapsed: notebook=${Math.round(collapsed.notebookWidth)}px of ${collapsed.viewport}px ` +
-      `viewport, editVisible=${collapsed.editVisible}`);
-    if (collapsed.editVisible) {
-      return fail("collapsing the editor left it visible");
-    }
-    // Full width, allowing for scrollbars/rounding — not merely "wider than the
-    // 720px floor", because the point of collapsing is to get everything.
-    if (collapsed.notebookWidth < collapsed.viewport - 40) {
-      return fail(
-        `collapsing the editor left the notebook only ${Math.round(collapsed.notebookWidth)}px ` +
-        `of a ${collapsed.viewport}px viewport. The edit pane is hidden but the grid still ` +
-        `reserves its columns, so the notebook is being sized to content — below 640px it ` +
-        `will render "Open on a larger screen" instead of the editor.`
-      );
+      const leftStillEditor = await page
+        .frames()
+        .find((f) => f.url().includes("/workbench/panel"))
+        ?.evaluate(() => !!document.getElementById("suite-sections"));
+      if (!leftStillEditor) {
+        return fail(
+          "the left pane is no longer the assignment editor — the Edit link " +
+          "navigated the pane instead of opening into the notebook pane.");
+      }
     }
 
     console.log("E2E OK — workbench isolation chain intact, panes wired as designed.");

--- a/changelog.d/ci-apt-retry.md
+++ b/changelog.d/ci-apt-retry.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Browser probe setup retries the Ubuntu package fetch.** Installing Node and
+  npm is an unauthenticated plain-HTTP fetch of ~40 packages from
+  `archive.ubuntu.com`; when that mirror is unreachable the step exits 100 and
+  takes the whole probe — and the required editor-smoke gate — down with it.
+  Observed on PR #1264: `Unable to connect to archive.ubuntu.com`. The
+  network-bound half now retries three times with a short backoff. `npm ci` is
+  deliberately left outside the loop, so a genuine lockfile failure still fails
+  once and clearly.

--- a/changelog.d/ci-mirror-timeout.md
+++ b/changelog.d/ci-mirror-timeout.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **The CI image rebuild no longer times out.** `mirror-images.yml` builds the
+  derived `swift-ci` image by apt-installing a heavy package set from
+  `archive.ubuntu.com` behind a retry loop; with that mirror flaking the build
+  step alone consumed 29.3 of its 30-minute budget and was killed, leaving the
+  image unpublished. Since the job runs weekly, a silent timeout means a stale
+  CI image for everyone. Budget raised to 60 minutes.

--- a/changelog.d/ci-probe-image-and-cache.md
+++ b/changelog.d/ci-probe-image-and-cache.md
@@ -1,0 +1,17 @@
+### Changed
+
+- **Browser probe jobs run in the `swift-ci` image and own a build cache.** They
+  previously used the plain Swift mirror and `apt-get`-installed Node and npm at
+  job start — the same per-job cost the `swift-ci` image already exists to
+  remove, and a hard failure whenever `archive.ubuntu.com` is unreachable.
+  `nodejs`/`npm` are now baked into that image and the probes use it; the apt
+  path remains as a guarded fallback so a caller on the plain mirror, or a run
+  that beats the image rebuild, still works.
+
+  They also now save and restore a probe-owned build cache when the shared
+  swift-tests key misses. That key is written by a job in another workflow, so
+  nothing could order the probes after it; a miss meant a cold Swift build, and
+  re-running a probe on the same commit paid for it again every time because
+  nothing the probes did ever populated a key they could read back. The shared
+  key is deliberately left alone — a probe winning that race would publish a
+  `.build` holding only `chickadee-server` for the swift-tests jobs to restore.

--- a/changelog.d/ci-probe-timeout-cold-build.md
+++ b/changelog.d/ci-probe-timeout-cold-build.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Browser probe jobs no longer time out on a cold build.** `browser-probe-setup`
+  builds `chickadee-server`, and the shared build cache it restores is keyed on
+  `hashFiles('Sources/**', 'Tests/**')` — so the key is new on any PR touching
+  either, and the job that populates it lives in a different workflow, which
+  `needs:` cannot order against. The probes therefore cold-build, and the setup
+  step alone measured 23.2 min on a passing run and 29.0 min on a killed one,
+  against a 30 min ceiling. The budget only ever fit the cache-hit path; on a
+  miss the job died in setup with every test step `skipped`, and GitHub reports
+  a timeout-kill as `cancelled`, which reads as an unrelated concurrency cancel.
+  Budgets raised to 50 min (75 for the grading probe, which runs 12 iterations
+  per engine on top of the same setup).

--- a/changelog.d/workbench-chrome-refinement.md
+++ b/changelog.d/workbench-chrome-refinement.md
@@ -1,0 +1,25 @@
+### Changed
+
+- **The workbench is now the assignment editor.** The `/instructor` dashboard's
+  Edit buttons open it, and its chrome has been cut back to what the panes do
+  not already provide: no Assignment/Solution tab strip, no Hide-editor or
+  Full-width-editor buttons, no repeated assignment title, and no Download in
+  the notebook pane. The left pane already names the assignment, lists its
+  files with links, and offers Edit for each.
+
+- **One Save, in the top-right corner.** "Save & Validate" and "Save to
+  assignment" were two buttons for what an author thinks of as one action.
+  The single Save writes the open notebook and the assignment's details and
+  re-validates.
+
+  It deliberately does **not** close the assignment. The standalone edit page
+  still does, unchanged — but the workbench is a live-edit surface, where the
+  suite, families and notebook endpoints all already write without changing
+  visibility, and closing on save there would pull a lab out from under the
+  students sitting in it.
+
+- **Clicking Edit in the Files table opens that notebook in the workbench's
+  notebook pane.** Previously those links carried no `embedded=1`, so inside
+  the workbench they navigated the *left* pane into a fully chromed notebook
+  page and the assignment editor disappeared. They are still ordinary links on
+  the standalone page.


### PR DESCRIPTION
UI review of the live page at `/instructor/DEJr2f/workbench`. Seven changes, all from that review.

## Removed, because the left pane already provides it

| Gone | Already in the left pane |
|---|---|
| Assignment/Solution tab strip | Files table lists both, with Edit buttons |
| Assignment title in the top bar | The edit page's own `<h1>` |
| Download in the notebook pane | Files table links each file |
| "Hide editor" / "Full-width editor" | — |

`#wb-single-edit` **stays**. It looks like the same class of button as the two removed, but below 1140px the panes stack and it is the only way back to the editor — removing it would make the narrow layout a dead end.

Removing collapse takes its state machine, its unit tests, and the collapsed-width browser assertion with it.

## The Files table now drives the notebook pane — and that fixes a live bug

Those Edit links carry no `embedded=1`. Inside the workbench, clicking one navigated the **left** pane into a fully chromed notebook page, nav bar and all, and the assignment editor disappeared. That is on production now.

They now post to the shell, which repoints the notebook pane. They remain ordinary links on the standalone page, so nothing changes there.

## One Save — and the part worth reviewing carefully

The two buttons were **not** redundant in behaviour, only in appearance:

| Button | Endpoint | Visibility |
|---|---|---|
| Save & Validate | `POST /edit/save` | sets `.closed` |
| Save to assignment | `POST /notebook/save` | never changes it — deliberate |

Merging naively onto close-on-save would mean fixing a typo mid-lab closes the assignment for students, which is precisely what the notebook endpoint's contract exists to prevent.

So the merged Save **does not close**. The workbench is a live-edit surface — `PUT /suite`, `PUT /families` and `POST /notebook/save` all already write without touching visibility — and this is now consistent with all of them. The standalone `/edit` page is untouched and still closes; the difference is a `liveEdit` field only the embedded form sends.

Both directions are pinned by test, because one form field is exactly the kind of thing that regresses unnoticed:
- save **without** `liveEdit` → `.closed` (standalone behaviour preserved)
- save **with** `liveEdit` on an open assignment → still open

## A naming trap worth knowing about

The shell needed to run the notebook pane's save. The obvious candidate, `window.chickadeeSaveNotebook`, **only flushes cells to JupyterLite's local storage** — using it would have reported a successful save that never reached the server. `notebook.js` now exposes `chickadeeSaveToAssignment`, the actual POST, resolving true/false.

## `/edit` becomes URL-only

With the dashboard pointing at the workbench and "Full-width editor" gone, `/instructor/:id/edit` is no longer linked from anywhere. Nothing breaks — the route stays, publish/save redirects still land there, and the sub-1140px workbench is usable — but the workbench is now *the* authoring surface rather than an alternative. Flagging it as the point of no return in this change.

## Testing

Verified against a real server in Chromium, every path live:

```
notebook frames=1 src=...file=assignment&view=personalized&embedded=1
pane keystroke reached the shell as chickadee:activity = true
view switch: present=true visible=true assignmentHasTemplate=1
after view switch:     src=...file=assignment&view=template&embedded=1
after Files-table open: src=...file=solution&view=personalized&embedded=1
E2E OK
```

The Files-table assertion also checks the left pane is **still the edit page** afterwards — that is the live bug above, asserted rather than assumed.

Screenshots reviewed at 1600/1280/1000 in light and dark before calling it done.

97 Swift tests across 4 suites, 150 JS tests, `check-styles`, `eslint`, `swiftlint --strict` all clean.

## Two process notes

**The dashboard had six Edit links, not the three I planned for** — it renders assignments in more contexts than I'd counted. Half-applying that change was the specific risk I'd flagged, so I verified the count rather than trusting the estimate.

**A skipped assertion, for the third time in this feature.** After deleting the tab strip, the smoke check's `solutionPresent` still keyed off `#wb-tab-solution`, so the whole Files-table block silently skipped while the run looked green. It now asserts the button exists and fails loudly if not. Three instances of the same class in one feature is a pattern, not bad luck — the fix each time has been to assert on the *absence of expected structure* rather than only on wrong values.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj)_