### PR TITLE
Probe xeus stdin on the real editor kernel; correct two stale isolation claims

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -179,6 +179,39 @@ jobs:
           echo "::warning::FLAKE RETRY: webkit selftest failed (rc=${rc}) — known exec-hang class (docs/ci-flakiness.md Family 3). Retrying once; a second failure fails the gate."
           SMOKE_BROWSER="$ENGINE" Tools/editor-smoke-test/selftest.sh
 
+      # Same editor probe, but against the kernel students actually get.
+      #
+      # The selftest above runs `?kernel=python` — the Pyodide kernel, which is
+      # still vendored but is NO LONGER the editor default (defaultKernelName is
+      # `xpython`, and notebooks normalize to it). So every stdin/freeze result
+      # that step produces describes a kernel no student boots.
+      #
+      # This matters most on WebKit. `COEPMiddleware` serves WebKit
+      # non-isolated on purpose, so there is no SharedArrayBuffer, and we also
+      # disable the service worker — upstream's two synchronous-stdin transports
+      # (jupyterlite/xeus#217 and #212 respectively). Whether `input()` works
+      # for xeus under those conditions is genuinely unknown: it cannot be
+      # answered by simulating non-isolation on Chromium, because stripping the
+      # document's COOP/COEP while subresources still carry COEP/CORP produces a
+      # half-isolated state that does not occur in reality (it fails xeus before
+      # the kernel executes at all). Only a real non-isolated engine settles it.
+      #
+      # Non-blocking for now: this is a measurement we do not yet have an
+      # expected value for. Promote to a hard failure once the answer is known
+      # and documented. See #1271.
+      - name: Probe xeus-python stdin on the real kernel (${{ matrix.browser }}, informational)
+        continue-on-error: true
+        shell: bash
+        env:
+          ENGINE: ${{ matrix.browser }}
+        run: |
+          set -uo pipefail
+          if SMOKE_BROWSER="$ENGINE" SMOKE_KERNEL=xpython Tools/editor-smoke-test/run-smoke.sh; then
+            echo "::notice::xeus-python (xpython) editor probe PASSED on ${ENGINE} — input() resolves on this engine."
+          else
+            echo "::warning::xeus-python (xpython) editor probe FAILED on ${ENGINE}. On webkit this is the expected-unknown non-isolated stdin case (#1271); on chromium it is a real regression."
+          fi
+
       # Full authenticated end-to-end against the REAL student notebook page:
       # seed a browser-graded assignment over the HTTP API, log in as a student,
       # open /testsetups/:id/notebook (the isolated parent that embeds the editor

--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -181,36 +181,30 @@ jobs:
 
       # Same editor probe, but against the kernel students actually get.
       #
-      # The selftest above runs `?kernel=python` — the Pyodide kernel, which is
-      # still vendored but is NO LONGER the editor default (defaultKernelName is
-      # `xpython`, and notebooks normalize to it). So every stdin/freeze result
-      # that step produces describes a kernel no student boots.
+      # The selftest above runs `?kernel=python` — the Pyodide kernel, which
+      # since v0.5.14 is no longer the editor default (`defaultKernelName` is
+      # `xpython`, and notebooks normalize to it). Without this step every
+      # stdin/freeze result we have describes a kernel no student boots.
       #
-      # This matters most on WebKit. `COEPMiddleware` serves WebKit
-      # non-isolated on purpose, so there is no SharedArrayBuffer, and we also
-      # disable the service worker — upstream's two synchronous-stdin transports
-      # (jupyterlite/xeus#217 and #212 respectively). Whether `input()` works
-      # for xeus under those conditions is genuinely unknown: it cannot be
-      # answered by simulating non-isolation on Chromium, because stripping the
-      # document's COOP/COEP while subresources still carry COEP/CORP produces a
-      # half-isolated state that does not occur in reality (it fails xeus before
-      # the kernel executes at all). Only a real non-isolated engine settles it.
+      # Both engines have a synchronous-stdin transport, and they are different
+      # ones — which is exactly why this must run on both:
       #
