### PR TITLE
Workbench: writes stay in the pane instead of navigating it away

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -296,6 +296,64 @@
         }
     }
 
+    // ── Re-rendering the surface you are on ──────────────────────────────────
+    //
+    // `location.reload()` is the obvious way to pick up a server-side change,
+    // and it is wrong inside a workbench pane: the pane's URL is the panel
+    // route, but a page that got there by following a handler's redirect is
+    // sitting on the chromed standalone editor, and reloading pins it there.
+    // Pages that are rendered into a pane carry `data-ck-panel-url` on <body>
+    // (emitted by base.leaf), which names the URL that re-renders them
+    // correctly.
+    //
+    // Scroll position rides across, because every caller is re-rendering after
+    // a small edit — uploading one support file, renaming one section — and
+    // landing back at the top of a long assignment each time is its own kind
+    // of lost work.
+    var PANEL_SCROLL_KEY = 'chickadee:panel-scroll';
+
+    // Defensive about `document` for the same reason this file carries a
+    // `module.exports` branch: the .mjs unit tests evaluate it in a vm context
+    // with a hand-built `window`, not a DOM.
+    function panelURL() {
+        if (typeof document === 'undefined' || !document.body) return null;
+        return document.body.getAttribute('data-ck-panel-url') || null;
+    }
+
+    function reloadEditSurface() {
+        var url = panelURL();
+        if (!url) {
+            window.location.reload();
+            return;
+        }
+        try {
+            window.sessionStorage.setItem(PANEL_SCROLL_KEY + ':' + url, String(window.scrollY));
+        } catch (_) {
+            // Private mode. Losing the scroll offset is not worth failing a save.
+        }
+        window.location.replace(url);
+    }
+
+    // On `load`, not at parse: the suite table's rows are written by JS after
+    // this file runs, so restoring against the not-yet-populated page would
+    // clamp to a height that is about to triple.
+    function restorePanelScroll() {
+        var url = panelURL();
+        if (!url) return;
+        var saved;
+        try {
+            saved = window.sessionStorage.getItem(PANEL_SCROLL_KEY + ':' + url);
+            window.sessionStorage.removeItem(PANEL_SCROLL_KEY + ':' + url);
+        } catch (_) { return; }
+        if (saved == null) return;
+        var y = parseInt(saved, 10);
+        if (!isNaN(y) && y > 0) window.scrollTo(0, y);
+    }
+
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+        window.addEventListener('load', restorePanelScroll);
+    }
+
     var root = typeof window !== 'undefined' ? window : globalThis;
     root.ChickadeeUI = {
         escapeHtml: escapeHtml,
@@ -305,6 +363,7 @@
         extractErrorMessage: extractErrorMessage,
         fetchJSON: fetchJSON,
         notifyWorkbench: notifyWorkbench,
+        reloadEditSurface: reloadEditSurface,
         renderSparkline: renderSparkline,
         accordion: {
             CARET_HTML: CARET_HTML,

--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -312,16 +312,31 @@
     // of lost work.
     var PANEL_SCROLL_KEY = 'chickadee:panel-scroll';
 
+    // The exact shape `InstructorDashboardRoutes` emits, and nothing else.
+    //
+    // `panelURL()` reads an attribute out of the DOM and `reloadEditSurface`
+    // hands the result to `location.replace` — a navigation sink. The attribute
+    // is server-written today, so nothing reaches it that the server did not
+    // put there; the pattern exists so that stays true if some future page ever
+    // sets it from data it did not author. Unvalidated, a `javascript:` value in
+    // that attribute would execute. Same guard, same reasoning as
+    // `SAFE_PANE_URL` in workbench.js, which pins the notebook iframe's src.
+    var SAFE_PANEL_URL = /^\/instructor\/[A-Za-z0-9_-]+\/workbench\/panel$/;
+
     // Defensive about `document` for the same reason this file carries a
     // `module.exports` branch: the .mjs unit tests evaluate it in a vm context
     // with a hand-built `window`, not a DOM.
     function panelURL() {
         if (typeof document === 'undefined' || !document.body) return null;
-        return document.body.getAttribute('data-ck-panel-url') || null;
+        var url = document.body.getAttribute('data-ck-panel-url');
+        return (typeof url === 'string' && SAFE_PANEL_URL.test(url)) ? url : null;
     }
 
     function reloadEditSurface() {
         var url = panelURL();
+        // A rejected or absent URL falls back to a plain reload rather than
+        // failing: the surface still re-renders, which is what the caller asked
+        // for. Only the pane-aware destination is lost.
         if (!url) {
             window.location.reload();
             return;

--- a/Public/embedded-pane.js
+++ b/Public/embedded-pane.js
@@ -67,10 +67,19 @@
 
         var form = document.querySelector('form[action$="/edit/save"]');
         if (form) {
-            // The form posts and the pane navigates to the redirect target,
-            // which re-renders this same page. Reply before submitting: once
-            // the navigation starts this document is going away, and a reply
-            // sent after that never arrives.
+            // `chickadeeSubmitInPlace` is what this pane's own submit handler
+            // uses, so Save and a click on the form's submit button take the
+            // identical path. It resolves with the real outcome and never
+            // rejects, which is why the reply can wait for it — this used to
+            // reply `ok` optimistically and then submit natively, because the
+            // pane was about to navigate away and a later reply would never
+            // arrive. It reported success on a 500.
+            if (typeof window.chickadeeSubmitInPlace === 'function') {
+                window.chickadeeSubmitInPlace(form).then(function (ok) {
+                    post('save-result', { ok: ok !== false });
+                });
+                return;
+            }
             post('save-result', { ok: true });
             form.requestSubmit ? form.requestSubmit() : form.submit();
             return;

--- a/Public/inplace-forms.js
+++ b/Public/inplace-forms.js
@@ -1,0 +1,148 @@
+// Public/inplace-forms.js
+//
+// Keeps the workbench's left pane on the left pane.
+//
+// The assignment editor persists most of what it owns through ordinary form
+// POSTs — save, create-solution, secret-reveal, and section create/rename —
+// and every one of those handlers answers with a redirect to
+// `/instructor/:id/edit`, the fully-chromed standalone editor. That is correct
+// for the standalone page and wrong inside the workbench, where the redirect
+// lands *in the pane*: the author adds a suite section and the pane is
+// suddenly a second copy of the editor, nav bar and all, sitting under the
+// workbench's own Save button. Adding a section is not an edge case, so
+// neither is the confusing state.
+//
+// This file intercepts those submits, POSTs them with fetch, and then puts the
+// pane back on the panel URL it was already showing. Nothing about the request
+// changes — same endpoint, same encoding, same fields — only where the browser
+// goes afterwards.
+//
+// Loaded by base.leaf only for embedded panes, so the standalone `/edit` page
+// never sees it and keeps its native submit-and-redirect behaviour exactly.
+//
+// A form opts in with `data-ck-inplace`. The attribute is unconditional in the
+// template (harmless where this script is not loaded), so the two renderings of
+// `assignment-edit.leaf` stay byte-identical apart from the parts that must
+// differ.
+
+(function () {
+    'use strict';
+
+    // Same marker `ChickadeeUI.reloadEditSurface` keys off: no panel URL means
+    // this page is not in a pane, and its forms should submit natively.
+    if (!document.body || !document.body.getAttribute('data-ck-panel-url')) return;
+
+    // ── Error surface ────────────────────────────────────────────────────────
+    // Same inline banner base.leaf uses for a failed multipart upload, for the
+    // same reason: a native dialog inside a pane is a modal over one third of
+    // the screen with no indication of which half raised it.
+    function showError(form, msg) {
+        var banner = form.querySelector('.inplace-error-banner');
+        if (!banner) {
+            banner = document.createElement('div');
+            banner.className = 'form-error inplace-error-banner';
+            banner.setAttribute('role', 'alert');
+            form.insertBefore(banner, form.firstChild);
+        }
+        banner.textContent = msg;
+        banner.scrollIntoView({ block: 'nearest' });
+    }
+
+    function clearError(form) {
+        var banner = form.querySelector('.inplace-error-banner');
+        if (banner) banner.remove();
+    }
+
+    // ── Request ──────────────────────────────────────────────────────────────
+
+    // Preserve each form's own encoding rather than sending everything as
+    // FormData. The section and secret-reveal endpoints decode
+    // `application/x-www-form-urlencoded` today; switching them to multipart
+    // would be a live change to how their handlers parse, made silently, for
+    // no reason. CSRF rides the header either way — the multipart body is not
+    // buffered before the middleware runs, which is why base.leaf's handler
+    // sends the header too.
+    function requestFor(form) {
+        var fd = new FormData(form);
+        if (form.enctype === 'multipart/form-data') {
+            return { body: fd, headers: {} };
+        }
+        return {
+            body: new URLSearchParams(fd),
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+        };
+    }
+
+    // Re-render the pane rather than patching its DOM. The panel is a whole
+    // page of server-rendered state with a dozen editors bound to it, and
+    // re-rendering it is exactly what the redirect was already doing — minus
+    // the wrong destination.
+    //
+    // This is also the reason Slice 1 stops here rather than going straight to
+    // one document: merged, a re-render would restart the Pyodide kernel, so
+    // the refresh has to become a DOM swap with re-initialisation. That work
+    // belongs with the merge, not ahead of it.
+
+    /// POST a form and re-render the pane. Resolves true on success, false on
+    /// failure (with the banner already shown) — never rejects, so callers
+    /// waiting on a save always get an answer.
+    function submitInPlace(form) {
+        if (!form) return Promise.resolve(false);
+        clearError(form);
+
+        var submitter = form.querySelector('[type="submit"]');
+        if (submitter) submitter.disabled = true;
+
+        var req = requestFor(form);
+        req.headers['x-csrf-token'] = ChickadeeUI.getCsrfToken();
+
+        return fetch(form.action, {
+            method: (form.method || 'POST').toUpperCase(),
+            headers: req.headers,
+            body: req.body,
+            credentials: 'same-origin'
+        }).then(function (res) {
+            // `res.ok` covers the redirect the handlers answer with: fetch
+            // follows it and reports the final 200. A non-OK status is the
+            // handler's own error page, so its text is the useful message.
+            if (res.ok) {
+                // Scheduled, not called: `submitInPlace` resolves to callers
+                // that need the outcome (the workbench's Save reports it back
+                // to the shell), and a `.then` is a microtask. Reloading here
+                // would start tearing this document down in the same turn the
+                // caller is still queued behind.
+                setTimeout(function () { ChickadeeUI.reloadEditSurface(); }, 0);
+                return true;
+            }
+            return res.text().then(function (text) {
+                showError(form, 'Save failed: ' + res.status + ' '
+                    + (ChickadeeUI.extractErrorMessage(text) || res.statusText));
+                if (submitter) submitter.disabled = false;
+                return false;
+            });
+        }).catch(function (err) {
+            showError(form, 'Save failed: ' + ((err && err.message) || 'network error'));
+            if (submitter) submitter.disabled = false;
+            return false;
+        });
+    }
+
+    // ── Wiring ───────────────────────────────────────────────────────────────
+
+    // Registered from base.leaf's embedded block, which runs before the inline
+    // multipart handler further down that file. That handler already bails on
+    // `e.defaultPrevented`, so preventing here is all it takes to keep the two
+    // from both firing.
+    document.addEventListener('submit', function (e) {
+        var form = e.target;
+        if (!form || typeof form.matches !== 'function') return;
+        if (!form.matches('[data-ck-inplace]')) return;
+        if (e.defaultPrevented) return;
+        e.preventDefault();
+        submitInPlace(form);
+    });
+
+    // Exposed for the one caller that reaches this write without a form
+    // submit: `embedded-pane.js`, answering the workbench's Save button.
+    window.chickadeeSubmitInPlace = submitInPlace;
+}());

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -1253,11 +1253,19 @@
                 var f = document.createElement('form');
                 f.method = 'POST';
                 f.action = action;
+                // Marked and submitted the same way the template's own section
+                // forms are, so that inside a workbench pane `inplace-forms.js`
+                // intercepts this too.  `requestSubmit()` rather than
+                // `submit()`: `submit()` deliberately skips submit listeners,
+                // which would send the pane to the chromed standalone editor —
+                // the same trap v0.4.133 hit with the multipart CSRF intercept.
+                f.setAttribute('data-ck-inplace', '');
                 var t = document.createElement('input');
                 t.type = 'hidden'; t.name = '_csrf'; t.value = csrfToken;
                 f.appendChild(t);
                 document.body.appendChild(f);
-                f.submit();
+                if (typeof f.requestSubmit === 'function') f.requestSubmit();
+                else f.submit();
             }
         });
 

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -16,7 +16,13 @@
 </div>
 #endif
 
-<form class="form form--wide" method="post" action="/instructor/#(assignmentID)/edit/save" enctype="multipart/form-data" novalidate>
+<!-- `data-ck-inplace` marks every form on this page whose handler answers with
+     a redirect to the chromed standalone editor.  That is right standalone and
+     wrong inside a workbench pane, where the redirect lands *in the pane*; when
+     `inplace-forms.js` is loaded (embedded renders only) it fetches the POST
+     and re-renders the pane instead.  Unconditional in the markup: the script
+     is not loaded on the standalone page, so the attribute is inert there. -->
+<form class="form form--wide" method="post" action="/instructor/#(assignmentID)/edit/save" enctype="multipart/form-data" novalidate data-ck-inplace>
     #csrfFormField()
     <div class="editor-titlebar">
         <div class="editor-title-col">
@@ -136,7 +142,7 @@
                         <a class="btn action-btn" id="solution-notebook-edit-btn"
                            data-wb-file="solution" href="#(solutionNotebookEditURL)">Edit</a>
                         #else:
-                        <form method="post" action="/instructor/#(assignmentID)/create-solution" class="inline-form">
+                        <form method="post" action="/instructor/#(assignmentID)/create-solution" class="inline-form" data-ck-inplace>
                             #csrfFormField()
                             <button class="btn action-btn" type="submit"
                                     title="Copy the assignment notebook as a starting point for the solution">Create solution</button>
@@ -173,7 +179,7 @@
     <div class="editor-block-head">
         <h2>Student Options</h2>
     </div>
-    <form method="post" action="/instructor/#(assignmentID)/secret-reveal">
+    <form method="post" action="/instructor/#(assignmentID)/secret-reveal" data-ck-inplace>
         #csrfFormField()
         <label class="form-label">
             <input type="checkbox" name="enabled" #if(secretRevealEnabled):checked#endif>
@@ -273,7 +279,7 @@
             <details class="add-section-details popup-anchor" id="add-suite-section-details">
                 <summary class="btn action-btn summary-btn">+ Section</summary>
                 <div class="add-section-popup card suite-section-popup">
-                    <form method="post" action="/instructor/#(assignmentID)/suite-sections" class="form popup-form">
+                    <form method="post" action="/instructor/#(assignmentID)/suite-sections" class="form popup-form" data-ck-inplace>
                         #csrfFormField()
                         <label class="form-label">
                             Section name
@@ -325,7 +331,8 @@
                 <!-- Edit mode (hidden by default) -->
                 <div class="section-edit" style="display:none">
                     <form class="section-rename-form" method="post"
-                          action="/instructor/#(assignmentID)/suite-sections/#(sec.sectionID)/rename">
+                          action="/instructor/#(assignmentID)/suite-sections/#(sec.sectionID)/rename"
+                          data-ck-inplace>
                         #csrfFormField()
                         <input class="form-input section-name-input" type="text" name="name" value="#(sec.name)" required>
                         <button class="btn btn-primary btn-tiny" type="submit">Save</button>
@@ -774,7 +781,7 @@ function checkUWDates(dateTimeValue, warningEl) {
      The top file table lists `supportFileRows`; this wires the
      "+ Upload file" button (FileReader → POST /scripts with tier=support
      and isTest=false) and per-row Remove buttons (DELETE /scripts/:name).
-     Reload on success to pick up the rendered changes.  -->
+     Re-render on success to pick up the changed file rows.  -->
 <script>
 (function () {
     var assignmentID = '#(assignmentID)';
@@ -829,7 +836,7 @@ function checkUWDates(dateTimeValue, warningEl) {
                     await uploadSupportFile(input.files[i]);
                 }
                 setStatus('Uploaded.', false);
-                window.location.reload();
+                ChickadeeUI.reloadEditSurface();
             } catch (e) {
                 setStatus('Upload failed — ' + e.message, true);
             } finally {
@@ -858,7 +865,7 @@ function checkUWDates(dateTimeValue, warningEl) {
                 alert('Remove failed: ' + resp.status + ' ' + errText);
                 return;
             }
-            window.location.reload();
+            ChickadeeUI.reloadEditSurface();
         } catch (e) {
             alert('Remove failed: ' + e.message);
         }

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -23,7 +23,13 @@
          (e.g. csrf-token captures). -->
     <script src="/chickadee-ui.js?v=#appVersion()"></script>
 </head>
-<body>
+<!-- `data-ck-panel-url` marks a page that is rendered *into* a workbench pane
+     and names the URL that re-renders it.  `inplace-forms.js` keys off it: a
+     form POST from inside a pane must come back to this URL, not follow the
+     handler's redirect to the fully-chromed standalone editor.  Absent on every
+     other page, where a missing Leaf variable is falsy and the attribute is
+     simply not emitted. -->
+<body#if(panelURL): data-ck-panel-url="#(panelURL)"#endif>
 <!-- Site chrome — the nav, the colour bar, and the course tabs.  Suppressed
      when `embedded` is set, i.e. when this page is being rendered *into a pane*
      of the assignment workbench (`workbench.leaf`) rather than as a top-level
@@ -132,6 +138,12 @@
      pane, so without this the shell would sit "idle" and sign the author out
      mid-edit. -->
 <script src="/embedded-activity.js?v=#appVersion()"></script>
+<!-- Keeps a pane's form POSTs from navigating it: each is fetched and the pane
+     re-renders itself, instead of following the handler's redirect to the
+     chromed standalone page.  Loaded before the multipart interceptor at the
+     foot of this file, which bails on `e.defaultPrevented` — so the two never
+     both fire on the same submit. -->
+<script src="/inplace-forms.js?v=#appVersion()"></script>
 <!-- Cross-pane wiring: Files-table Edit opens into the notebook pane, and the
      workbench's single Save is answered here. -->
 <script src="/embedded-pane.js?v=#appVersion()"></script>

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -200,4 +200,11 @@ struct EditAssignmentContext: Encodable {
     /// "Open workbench" link (the workbench must not link to itself).
     /// `nil` on the standalone `/edit` render.
     let embedded: Bool?
+    /// The URL that re-renders this page in place — set only on the embedded
+    /// render, where it is the panel route itself.  `base.leaf` emits it as
+    /// `data-ck-panel-url` and `inplace-forms.js` sends the pane back here
+    /// after a write, instead of letting the handler's redirect to the chromed
+    /// `/edit` page land inside the pane.  `nil` standalone, where following
+    /// that redirect is the correct behaviour.
+    let panelURL: String?
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -665,7 +665,11 @@ struct InstructorDashboardRoutes: RouteCollection {
             error: q?.error,
             // nil rather than `false` on the standalone page so its rendered
             // HTML is byte-identical to before the workbench existed.
-            embedded: embedded ? true : nil
+            embedded: embedded ? true : nil,
+            // Where a write inside the pane sends the pane afterwards.  Must
+            // match the route `InstructorWorkbenchRoutes` registers, since the
+            // pane is already showing it.
+            panelURL: embedded ? "/instructor/\(idStr)/workbench/panel" : nil
         )
     }
 }

--- a/Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorWorkbenchRoutes.swift
@@ -80,7 +80,9 @@ struct InstructorWorkbenchRoutes: RouteCollection {
         // non-async autoclosure, so the await has to stand on its own.
         var solutionHasTemplate = false
         if hasSolution {
-            let solutionData = try? await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            let solutionData = try? await solutionNotebookData(
+                for: assignment, setup: setup, db: req.db,
+                testSetupsDirectory: req.application.testSetupsDirectory)
             solutionHasTemplate = hasPlaceholders(solutionData)
         }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -266,7 +266,9 @@ extension WebRoutes {
         let workingCopyPath = userNotebookWorkingCopyRelativePath(
             setupID: setupID, userID: userID, fileKind: fileKind, viewMode: viewMode)
         if fileKind == .solution {
-            let solutionData = try await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            let solutionData = try await solutionNotebookData(
+                for: assignment, setup: setup, db: req.db,
+                testSetupsDirectory: req.application.testSetupsDirectory)
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
                 setupID: setupID,
@@ -447,7 +449,10 @@ extension WebRoutes {
         let data: Data? =
             switch fileKind {
             case .assignment: try? notebookData(for: setup)
-            case .solution: try? await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            case .solution:
+                try? await solutionNotebookData(
+                    for: assignment, setup: setup, db: req.db,
+                    testSetupsDirectory: req.application.testSetupsDirectory)
             }
         guard let data else { return false }
         return !NotebookSubstitution.placeholderNames(in: data).isEmpty
@@ -538,7 +543,9 @@ extension WebRoutes {
             fileKind: fileKind, isStaff: isStaff, requested: query.view)
         let defaultData: Data? =
             if fileKind == .solution {
-                try await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+                try await solutionNotebookData(
+                    for: assignment, setup: setup, db: req.db,
+                    testSetupsDirectory: req.application.testSetupsDirectory)
             } else {
                 nil
             }

--- a/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
@@ -202,7 +202,9 @@ extension WebRoutes {
         case .assignment:
             return try? notebookData(for: setup)
         case .solution:
-            return try? await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            return try? await solutionNotebookData(
+                for: assignment, setup: setup, db: req.db,
+                testSetupsDirectory: req.application.testSetupsDirectory)
         }
     }
 

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -413,10 +413,26 @@ private func applySubstitutions(
     }
 }
 
+/// The bytes of an assignment's reference solution, from whichever of the four
+/// places one can live.
+///
+/// The order is oldest-authority-first and deliberately unchanged from the
+/// three original sources; the draft is checked last so nothing that resolved
+/// before resolves differently now.
+///
+/// The draft branch closes a gap between this function and every *other* place
+/// that decides whether a solution exists.  `hasSolution` on the edit page and
+/// the workbench counts four sources including the draft, but this counted
+/// three — so `POST /create-solution`, which writes exactly and only the draft,
+/// redirected to `/notebook?file=solution` and got a 404 from its own redirect
+/// target.  The Files table then showed a solution with an Edit button that
+/// led nowhere, for any assignment whose solution was created that way and
+/// never validated.
 func solutionNotebookData(
     for assignment: APIAssignment?,
     setup: APITestSetup,
-    db: Database
+    db: Database,
+    testSetupsDirectory: String
 ) async throws -> Data {
     if let entryName = listZipEntries(zipPath: setup.zipPath).first(where: { $0.hasPrefix("solution.") }),
         let data = extractZipEntry(zipPath: setup.zipPath, entryName: entryName),
@@ -443,6 +459,14 @@ func solutionNotebookData(
         !data.isEmpty
     {
         return normalizeNotebookForJupyterLite(data)
+    }
+
+    if let setupID = assignment?.testSetupID ?? setup.id {
+        let draftPath = draftSolutionNotebookPath(
+            testSetupsDirectory: testSetupsDirectory, setupID: setupID)
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: draftPath)), !data.isEmpty {
+            return normalizeNotebookForJupyterLite(data)
+        }
     }
 
     throw AppError.notFound(resource: "Solution notebook (not yet available for this assignment)")

--- a/Tests/APITests/AssignmentRoutesEditorTests.swift
+++ b/Tests/APITests/AssignmentRoutesEditorTests.swift
@@ -385,6 +385,36 @@ import VaporTesting
         }
     }
 
+    /// `create-solution` writes exactly one thing — the draft notebook — and
+    /// then redirects to `/testsetups/:id/notebook?file=solution`.  For a while
+    /// that redirect 404'd: `solutionNotebookData` resolved a solution from the
+    /// setup zip or a validation submission but never from the draft, so the
+    /// button's own destination reported the solution did not exist.  Every
+    /// other place that asks "is there a solution?" counts the draft, which is
+    /// why the Files table happily rendered an Edit button beside the dead link.
+    ///
+    /// Asserted through the page rather than the function so it pins the
+    /// user-visible behaviour: click Create solution, land on an editor.
+    @Test func solutionNotebookPageResolvesADraftOnlySolution() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsInstructor()
+            let setup = try await insertSetup(id: "ed_draftonly_sol", notebookOnDisk: sampleNotebookData())
+            _ = try await insertAssignment(testSetupID: "ed_draftonly_sol", title: "Draft Only")
+            try writeDraftSolutionNotebook(
+                setupID: setup.id ?? "",
+                data: sampleNotebookData(marker: "draft-only-solution-marker"))
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setup.id ?? "")/notebook?file=solution",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .ok,
+                        "create-solution's own redirect target 404s for a draft-only solution")
+                })
+        }
+    }
+
     // MARK: - GET /instructor/new/draft/solution-notebook
     //
     // The draft solution endpoint reads from one of two locations: a

