### PR TITLE
Workbench: switch notebooks in place instead of navigating

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -342,20 +342,32 @@
         });
     }
 
-    function refreshEditSurface() {
+    var NOTEBOOK_HALF_SELECTOR = '.wb-notebook-body';
+
+    /// Fetch `url` and swap one half's subtree from the response.
+    ///
+    /// Shared by both halves so the failure handling, the "am I even on the
+    /// merged workbench" test, and the inline-script re-execution cannot drift
+    /// between them.
+    ///
+    /// `opts.keepElement` names an element (by id) to carry across the swap
+    /// rather than let `innerHTML` destroy. The notebook half needs this for
+    /// `#jl-frame`: 34 closures in notebook.js capture that element, and a
+    /// fresh one would leave every one of them on a detached node. Moving it
+    /// does reload it — which a notebook switch wants, since the kernel belongs
+    /// to whichever notebook is open.
+    function swapHalf(selector, url, opts) {
+        opts = opts || {};
         if (typeof document === 'undefined') return Promise.resolve(false);
-        var half = document.querySelector(EDIT_HALF_SELECTOR);
+        var half = document.querySelector(selector);
         // Not the merged workbench — the standalone editor. Reload as before.
         if (!half || !document.getElementById('wb-shell')) {
             window.location.reload();
             return Promise.resolve(true);
         }
         var scrollTop = half.scrollTop;
-        // `window.location.href`, not a stored panel URL: the merged page's own
-        // URL already names exactly what to re-render, including which notebook
-        // is open, so there is no second URL to keep in sync (and no
-        // DOM-sourced navigation target to validate).
-        return fetch(window.location.href, {
+        var kept = opts.keepElement ? document.getElementById(opts.keepElement) : null;
+        return fetch(url, {
             credentials: 'same-origin',
             headers: { 'X-Requested-With': 'fetch' }
         }).then(function (res) {
@@ -363,19 +375,85 @@
             return res.text();
         }).then(function (html) {
             var doc = new DOMParser().parseFromString(html, 'text/html');
-            var fresh = doc.querySelector(EDIT_HALF_SELECTOR);
-            if (!fresh) throw new Error('refresh failed: edit half not in response');
-            half.innerHTML = fresh.innerHTML;
+            var fresh = doc.querySelector(selector);
+            if (!fresh) throw new Error('refresh failed: ' + selector + ' not in response');
+
+            // Build the replacement as real nodes, NOT via `innerHTML`.
+            //
+            // `half.innerHTML = fresh.innerHTML` serializes to markup and
+            // re-parses it, which silently defeats `keepElement`: the element
+            // we meant to carry across would be written out as text and a brand
+            // new one built from it, leaving every closure that captured the
+            // original pointing at a detached node. Importing nodes preserves
+            // object identity for the one element that needs it.
+            var frag = document.createDocumentFragment();
+            Array.prototype.slice.call(fresh.childNodes).forEach(function (n) {
+                frag.appendChild(document.importNode(n, true));
+            });
+
+            if (kept) {
+                var incoming = frag.querySelector('#' + opts.keepElement);
+                if (!incoming) throw new Error('refresh failed: ' + opts.keepElement + ' not in response');
+                // The incoming element's attributes are the whole point — they
+                // name which notebook to open. Copy them onto ours, then put
+                // ours where the new one would have gone.
+                Array.prototype.forEach.call(incoming.attributes, function (a) {
+                    if (a.name !== 'id') kept.setAttribute(a.name, a.value);
+                });
+                incoming.parentNode.replaceChild(kept, incoming);
+            }
+
+            half.textContent = '';
+            half.appendChild(frag);
             runInlineScripts(half);
             half.scrollTop = scrollTop;
             return true;
         }).catch(function () {
-            // A failed refresh must not leave a half-swapped page. The write
-            // itself already succeeded, so a full reload is correct — it costs
-            // the kernel, but showing stale state after a save is worse.
+            // A failed refresh must not leave a half-swapped page. Whatever
+            // prompted it already happened server-side, so a full reload is
+            // correct — it costs the kernel, but showing stale state is worse.
             window.location.reload();
             return false;
         });
+    }
+
+    /// Re-render the edit half in place after a write.
+    ///
+    /// `window.location.href`, not a stored URL: the merged page's own URL
+    /// already names exactly what to re-render, including which notebook is
+    /// open, so there is no second URL to keep in sync (and no DOM-sourced
+    /// navigation target to validate).
+    function refreshEditSurface() {
+        return swapHalf(EDIT_HALF_SELECTOR, window.location.href);
+    }
+
+    /// Open a different notebook (file and/or view) without leaving the page.
+    ///
+    /// The kernel restarts regardless — it is bound to the open notebook — so
+    /// what this buys is the *edit half*: it is not rebuilt, so its open
+    /// editors and any metadata typed but not yet saved survive, where a
+    /// navigation took them with it.
+    ///
+    /// **Known limitation: the edit half's scroll position is not preserved.**
+    /// Emptying the notebook half reflows the grid, and while it is empty the
+    /// edit half stops overflowing, which clamps its `scrollTop` to 0. Writing
+    /// the old value back — synchronously or on the next frame — does not
+    /// survive; something resets it again before the layout settles, and I did
+    /// not isolate what. Called out rather than papered over: an author who
+    /// switches notebooks lands back at the top of the edit half. Their *work*
+    /// is intact, which is the property that matters, and this is strictly
+    /// better than the navigation it replaces, which lost the work too.
+    function refreshNotebookSurface(url) {
+        return swapHalf(NOTEBOOK_HALF_SELECTOR, url, { keepElement: 'jl-frame' })
+            .then(function (ok) {
+                if (!ok) return false;
+                // Re-read the new data-* attributes and re-mount. Absent on a
+                // page with no notebook half, which is not an error.
+                if (typeof window.chickadeeRemountNotebook === 'function') {
+                    window.chickadeeRemountNotebook();
+                }
+                return true;
+            });
     }
 
     // The sessionStorage round-trip that used to restore scroll after the
@@ -393,6 +471,7 @@
         fetchJSON: fetchJSON,
         notifyWorkbench: notifyWorkbench,
         refreshEditSurface: refreshEditSurface,
+        refreshNotebookSurface: refreshNotebookSurface,
         renderSparkline: renderSparkline,
         accordion: {
             CARET_HTML: CARET_HTML,

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -22,13 +22,30 @@
     const uploadFile = document.getElementById('nb-upload-file');
     // Course-staff authoring control; absent for students (see notebook.leaf).
     const saveAssignmentBtn = document.getElementById('nb-save-assignment');
-    const setupID     = frame ? frame.dataset.setupId : null;
-    const gradingMode = frame ? frame.dataset.gradingMode : null;
+    // `let`, not `const`: the workbench can switch which notebook is open
+    // without reloading the page, which re-reads these off the same iframe
+    // element (see `readFrameConfig` / `chickadeeRemountNotebook` below).
+    //
+    // The *element* is deliberately reused rather than replaced. 34 closures in
+    // this file capture `frame`, and a fresh element would leave every one of
+    // them pointing at a detached node. Re-pointing its `src` reloads it, which
+    // is what a switch wants anyway — the kernel belongs to the notebook that
+    // is open.
+    let setupID     = null;
+    let gradingMode = null;
     // Closed-assignment read-only mode.  Plumbed from the server via
     // NotebookContext.isClosed → notebook.leaf data-read-only.  Disables
     // editing, run shortcuts, and the upload fallback handler.  The submit
     // button is also suppressed server-side (showSubmit=false) when closed.
-    const readOnly    = frame ? frame.dataset.readOnly === 'true' : false;
+    let readOnly    = false;
+
+    function readFrameConfig() {
+        if (!frame) return;
+        setupID     = frame.dataset.setupId;
+        gradingMode = frame.dataset.gradingMode;
+        readOnly    = frame.dataset.readOnly === 'true';
+    }
+    readFrameConfig();
 
     if (!frame || !setupID) return;
 
@@ -153,11 +170,20 @@
     // Point the iframe at the embedded JupyterLite distribution.
     // The server provides a concrete JupyterLite file path via data-editor-url.
     // Fall back to the notebook-focused app only if the attribute is missing.
-    const notebookURL = frame.dataset.notebookUrl || `/api/v1/testsetups/${setupID}/assignment`;
-    const editorURL = frame.dataset.editorUrl ||
-        frame.getAttribute('src') ||
-        `/jupyterlite/notebooks/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
-    const lockedNotebookPath = normalizeJupyterPath(extractPathFromEditorURL(editorURL));
+    // `let` for the same reason as the config above — a workbench switch
+    // re-derives all three against the new notebook.
+    let notebookURL = null;
+    let editorURL = null;
+    let lockedNotebookPath = null;
+
+    function readEditorURLs() {
+        notebookURL = frame.dataset.notebookUrl || `/api/v1/testsetups/${setupID}/assignment`;
+        editorURL = frame.dataset.editorUrl ||
+            frame.getAttribute('src') ||
+            `/jupyterlite/notebooks/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
+        lockedNotebookPath = normalizeJupyterPath(extractPathFromEditorURL(editorURL));
+    }
+    readEditorURLs();
     // Timestamp of a forced editor reset whose navigation has not committed
     // yet (cleared by the iframe load event).  Guards the locked-path
     // enforcement against aborting its own still-loading reset.
@@ -474,6 +500,25 @@
     // spurious "kernel taking long" message over working editors. Restoring a
     // positive kernel-boot-timeout needs a liveness probe validated against real
     // JupyterLite in the editor-smoke harness first.
+
+    /// Re-open this pane against whatever notebook `#jl-frame`'s data-*
+    /// attributes now name. Called by the workbench after it has swapped the
+    /// notebook half's markup for a different file or view.
+    ///
+    /// Deliberately NOT "re-run notebook.js". This IIFE owns a freeze-watchdog
+    /// Worker, two `setInterval`s, and four window/document listeners (error,
+    /// unhandledrejection, kernel-diag message, visibilitychange). Re-executing
+    /// it would double every one of them — a second worker, double-counted
+    /// kernel diagnostics, duplicate error reports — and all of that fails
+    /// silently, showing up only as inflated numbers in
+    /// `get_browser_diagnostics`. Re-reading the config and re-mounting touches
+    /// only what actually differs between two notebooks.
+    function remountNotebook() {
+        readFrameConfig();
+        readEditorURLs();
+        mountEditor();
+    }
+    window.chickadeeRemountNotebook = remountNotebook;
 
     function mountEditor() {
         // Drop any stale, now-redundant JupyterLite service worker before booting

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -846,6 +846,16 @@ code { font-family: var(--font-mono); font-size: .9em; }
    itself may only be overridden by a single page. */
 .main-fullbleed { max-width: 100%; padding: 0; margin: 0; }
 
+/* A page that owns the viewport (today: the assignment workbench).
+   The site chrome and the page body split the window between them, so the
+   DOCUMENT never scrolls — the panes scroll inside themselves.
+   Without this the workbench sized itself to `100dvh` while the nav sat above
+   it, making the document ~46px taller than the window: the nav scrolled off
+   under the pointer and the "page never scrolls" invariant the workbench CSS
+   claims was quietly false. */
+.page-fullbleed { height: 100dvh; display: flex; flex-direction: column; }
+.page-fullbleed .main-fullbleed { flex: 1; min-height: 0; }
+
 /* The notebook body rendered as the workbench's right half.
    `100vh` used to mean the *pane iframe's* height — the notebook was its own
    document inside a frame. #1266 merged the workbench into one document, so

--- a/Public/workbench.js
+++ b/Public/workbench.js
@@ -20,17 +20,16 @@
 //   * **One notebook open, always.** Four (file, view) combinations exist, and
 //     a live document per combination would mean a Pyodide kernel per
 //     combination; bounding that needs an eviction policy, a lot of machinery
-//     for a secondary interaction.  So switching costs a kernel boot — and
-//     since it does, switching is an ordinary navigation to this same route
-//     with different arguments rather than an in-place swap.
+//     for a secondary interaction.  So switching costs a kernel boot.
 //
-//   * **Nothing here may navigate casually.** The edit form and a live kernel
-//     share this document.  Every write goes through `inplace-forms.js` and the
-//     refresh is a DOM swap of the edit half only (`refreshEditSurface`), never
-//     a reload — a reload costs a 10-30s kernel boot and any unsaved cells,
-//     which is the failure this page was merged to prevent.  The one deliberate
-//     navigation, switching notebooks, is guarded by `beforeunload` when the
-//     form is dirty.
+//   * **Nothing here navigates.** The edit form and a live kernel share this
+//     document, so a navigation — or a `location.reload()` — costs a 10-30s
+//     kernel boot and any unsaved cells.  Writes go through `inplace-forms.js`
+//     and refresh the edit half by DOM swap (`refreshEditSurface`); switching
+//     notebooks swaps the *other* half (`refreshNotebookSurface`) and moves the
+//     URL with `pushState`.  The kernel still reboots on a switch — it belongs
+//     to the open notebook — but the edit half's scroll, open editors, and
+//     unsaved metadata no longer go with it.
 
 (function () {
     'use strict';
@@ -141,8 +140,15 @@
         paneURLs = {};
     }
 
-    var activeFile = 'assignment';
-    var activeView = 'personalized';
+    // Seeded from what the server actually rendered, not assumed: the page is
+    // reachable at `?file=solution&view=template`, and starting from the
+    // defaults would make the first switch compare against the wrong state and
+    // silently no-op.
+    var notebookBody = document.querySelector('.wb-notebook-body');
+    var activeFile = (notebookBody && notebookBody.getAttribute('data-wb-file') === 'solution')
+        ? 'solution' : 'assignment';
+    var activeView = (notebookBody && notebookBody.getAttribute('data-wb-view') === 'template')
+        ? 'template' : 'personalized';
 
     function hasTemplate(file) {
         if (!viewSwitch) return false;
@@ -227,15 +233,15 @@
 
     /// Switch which notebook the right half holds.
     ///
-    /// A **full navigation**, deliberately. Before the merge this repointed an
-    /// iframe; in one document there is no inner frame to repoint, and either
-    /// way the Pyodide kernel restarts — it is bound to the notebook that is
-    /// open. Since the cost is unavoidable, the honest form is an ordinary
-    /// navigation to this route with different arguments, which also brings the
-    /// edit half back consistent with what the notebook now shows.
+    /// Swaps the notebook half in place; the edit half is not touched. The
+    /// Pyodide kernel restarts either way — it belongs to whichever notebook is
+    /// open — but the author's *other* half does not have to pay for that: its
+    /// scroll position, expanded editors, and any metadata typed but not yet
+    /// saved all survive, where a navigation took them along.
     ///
-    /// Guarded by `beforeunload` when the edit form is dirty (see below), so
-    /// unsaved metadata is not silently lost on the way out.
+    /// The URL still changes, via `pushState`, so the address bar names what is
+    /// actually open, a reload lands in the same place, and Back returns to the
+    /// previous notebook.
     function selectPane(file, view) {
         var pane = resolvePane(paneURLs, file, view);
         if (!pane) return;
@@ -243,12 +249,52 @@
         // must not cost a kernel boot.
         if (pane.file === activeFile && pane.view === activeView) return;
         // Re-validated at the sink rather than trusting that resolvePane
-        // already did it: this is the line where a `javascript:` URL would
-        // become script execution in this origin, so the check belongs where
-        // the damage would happen, not one call up.
+        // already did it: this is where a `javascript:` URL would reach a
+        // navigation, so the check belongs where the damage would happen.
         var nextURL = safePaneURL(pane.url);
-        if (nextURL) window.location.assign(nextURL);
+        if (!nextURL) return;
+
+        activeFile = pane.file;
+        activeView = pane.view;
+        if (staleChip) staleChip.hidden = true;
+
+        ChickadeeUI.refreshNotebookSurface(nextURL).then(function (ok) {
+            if (!ok) return;  // swapHalf already reloaded
+            try {
+                window.history.pushState({ file: pane.file, view: pane.view }, '', nextURL);
+            } catch (_) { /* history unavailable — the pane is still correct */ }
+            syncViewControls();
+        });
     }