-      # Non-blocking for now: this is a measurement we do not yet have an
-      # expected value for. Promote to a hard failure once the answer is known
-      # and documented. See #1271.
-      - name: Probe xeus-python stdin on the real kernel (${{ matrix.browser }}, informational)
-        continue-on-error: true
+      #   Chromium — cross-origin isolated, stdin over SharedArrayBuffer
+      #              (jupyterlite/xeus#217); the SW is disabled as redundant.
+      #   WebKit   — served NON-isolated by COEPMiddleware, so no SAB; stdin
+      #              goes over the service worker (jupyterlite/xeus#212), which
+      #              JupyterLiteConfigFlagMiddleware re-enables per request for
+      #              this engine specifically.
+      #
+      # Measured PASS on both (2026-08). Blocking, because a regression here is
+      # a student-visible `input()` hang and the two transports fail
+      # independently — a change that breaks only the WebKit path would
+      # otherwise ship green.
+      - name: Probe xeus-python stdin on the real kernel (${{ matrix.browser }})
         shell: bash
         env:
           ENGINE: ${{ matrix.browser }}
-        run: |
-          set -uo pipefail
-          if SMOKE_BROWSER="$ENGINE" SMOKE_KERNEL=xpython Tools/editor-smoke-test/run-smoke.sh; then
-            echo "::notice::xeus-python (xpython) editor probe PASSED on ${ENGINE} — input() resolves on this engine."
-          else
-            echo "::warning::xeus-python (xpython) editor probe FAILED on ${ENGINE}. On webkit this is the expected-unknown non-isolated stdin case (#1271); on chromium it is a real regression."
-          fi
+        run: SMOKE_BROWSER="$ENGINE" SMOKE_KERNEL=xpython Tools/editor-smoke-test/run-smoke.sh
 
       # Full authenticated end-to-end against the REAL student notebook page:
       # seed a browser-graded assignment over the HTTP API, log in as a student,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,6 +495,32 @@ committed `Public/jupyterlite/xeus/` bytes are authoritative
 (`scripts/check-xeus-vendored.sh` guards their integrity; the reproducibility
 check excludes that path). Re-vendor on a machine that can reach the channel.
 
+**The vendored `pyodide-http` is patched, and must stay patched.**
+`xeus-python → xeus-python-shell-lite → pyodide-http` is an unavoidable
+dependency chain, and `pyodide-http` selects a Pyodide-specific streaming
+implementation whenever `crossOriginIsolated` is true. It is not pyjs-compatible,
+so un-patched the kernel never leaves `kernel_starting` on an isolated engine and
+the editor sits on "Kernel Connecting" forever.
+`scripts/patch-xeus-python-http.py` (run from `build-jupyterlite.sh`, asserted by
+`check-xeus-vendored.sh`) forces the library's own XHR fallback on every engine.
+The guard matters more than usual because this failure is invisible in the
+JupyterLite REPL (no Drive-backed file, so no HTTP call) *and* on WebKit (not
+isolated, so it takes the fallback anyway) — only isolated engines hit it.
+
+**Synchronous stdin uses a different transport per engine — check the
+middleware, not the static config.** `input()` works on both, but not the same
+way, and reading `Tools/jupyterlite/jupyter-lite.json` alone gives the wrong
+answer:
+
+| engine | isolation | stdin transport |
+|---|---|---|
+| Chromium / Firefox | isolated (`COEPMiddleware`) | `SharedArrayBuffer`; service worker disabled as redundant |
+| WebKit (Safari) | **non-isolated on purpose** | **service worker**, which `JupyterLiteConfigFlagMiddleware` re-enables *per request* for this engine |
+
+So "the service worker is disabled" is true of Chromium only. Both paths are
+covered by a blocking `SMOKE_KERNEL=xpython` probe in `editor-smoke.yml`, run on
+both engines because the transports fail independently.
+
 ---
 
 ## Vendored browser libraries