--- a/Tests/APITests/InstructorWorkbenchRoutesTests.swift
+++ b/Tests/APITests/InstructorWorkbenchRoutesTests.swift
@@ -128,6 +128,105 @@ import VaporTesting
                     // closing the assignment.
                     #expect(!html.contains("Save &amp; Validate"))
                     #expect(html.contains("name=\"liveEdit\""))
+                    // Every write on this page redirects to the chromed
+                    // standalone editor.  Inside a pane that redirect lands
+                    // *in the pane*, which is what made the workbench confusing
+                    // to use: adding a suite section replaced the editor with a
+                    // second copy of itself.  These two attributes are the whole
+                    // fix — the marker on each such form, and the URL the pane
+                    // returns to instead.
+                    #expect(
+                        html.contains(
+                            "data-ck-panel-url=\"/instructor/\(assignment.publicID)/workbench/panel\""))
+                    #expect(html.contains("/inplace-forms.js"))
+                    #expect(html.contains("data-ck-inplace"))
+                })
+        }
+    }
+
+    /// Each navigating write is marked individually, so this counts them rather
+    /// than asserting the attribute appears at all.  A form that loses its
+    /// marker keeps working on the standalone page and silently goes back to
+    /// navigating the pane — a regression with no error and no failing test
+    /// unless the count is pinned.
+    @Test func everyNavigatingWriteFormIsMarkedForInPlaceSubmission() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(
+                id: "setup_wb7",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[],\
+                    "sections":[{"id":"sec1","name":"Question 1","variables":[],"expressions":[]}],\
+                    "timeLimitSeconds":10,"makefile":null}
+                    """,
+                on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb7", title: "Marked Lab", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/workbench/panel",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    // Compare the marked set to the expected set rather than
+                    // counting occurrences of the attribute: counting passes if
+                    // the marker lands on the wrong form, and it also matches
+                    // the word where it appears in a template comment.
+                    let base = "/instructor/\(assignment.publicID)"
+                    let expected: Set<String> = [
+                        "\(base)/edit/save",
+                        "\(base)/create-solution",
+                        "\(base)/secret-reveal",
+                        "\(base)/suite-sections",
+                        "\(base)/suite-sections/sec1/rename",
+                    ]
+                    #expect(
+                        markedFormActions(in: html) == expected,
+                        "a write form lost its in-place marker, or one gained it")
+                })
+        }
+    }
+
+    /// The `action` of every `<form>` in `html` that carries `data-ck-inplace`.
+    /// Deliberately parses the open tags rather than searching the whole
+    /// document, so prose in a template comment cannot be mistaken for markup.
+    private func markedFormActions(in html: String) -> Set<String> {
+        var actions: Set<String> = []
+        for chunk in html.components(separatedBy: "<form ").dropFirst() {
+            guard let end = chunk.firstIndex(of: ">") else { continue }
+            let tag = String(chunk[chunk.startIndex..<end])
+            guard tag.contains("data-ck-inplace") else { continue }
+            guard let actionStart = tag.range(of: "action=\"") else { continue }
+            let rest = tag[actionStart.upperBound...]
+            guard let quote = rest.firstIndex(of: "\"") else { continue }
+            actions.insert(String(rest[rest.startIndex..<quote]))
+        }
+        return actions
+    }
+
+    /// Standalone, the markers are inert: the script that acts on them is not
+    /// loaded and there is no panel URL to return to.  Pinned as its own test
+    /// because the whole safety of marking the forms unconditionally rests on
+    /// it.
+    @Test func standaloneEditPageCarriesTheMarkersButNotTheInterceptor() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "setup_wb8", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_wb8", title: "Inert Lab", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/edit",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        markedFormActions(in: html).contains(
+                            "/instructor/\(assignment.publicID)/edit/save"))
+                    #expect(!html.contains("/inplace-forms.js"))
+                    #expect(!html.contains("data-ck-panel-url=\""))
                 })
         }
     }

--- a/Tests/BrowserRunnerJSTests/reload-edit-surface.test.mjs
+++ b/Tests/BrowserRunnerJSTests/reload-edit-surface.test.mjs
@@ -1,0 +1,91 @@
+// Unit tests for ChickadeeUI.reloadEditSurface — how a page that is rendered
+// into a workbench pane re-renders itself after a write.
+//
+// The property under test is a navigation sink. `reloadEditSurface` reads
+// `data-ck-panel-url` off <body> and hands it to `location.replace`, which is
+// DOM text reaching a sink that will execute a `javascript:` URL. The attribute
+// is server-written today, so nothing hostile reaches it — the guard exists so
+// that stays true if a future page ever sets it from data it did not author,
+// and CodeQL flags the unguarded form (it flagged exactly this one).
+//
+// The fallback matters as much as the rejection: a rejected URL must still
+// re-render the surface, because every caller has just written something to the
+// server and is asking to see the result. Failing closed by doing nothing would
+// leave the author looking at stale state with no error.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+
+/// Load chickadee-ui.js against a stub DOM whose <body> carries `panelAttr`,
+/// recording which navigation the module performs.
+function load(panelAttr) {
+  const calls = [];
+  const body = {
+    getAttribute: (name) => (name === 'data-ck-panel-url' ? panelAttr : null),
+  };
+  const document = { body, querySelector: () => null };
+  const window = {
+    location: {
+      origin: 'https://chickadee.example',
+      reload: () => calls.push({ kind: 'reload' }),
+      replace: (url) => calls.push({ kind: 'replace', url }),
+    },
+    document,
+    scrollY: 0,
+    sessionStorage: { setItem: () => {}, getItem: () => null, removeItem: () => {} },
+  };
+  window.parent = window;
+
+  const context = vm.createContext({ window, document, globalThis: {} });
+  vm.runInContext(source, context);
+  return { ui: window.ChickadeeUI, calls };
+}
+
+test('reloadEditSurface: navigates to a well-formed panel URL', () => {
+  const { ui, calls } = load('/instructor/DEJr2f/workbench/panel');
+  ui.reloadEditSurface();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].kind, 'replace');
+  assert.equal(calls[0].url, '/instructor/DEJr2f/workbench/panel');
+});
+
+test('reloadEditSurface: plainly reloads when there is no panel URL', () => {
+  // The standalone /edit page. It emits no attribute, and following its own
+  // handlers' redirects is the correct behaviour there.
+  const { ui, calls } = load(null);
+  ui.reloadEditSurface();
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].kind, 'reload');
+});
+
+test('reloadEditSurface: refuses a URL that is not a panel route', () => {
+  // Each of these reaches `location.replace` if the pattern is dropped; the
+  // first two would execute. All must fall back to a plain reload — the surface
+  // still re-renders, only the pane-aware destination is lost.
+  const hostile = [
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    'https://evil.example/instructor/x/workbench/panel',
+    '//evil.example/instructor/x/workbench/panel',
+    '/instructor/x/workbench/panel/../../../admin',
+    '/instructor/x/edit',
+    '/instructor/x/workbench/panel?next=evil',
+    '',
+  ];
+
+  for (const url of hostile) {
+    const { ui, calls } = load(url);
+    ui.reloadEditSurface();
+    assert.equal(calls.length, 1, `expected exactly one navigation for ${JSON.stringify(url)}`);
+    assert.equal(
+      calls[0].kind, 'reload',
+      `${JSON.stringify(url)} reached location.replace — the panel-URL pattern let it through`);
+  }
+});

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -33,7 +33,10 @@
 //   5. a keystroke in a pane reaches the shell as `chickadee:activity`, the
 //      chain that stops the idle watchdog signing an author out mid-edit;
 //   6. the view switch appears on a notebook that carries placeholders and
-//      repoints to `view=template`, and the tabs repoint to the other file.
+//      repoints to `view=template`, and the tabs repoint to the other file;
+//   7. a write from the pane (creating a suite section) leaves the pane on the
+//      panel URL rather than following the handler's redirect into the chromed
+//      standalone editor, and does not disturb the notebook document.
 //
 // WebKit is expected NON-isolated at every level — it needs the comlink path —
 // so there the assertion is inverted, exactly as in notebook-page-check.mjs.
@@ -471,6 +474,102 @@ async function main() {
           "the left pane is no longer the assignment editor — the Edit link " +
           "navigated the pane instead of opening into the notebook pane.");
       }
+
+      // Repointing the `src` attribute is not the same as loading a document,
+      // and the difference is not cosmetic: this assertion passed for a build
+      // where the solution notebook 404'd and the pane held a
+      // `chrome-error://` page. The author saw an error where the editor should
+      // be and the check said OK.
+      const solutionCommitted = page
+        .frames()
+        .some((f) => f.url().includes("/notebook?") && f.url().includes("file=solution"));
+      if (!solutionCommitted) {
+        return fail(
+          "the notebook pane's src says file=solution but no such document committed — " +
+          "the solution page failed to load (a 404 leaves a chrome-error frame here).",
+          page.frames().map((f) => f.url() || "(blank)").join("\n  "));
+      }
+    }
+
+    // 7. A write from the pane keeps the pane — and keeps the notebook alive.
+    //
+    //    Every write on the edit page answers with a redirect to
+    //    `/instructor/:id/edit`, the fully-chromed standalone editor. Inside the
+    //    workbench that redirect lands IN THE PANE: the author adds a suite
+    //    section and the editor is replaced by a second copy of itself, nav bar
+    //    and all, under the workbench's own Save button. Adding a section is
+    //    not an edge case, so neither was the broken state.
+    //
+    //    The second assertion is forward-looking. Today a pane re-render cannot
+    //    touch the notebook, because they are separate documents — so the probe
+    //    below is nearly free. It stops being free the moment the panes become
+    //    one document, where the same write would tear down the live Pyodide
+    //    kernel and the author's unsaved cells with it. Writing it now means the
+    //    merge has a test that already knows what it must not break.
+    {
+      // Marked from inside the frame, via Playwright, rather than by reaching
+      // through `contentWindow` from the shell: the shell cannot touch the
+      // notebook frame's window (the browser reports it cross-origin under the
+      // isolation headers this page depends on, even though both documents are
+      // same-origin). Playwright evaluates per-frame and is not subject to that,
+      // and a Frame handle survives navigation — which is precisely what makes
+      // it a document-identity probe. If the document is replaced, the property
+      // is gone from the new one.
+      const notebookFrame = page.frames().find((f) => f.url().includes("/notebook?"));
+      if (!notebookFrame) {
+        return fail(
+          "no notebook frame to probe — the workbench is not showing a notebook.",
+          page.frames().map((f) => f.url() || "(blank)").join("\n  "));
+      }
+      await notebookFrame.evaluate(() => { window.__ckWorkbenchProbe = "alive"; });
+      // Read it back before relying on it. An unsettable probe would make the
+      // survival assertion below pass while testing nothing.
+      const probeStuck = await notebookFrame.evaluate(
+        () => window.__ckWorkbenchProbe === "alive");
+      if (!probeStuck) {
+        return fail(
+          "could not mark the notebook document, so the survival assertion below " +
+          "would prove nothing. The notebook frame is probably still navigating.");
+      }
+
+      const panel = page.frames().find((f) => f.url().includes("/workbench/panel"));
+      const sectionName = "Probe Section";
+      await panel.evaluate(() => {
+        document.getElementById("add-suite-section-details").open = true;
+      });
+      await panel.fill('#add-suite-section-details input[name="name"]', sectionName);
+      await panel.click('#add-suite-section-details button[type="submit"]');
+      await page.waitForTimeout(2500);
+
+      const panelAfter = page.frames().find((f) => f.url().includes("/workbench/panel"));
+      if (!panelAfter) {
+        return fail(
+          "after creating a suite section the left pane left /workbench/panel — the " +
+          "handler's redirect to the chromed /edit page navigated the pane. This is " +
+          "exactly what inplace-forms.js exists to prevent.",
+          page.frames().map((f) => f.url()).join("\n"));
+      }
+
+      const sectionLanded = await panelAfter.evaluate(
+        (name) => Array.from(document.querySelectorAll(".section-header strong"))
+          .some((el) => el.textContent.trim() === name),
+        sectionName);
+      if (!sectionLanded) {
+        return fail(
+          `the pane re-rendered but "${sectionName}" is not in it — the POST did not ` +
+          `land, so staying on the panel URL proved nothing.`);
+      }
+
+      const notebookSurvived = await notebookFrame
+        .evaluate(() => window.__ckWorkbenchProbe === "alive")
+        .catch(() => false);
+      if (!notebookSurvived) {
+        return fail(
+          "a write in the left pane replaced the notebook document. Today that is a " +
+          "kernel reboot; once the panes are one document it is the author's unsaved " +
+          "cells.");
+      }
+      console.log("suite-section write: pane stayed on the panel, notebook document intact");
     }
 
     console.log("E2E OK — workbench isolation chain intact, panes wired as designed.");

--- a/changelog.d/workbench-inplace-writes.md
+++ b/changelog.d/workbench-inplace-writes.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- **Writes in the workbench no longer navigate the editor pane away.** Every
+  form on the assignment editor — Save, Create solution, the secret-reveal
+  toggle, and suite-section create/rename/delete — redirects to the chromed
+  standalone editor when it succeeds. Inside the workbench that redirect landed
+  *in the left pane*, so adding a suite section replaced the editor with a
+  second copy of itself under the workbench's own Save button; because the
+  standalone page is not cross-origin isolated, the browser then refused it
+  under `require-corp` and the pane went blank. Those writes are now fetched and
+  the pane re-renders itself, keeping the author's scroll position. The
+  standalone `/edit` page is unchanged and still follows its redirects.
+- **The workbench's Save reports the real result.** It replied "saved" before
+  submitting, because the pane was about to navigate and a later reply would
+  never arrive — so a failed save looked like a successful one.
+- **`Create solution` no longer redirects to a 404.** It writes a draft
+  notebook, but the solution resolver only looked in the test-setup zip and at
+  validation submissions, so its own redirect target reported that no solution
+  existed. Every other place that asks whether an assignment has a solution
+  already counted the draft, which is why the Files table showed an Edit button
+  beside a dead link.


### PR DESCRIPTION
## The problem

Using the workbench, the left pane navigates, and once it does the page stops making sense — you are looking at a dashboard, or a fully-chromed edit page, inside a frame that still has the workbench's Save button above it.

Every source is nameable, and seven of them are ordinary *writes*:

| Source | What landed in the pane |
|---|---|
| `POST /edit/save` | redirect → chromed `/instructor/:id/edit` |
| `POST /create-solution` | same |
| `POST /secret-reveal` | same |
| `POST /suite-sections` (+ rename, delete) | same |
| support-file upload / delete | `window.location.reload()` |

So the confusing state is not an edge case — it is what happens the first time you add a suite section.

It is also worse than "confusing". The standalone `/edit` page is not cross-origin isolated, so once the redirect lands in the pane the browser refuses it under `require-corp` and the pane goes **blank**. That is visible in this PR's falsification run, where removing the fix leaves `chrome-error://chromewebdata/` where the editor should be.

## The fix

Each of those forms is marked `data-ck-inplace` and intercepted by a new `Public/inplace-forms.js`: the POST is fetched — same endpoint, same encoding, same fields — and the pane re-renders itself from the panel URL rather than following the redirect. Scroll position rides across, so saving does not also throw the author back to the top of a long assignment.

The interceptor is loaded only on embedded renders (`base.leaf`'s `#if(embedded)` block), so the standalone page keeps native submit-and-redirect exactly and the markers are inert there.

Re-rendering the pane rather than patching its DOM is deliberate: the panel is a page of server-rendered state with a dozen editors bound to it, and re-rendering is what the redirect was already doing, minus the wrong destination.

## Why this is a slice, not the whole thing

The goal is a single page with no left iframe. That cannot land first: merged, the JupyterLite kernel is a *sibling* of the edit form, so every one of these writes would destroy it (a 10–30 s reboot plus unsaved cells). The writes had to stop navigating before the iframe can come out.

This slice therefore fixes the reported problem on its own, with the iframe still in place as a safety net. The follow-up slice replaces the "re-render the pane" tail with a DOM swap plus re-initialisation and deletes the cross-frame layer entirely. `workbench-check.mjs` already asserts the notebook document survives a write, so that merge inherits a test that knows what it must not break.

## Two bugs fixed along the way

- **The workbench's Save reported success on failure.** It replied `save-result: ok` *before* submitting, because the pane was about to navigate and a later reply would never arrive. It now awaits the real outcome.

- **`POST /create-solution` redirected to a 404.** It writes a draft notebook, but `solutionNotebookData` resolved a solution only from the setup zip or a validation submission — never the draft — so the button's own redirect target reported that no solution existed. Every other place that asks "is there a solution?" already counts the draft, which is why the Files table rendered an Edit button beside a dead link. The draft is checked last, so nothing that resolved before resolves differently.

  Found because the new browser-check step could not run against a solution that would not load. The pre-existing step 6b asserted only the iframe's `src` **attribute** and had been passing green against a `chrome-error` frame — it now asserts the document actually committed.

## Verification

Every new assertion was confirmed to fail when the thing it tests is removed:

| Assertion | Broken by | Result |
|---|---|---|
| forms carry the in-place marker | unmarking `/secret-reveal` | red |
| pane carries `data-ck-panel-url` | `panelURL: nil` | red |
| standalone omits the interceptor | loading it unconditionally | red |
| pane stays on the panel after a write | unmarking `+ Section` | red |
| solution page resolves a draft-only solution | reverting the draft branch | red |

- Full Swift suite: **3010 tests in 352 suites pass**
- `.mjs` suite: **150 pass**
- `format.sh` / `lint.sh` / `swiftlint.sh` / `check-styles.sh` / `check-css-vars.sh` / `check-design-tokens.sh` / `eslint.sh` / `no-new-xctest.sh`: clean
- `workbench-check.mjs` passes end to end in chromium, including the new step 7
- Screenshotted light and dark at 1600 / 1280 / 1000: the section lands, the pane stays the editor, the notebook keeps its kernel, and the author stays where they were scrolled

```
SMOKE_CHECK=workbench-check.mjs SMOKE_BROWSER=chromium Tools/editor-smoke-test/run-smoke.sh
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj)_