### PR TITLE
fix: browser Lua personalization + three more Lua arms (audit sweep F5–F6)

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -278,7 +278,11 @@
         if (lowerSubmissionName.endsWith('.ipynb')) {
             const notebookText = new TextDecoder().decode(submissionBytes);
             extractNotebookToMap(files, runnerCore, submissionFilename, notebookText);
-        } else if (lowerSubmissionName.endsWith('.py') || lowerSubmissionName.endsWith('.r')) {
+        } else if (['.py', '.r', '.lua'].some((ext) => lowerSubmissionName.endsWith(ext))) {
+            // The graded-script extensions (mirror AssignmentLanguage.scriptExtensions).
+            // `.lua` was missing, so a directly-uploaded .lua source got no
+            // student-module hint and test_runtime.lua's hint-only student_file()
+            // could not locate it. A new language is added here too.
             files['.chickadee_student_module'] = submissionFilename;
         }
 
@@ -303,8 +307,15 @@
             if (parsed && typeof parsed.seed === 'string' && parsed.seed) {
                 assignmentSeed = parsed.seed;
             }
-            if (parsed && parsed.language === 'r') {
-                assignmentLanguage = 'r';
+            if (parsed && typeof parsed.language === 'string' && parsed.language) {
+                // Honour whatever language the server resolved (python/r/lua).
+                // Testing only `=== 'r'` left every Lua assignment on 'python',
+                // so the `'lua'` inputs writer below was dead code and a
+                // browser-graded Lua assignment wrote _ck_inputs.py — the Lua
+                // runtime reads _ck_inputs.lua and saw an empty table, so every
+                // per-student value went missing. The browser twin of the
+                // server-side resolve/rederive gap.
+                assignmentLanguage = parsed.language;
             }
             if (parsed && parsed.personalizedInputs && typeof parsed.personalizedInputs === 'object') {
                 personalizedInputs = parsed.personalizedInputs;

--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -29,6 +29,8 @@ let jupyterLitePythonKernelName = "xpython"
 let jupyterLitePythonKernelDisplayName = "Python (xeus-python)"
 let jupyterLiteRKernelName = "xr"
 let jupyterLiteRKernelDisplayName = "R (xeus-r)"
+let jupyterLiteLuaKernelName = "xlua"
+let jupyterLiteLuaKernelDisplayName = "Lua (xeus-lua)"
 
 /// Kernelspec names treated as "this is a Python notebook" when normalizing.
 ///
@@ -134,8 +136,16 @@ func mergeNotebook(student studentData: Data, instructor instructorData: Data) -
 ///   vendored xeus-python kernel.
 /// - R notebooks (`ir`, `r`, `webr`, `xr`) →
 ///   kernelspec.name = "xr", display_name = "R (xeus-r)" — the vendored xeus-r kernel.
+/// - Lua notebooks (`xlua`, `lua`) →
+///   kernelspec.name = "xlua", display_name = "Lua (xeus-lua)" — the vendored
+///   xeus-lua kernel.
 /// - Any other explicit kernelspec → returned unchanged.
 /// - Returns original data unchanged if JSON parsing fails.
+///
+/// The non-default languages read their aliases from `notebookKernelNames`, so a
+/// new language needs an arm here as well as a descriptor — this function is one
+/// of the enumerated sites the compiler cannot flag, and it shipped without a
+/// Lua arm (see docs/lua-architecture-audit.md).
 func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
     guard var notebook = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
     else { return data }
@@ -156,10 +166,22 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
             languageInfo["name"] = "r"
         }
         metadata["language_info"] = languageInfo
+    } else if let name = existingName, AssignmentLanguage.luaKernelNames.contains(name) {
+        // Lua notebook (`xlua`, or a bare `lua` from an import) → normalize to
+        // the vendored xeus-lua kernel. Without this arm a `lua`-named notebook
+        // fell through to "unknown → leave unchanged" and never attached xlua —
+        // the R arm existed but its Lua twin did not.
+        kernelSpec["name"] = jupyterLiteLuaKernelName
+        kernelSpec["display_name"] = jupyterLiteLuaKernelDisplayName
+        metadata["kernelspec"] = kernelSpec
+        if (languageInfo["name"] as? String).map({ $0.isEmpty }) != false {
+            languageInfo["name"] = "lua"
+        }
+        metadata["language_info"] = languageInfo
     } else if let name = existingName, !name.isEmpty,
         !pythonKernelNames.contains(name)
     {
-        // Unknown non-Python, non-R kernel → leave unchanged.
+        // Unknown non-Python, non-R, non-Lua kernel → leave unchanged.
         return data
     } else {
         // Python kernel (or missing kernelspec) → normalize to xeus-python.

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -331,7 +331,7 @@ func contentType(for filename: String) -> HTTPMediaType {
     switch URL(fileURLWithPath: filename).pathExtension.lowercased() {
     case "ipynb", "json":
         return .json
-    case "py", "r", "sh", "bash", "zsh", "rb", "pl", "js", "php", "txt", "md", "csv":
+    case "py", "r", "lua", "sh", "bash", "zsh", "rb", "pl", "js", "php", "txt", "md", "csv":
         return .plainText
     default:
         return HTTPMediaType(type: "application", subType: "octet-stream")

--- a/Tests/APITests/NotebookKernelNormalizationTests.swift
+++ b/Tests/APITests/NotebookKernelNormalizationTests.swift
@@ -1,0 +1,68 @@
+// Tests/APITests/NotebookKernelNormalizationTests.swift
+//
+// `normalizeNotebookForJupyterLite` collapses a notebook's kernelspec aliases to
+// the ONE vendored kernel name the editor can attach (xr / xlua / xpython). It
+// had an R arm and a Python default but no Lua arm (audit F6), so a `lua`/`xlua`
+// notebook fell through "unknown → leave unchanged" and never attached xeus-lua.
+// These pin every non-default language's aliases to its vendored kernel.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct NotebookKernelNormalizationTests {
+
+    private func kernelName(afterNormalizing kernelspecName: String) throws -> String? {
+        let json = #"{"nbformat":4,"metadata":{"kernelspec":{"name":"\#(kernelspecName)"}},"cells":[]}"#
+        let out = normalizeNotebookForJupyterLite(Data(json.utf8))
+        let obj = try #require(
+            (try? JSONSerialization.jsonObject(with: out)) as? [String: Any])
+        let metadata = try #require(obj["metadata"] as? [String: Any])
+        let kernelspec = try #require(metadata["kernelspec"] as? [String: Any])
+        return kernelspec["name"] as? String
+    }
+
+    /// The vendored kernel name each language's notebooks must normalize to.
+    /// Python is the default (missing/unknown-python → xpython).
+    static let vendored: [AssignmentLanguage: String] = [
+        .python: jupyterLitePythonKernelName,
+        .r: jupyterLiteRKernelName,
+        .lua: jupyterLiteLuaKernelName,
+    ]
+
+    /// Every alias of every non-default language normalizes to that language's
+    /// vendored kernel — the guard whose absence let a Lua notebook keep a
+    /// `lua` kernelspec the editor cannot attach.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func everyKernelAliasNormalizesToItsVendoredKernel(_ language: AssignmentLanguage) throws {
+        guard language != .default else { return }  // Python has no positive aliases
+        let expected = try #require(Self.vendored[language])
+        for alias in language.notebookKernelNames {
+            #expect(
+                try kernelName(afterNormalizing: alias) == expected,
+                "a `\(alias)` notebook must normalize to \(expected) so the editor attaches it")
+        }
+    }
+
+    @Test func luaNotebookNormalizesToXlua() throws {
+        // The specific F6 regression.
+        #expect(try kernelName(afterNormalizing: "lua") == "xlua")
+        #expect(try kernelName(afterNormalizing: "xlua") == "xlua")
+    }
+
+    @Test func pythonAndMissingKernelsBecomeXpython() throws {
+        #expect(try kernelName(afterNormalizing: "python3") == "xpython")
+        let missing = normalizeNotebookForJupyterLite(
+            Data(#"{"nbformat":4,"metadata":{},"cells":[]}"#.utf8))
+        let obj = try #require((try? JSONSerialization.jsonObject(with: missing)) as? [String: Any])
+        let kernelspec =
+            (obj["metadata"] as? [String: Any])?["kernelspec"] as? [String: Any]
+        #expect(kernelspec?["name"] as? String == "xpython")
+    }
+
+    @Test func genuinelyUnknownKernelIsLeftUnchanged() throws {
+        #expect(try kernelName(afterNormalizing: "julia-1.9") == "julia-1.9")
+    }
+}

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -1315,6 +1315,35 @@ test('an R assignment gets _ck_inputs.R, not _ck_inputs.py', async () => {
   assert.match(String(worker.files['_ck_inputs.R']), /`threshold` = 42/);
 });
 
+test('a Lua assignment gets _ck_inputs.lua, not _ck_inputs.py', async () => {
+  // The browser twin of the server-side resolve/rederive gap: the runner only
+  // tested `parsed.language === 'r'`, so a Lua assignment stayed on 'python' and
+  // wrote _ck_inputs.py — the Lua runtime reads _ck_inputs.lua and saw an empty
+  // table, so every per-student value went silently missing.
+  const harness = await loadRunnerHarness({
+    zipFiles: { 'publictest_a.lua': 'local chickadee = require("test_runtime")\nJSON_RESULT_PASS\n' },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 10,
+      testSuites: [{ script: 'publictest_a.lua', tier: 'public' }],
+    },
+    assignmentSeed: 'abc123',
+    assignmentLanguage: 'lua',
+    personalizedInputs: { threshold: '42' },
+  });
+
+  await harness.window.BrowserRunner.runAndSubmit(
+    new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+    'setup_lua_inputs',
+  );
+
+  const worker = harness.gradingWorkerFactory.created[0];
+  assert.equal(worker.files['_ck_inputs.py'], undefined, 'a Lua assignment must not get the Python inputs file');
+  assert.equal(worker.files['_ck_inputs.R'], undefined, 'a Lua assignment must not get the R inputs file');
+  assert.match(String(worker.files['_ck_inputs.lua']), /return \{/);
+  assert.match(String(worker.files['_ck_inputs.lua']), /\["threshold"\] = 42/);
+});
+
 test('GradingWorkerExecutor grades pass/fail through one worker and classifies non-python on the main thread', async () => {
   // Happy path of the worker executor: one worker is spawned and re-used for
   // every python script (no terminate), pass/fail are graded from the worker's

--- a/docs/lua-architecture-audit.md
+++ b/docs/lua-architecture-audit.md
@@ -7,6 +7,31 @@ new guard. Findings are ranked; **defect** means wrong marks, data loss, or
 silent failure on concrete inputs, as distinct from maintainability risk and
 taste.*
 
+## Status: all findings resolved
+
+Kept as the record of what was wrong and how it was found — the findings below
+describe `0280225`, **not** current behaviour. Every one has since been fixed:
+
+| Finding | Fixed in | What landed |
+|---|---|---|
+| F1 — `resolve`/`rederive` have no Lua arm | #1284 | one shared `gradedScriptLanguage(in:)` + `fromNotebookMetadata`; authored-items flip; `allCases` resolution rows |
+| F2 — no Lua interpreter in CI | #1285 | `lua5.4` in the ci-image + apt fallback; two did-not-skip proofs that fail rather than skip under `CI` |
+| F3 — `equal` ≠ `unordered_equal` | #1285 | `unordered_equal` reuses `equal` (greedy multiset); both embeds synced |
+| F4 — stdout capture defeated | #1285 | `io` proxy doubles as `io.stdout`, `write` is self-aware and chainable |
+| F5 — browser Lua personalization missing | #1286 | the runner honours the server's resolved language |
+| F6 — normalizer / hint / content-type Lua arms | #1286 | `xlua` normalization, `.lua` student-module hint, `text/plain` |
+
+F5 and F6 were **not** in the original findings: they came from the
+enumerated-not-discovered sweep this audit recommended, and F5 turned out to be
+a live wrong-marks defect of the same shape as F1, on the browser side. That is
+the argument for running the sweep rather than trusting the census.
+
+Two flagged sites were deliberately left alone, and both are documented at their
+call site: `KernelImportGuard.language(forFile:)` declines `.lua` (the
+`chickadee-lua` inventory is empty, so a guard would reject every `require`,
+starting with `require("test_runtime")`), and `isolatedWorkerScripts` is
+accurate today and covered by `IsolatedWorkerScriptDriftTests`.
+
 ---
 
 ## F1 — DEFECT (critical). The language dispatch never dispatches: `resolve` and `rederive` have no Lua arm, so every server-side decision for a real Lua assignment is made as Python


### PR DESCRIPTION
The last findings from the audit follow-up, from the enumerated-not-discovered sweep `docs/lua-architecture-audit.md` called for. Three commits; closes out the series after #1283 (audit), #1284 (F1), #1285 (F2–F4).

## F5 — browser-graded Lua personalization was silently missing *(commit 1)*

`Public/browser-runner.js` defaulted `assignmentLanguage` to `'python'` and only tested `parsed.language === 'r'`. So a Lua assignment stayed on `'python'`, the `_ck_inputs.lua` writer three lines below was **dead code**, and a browser-graded Lua assignment with personalization got `_ck_inputs.py` — which the Lua runtime never reads, so every per-student value silently read as missing. A wrong mark, not a crash.

This is the **browser twin of F1**: the server already resolves and sends the language (and after #1284 it resolves Lua correctly), it just wasn't honoured on the client. Now it is, whatever the server says.

The new JS test mirrors the existing R one, and I verified it **fails against the old code** before the fix went in.

## F6 — three more Lua arms the compiler can't ask for *(commit 2)*

Each is an if/else chain or extension list that grew Python and R arms and no Lua one:

- **`normalizeNotebookForJupyterLite`** mapped `rKernelNames` → `xr` and sent every other *named* kernel down "unknown → leave unchanged", so a `lua`-named notebook never normalized to `xlua` and the editor couldn't attach a kernel. There was no `jupyterLiteLuaKernelName` constant at all.
- **The browser runner's student-module hint** was written only for `.py`/`.R` uploads. `test_runtime.lua`'s `student_file()` is hint-only (Lua can't list a directory), so a directly-uploaded `.lua` source fell back to `solution.lua` or nothing.
- **`contentType(for:)`** served `.lua` as `application/octet-stream` instead of `text/plain` (cosmetic — a download prompt instead of display).

`NotebookKernelNormalizationTests` pins every language's aliases to its vendored kernel by iterating `allCases`, so a fourth language fails here rather than silently keeping a kernel the editor can't attach.

## Audit doc status *(commit 3)*

`docs/lua-architecture-audit.md` read as a list of live critical defects, which it no longer is. It now opens with a table mapping each finding (F1–F6) to the PR that fixed it, and marks the body as a record of `0280225` rather than current behaviour.

## Deliberately not changed

Two sites the sweep flagged are correct as-is: `KernelImportGuard.language(forFile:)` declines `.lua` on purpose (the `chickadee-lua` inventory is empty, so a guard would reject every `require`), and `isolatedWorkerScripts` is accurate today and already covered by `IsolatedWorkerScriptDriftTests`.

## Verification

40 Swift tests across the normalizer / zip / language / conformance suites, the full 235-test JS suite, SwiftLint (`--strict`) + `swift-format` clean, `generate-js-constants --check` clean.

Refs `docs/lua-architecture-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iNSs5MJjkiGcTKx3R19DK