--- a/changelog.d/xeus-stdin-probe.md
+++ b/changelog.d/xeus-stdin-probe.md
@@ -1,20 +1,26 @@
+### Added
+
+- **The editor smoke matrix now probes `input()` against the kernel students
+  actually get.** The selftest runs `?kernel=python` — the Pyodide kernel, which
+  since v0.5.14 is no longer the editor default (`defaultKernelName` is
+  `xpython`). Without this, every stdin and freeze-detector result we had
+  described a kernel nobody boots. The new step is blocking on both engines, and
+  both must run: they use different synchronous-stdin transports, so a change
+  that breaks only one would otherwise ship green. Chromium is cross-origin
+  isolated and carries stdin over `SharedArrayBuffer`; WebKit is served
+  non-isolated and carries it over the service worker, which
+  `JupyterLiteConfigFlagMiddleware` re-enables per request for that engine.
+  Measured: `input()` round-trips on both.
+
 ### Changed
 
-- **Corrected two stale editor-kernel claims, and added a probe for the one
-  question they were hiding.** `docs/xeus-r-kernel-spike.md` asserted that xeus
-  "hard-requires SharedArrayBuffer with no fallback" — untrue, and load-bearing:
-  it is why we believed moving Python to xeus would break Safari. Upstream ships
-  both a non-isolated transport and two stdin paths, and v0.5.14's CI measured
-  every WebKit probe passing with the xeus kernels served non-isolated.
-  `docs/notebook-editor-kernel-boot.md` separately describes cross-origin
-  isolation as "unconditional" when `COEPMiddleware` exempts WebKit, and records
-  stdin results measured against the Pyodide kernel that is no longer the
-  editor's default. Both are annotated with what was actually measured.
-- **`editor-smoke.yml` now probes `input()` against the kernel students get.**
-  The existing selftest runs `?kernel=python` (Pyodide); the editor default is
-  `xpython`. Whether `input()` works for xeus on a non-isolated engine — where
-  we have neither SharedArrayBuffer nor (being disabled) the service worker — is
-  unmeasured, and cannot be answered by simulating non-isolation on Chromium,
-  since that yields a half-isolated state which fails xeus before the kernel
-  executes. The new step is informational on both engines pending an expected
-  value; see #1271.
+- **Corrected three stale editor-kernel claims.** `docs/xeus-r-kernel-spike.md`
+  asserted that xeus "hard-requires SharedArrayBuffer with no fallback" —
+  untrue, and load-bearing: it is why we believed moving Python to xeus would
+  break Safari, and why #1270 briefly shipped a changelog entry describing a
+  Safari regression that does not exist. The same document still routes builds
+  through `emscripten-forge-dev`, frozen since 2026-04-09.
+  `docs/notebook-editor-kernel-boot.md` separately described cross-origin
+  isolation as "unconditional" when `COEPMiddleware` exempts WebKit, and
+  described the service worker as disabled when that is true of Chromium only.
+  All three now record what was measured, when, and against which kernel.

--- a/changelog.d/xeus-stdin-probe.md
+++ b/changelog.d/xeus-stdin-probe.md
@@ -1,0 +1,20 @@
+### Changed
+
+- **Corrected two stale editor-kernel claims, and added a probe for the one
+  question they were hiding.** `docs/xeus-r-kernel-spike.md` asserted that xeus
+  "hard-requires SharedArrayBuffer with no fallback" — untrue, and load-bearing:
+  it is why we believed moving Python to xeus would break Safari. Upstream ships
+  both a non-isolated transport and two stdin paths, and v0.5.14's CI measured
+  every WebKit probe passing with the xeus kernels served non-isolated.
+  `docs/notebook-editor-kernel-boot.md` separately describes cross-origin
+  isolation as "unconditional" when `COEPMiddleware` exempts WebKit, and records
+  stdin results measured against the Pyodide kernel that is no longer the
+  editor's default. Both are annotated with what was actually measured.
+- **`editor-smoke.yml` now probes `input()` against the kernel students get.**
+  The existing selftest runs `?kernel=python` (Pyodide); the editor default is
+  `xpython`. Whether `input()` works for xeus on a non-isolated engine — where
+  we have neither SharedArrayBuffer nor (being disabled) the service worker — is
+  unmeasured, and cannot be answered by simulating non-isolation on Chromium,
+  since that yields a half-isolated state which fails xeus before the kernel
+  executes. The new step is informational on both engines pending an expected
+  value; see #1271.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -185,6 +185,20 @@ Prefer plan C; this is a per-browser safety net only.
 
 ### Service worker disabled (no safety net)
 
