### PR TITLE
fix: Lua audit follow-ups — CI interpreter, unordered_equal, stdout capture (F2–F4)

### DIFF
--- a/.github/docker/ci-image/Dockerfile
+++ b/.github/docker/ci-image/Dockerfile
@@ -26,6 +26,12 @@ FROM ${BASE_IMAGE}
 #             NotebookCheckRendererR, PersonalizationEvaluatorR, WorkerTests R
 #             normalization); without it every hasRscript guard skips silently
 #             and a shipped feature's grading path has zero CI coverage
+# lua5.4    — the Lua execution-path suites (LuaNativeGradingTests,
+#             LuaPersonalizationDriverTests, the conformance matrix's executed
+#             Lua rows); provides /usr/bin/lua via update-alternatives. Same
+#             silent-skip trap as r-base: it shipped in #1282 without this line,
+#             so every native Lua grading test guarded `luaAvailable` and skipped
+#             — the did-not-skip probes below now fail in CI if it regresses
 # python3-pandas / python3-matplotlib — NotebookCheckRuntimeState tests that
 #             exercise dataframe/plot check kinds against a real interpreter
 # nodejs/npm/ca-certificates — the browser probe jobs (editor smoke, exec-hang,
@@ -38,6 +44,6 @@ FROM ${BASE_IMAGE}
 #             editor-smoke gate went red because of an Ubuntu mirror.
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends file python3 zip unzip curl \
-        r-base python3-pandas python3-matplotlib \
+        r-base python3-pandas python3-matplotlib lua5.4 \
         nodejs npm ca-certificates \
     && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -200,12 +200,12 @@ jobs:
         # swift-ci rebuild — see mirror-images.yml), degrading to the old
         # per-job install instead of failing the job.
         run: |
-          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null; then
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v lua >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 lua5.4 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -285,12 +285,12 @@ jobs:
         # swift-ci rebuild — see mirror-images.yml), degrading to the old
         # per-job install instead of failing the job.
         run: |
-          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null; then
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v lua >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 lua5.4 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -370,11 +370,11 @@ jobs:
         # swift-ci image; the apt-get path is the stale-image fallback (see
         # the api-tests job note).
         run: |
-          if command -v file >/dev/null && command -v python3 >/dev/null; then
+          if command -v file >/dev/null && command -v python3 >/dev/null && command -v lua >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
-          apt-get update -qq && apt-get install -y --no-install-recommends file python3
+          apt-get update -qq && apt-get install -y --no-install-recommends file python3 lua5.4
 
       - name: Run WorkerTests
         # `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` caps Swift

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -2032,46 +2032,39 @@ function M.equal(actual, expected)
     return actual == expected
 end
 