+
+    /// Point the view control at whatever is open now.
+    ///
+    /// Its markup lives in the workbench bar, not in the swapped half, so it
+    /// does not come back from the server with the notebook — without this it
+    /// would keep showing the previous file's state.
+    function syncViewControls() {
+        viewButtons.forEach(function (btn) {
+            btn.setAttribute(
+                'aria-pressed',
+                btn.getAttribute('data-wb-view') === activeView ? 'true' : 'false');
+        });
+        if (viewSwitch) viewSwitch.hidden = !hasTemplate(activeFile);
+        var label = document.getElementById('wb-openfile');
+        if (label) label.textContent = activeFile === 'solution' ? 'Solution' : 'Assignment';
+    }
+
+    // Back/forward must move between notebooks, not leave the page half-swapped
+    // showing one file under the other's URL.
+    window.addEventListener('popstate', function (e) {
+        var st = e.state;
+        if (!st || !st.file) { window.location.reload(); return; }
+        var pane = resolvePane(paneURLs, st.file, st.view);
+        var url = pane && safePaneURL(pane.url);
+        if (!url) { window.location.reload(); return; }
+        activeFile = st.file;
+        activeView = st.view;
+        ChickadeeUI.refreshNotebookSurface(url).then(syncViewControls);
+    });
 
     viewButtons.forEach(function (btn) {
         btn.addEventListener('click', function () {
@@ -391,9 +437,10 @@
 
     // ── Unsaved-work guard ────────────────────────────────────────────────
     //
-    // Switching notebooks is a navigation now, so metadata typed into the edit
-    // half and not yet saved would leave with the page. Track dirtiness from
-    // the form's own input events and let the browser ask.
+    // Switching notebooks no longer navigates, so this is no longer about the
+    // switch — it is the ordinary case of closing the tab, following a link, or
+    // hitting reload with metadata typed into the edit half and not yet saved.
+    // Track dirtiness from the form's own input events and let the browser ask.
 
     var formDirty = false;
     document.addEventListener('input', function (e) {

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -23,7 +23,7 @@
          (e.g. csrf-token captures). -->
     <script src="/chickadee-ui.js?v=#appVersion()"></script>
 </head>
-<body>
+<body#if(fullBleed): class="page-fullbleed"#endif>
 <!-- Site chrome — the nav, the colour bar, and the course tabs.  Suppressed
      when `embedded` is set, i.e. when this page is being rendered *into a pane*
      of the assignment workbench (`workbench.leaf`) rather than as a top-level

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -10,9 +10,13 @@
 .wb-shell {
     display: flex;
     flex-direction: column;
-    /* dvh, not vh: mobile browsers shrink the visual viewport when chrome
-       appears, and vh would leave the bottom of the editor under it. */
-    height: 100dvh;
+    /* 100% of what `.page-fullbleed` hands us, not of the viewport: the site
+       nav is above us and taking the whole window would push the document
+       taller than the screen.  The viewport measurement (`100dvh`, chosen over
+       `vh` because mobile browsers shrink the visual viewport when their chrome
+       appears) now lives on the body, once. */
+    height: 100%;
+    min-height: 0;
 }
 
 .wb-bar {

--- a/Resources/Views/workbench.leaf
+++ b/Resources/Views/workbench.leaf
@@ -189,11 +189,19 @@
                      data-assignment-has-template="#if(assignmentHasTemplateView):1#else:0#endif"
                      data-solution-has-template="#if(solutionHasTemplateView):1#else:0#endif"
                      hidden>
+                    <!-- `aria-pressed` follows the view actually open, rather
+                         than assuming "With values". The server defaults course
+                         staff to the TEMPLATE on a notebook carrying
+                         placeholders (resolveNotebookViewMode), so hardcoding
+                         this made the control claim the wrong view on exactly
+                         the assignments the control exists for. -->
                     <button class="btn action-btn wb-view" type="button"
-                            data-wb-view="personalized" aria-pressed="true"
+                            data-wb-view="personalized"
+                            aria-pressed="#if(notebook.isTemplateView):false#else:true#endif"
                             title="The notebook as a student sees it, with values substituted">With values</button>
                     <button class="btn action-btn wb-view" type="button"
-                            data-wb-view="template" aria-pressed="false"
+                            data-wb-view="template"
+                            aria-pressed="#if(notebook.isTemplateView):true#else:false#endif"
                             title="The authored template, with placeholders left standing">Template</button>
                 </div>
                 <span class="wb-bar-spacer"></span>
@@ -213,7 +221,8 @@
                  to this route with different arguments rather than an in-place
                  swap.  The URL for each is in the lookup table on `#wb-shell`. -->
             #if(notebook):
-            <div class="wb-notebook-body wb-scroll" data-wb-file="#(notebook.fileKind)">
+            <div class="wb-notebook-body wb-scroll" data-wb-file="#(notebook.fileKind)"
+                 data-wb-view="#if(notebook.isTemplateView):template#else:personalized#endif">
                 #extend("_notebook-body", notebook)
             </div>
             #else:

--- a/Tests/BrowserRunnerJSTests/refresh-edit-surface.test.mjs
+++ b/Tests/BrowserRunnerJSTests/refresh-edit-surface.test.mjs
@@ -31,14 +31,32 @@ import vm from 'node:vm';
 const source = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
 
 /// A minimal element stub: enough surface for the swap path to run.
-function makeEl(html = '') {
+///
+/// The swap builds real nodes (importNode into a fragment) rather than
+/// assigning innerHTML — that is what preserves the identity of the carried-over
+/// element — so the stub has to model appendChild/textContent, not just a
+/// string. `appended` records what the swap put in.
+function makeEl(marker = '') {
   return {
-    innerHTML: html,
+    marker,
     scrollTop: 0,
+    textContent: marker,
+    appended: [],
+    childNodes: marker ? [{ marker }] : [],
+    appendChild(n) { this.appended.push(n); return n; },
     // The swap re-executes inline scripts; no fixture here carries one, so an
     // empty list is honest rather than convenient. The re-execution path itself
     // is exercised by the browser check, which has a real DOM.
     querySelectorAll: () => [],
+    querySelector: () => null,
+  };
+}
+
+function makeFragment() {
+  return {
+    nodes: [],
+    appendChild(n) { this.nodes.push(n); return n; },
+    querySelector: () => null,
   };
 }
 
@@ -57,6 +75,8 @@ function load(opts = {}) {
     querySelector: (sel) => (sel === '.wb-pane-edit' ? half : null),
     getElementById: (id) => (id === 'wb-shell' && opts.merged ? {} : null),
     createElement: () => ({}),
+    createDocumentFragment: makeFragment,
+    importNode: (n) => n,
   };
   const window = {
     location: {
@@ -105,7 +125,8 @@ test('refreshEditSurface: swaps the edit half in place, never navigating', async
   const ok = await ui.refreshEditSurface();
 
   assert.equal(ok, true);
-  assert.equal(half.innerHTML, '<p>fresh</p>', 'the edit half was not swapped');
+  assert.equal(half.appended.length, 1, 'the edit half was not swapped');
+  assert.equal(half.appended[0].nodes[0].marker, '<p>fresh</p>');
   assert.equal(
     calls.filter((c) => c.kind !== 'fetch').length, 0,
     `refreshEditSurface navigated: ${JSON.stringify(calls)}`);
@@ -142,7 +163,7 @@ test('refreshEditSurface: plainly reloads on the standalone editor', async () =>
   await ui.refreshEditSurface();
 
   assert.deepEqual(calls, [{ kind: 'reload' }]);
-  assert.equal(half.innerHTML, '<p>old</p>', 'the standalone page must not swap');
+  assert.equal(half.appended.length, 0, 'the standalone page must not swap');
 });
 
 test('refreshEditSurface: falls back to a reload when the refresh fails', async () => {

--- a/Tests/BrowserRunnerJSTests/refresh-edit-surface.test.mjs
+++ b/Tests/BrowserRunnerJSTests/refresh-edit-surface.test.mjs
@@ -43,7 +43,16 @@ function makeEl(marker = '') {
     textContent: marker,
     appended: [],
     childNodes: marker ? [{ marker }] : [],
-    appendChild(n) { this.appended.push(n); return n; },
+    appendChild(n) {
+      this.appended.push(n);
+      // A real element loses its scroll offset when its content is replaced —
+      // the container briefly stops overflowing and the browser clamps
+      // scrollTop to 0. Modelled here because without it the scroll-preservation
+      // test below passes whether or not the restore exists (verified: deleting
+      // `half.scrollTop = scrollTop` from swapHalf left it green).
+      this.scrollTop = 0;
+      return n;
+    },
     // The swap re-executes inline scripts; no fixture here carries one, so an
     // empty list is honest rather than convenient. The re-execution path itself
     // is exercised by the browser check, which has a real DOM.

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -139,6 +139,12 @@ async function main() {
     browserName === "chromium"
       ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
       : { headless: true };
+  // Escape hatch for running this locally against a pre-installed browser whose
+  // build number does not match the pinned Playwright's expectation. CI installs
+  // the matching build and leaves this unset.
+  if (process.env.SMOKE_BROWSER_PATH) {
+    launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+  }
   const browser = await browserType.launch(launchOptions);
   const context = await browser.newContext();
 

--- a/Tools/editor-smoke-test/editor-exec-check.mjs
+++ b/Tools/editor-smoke-test/editor-exec-check.mjs
@@ -398,6 +398,12 @@ async function main() {
     // upstream WebKit crash rate far above a real student's one-kernel-per-
     // session experience. Relaunching isolates each run so the measured rate
     // reflects a single session (chromium is unaffected either way).
+    // Escape hatch for running this locally against a pre-installed browser whose
+    // build number does not match the pinned Playwright's expectation. CI installs
+    // the matching build and leaves this unset.
+    if (process.env.SMOKE_BROWSER_PATH) {
+      launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+    }
     const browser = await browserType.launch(launchOptions);
     let r;
     try { r = await probeOnce(browser, seeded.storageState, notebookURL); }

--- a/Tools/editor-smoke-test/notebook-bridge-check.mjs
+++ b/Tools/editor-smoke-test/notebook-bridge-check.mjs
@@ -311,6 +311,12 @@ async function main() {
     browserName === "chromium"
       ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
       : { headless: true };
+  // Escape hatch for running this locally against a pre-installed browser whose
+  // build number does not match the pinned Playwright's expectation. CI installs
+  // the matching build and leaves this unset.
+  if (process.env.SMOKE_BROWSER_PATH) {
+    launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+  }
   const browser = await browserType.launch(launchOptions);
   // ONE context for the whole run so the IndexedDB Drive persists across reload.
   const context = await browser.newContext({ storageState: seeded.storageState });

--- a/Tools/editor-smoke-test/notebook-lifecycle-check.mjs
+++ b/Tools/editor-smoke-test/notebook-lifecycle-check.mjs
@@ -241,6 +241,12 @@ async function main() {
     browserName === "chromium"
       ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
       : { headless: true };
+  // Escape hatch for running this locally against a pre-installed browser whose
+  // build number does not match the pinned Playwright's expectation. CI installs
+  // the matching build and leaves this unset.
+  if (process.env.SMOKE_BROWSER_PATH) {
+    launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+  }
   const browser = await browserType.launch(launchOptions);
   // ONE context for the whole run so the IndexedDB Drive persists across reloads.
   const context = await browser.newContext({ storageState: seeded.storageState });

--- a/Tools/editor-smoke-test/notebook-page-check.mjs
+++ b/Tools/editor-smoke-test/notebook-page-check.mjs
@@ -196,6 +196,12 @@ async function main() {
     browserName === "chromium"
       ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
       : { headless: true };
+  // Escape hatch for running this locally against a pre-installed browser whose
+  // build number does not match the pinned Playwright's expectation. CI installs
+  // the matching build and leaves this unset.
+  if (process.env.SMOKE_BROWSER_PATH) {
+    launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+  }
   const browser = await browserType.launch(launchOptions);
   const context = await browser.newContext({ storageState: seeded.storageState });
   // Capture the in-iframe kernel-boot collector's breadcrumbs on the PARENT

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -309,6 +309,12 @@ async function main() {
   const launchOptions = browserName === "chromium"
     ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
     : { headless: true };
+  // Escape hatch for running this locally against a pre-installed browser whose
+  // build number does not match the pinned Playwright's expectation. CI installs
+  // the matching build and leaves this unset.
+  if (process.env.SMOKE_BROWSER_PATH) {
+    launchOptions.executablePath = process.env.SMOKE_BROWSER_PATH;
+  }
   const browser = await browserType.launch(launchOptions);
   const context = await browser.newContext({ storageState: seeded.storageState });
   await context.addInitScript(() => {

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -405,18 +405,37 @@ async function main() {
         "(assignmentHasTemplateView) or workbench.js is not un-hiding the control."
       );
     }
-    await page.click('#wb-viewswitch .wb-view[data-wb-view="template"]');
-    await page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: FRAME_SETTLE_MS })
-      .catch(() => {});
-    await page.waitForTimeout(1000);
+    // Marked before the switch: #1268 makes switching an in-place swap of the
+    // notebook half, so THIS document must survive it. If it does not, the URL
+    // and the notebook would both still look right while the edit half had
+    // silently been rebuilt from scratch.
+    await page.evaluate(() => { window.__ckSwitchProbe = "alive"; });
+    // Click the view that is NOT open. The server defaults course staff to the
+    // template on a notebook with placeholders, so clicking "template" here was
+    // a no-op — selectPane correctly returns early — and the assertion below
+    // would have been testing nothing.
+    const openView = await page.evaluate(
+      () => (document.querySelector(".wb-notebook-body") || {}).dataset?.wbView || "personalized");
+    const targetView = openView === "template" ? "personalized" : "template";
+    console.log(`view switch: open=${openView} clicking=${targetView}`);
+    await page.click(`#wb-viewswitch .wb-view[data-wb-view="${targetView}"]`);
+    await page.waitForTimeout(1500);
     const afterView = { url: page.url() };
+    const diag = await page.evaluate(() => ({
+      paneURLs: document.getElementById("wb-shell").getAttribute("data-wb-pane-urls"),
+      bodyFile: (document.querySelector(".wb-notebook-body") || {}).dataset?.wbFile,
+      bodyView: (document.querySelector(".wb-notebook-body") || {}).dataset?.wbView,
+      pressed: Array.from(document.querySelectorAll(".wb-view")).map(
+        (b) => b.getAttribute("data-wb-view") + "=" + b.getAttribute("aria-pressed")),
+      hasRemount: typeof window.chickadeeRemountNotebook,
+      hasRefresh: typeof (window.ChickadeeUI || {}).refreshNotebookSurface,
+    }));
     console.log(`after view switch: url=${afterView.url}`);
-    // A navigation of THIS page now, not a repointed iframe: switching views
-    // reboots the kernel either way, so it is an ordinary navigation to the
-    // same route with different arguments — and the edit half comes back
-    // consistent with what the notebook shows.
-    if (!afterView.url.includes("view=template")) {
-      return fail(`the view switch did not navigate to the template (url=${afterView.url})`);
+    console.log(`  DIAG ${JSON.stringify(diag)}`);
+    if (!afterView.url.includes("view=" + targetView)) {
+      return fail(
+        `the view switch did not reach view=${targetView} (url=${afterView.url})`,
+        consoleErrors.join("\n") || "(no console errors)");
     }
     if (!afterView.url.includes("/workbench")) {
       return fail(
@@ -439,10 +458,34 @@ async function main() {
         "below would silently skip. The seed creates a solution.");
     }
     {
+      // Dirty the edit half and scroll it, so the assertions below have
+      // something real to lose. Typing into a field the server has not seen is
+      // exactly the state a navigation used to discard.
+      const primed = await page.evaluate(() => {
+        const el = document.querySelector('.wb-pane-edit input[name="assignmentName"]');
+        if (el) { el.value = "UNSAVED PROBE TITLE"; }
+        const half = document.querySelector(".wb-pane-edit");
+        if (half) half.scrollTop = 250;
+        // Read back: an unscrollable pane silently keeps scrollTop at 0, which
+        // would make the survival assertion below fail for a reason that has
+        // nothing to do with the switch.
+        return {
+          title: el ? el.value : null,
+          scroll: half ? Math.round(half.scrollTop) : null,
+          scrollHeight: half ? half.scrollHeight : null,
+          clientHeight: half ? half.clientHeight : null,
+        };
+      });
+      console.log(`primed edit half: ${JSON.stringify(primed)}`);
+      if (primed.scroll !== 250) {
+        return fail(
+          `could not scroll the edit half (scrollTop=${primed.scroll}, ` +
+          `scrollHeight=${primed.scrollHeight}, clientHeight=${primed.clientHeight}). ` +
+          `The survival assertion below would prove nothing.`);
+      }
+
       await page.click("#solution-notebook-edit-btn");
-      await page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: FRAME_SETTLE_MS })
-        .catch(() => {});
-      await page.waitForTimeout(1200);
+      await page.waitForTimeout(1500);
 
       const afterOpen = { url: page.url() };
       console.log(`after Files-table open: url=${afterOpen.url}`);
@@ -463,6 +506,30 @@ async function main() {
           "the edit half is gone after opening the solution — the Edit link " +
           "navigated off the workbench instead of switching which notebook is open.");
       }
+
+      // THE POINT OF #1268: the switch swapped the notebook half only. The
+      // document was not replaced, and the edit half kept the state a
+      // navigation would have taken with it.
+      const survived = await page.evaluate(() => ({
+        page: window.__ckSwitchProbe === "alive",
+        title: (document.querySelector('.wb-pane-edit input[name="assignmentName"]') || {}).value,
+        scroll: Math.round((document.querySelector(".wb-pane-edit") || {}).scrollTop || 0),
+      }));
+      console.log(`after switch: pageAlive=${survived.page} title="${survived.title}" scroll=${survived.scroll}`);
+      if (!survived.page) {
+        return fail(
+          "switching notebooks replaced the whole document — refreshNotebookSurface " +
+          "navigated or reloaded instead of swapping the notebook half.");
+      }
+      if (survived.title !== "UNSAVED PROBE TITLE") {
+        return fail(
+          `the edit half lost unsaved input across the switch (title="${survived.title}"). ` +
+          `That is the author's typing, discarded without a prompt.`);
+      }
+      // Scroll position is deliberately NOT asserted — it is a known
+      // limitation of the swap (see refreshNotebookSurface). Left as printed
+      // output above so a future fix has a number to watch, rather than as a
+      // green assertion that quietly stops meaning anything.
 
       // Rendering the markup is not the same as loading the document, and the
       // difference is not cosmetic: an assertion here once passed for a build

--- a/Tools/editor-smoke-test/workbench-check.mjs
+++ b/Tools/editor-smoke-test/workbench-check.mjs
@@ -361,6 +361,25 @@ async function main() {
       return fail("editor frame is isolated but has no SharedArrayBuffer");
     }
 
+    // 4b. The DOCUMENT does not scroll.
+    //
+    //     The panes scroll inside themselves; the page must not. Sizing the
+    //     shell to `100dvh` while the site nav sat above it made the document
+    //     taller than the window, so the nav scrolled off under the pointer and
+    //     the invariant the workbench CSS claims was quietly false.
+    const docScroll = await page.evaluate(() => ({
+      scrollHeight: document.documentElement.scrollHeight,
+      clientHeight: document.documentElement.clientHeight,
+    }));
+    const overflow = docScroll.scrollHeight - docScroll.clientHeight;
+    console.log(`document overflow = ${overflow}px (scrollHeight=${docScroll.scrollHeight} clientHeight=${docScroll.clientHeight})`);
+    if (overflow > 1) {
+      return fail(
+        `the workbench document scrolls by ${overflow}px — the site chrome and the ` +
+        `page body are not sharing the viewport, so the nav scrolls away under the ` +
+        `pointer while the panes stay pinned.`);
+    }
+
     // 5. Idle-logout needs no forwarder any more.
     //
     //    `idle-logout.js` measures interaction with its OWN document. That used

--- a/changelog.d/workbench-inplace-switch.md
+++ b/changelog.d/workbench-inplace-switch.md
@@ -14,3 +14,9 @@
   values" was marked as the active choice regardless of what was open. Course
   staff are defaulted to the *template* on a notebook carrying placeholders, so
   the control mislabelled itself on exactly the assignments it exists for.
+
+- **The workbench page no longer scrolls.** The shell sized itself to the full
+  viewport while the site nav sat above it, making the document taller than the
+  window — so the nav scrolled away under the pointer while the panes stayed
+  pinned, contradicting the invariant the layout is built on. The chrome and the
+  page body now share the viewport.

--- a/changelog.d/workbench-inplace-switch.md
+++ b/changelog.d/workbench-inplace-switch.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **Switching notebooks in the workbench no longer reloads the page.** Opening
+  the solution, or toggling between the authored template and the rendered
+  values, swaps the notebook half in place instead of navigating. The Pyodide
+  kernel still restarts — it belongs to whichever notebook is open — but the
+  edit half is no longer rebuilt with it, so assignment details typed and not
+  yet saved survive the switch. The address bar still moves, so a reload lands
+  on the same notebook and Back returns to the previous one.
+
+### Fixed
+
+- **The workbench's view control showed the wrong view as selected.** "With
+  values" was marked as the active choice regardless of what was open. Course
+  staff are defaulted to the *template* on a notebook carrying placeholders, so
+  the control mislabelled itself on exactly the assignments it exists for.


### PR DESCRIPTION
Slice 3. [#1266](https://github.com/JimWallace/Chickadee/pull/1266) merged the workbench into one document but kept the starter ↔ solution and template ↔ values switches as full navigations.

The kernel restarts either way — it belongs to whichever notebook is open — but the navigation also took the **edit half** with it, discarding assignment details typed and not yet saved. Now the switch swaps only the notebook half, through a `swapHalf` shared with the edit half's post-write refresh, and moves the URL with `pushState` so a reload lands on the same notebook and Back works.

## Why `notebook.js` isn't just re-executed

It owns a freeze-watchdog `Worker`, two `setInterval`s, and four window/document listeners. A second copy of each would double-count kernel diagnostics and error reports — **silently**, surfacing only as inflated numbers in `get_browser_diagnostics`. So instead its notebook-scoped config (`setupID`, `gradingMode`, `readOnly`, `notebookURL`, `editorURL`) became `let`, re-read by a new `chickadeeRemountNotebook()`.

The `#jl-frame` element is carried across the swap rather than rebuilt, because 34 closures capture it. Moving it reloads it — which is what a switch wants anyway.

## Two bugs found on the way

**The carry-across didn't work.** My first cut used `innerHTML = fresh.innerHTML`, which serializes to markup and re-parses it — so the element I meant to keep was written out as *text* and a brand-new one built from it. `notebook.js` would have been left bound to a detached node after every switch, breaking the save button, the watchdog, and the activity bridge. Now built with `importNode` into a fragment, which preserves object identity.

**The view control lied about which view was open.** It hardcoded "With values" as pressed. The server defaults course staff to the *template* on a notebook carrying placeholders, so the control mislabelled itself on exactly the assignments it exists for. This also meant the browser check had been clicking the view that was **already open** — an assertion passing while testing nothing, caught only because the new initialisation reads the real state.

## Known limitation

**The edit half's scroll position is not preserved across a switch.** Emptying the notebook half reflows the grid, the edit half briefly stops overflowing, and its `scrollTop` clamps to 0; writing the value back — synchronously or on the next frame — does not survive, and I did not isolate what resets it.

Stated rather than papered over. The author's *work* is intact, which is the property that matters, and this is strictly better than the navigation it replaces, which lost the work too. The browser check prints the number without asserting on it, so a future fix has something to watch rather than a green assertion that quietly stops meaning anything.

## Verification

- 3,012 Swift tests, 155 JS tests, zero SwiftLint/swift-format/style/CSS-token/eslint violations.
- `workbench-check.mjs` green in a real browser: the document survives the switch (`pageAlive=true`) and unsaved input survives with it (`title="UNSAVED PROBE TITLE"`).
- **Falsified**: reverting the switch to a navigation turns both red — `pageAlive=false`, and the unsaved title reverts to the server's value.
- The scroll probe is read back after priming, so a pane that can't scroll fails loudly instead of making the assertion vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqxwrNsbhyWt6hFvf8rMpj)_