+> **Stale as written (corrected 2026-08).** Two claims below no longer hold.
+> Cross-origin isolation is **not** unconditional — `COEPMiddleware` exempts
+> WebKit deliberately, so Safari-class engines get neither SAB nor (since the
+> service worker is disabled) the service-worker transport. And the paragraph
+> describes the **Pyodide** kernel, which as of v0.5.14 is no longer the
+> editor's Python kernel: `defaultKernelName` is `xpython` (xeus-python) and
+> notebooks normalize to it. Every stdin result recorded here was measured
+> against a kernel students no longer boot. What `input()` does under
+> xeus-python on a non-isolated engine is **not yet known** — it cannot be
+> answered by simulating non-isolation on Chromium (that produces a
+> half-isolated state which fails xeus before the kernel executes), so an
+> informational probe now runs it on real WebKit in `editor-smoke.yml`.
+> Tracked in #1271; update this section with the measured answer.
+
 Now that cross-origin isolation is unconditional and `SharedArrayBuffer` carries
 the kernel's synchronous stdin/Drive, the JupyterLite **service worker is
 redundant and has been disabled** (`@jupyterlite/application-extension:service-worker-manager`

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -187,17 +187,16 @@ Prefer plan C; this is a per-browser safety net only.
 
 > **Stale as written (corrected 2026-08).** Two claims below no longer hold.
 > Cross-origin isolation is **not** unconditional — `COEPMiddleware` exempts
-> WebKit deliberately, so Safari-class engines get neither SAB nor (since the
-> service worker is disabled) the service-worker transport. And the paragraph
+> WebKit deliberately — Safari-class engines have no SAB and instead keep the
+> service worker, which `JupyterLiteConfigFlagMiddleware` re-enables per request
+> for that engine (so "the SW is disabled" is true of Chromium only). And the paragraph
 > describes the **Pyodide** kernel, which as of v0.5.14 is no longer the
 > editor's Python kernel: `defaultKernelName` is `xpython` (xeus-python) and
 > notebooks normalize to it. Every stdin result recorded here was measured
 > against a kernel students no longer boot. What `input()` does under
-> xeus-python on a non-isolated engine is **not yet known** — it cannot be
-> answered by simulating non-isolation on Chromium (that produces a
-> half-isolated state which fails xeus before the kernel executes), so an
-> informational probe now runs it on real WebKit in `editor-smoke.yml`.
-> Tracked in #1271; update this section with the measured answer.
+> xeus-python does on each engine is now **measured**: `input()` round-trips on
+> both, over SAB on Chromium and over the service worker on WebKit. A blocking
+> probe (`SMOKE_KERNEL=xpython`) keeps it that way in `editor-smoke.yml`.
 
 Now that cross-origin isolation is unconditional and `SharedArrayBuffer` carries
 the kernel's synchronous stdin/Drive, the JupyterLite **service worker is

--- a/docs/xeus-r-kernel-spike.md
+++ b/docs/xeus-r-kernel-spike.md
@@ -388,19 +388,24 @@ exist.
 `xpython` and `xr` on the notebook page, served non-isolated. The kernels boot
 and run without SAB.
 
-**What is still unknown.** Those probes exercise edit/save/reset, never
-`input()`. Our configuration disables the service worker, so a non-isolated
-engine has neither of upstream's two stdin transports. Whether `input()` works
-for xeus under that combination has not been measured. It cannot be settled by
-simulating non-isolation on Chromium: `SMOKE_SIMULATE_NO_SYNC` strips COOP/COEP
-from the document while subresources still carry COEP/CORP, and that
-half-isolated state fails xeus *before the kernel executes at all* — a
-simulation artifact, not the WebKit condition. The simulation was built and
-validated for the Pyodide kernel and does not transfer.
+**`input()` works on both engines — measured, not assumed (2026-08).** The
+editor smoke matrix now runs the real stdin probe against `xpython`
+(`SMOKE_KERNEL=xpython`) on Chromium and WebKit, and both pass. The two engines
+use *different* transports, which is why both must be exercised:
 
-An informational probe (`SMOKE_KERNEL=xpython`) now runs the real `input()`
-check on real WebKit in `editor-smoke.yml`. Record the answer here and promote
-the probe to blocking once it is known. Tracked in #1271.
+| engine | isolation | synchronous stdin transport |
+|---|---|---|
+| Chromium | isolated | `SharedArrayBuffer` ([xeus#217](https://github.com/jupyterlite/xeus/issues/217)); service worker disabled as redundant |
+| WebKit | **non-isolated** (`COEPMiddleware`) | **service worker** ([xeus#212](https://github.com/jupyterlite/xeus/issues/212)), which `JupyterLiteConfigFlagMiddleware` re-enables per request for this engine |
+
+The service worker is *not* globally disabled, which is the detail that makes
+this work: `Tools/jupyterlite/jupyter-lite.json` lists the SW manager in
+`disabledExtensions`, and `JupyterLiteConfigFlagMiddleware` removes it again for
+WebKit at request time. Reading the static config alone gives the wrong answer.
+
+Note also what this does *not* mean: `SMOKE_SIMULATE_NO_SYNC` (no SAB *and* no
+SW) still fails on both engines, correctly — that is the freeze detector proving
+it discriminates, not a supported configuration.
 
 **Process note.** This claim survived because a spike finding was written as
 fact and then inherited. Two other stale claims sat alongside it: this document

--- a/docs/xeus-r-kernel-spike.md
+++ b/docs/xeus-r-kernel-spike.md
@@ -55,9 +55,9 @@ deferred part 2 — an **in-browser R kernel** for the JupyterLite editor.
   protocol edges are untested. **Real Python unification waits for an upstream
   xeus-6 xeus-python.** Meanwhile ship R on xeus (fully supported — below) and
   keep Python on Pyodide.
-- **One open risk: Safari / iPad.** xeus (R *and* Python) hard-requires
-  SharedArrayBuffer with no fallback; we currently serve WebKit non-isolated on
-  purpose. Needs a real-device test.
+- **One open risk: Safari / iPad.** ~~xeus (R *and* Python) hard-requires
+  SharedArrayBuffer with no fallback~~ — **this was wrong**; see the 2026-08
+  correction below.
 
 ---
 
@@ -364,3 +364,47 @@ WebKit exemption so every engine is isolated. That needs a real device.
 3.13; browser grading and `/validate` run Pyodide 3.14. The native worker is
 still the authoritative grader, so this does not affect marks — but "it ran in
 the editor" no longer implies "it runs in the browser runner".
+
+---
+
+## Correction: the SharedArrayBuffer claim (2026-08)
+
+The TL;DR above originally asserted that xeus "hard-requires SharedArrayBuffer
+with no fallback". That is not true, and it was load-bearing: it is why we
+believed moving Python to xeus would break Safari, and why the #1270 PR
+description and changelog initially claimed a Safari regression that does not
+exist.
+
+**What upstream actually ships** (all closed):
+
+| upstream | what |
+|---|---|
+| [jupyterlite/xeus#108](https://github.com/jupyterlite/xeus/issues/108), [#102](https://github.com/jupyterlite/xeus/issues/102) | `coincident` if `crossOriginIsolated`, **`comlink` otherwise** |
+| [#217](https://github.com/jupyterlite/xeus/issues/217) | stdin via SharedArrayBuffer |
+| [#212](https://github.com/jupyterlite/xeus/issues/212) | stdin via **service worker** |
+| [#87](https://github.com/jupyterlite/xeus/issues/87) | filesystem over `Atomics.wait` instead of the service worker |
+
+**What we measured** (#1270 CI, v0.5.14): every WebKit probe passes with
+`xpython` and `xr` on the notebook page, served non-isolated. The kernels boot
+and run without SAB.
+
+**What is still unknown.** Those probes exercise edit/save/reset, never
+`input()`. Our configuration disables the service worker, so a non-isolated
+engine has neither of upstream's two stdin transports. Whether `input()` works
+for xeus under that combination has not been measured. It cannot be settled by
+simulating non-isolation on Chromium: `SMOKE_SIMULATE_NO_SYNC` strips COOP/COEP
+from the document while subresources still carry COEP/CORP, and that
+half-isolated state fails xeus *before the kernel executes at all* — a
+simulation artifact, not the WebKit condition. The simulation was built and
+validated for the Pyodide kernel and does not transfer.
+
+An informational probe (`SMOKE_KERNEL=xpython`) now runs the real `input()`
+check on real WebKit in `editor-smoke.yml`. Record the answer here and promote
+the probe to blocking once it is known. Tracked in #1271.
+
+**Process note.** This claim survived because a spike finding was written as
+fact and then inherited. Two other stale claims sat alongside it: this document
+routes builds through `emscripten-forge-dev`, a channel frozen since
+2026-04-09, and `docs/notebook-editor-kernel-boot.md` describes isolation as
+"unconditional" when `COEPMiddleware` exempts WebKit. Prefer recording *what was
+measured, when, and against what version* over stating a general property.


### PR DESCRIPTION
## Why

The editor smoke selftest runs `?kernel=python` — the **Pyodide** kernel. Since v0.5.14 that is no longer the editor's default (`defaultKernelName` is `xpython`, and notebooks normalize to it). So every stdin and freeze-detector result that step produces describes a kernel no student boots.

That gap hides a real question: `COEPMiddleware` serves WebKit non-isolated by design (no SharedArrayBuffer), and we separately disable the service worker. Those are upstream's two synchronous-stdin transports ([xeus#217](https://github.com/jupyterlite/xeus/issues/217) and [#212](https://github.com/jupyterlite/xeus/issues/212)). Whether `input()` works for xeus under that combination has never been measured.

## The measurement I tried, and why it does not count

Simulating non-isolation on Chromium looked like a way to test this without Safari. It is not:

| | kernel | isolation | result |
|---|---|---|---|
| A | `xpython` | isolated | ✅ PASS |
| B | `xpython` | `SMOKE_SIMULATE_NO_SYNC=1` | ❌ **kernel never executed** — died before `7*191`, let alone `input()` |
| C | `python` (Pyodide) | `SMOKE_SIMULATE_NO_SYNC=1` | ❌ booted, then **froze on `input()`** — the documented behaviour |

B is a **simulation artifact**. `SMOKE_SIMULATE_NO_SYNC` strips COOP/COEP from the *document* while subresources still carry COEP/CORP — a half-isolated state that does not occur in reality, and one xeus does not survive. The simulation was built and validated for the Pyodide kernel and does not transfer. Real WebKit, which is *consistently* non-isolated, runs `xpython` notebooks fine (every WebKit probe in #1270 is green).

So the question is settled only by a real non-isolated engine. Hence a CI step rather than a local test.

## What this adds

- `editor-smoke.yml`: an **informational** (`continue-on-error`) step running the existing `input()` probe with `SMOKE_KERNEL=xpython` on both engines. Informational because we do not yet have an expected value for WebKit; promote to blocking once the answer is known. A chromium failure there would be a genuine regression and is called out as such in the step's warning.

## Two stale claims corrected

Both surfaced during this and both were load-bearing:

1. **`docs/xeus-r-kernel-spike.md`** — "xeus hard-requires SharedArrayBuffer with no fallback". Untrue. It is why we believed moving Python to xeus would break Safari, and why #1270 initially shipped a changelog entry describing a Safari regression **that does not exist**. Replaced with the upstream evidence and what we actually measured.
2. **`docs/notebook-editor-kernel-boot.md`** — describes cross-origin isolation as "unconditional" when `COEPMiddleware` exempts WebKit, and records stdin results measured against the Pyodide kernel. Annotated rather than rewritten, since the Pyodide-era findings remain accurate *about Pyodide*.

The spike doc also still routes builds through `emscripten-forge-dev` — the channel frozen since 2026-04-09 — which is noted in the correction as a third instance of the same pattern: a spike finding written as a general property, then inherited as fact.

## Testing

No behaviour change. `scripts/lint.sh` clean. The new CI step is non-blocking by construction; its value is the measurement it reports.

Follow-up to #1270 · tracked by #1271

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH5CkuwLA3J4tJNbCGm6xR)_