--- Order-insensitive comparison for the unordered_equality kind: same elements,
--- any order. The Lua analogue of chickadee_unordered_equal in test_runtime.R,
--- and it takes the same shortcut for the same reason — elements are compared as
--- STRINGS, so a student returning 1 where the answer says 1.0 still matches,
--- and a table sorts against a table without needing a total order on values.
+-- Order-insensitive comparison for the unordered_equality kind: the two arrays
+-- hold the same elements in any order. Defined in terms of \`M.equal\`, greedily
+-- pairing each actual element with an as-yet-unused expected one — so it can
+-- NEVER disagree with \`equal\`, because it IS \`equal\`, applied pairwise.
 --
--- \`table.sort\` with a mixed-type array raises ("attempt to compare number with
--- string"), which is exactly the case an unordered comparison must survive, so
--- the mapping to strings happens before the sort rather than inside it.
+-- The previous version keyed each element through a string rendering and sorted
+-- the keys, which was a second, weaker notion of equality living beside the real
+-- one. It disagreed with \`equal\` in both directions: {1} vs {1.0} rendered
+-- "1" vs "1.0" and failed while equal(1, 1.0) passed; and { {"a, b"} } vs
+-- { {"a", "b"} } rendered alike (the comma-join) and passed while they are
+-- plainly different. Keying only reached the top level, so nested tables were
+-- worse still. Delegating to \`equal\` removes the whole second notion.
 --
--- The sort key is NOT \`M.format\`, and that was a real bug when it was: Lua 5.4
--- prints the integer 1 as "1" and the float 1.0 as "1.0", so
--- \`unordered_equal({1,2}, {1.0,2.0})\` answered false while \`M.equal(1, 1.0)\`
--- answered true — the same submission passing \`boundaryEquality\` and failing
--- \`unorderedEquality\`. Numbers are normalised through \`%.17g\`, which collapses
--- the integer/float split without losing precision, and the key carries a type
--- tag so the number 1 and the string "1" stay distinct the way \`==\` says they
--- are.
-local function unordered_key(value)
-    local kind = type(value)
-    if kind == "number" then
-        return "n:" .. string.format("%.17g", value)
-    end
-    return kind:sub(1, 1) .. ":" .. M.format(value)
-end
-
+-- Greedy matching is exact here because \`equal\` is an equivalence relation
+-- (exact value equality is transitive): if an actual element equals several
+-- expected ones they are mutually equal, so consuming any is safe. O(n^2),
+-- which is nothing at the sizes a generated case compares.
 function M.unordered_equal(actual, expected)
     if type(actual) ~= "table" or type(expected) ~= "table" then
         return false
     end
     if #actual ~= #expected then return false end
-    local a, b = {}, {}
+    local used = {}
     for i = 1, #actual do
-        a[i] = unordered_key(actual[i])
-        b[i] = unordered_key(expected[i])
-    end
-    table.sort(a)
-    table.sort(b)
-    for i = 1, #a do
-        if a[i] ~= b[i] then return false end
+        local matched = false
+        for j = 1, #expected do
+            if not used[j] and M.equal(actual[i], expected[j]) then
+                used[j] = true
+                matched = true
+                break
+            end
+        end
+        if not matched then return false end
     end
     return true
 end

--- a/Sources/APIServer/Utilities/PatternFamilyRendererLua.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRendererLua.swift
@@ -390,12 +390,24 @@ private func luaPerformanceCase(
 /// `.stdoutEquality` — what the call prints, compared after trimming trailing
 /// whitespace on each line (so a stray trailing space is not a failure).
 ///
-/// Lua has no `capture.output`, so `print` and `io.write` are swapped for
-/// collectors around the call and restored afterwards. They are swapped in the
-/// STUDENT's environment table, not in `_G`: the submission is loaded with
-/// `__index = _G`, so an assignment into its own table shadows the global for
-/// the student's code while leaving the harness's own `print` untouched — which
-/// matters because `chickadee.failed` writes the result JSON with `io.write`.
+/// Lua has no `capture.output`, so `print` and `io` are swapped for collectors
+/// around the call and restored afterwards. They are swapped in the STUDENT's
+/// environment table, not in `_G`: the submission is loaded with `__index = _G`,
+/// so an assignment into its own table shadows the global for the student's code
+/// while leaving the harness's own `print` untouched — which matters because
+/// `chickadee.failed` writes the result JSON with `io.write`.
+///
+/// The `io` proxy captures every ordinary way a student prints: `print`,
+/// `io.write(...)`, `io.stdout:write(...)`, and chained `io.write(a):write(b)` —
+/// the proxy's `write` drops a leading self argument (so the method form works)
+/// and returns the handle (so chaining works), and `io.stdout` is the same
+/// handle. Earlier this swapped only a bare `io.write`, so `io.stdout:write` and
+/// chained writes escaped capture and a CORRECT submission failed with empty
+/// output. The one path still uncapturable is a student who binds
+/// `local print = print` (or `local w = io.write`) *before* the call: that is an
+/// upvalue frozen at load time, which per-call swapping cannot reach. This kind
+/// grades output produced through `print` / `io.write` / `io.stdout`, which is
+/// what an assignment using it should ask for.
 private func luaStdoutCase(
     family: PatternFamily, case c: PatternCase, prelude: String
 ) -> String {
@@ -427,12 +439,22 @@ private func luaStdoutCase(
             end
             captured[#captured + 1] = table.concat(parts, "\\t") .. "\\n"
         end
+
+        -- A stand-in handle used for both `io` and `io.stdout`, so print,
+        -- io.write, io.stdout:write and chained io.write(a):write(b) are all
+        -- captured. `write` drops a leading self argument (the method forms) and
+        -- returns the handle (so chaining works).
+        local ck_stdout = {}
+        function ck_stdout.write(...)
+            local n = select("#", ...)
+            local start = (n >= 1 and select(1, ...) == ck_stdout) and 2 or 1
+            for i = start, n do
+                captured[#captured + 1] = tostring((select(i, ...)))
+            end
+            return ck_stdout
+        end
         student.io = setmetatable(
-            { write = function(...)
-                for i = 1, select("#", ...) do
-                    captured[#captured + 1] = tostring((select(i, ...)))
-                end
-            end },
+            { write = ck_stdout.write, stdout = ck_stdout },
             { __index = io })
 
         local ok, result = pcall(target\(ctx.callArgsSuffix))

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -822,46 +822,39 @@ let testRuntimeLua =
         return actual == expected
     end
 
-    -- Order-insensitive comparison for the unordered_equality kind: same elements,
-    -- any order. The Lua analogue of chickadee_unordered_equal in test_runtime.R,
-    -- and it takes the same shortcut for the same reason — elements are compared as
-    -- STRINGS, so a student returning 1 where the answer says 1.0 still matches,
-    -- and a table sorts against a table without needing a total order on values.
+    -- Order-insensitive comparison for the unordered_equality kind: the two arrays
+    -- hold the same elements in any order. Defined in terms of `M.equal`, greedily
+    -- pairing each actual element with an as-yet-unused expected one — so it can
+    -- NEVER disagree with `equal`, because it IS `equal`, applied pairwise.
     --
-    -- `table.sort` with a mixed-type array raises ("attempt to compare number with
-    -- string"), which is exactly the case an unordered comparison must survive, so
-    -- the mapping to strings happens before the sort rather than inside it.
+    -- The previous version keyed each element through a string rendering and sorted
+    -- the keys, which was a second, weaker notion of equality living beside the real
+    -- one. It disagreed with `equal` in both directions: `{1}` vs `{1.0}` rendered
+    -- "1" vs "1.0" and failed while `equal(1, 1.0)` passed; and `{ {"a, b"} }` vs
+    -- `{ {"a", "b"} }` rendered alike (the comma-join) and passed while they are
+    -- plainly different. Keying only reached the top level, so nested tables were
+    -- worse still. Delegating to `equal` removes the whole second notion.
     --
-    -- The sort key is NOT `M.format`, and that was a real bug when it was: Lua 5.4
-    -- prints the integer 1 as "1" and the float 1.0 as "1.0", so
-    -- `unordered_equal({1,2}, {1.0,2.0})` answered false while `M.equal(1, 1.0)`
-    -- answered true — the same submission passing `boundaryEquality` and failing
-    -- `unorderedEquality`. Numbers are normalised through `%.17g`, which collapses
-    -- the integer/float split without losing precision, and the key carries a type
-    -- tag so the number 1 and the string "1" stay distinct the way `==` says they
-    -- are.
-    local function unordered_key(value)
-        local kind = type(value)
-        if kind == "number" then
-            return "n:" .. string.format("%.17g", value)
-        end
-        return kind:sub(1, 1) .. ":" .. M.format(value)
-    end
-
+    -- Greedy matching is exact here because `equal` is an equivalence relation
+    -- (exact value equality is transitive): if an actual element equals several
+    -- expected ones they are mutually equal, so consuming any is safe. O(n^2),
+    -- which is nothing at the sizes a generated case compares.
     function M.unordered_equal(actual, expected)
         if type(actual) ~= "table" or type(expected) ~= "table" then
             return false
         end
         if #actual ~= #expected then return false end
-        local a, b = {}, {}
+        local used = {}
         for i = 1, #actual do
-            a[i] = unordered_key(actual[i])
-            b[i] = unordered_key(expected[i])
-        end
-        table.sort(a)
-        table.sort(b)
-        for i = 1, #a do
-            if a[i] ~= b[i] then return false end
+            local matched = false
+            for j = 1, #expected do
+                if not used[j] and M.equal(actual[i], expected[j]) then
+                    used[j] = true
+                    matched = true
+                    break
+                end
+            end
+            if not matched then return false end
         end
         return true
     end

--- a/Tests/APITests/LanguageConformanceMatrixTests.swift
+++ b/Tests/APITests/LanguageConformanceMatrixTests.swift
@@ -272,6 +272,32 @@ import Testing
         }
     }
 
+    /// The did-not-skip proof (audit F2). Every language's execution tests
+    /// guard on the interpreter being present and `return` silently when it is
+    /// not — which is correct on a developer laptop and a silent hole in CI,
+    /// where absence means a shipped grading path has zero coverage. `lua5.4`
+    /// shipped in #1282 without being added to the CI image, so every native
+    /// Lua test skipped while the suite reported green.
+    ///
+    /// This converts that into a hard failure: under `CI`, every interpreter
+    /// MUST answer its probe. It runs only in CI (a laptop legitimately lacks
+    /// R or Lua), so it never blocks local work — but it cannot be satisfied by
+    /// skipping.
+    @Test func noInterpreterIsSilentlyAbsentInCI() {
+        guard ProcessInfo.processInfo.environment["CI"] != nil else { return }
+        for language in AssignmentLanguage.allCases {
+            let probe = language.interpreterProbe
+            let (code, _) = Self.run(probe.command, probe.versionArguments, in: Self.repoRoot)
+            #expect(
+                code == 0,
+                """
+                \(language)'s interpreter (`\(probe.command)`) is absent in CI, so its execution \
+                tests skipped silently and its grading path has no coverage. Add it to \
+                .github/docker/ci-image/Dockerfile and the per-job apt fallback in swift-tests.yml.
+                """)
+        }
+    }
+
     // MARK: - Renderer coverage (never skipped)
 
     @Test(arguments: AssignmentLanguage.allCases)

--- a/Tests/APITests/LuaStdoutCaptureTests.swift
+++ b/Tests/APITests/LuaStdoutCaptureTests.swift
@@ -1,0 +1,111 @@
+// Tests/APITests/LuaStdoutCaptureTests.swift
+//
+// Executes a generated `.stdoutEquality` Lua test against the real `lua`
+// interpreter to prove the capture catches the ways a student actually prints
+// (audit F4). The renderer swaps `print` and `io` in the student's environment;
+// an earlier version swapped only a bare `io.write`, so `io.stdout:write` and
+// chained `io.write(a):write(b)` escaped and a CORRECT submission failed with
+// empty output. Verified by running, not reading, because the defect was a
+// wrong mark rather than a compile error.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite(.timeLimit(.minutes(2))) struct LuaStdoutCaptureTests {
+
+    static var luaAvailable: Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["lua", "-v"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+
+    private static var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // APITests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    /// The generated `.stdoutEquality` case script for Lua (the one that reads
+    /// `expected_output`, not any existence guard).
+    private func stdoutCaseScript() throws -> String {
+        let scripts = renderPatternFamily(
+            GeneratedSourceFixtures.family(kind: .stdoutEquality), language: .lua)
+        return try #require(scripts.first { $0.source.contains("expected_output") }).source
+    }
+
+    /// Grade `submission` with the generated script + the canonical runtime,
+    /// returning the outcome status parsed from the last JSON line.
+    private func grade(_ submission: String) throws -> String {
+        guard Self.luaAvailable else { return "pass" }  // skip: treated as no-op
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-luastdout-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let runtime = try String(
+            contentsOf: Self.repoRoot.appendingPathComponent(
+                "Tools/runner-support/test_runtime.lua"), encoding: .utf8)
+        try runtime.write(
+            to: dir.appendingPathComponent("test_runtime.lua"), atomically: true, encoding: .utf8)
+        try stdoutCaseScript().write(
+            to: dir.appendingPathComponent("publictest_fam_01.lua"), atomically: true,
+            encoding: .utf8)
+        try submission.write(
+            to: dir.appendingPathComponent("solution.lua"), atomically: true, encoding: .utf8)
+        try "solution.lua".write(
+            to: dir.appendingPathComponent(".chickadee_student_module"), atomically: true,
+            encoding: .utf8)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["lua", "publictest_fam_01.lua"]
+        process.currentDirectoryURL = dir
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        let text =
+            String(
+                data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let lastLine = text.split(separator: "\n").last.map(String.init) ?? ""
+        if lastLine.contains("\"status\":\"pass\"") { return "pass" }
+        if lastLine.contains("\"status\":\"fail\"") { return "fail" }
+        return "error"
+    }
+
+    // The fixture family prints the string "hello" for `classify`.
+
+    @Test func printIsCaptured() throws {
+        guard Self.luaAvailable else { return }
+        #expect(try grade(#"function classify(x) print("hello") end"#) == "pass")
+    }
+
+    @Test func ioStdoutWriteIsCaptured() throws {
+        guard Self.luaAvailable else { return }
+        // The regression: this escaped the old bare-io.write swap and failed a
+        // correct submission with empty output.
+        #expect(try grade("function classify(x) io.stdout:write(\"hello\\n\") end") == "pass")
+    }
+
+    @Test func chainedIoWriteIsCaptured() throws {
+        guard Self.luaAvailable else { return }
+        // Chained writes used to crash on the collector returning nil.
+        #expect(try grade("function classify(x) io.write(\"hel\"):write(\"lo\") end") == "pass")
+    }
+
+    @Test func wrongOutputStillFails() throws {
+        guard Self.luaAvailable else { return }
+        // The capture is stronger, but the check still bites.
+        #expect(try grade(#"function classify(x) print("goodbye") end"#) == "fail")
+    }
+}

--- a/Tests/Fixtures/generated-source/lua/pattern/stdout_equality/publictest_fam_01.lua
+++ b/Tests/Fixtures/generated-source/lua/pattern/stdout_equality/publictest_fam_01.lua
@@ -28,12 +28,22 @@ student.print = function(...)
     end
     captured[#captured + 1] = table.concat(parts, "\t") .. "\n"
 end
+
+-- A stand-in handle used for both `io` and `io.stdout`, so print,
+-- io.write, io.stdout:write and chained io.write(a):write(b) are all
+-- captured. `write` drops a leading self argument (the method forms) and
+-- returns the handle (so chaining works).
+local ck_stdout = {}
+function ck_stdout.write(...)
+    local n = select("#", ...)
+    local start = (n >= 1 and select(1, ...) == ck_stdout) and 2 or 1
+    for i = start, n do
+        captured[#captured + 1] = tostring((select(i, ...)))
+    end
+    return ck_stdout
+end
 student.io = setmetatable(
-    { write = function(...)
-        for i = 1, select("#", ...) do
-            captured[#captured + 1] = tostring((select(i, ...)))
-        end
-    end },
+    { write = ck_stdout.write, stdout = ck_stdout },
     { __index = io })
 
 local ok, result = pcall(target, x)

--- a/Tests/WorkerTests/LuaNativeGradingTests.swift
+++ b/Tests/WorkerTests/LuaNativeGradingTests.swift
@@ -37,6 +37,23 @@ import Testing
         return process.terminationStatus == 0
     }
 
+    /// The did-not-skip proof for the WorkerTests job (audit F2). Every test
+    /// below guards `luaAvailable` and returns silently when Lua is absent —
+    /// right on a laptop, a silent hole in CI. `lua5.4` shipped in #1282 without
+    /// being added to the CI image, so this whole suite skipped while reporting
+    /// green. Under `CI`, Lua MUST be present; this cannot be satisfied by
+    /// skipping.
+    @Test func luaIsPresentInCI() {
+        guard ProcessInfo.processInfo.environment["CI"] != nil else { return }
+        #expect(
+            Self.luaAvailable,
+            """
+            lua5.4 is absent in the CI image, so every native Lua grading test skipped silently. \
+            Add it to .github/docker/ci-image/Dockerfile and the WorkerTests apt fallback in \
+            swift-tests.yml.
+            """)
+    }
+
     /// A grading workspace shaped like the one `RunnerDaemon` materializes:
     /// the injected runtime, the student's submission, and the hint file that
     /// tells `chickadee.student_file()` which upload to grade.

--- a/Tests/WorkerTests/LuaUnorderedEqualTests.swift
+++ b/Tests/WorkerTests/LuaUnorderedEqualTests.swift
@@ -1,0 +1,102 @@
+// Tests/WorkerTests/LuaUnorderedEqualTests.swift
+//
+// Executes `chickadee.unordered_equal` against the real `lua` interpreter, over
+// the values where it used to disagree with `chickadee.equal` (audit F3). The
+// rewrite defines unordered_equal in terms of equal (greedy pairwise multiset
+// match), so the invariant is simply: for any two arrays, unordered_equal is
+// true whenever equal is — plus it accepts genuine reorderings. Run rather than
+// inspected, because the defect was a wrong mark, not a compile error.
+
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite(.timeLimit(.minutes(2))) struct LuaUnorderedEqualTests {
+
+    static var luaAvailable: Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["lua", "-v"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+
+    /// Runs `program` with the embedded `test_runtime.lua` on `package.path`,
+    /// returning trimmed stdout.
+    private func runLua(_ program: String) throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-unordered-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try testRuntimeLua.write(
+            to: dir.appendingPathComponent("test_runtime.lua"), atomically: true, encoding: .utf8)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["lua", "-e", program]
+        process.currentDirectoryURL = dir
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        return (String(data: data, encoding: .utf8) ?? "").trimmingCharacters(
+            in: .whitespacesAndNewlines)
+    }
+
+    /// The eight values from the audit table where the old string-keyed
+    /// implementation disagreed with `equal`. Every one must now agree.
+    @Test func unorderedEqualNeverDisagreesWithEqual() throws {
+        guard Self.luaAvailable else { return }
+        // Each pair is `{ actual, expected }` as Lua source; the harness reports
+        // any pair whose equal / unordered_equal verdicts differ.
+        let pairs = [
+            "{1,2}, {1.0,2.0}",
+            "{{1,2},{3,4}}, {{1.0,2.0},{3.0,4.0}}",
+            #"{{"a, b"}}, {{"a","b"}}"#,
+            "{{{1,2}}}, {{{9,9}}}",
+            "{9007199254740993}, {9007199254740992}",
+            "{chickadee.NULL}, {{}}",
+            #"{{1}}, {{"1"}}"#,
+            "{-0.0, 5}, {0.0, 5}",
+        ]
+        let cases = pairs.map { "{ \($0) }" }.joined(separator: ", ")
+        let program = """
+            local chickadee = require("test_runtime")
+            local cases = { \(cases) }
+            local disagreements = {}
+            for i, c in ipairs(cases) do
+                local eq = chickadee.equal(c[1], c[2])
+                local un = chickadee.unordered_equal(c[1], c[2])
+                if eq ~= un then disagreements[#disagreements + 1] = i end
+            end
+            io.write(#disagreements == 0 and "OK" or ("DISAGREE:" .. table.concat(disagreements, ",")))
+            """
+        let result = try runLua(program)
+        #expect(
+            result == "OK",
+            "equal and unordered_equal disagree on case(s) \(result) — the F3 regression is back")
+    }
+
+    /// The other half of the contract: a genuine reordering (and correct
+    /// multiset semantics) must still be accepted, so the fix did not make
+    /// unordered_equal a synonym for equal.
+    @Test func unorderedEqualStillAcceptsReorderings() throws {
+        guard Self.luaAvailable else { return }
+        let program = """
+            local chickadee = require("test_runtime")
+            local ok = chickadee.unordered_equal({1,2,3}, {3,1,2})
+                and chickadee.unordered_equal({{1,2},{3,4}}, {{3,4},{1,2}})
+                and chickadee.unordered_equal({1,1,2}, {2,1,1})
+                and not chickadee.unordered_equal({1,1,2}, {1,2,2})
+                and not chickadee.unordered_equal({1,2,3}, {1,2})
+            io.write(ok and "OK" or "WRONG")
+            """
+        #expect(try runLua(program) == "OK")
+    }
+}

--- a/Tools/runner-support/test_runtime.lua
+++ b/Tools/runner-support/test_runtime.lua
@@ -152,46 +152,39 @@ function M.equal(actual, expected)
     return actual == expected
 end
 
--- Order-insensitive comparison for the unordered_equality kind: same elements,
--- any order. The Lua analogue of chickadee_unordered_equal in test_runtime.R,
--- and it takes the same shortcut for the same reason — elements are compared as
--- STRINGS, so a student returning 1 where the answer says 1.0 still matches,
--- and a table sorts against a table without needing a total order on values.
+-- Order-insensitive comparison for the unordered_equality kind: the two arrays
+-- hold the same elements in any order. Defined in terms of `M.equal`, greedily
+-- pairing each actual element with an as-yet-unused expected one — so it can
+-- NEVER disagree with `equal`, because it IS `equal`, applied pairwise.
 --
--- `table.sort` with a mixed-type array raises ("attempt to compare number with
--- string"), which is exactly the case an unordered comparison must survive, so
--- the mapping to strings happens before the sort rather than inside it.
+-- The previous version keyed each element through a string rendering and sorted
+-- the keys, which was a second, weaker notion of equality living beside the real
+-- one. It disagreed with `equal` in both directions: `{1}` vs `{1.0}` rendered
+-- "1" vs "1.0" and failed while `equal(1, 1.0)` passed; and `{ {"a, b"} }` vs
+-- `{ {"a", "b"} }` rendered alike (the comma-join) and passed while they are
+-- plainly different. Keying only reached the top level, so nested tables were
+-- worse still. Delegating to `equal` removes the whole second notion.
 --
--- The sort key is NOT `M.format`, and that was a real bug when it was: Lua 5.4
--- prints the integer 1 as "1" and the float 1.0 as "1.0", so
--- `unordered_equal({1,2}, {1.0,2.0})` answered false while `M.equal(1, 1.0)`
--- answered true — the same submission passing `boundaryEquality` and failing
--- `unorderedEquality`. Numbers are normalised through `%.17g`, which collapses
--- the integer/float split without losing precision, and the key carries a type
--- tag so the number 1 and the string "1" stay distinct the way `==` says they
--- are.
-local function unordered_key(value)
-    local kind = type(value)
-    if kind == "number" then
-        return "n:" .. string.format("%.17g", value)
-    end
-    return kind:sub(1, 1) .. ":" .. M.format(value)
-end
-
+-- Greedy matching is exact here because `equal` is an equivalence relation
+-- (exact value equality is transitive): if an actual element equals several
+-- expected ones they are mutually equal, so consuming any is safe. O(n^2),
+-- which is nothing at the sizes a generated case compares.
 function M.unordered_equal(actual, expected)
     if type(actual) ~= "table" or type(expected) ~= "table" then
         return false
     end
     if #actual ~= #expected then return false end
-    local a, b = {}, {}
+    local used = {}
     for i = 1, #actual do
-        a[i] = unordered_key(actual[i])
-        b[i] = unordered_key(expected[i])
-    end
-    table.sort(a)
-    table.sort(b)
-    for i = 1, #a do
-        if a[i] ~= b[i] then return false end
+        local matched = false
+        for j = 1, #expected do
+            if not used[j] and M.equal(actual[i], expected[j]) then
+                used[j] = true
+                matched = true
+                break
+            end
+        end
+        if not matched then return false end
     end
     return true
 end


### PR DESCRIPTION
The remaining fixes from `docs/lua-architecture-audit.md`, after F1 (#1284). Three independent, each-locally-verified commits bundled into one PR to save CI cycles.

## F2 — no native Lua test ever ran in CI *(commit 1)*
The CI image installed `python3`/`r-base` but not `lua5.4`, and every native Lua execution test guards `luaAvailable` and returns silently when absent — so `LuaNativeGradingTests`, `LuaPersonalizationDriverTests` and the conformance matrix's executed Lua rows all skipped while the suite reported green. Adds `lua5.4` to the ci-image Dockerfile and the per-job apt fallback (with `command -v lua` in the skip-check, so a stale image installs it immediately). Adds two did-not-skip proofs that **fail** rather than skip under `CI` — one per test job (`noInterpreterIsSilentlyAbsentInCI` in APITests, `luaIsPresentInCI` in WorkerTests).

## F3 — `equal` and `unordered_equal` disagreed *(commit 2)*
`unordered_equal` keyed elements through a string rendering — a second, weaker notion of equality. It disagreed with `equal` in both directions (correct answers failing on `{1}` vs `{1.0}`; wrong answers passing on the comma-join collision), and only at the top level. Rewritten as greedy pairwise `equal` multiset matching, which is exact because `equal` is an equivalence relation, so the two can never disagree. Synced into both embedded copies; both drift guards green. `LuaUnorderedEqualTests` runs the eight previously-disagreeing pairs against real `lua`.

## F4 — Lua stdout capture defeated by idiomatic student code *(commit 3)*
The `.stdoutEquality` capture swapped only a bare `io.write`, so `io.stdout:write(...)` and chained `io.write(a):write(b)` escaped and a **correct** submission failed with empty output. The `io` proxy now serves as both `io` and `io.stdout`, its `write` drops a leading self argument (method forms) and returns the handle (chaining). The one residual — a student binding `local print = print` before the call — is an upvalue frozen at load time and is documented. Golden regenerated; `LuaStdoutCaptureTests` renders the family and runs each case against real `lua`.

## Verification
Locally, now that `lua5.4` is installed: 65 tests across the Lua / language / golden / drift / conformance / vocabulary suites pass, the full 234-test JS suite passes, both runtime-drift guards accept the synced embeds, `generate-js-constants --check` clean, `swift-format` + SwiftLint (`--strict`) clean. Only the one Lua stdout golden changed (spec_hash/manifest stable).

Refs `docs/lua-architecture-audit.md` F2, F3, F4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iNSs5MJjkiGcTKx3R19DK

---
_Generated by [Claude Code](https://claude.ai/code/session_019iNSs5MJjkiGcTKx3R19DK)_