### PR TITLE
refactor: derive the last per-language facts instead of enumerating them

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -68,6 +68,16 @@
     const LUA_KERNEL_NAMES = ['lua', 'xlua'];
     // CHICKADEE_GENERATED:LUA_KERNEL_NAMES:END
 
+    // Filename extensions that mark a directly-uploaded file as gradeable
+    // source, so it gets a `.chickadee_student_module` hint. A GENERATED copy of
+    // the union of LanguageDescriptor.scriptExtensions — same rule as above:
+    // edit the Swift literal and re-run the script, never this line. Hand-listing
+    // them here is what omitted `.lua`, leaving a Lua upload with no hint and
+    // test_runtime.lua (which cannot list a directory) unable to find it.
+    // CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:BEGIN
+    const GRADED_SCRIPT_EXTENSIONS = ['.lua', '.py', '.r'];
+    // CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:END
+
     // -------------------------------------------------------------------------
     // Public API — called by notebook.js on Submit
     // -------------------------------------------------------------------------
@@ -278,11 +288,10 @@
         if (lowerSubmissionName.endsWith('.ipynb')) {
             const notebookText = new TextDecoder().decode(submissionBytes);
             extractNotebookToMap(files, runnerCore, submissionFilename, notebookText);
-        } else if (['.py', '.r', '.lua'].some((ext) => lowerSubmissionName.endsWith(ext))) {
-            // The graded-script extensions (mirror AssignmentLanguage.scriptExtensions).
-            // `.lua` was missing, so a directly-uploaded .lua source got no
-            // student-module hint and test_runtime.lua's hint-only student_file()
-            // could not locate it. A new language is added here too.
+        } else if (GRADED_SCRIPT_EXTENSIONS.some((ext) => lowerSubmissionName.endsWith(ext))) {
+            // Generated from LanguageDescriptor.scriptExtensions, so a new
+            // language's uploads get a student-module hint the day its literal
+            // lands rather than whenever someone remembers this line.
             files['.chickadee_student_module'] = submissionFilename;
         }
 

--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -17,20 +17,16 @@ import Vapor
 /// Tiers that students cannot see in the notebook or in downloads.
 let hiddenTiersForStudents: Set<String> = ["secret", "release"]
 
-// JupyterLite kernel identifiers used when normalizing notebook metadata.
+// The JupyterLite kernel each language normalizes onto lives on its
+// `LanguageDescriptor` (`jupyterLiteKernelName` / `jupyterLiteKernelDisplayName`),
+// not in per-language constants here. Every editor kernel is a xeus kernel built
+// from an emscripten-forge env, attached by `name`; the display names
+// deliberately omit the language version the kernelspec carries (e.g.
+// "Python 3.13 (XPython)"), so a kernel rebuild does not churn stored notebooks.
 //
-// Both editor kernels are now xeus kernels built from one emscripten-forge env
-// (Tools/jupyterlite/environment.yml): Python moved off the Pyodide kernel onto
-// xeus-python so the editor runs a single kernel technology. Attachment is by
-// `name`; the display names are friendly labels and deliberately omit the
-// language version the kernelspec carries (e.g. "Python 3.13 (XPython)"), so a
-// kernel rebuild does not churn every stored notebook's metadata.
-let jupyterLitePythonKernelName = "xpython"
-let jupyterLitePythonKernelDisplayName = "Python (xeus-python)"
-let jupyterLiteRKernelName = "xr"
-let jupyterLiteRKernelDisplayName = "R (xeus-r)"
-let jupyterLiteLuaKernelName = "xlua"
-let jupyterLiteLuaKernelDisplayName = "Lua (xeus-lua)"
+// They were free constants plus one hand-written `else if` per language, which
+// is how the Lua arm came to be missing. Reading them off the descriptor lets
+// `normalizeNotebookForJupyterLite` iterate `allCases` instead.
 
 /// Kernelspec names treated as "this is a Python notebook" when normalizing.
 ///
@@ -157,39 +153,37 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
     var kernelSpec = existingKernelSpec ?? [:]
     var languageInfo = metadata["language_info"] as? [String: Any] ?? [:]
 
-    if let name = existingName, AssignmentLanguage.rKernelNames.contains(name) {
-        // R notebook (IRkernel / legacy webr / xeus-r) → normalize to the vendored xeus-r kernel.
-        kernelSpec["name"] = jupyterLiteRKernelName
-        kernelSpec["display_name"] = jupyterLiteRKernelDisplayName
+    // DISCOVERED, not enumerated. Each non-default language claims the aliases in
+    // its own `notebookKernelNames` and normalizes onto its own descriptor's
+    // vendored kernel, so a new language needs no arm here. This was three
+    // hand-written arms and shipped without a Lua one, leaving a `lua`-named
+    // notebook on "unknown → leave unchanged" with no kernel the editor could
+    // attach (docs/lua-architecture-audit.md F6).
+    let matched = AssignmentLanguage.allCases.first {
+        $0 != .default && existingName.map($0.notebookKernelNames.contains) == true
+    }
+
+    if let language = matched {
+        kernelSpec["name"] = language.descriptor.jupyterLiteKernelName
+        kernelSpec["display_name"] = language.descriptor.jupyterLiteKernelDisplayName
         metadata["kernelspec"] = kernelSpec
         if (languageInfo["name"] as? String).map({ $0.isEmpty }) != false {
-            languageInfo["name"] = "r"
+            // The raw value IS the language_info name (`r`, `lua`, `python`), so
+            // the two cannot drift.
+            languageInfo["name"] = language.rawValue
         }
         metadata["language_info"] = languageInfo
-    } else if let name = existingName, AssignmentLanguage.luaKernelNames.contains(name) {
-        // Lua notebook (`xlua`, or a bare `lua` from an import) → normalize to
-        // the vendored xeus-lua kernel. Without this arm a `lua`-named notebook
-        // fell through to "unknown → leave unchanged" and never attached xlua —
-        // the R arm existed but its Lua twin did not.
-        kernelSpec["name"] = jupyterLiteLuaKernelName
-        kernelSpec["display_name"] = jupyterLiteLuaKernelDisplayName
-        metadata["kernelspec"] = kernelSpec
-        if (languageInfo["name"] as? String).map({ $0.isEmpty }) != false {
-            languageInfo["name"] = "lua"
-        }
-        metadata["language_info"] = languageInfo
-    } else if let name = existingName, !name.isEmpty,
-        !pythonKernelNames.contains(name)
-    {
-        // Unknown non-Python, non-R, non-Lua kernel → leave unchanged.
+    } else if let name = existingName, !name.isEmpty, !pythonKernelNames.contains(name) {
+        // A kernel no language claims → leave unchanged.
         return data
     } else {
-        // Python kernel (or missing kernelspec) → normalize to xeus-python.
-        kernelSpec["name"] = jupyterLitePythonKernelName
-        kernelSpec["display_name"] = jupyterLitePythonKernelDisplayName
+        // Python kernel (or missing kernelspec) → the default's vendored kernel.
+        let python = AssignmentLanguage.default
+        kernelSpec["name"] = python.descriptor.jupyterLiteKernelName
+        kernelSpec["display_name"] = python.descriptor.jupyterLiteKernelDisplayName
         metadata["kernelspec"] = kernelSpec
         if (languageInfo["name"] as? String)?.isEmpty != false {
-            languageInfo["name"] = "python"
+            languageInfo["name"] = python.rawValue
         }
         metadata["language_info"] = languageInfo
     }

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -328,13 +328,19 @@ func buildFileResponse(data: Data, filename: String) -> Response {
 }
 
 func contentType(for filename: String) -> HTTPMediaType {
-    switch URL(fileURLWithPath: filename).pathExtension.lowercased() {
+    let ext = URL(fileURLWithPath: filename).pathExtension.lowercased()
+    switch ext {
     case "ipynb", "json":
         return .json
-    case "py", "r", "lua", "sh", "bash", "zsh", "rb", "pl", "js", "php", "txt", "md", "csv":
+    case "sh", "bash", "zsh", "rb", "pl", "js", "php", "txt", "md", "csv":
         return .plainText
     default:
-        return HTTPMediaType(type: "application", subType: "octet-stream")
+        // Every assignment language's own extension is text, from the one
+        // table — hand-listing them here is what served `.lua` as
+        // octet-stream, offering a download prompt instead of displaying it.
+        return AssignmentLanguage(scriptExtension: ext) != nil
+            ? .plainText
+            : HTTPMediaType(type: "application", subType: "octet-stream")
     }
 }
 

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -170,6 +170,21 @@ public struct LanguageDescriptor: Equatable, Sendable {
     /// browser-grading kernel, named in the authoring rejection message.
     public let kernelEnvironmentFileName: String
 
+    /// The vendored JupyterLite kernel a notebook in this language is
+    /// normalized onto, and the friendly label shown beside it.
+    ///
+    /// `normalizeNotebookForJupyterLite` collapses every alias in
+    /// `notebookKernelNames` onto this name, so the editor can attach a kernel.
+    /// It is a descriptor field rather than a per-language constant because the
+    /// normalizer was a hand-written arm per language and shipped without a Lua
+    /// one — a `lua`-named notebook fell through "unknown → leave unchanged"
+    /// and never attached xeus-lua (docs/lua-architecture-audit.md F6).
+    ///
+    /// The display name deliberately omits the language version the kernelspec
+    /// carries, so a kernel rebuild does not churn every stored notebook.
+    public let jupyterLiteKernelName: String
+    public let jupyterLiteKernelDisplayName: String
+
     /// How a missing dependency presents to a student at grade time, phrased for
     /// that same rejection message.
     public let missingDependencyFailureDescription: String
@@ -222,6 +237,8 @@ public struct LanguageDescriptor: Equatable, Sendable {
         inputsFileName: String,
         notebookKernelNames: Set<String>,
         kernelEnvironmentFileName: String,
+        jupyterLiteKernelName: String,
+        jupyterLiteKernelDisplayName: String,
         missingDependencyFailureDescription: String,
         interpreterProbe: InterpreterProbe,
         moduleResolution: ModuleResolution,
@@ -233,6 +250,8 @@ public struct LanguageDescriptor: Equatable, Sendable {
         self.inputsFileName = inputsFileName
         self.notebookKernelNames = notebookKernelNames
         self.kernelEnvironmentFileName = kernelEnvironmentFileName
+        self.jupyterLiteKernelName = jupyterLiteKernelName
+        self.jupyterLiteKernelDisplayName = jupyterLiteKernelDisplayName
         self.missingDependencyFailureDescription = missingDependencyFailureDescription
         self.interpreterProbe = interpreterProbe
         self.moduleResolution = moduleResolution
@@ -257,6 +276,8 @@ extension AssignmentLanguage {
                 inputsFileName: "_ck_inputs.py",
                 notebookKernelNames: [],
                 kernelEnvironmentFileName: "environment-python.yml",
+                jupyterLiteKernelName: "xpython",
+                jupyterLiteKernelDisplayName: "Python (xeus-python)",
                 missingDependencyFailureDescription: "an ImportError",
                 interpreterProbe: .init(command: "python3", versionArguments: ["--version"]),
                 moduleResolution: .byName(
@@ -275,6 +296,8 @@ extension AssignmentLanguage {
                 inputsFileName: "_ck_inputs.R",
                 notebookKernelNames: AssignmentLanguage.rKernelNames,
                 kernelEnvironmentFileName: "environment-r.yml",
+                jupyterLiteKernelName: "xr",
+                jupyterLiteKernelDisplayName: "R (xeus-r)",
                 missingDependencyFailureDescription: "an error from library()",
                 interpreterProbe: .init(command: "R", versionArguments: ["--version"]),
                 // `source("test_runtime.R")` is a file read, not a module load:
@@ -291,6 +314,8 @@ extension AssignmentLanguage {
                 inputsFileName: "_ck_inputs.lua",
                 notebookKernelNames: AssignmentLanguage.luaKernelNames,
                 kernelEnvironmentFileName: "environment-lua.yml",
+                jupyterLiteKernelName: "xlua",
+                jupyterLiteKernelDisplayName: "Lua (xeus-lua)",
                 missingDependencyFailureDescription: "an error from require()",
                 // `-v`, not `--version` — see `interpreterProbe`'s note.
                 interpreterProbe: .init(command: "lua", versionArguments: ["-v"]),

--- a/Tests/APITests/LanguagePipelineWalkTests.swift
+++ b/Tests/APITests/LanguagePipelineWalkTests.swift
@@ -1,0 +1,146 @@
+// Tests/APITests/LanguagePipelineWalkTests.swift
+//
+// One end-to-end walk per language, along the chain a real assignment actually
+// travels: resolve → render a family → render a check → write the inputs file →
+// normalize the notebook for the editor. Every step is asserted against the
+// language the FIRST step resolved, not against a language the test supplied.
+//
+// WHY THIS SHAPE. The existing matrix (LanguageConformanceMatrixTests) proves
+// each stage works when handed `.lua` explicitly. That is necessary and it is
+// not sufficient: every defect in docs/lua-architecture-audit.md sat in the
+// JOINT between stages, where something asked "which language is this?" and
+// answered Python —
+//
+//   * F1: `resolve`/`rederive` string-matched `.R` and rKernelNames, so a Lua
+//     assignment resolved to Python and every downstream stage was handed the
+//     wrong language. Nothing failed, because nothing asked resolution anything.
+//   * F5: the browser made the same mistake independently.
+//   * F6: `normalizeNotebookForJupyterLite` had no Lua arm.
+//
+// A test that starts from a manifest and walks forward catches that class: the
+// language is DISCOVERED at step 1 and carried, so a stage that disagrees with
+// resolution fails here rather than silently grading as Python.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct LanguagePipelineWalkTests {
+
+    /// A manifest whose only graded script is written in `language`, i.e. the
+    /// shape a real assignment in that language has.
+    private func manifest(gradedScriptIn language: AssignmentLanguage) throws -> TestProperties {
+        let script = "publictest_walk.\(language.generatedScriptExtension)"
+        let json = """
+            {"schemaVersion":1,"requiredFiles":[],\
+            "testSuites":[{"tier":"public","script":"\(script)"}],"timeLimitSeconds":10}
+            """
+        return try JSONDecoder().decode(TestProperties.self, from: Data(json.utf8))
+    }
+
+    /// A notebook carrying `language`'s own kernel, or a bare Python one for the
+    /// default (which has no positive aliases).
+    private func notebook(for language: AssignmentLanguage) -> Data {
+        let kernel = language.notebookKernelNames.min() ?? "python3"
+        let json = """
+            {"nbformat":4,"metadata":{"kernelspec":{"name":"\(kernel)"}},"cells":[]}
+            """
+        return Data(json.utf8)
+    }
+
+    /// THE WALK. Each leg consumes the language the previous leg produced.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theWholePipelineAgreesOnTheLanguage(_ expected: AssignmentLanguage) throws {
+        // 1. RESOLUTION — the leg F1 broke. Everything after this consumes
+        //    `resolved`, never `expected`, so a resolution that answers Python
+        //    fails the legs below rather than quietly grading as Python.
+        let props = try manifest(gradedScriptIn: expected)
+        let resolved = AssignmentLanguage.resolve(manifest: props, notebookData: nil)
+        #expect(
+            resolved == expected,
+            """
+            A manifest whose only graded script is \
+            `publictest_walk.\(expected.generatedScriptExtension)` resolved to \(resolved). \
+            Everything downstream — renderers, the inputs file, the expression driver — is \
+            handed this answer, so a wrong one grades the assignment as \(resolved).
+            """)
+
+        // 2. PATTERN FAMILY — rendered for the RESOLVED language.
+        let familyScripts = renderPatternFamily(
+            GeneratedSourceFixtures.family(kind: .boundaryEquality), language: resolved)
+        #expect(!familyScripts.isEmpty, "\(resolved) rendered no family scripts")
+        for script in familyScripts {
+            #expect(
+                script.filename.hasSuffix(".\(resolved.generatedScriptExtension)"),
+                "\(resolved) generated \(script.filename), which is not a \(resolved) script")
+        }
+
+        // 3. NOTEBOOK CHECK — every language renders at least one kind, and it
+        //    lands on the same extension.
+        let supported = NotebookCheckKind.allCases.filter {
+            !(GeneratedSourceFixtures.notebookCheckKindExceptions[resolved] ?? []).contains($0)
+        }
+        let checkKind = try #require(supported.first, "\(resolved) supports no notebook check kind")
+        let check = renderNotebookCheck(GeneratedSourceFixtures.check(kind: checkKind), language: resolved)
+        #expect(
+            check.script.filename.hasSuffix(".\(resolved.generatedScriptExtension)"),
+            "\(resolved)/\(checkKind) generated \(check.script.filename)")
+
+        // 4. PER-STUDENT INPUTS — the filename the worker writes must be the one
+        //    this language's runtime reads. F5's browser twin wrote Python's.
+        let inputs = resolved.renderInputsFile(["threshold": resolved.literal(.int(42))])
+        #expect(!inputs.isEmpty, "\(resolved) rendered an empty inputs file")
+        #expect(
+            resolved.inputsFileName.hasSuffix(".\(resolved.generatedScriptExtension)")
+                || resolved.inputsFileName.lowercased()
+                    .hasSuffix(".\(resolved.generatedScriptExtension.lowercased())"),
+            """
+            \(resolved) writes \(resolved.inputsFileName), which is not a \
+            .\(resolved.generatedScriptExtension) file — the runtime loads it as source, so the \
+            extension has to match the language.
+            """)
+
+        // 5. EDITOR KERNEL — the notebook this language's students open must
+        //    normalize onto a kernel the editor can attach. The leg F6 broke.
+        let normalized = normalizeNotebookForJupyterLite(notebook(for: resolved))
+        let object = try #require(
+            (try? JSONSerialization.jsonObject(with: normalized)) as? [String: Any])
+        let kernelspec = try #require(
+            (object["metadata"] as? [String: Any])?["kernelspec"] as? [String: Any])
+        #expect(
+            kernelspec["name"] as? String == resolved.descriptor.jupyterLiteKernelName,
+            """
+            A \(resolved) notebook normalized to \(kernelspec["name"] as? String ?? "nil") rather \
+            than \(resolved.descriptor.jupyterLiteKernelName), so the editor cannot attach a \
+            kernel to it.
+            """)
+    }
+
+    /// The notebook half of leg 1: a language with positive kernel aliases must
+    /// resolve from its notebook alone, which is the only signal a brand-new
+    /// notebook assignment has (empty suite, nothing recorded).
+    @Test(arguments: AssignmentLanguage.allCases)
+    func aBrandNewNotebookAssignmentResolvesFromItsKernel(_ expected: AssignmentLanguage) throws {
+        guard expected != .default else { return }  // no positive aliases by design
+        let empty = try JSONDecoder().decode(
+            TestProperties.self,
+            from: Data(
+                #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
+                    .utf8))
+        for alias in expected.notebookKernelNames {
+            let json = #"{"nbformat":4,"metadata":{"kernelspec":{"name":"\#(alias)"}},"cells":[]}"#
+            let resolved = AssignmentLanguage.resolve(
+                manifest: empty, notebookData: Data(json.utf8))
+            #expect(
+                resolved == expected,
+                """
+                A brand-new assignment whose starter notebook carries the `\(alias)` kernel \
+                resolved to \(resolved). Its suite is empty and nothing is recorded, so the \
+                kernel is the only signal there is — getting it wrong is sticky, because the \
+                first save records the resolved language.
+                """)
+        }
+    }
+}

--- a/Tests/APITests/NotebookKernelNormalizationTests.swift
+++ b/Tests/APITests/NotebookKernelNormalizationTests.swift
@@ -24,26 +24,32 @@ import Testing
         return kernelspec["name"] as? String
     }
 
-    /// The vendored kernel name each language's notebooks must normalize to.
-    /// Python is the default (missing/unknown-python → xpython).
-    static let vendored: [AssignmentLanguage: String] = [
-        .python: jupyterLitePythonKernelName,
-        .r: jupyterLiteRKernelName,
-        .lua: jupyterLiteLuaKernelName,
-    ]
-
     /// Every alias of every non-default language normalizes to that language's
     /// vendored kernel — the guard whose absence let a Lua notebook keep a
     /// `lua` kernelspec the editor cannot attach.
+    ///
+    /// The expected kernel comes from the DESCRIPTOR rather than a table here:
+    /// a hand-maintained map in the test is the same enumerated shape as the
+    /// hand-written arms this replaced, and it would need editing for a fourth
+    /// language exactly when it should be failing instead.
     @Test(arguments: AssignmentLanguage.allCases)
     func everyKernelAliasNormalizesToItsVendoredKernel(_ language: AssignmentLanguage) throws {
         guard language != .default else { return }  // Python has no positive aliases
-        let expected = try #require(Self.vendored[language])
+        let expected = language.descriptor.jupyterLiteKernelName
         for alias in language.notebookKernelNames {
             #expect(
                 try kernelName(afterNormalizing: alias) == expected,
                 "a `\(alias)` notebook must normalize to \(expected) so the editor attaches it")
         }
+    }
+
+    /// The vendored kernel names must be distinct, or two languages' notebooks
+    /// would attach the same kernel — a copied descriptor literal.
+    @Test func vendoredKernelNamesAreDistinct() {
+        let names = AssignmentLanguage.allCases.map(\.descriptor.jupyterLiteKernelName)
+        #expect(Set(names).count == names.count, "two languages share a vendored kernel: \(names)")
+        let labels = AssignmentLanguage.allCases.map(\.descriptor.jupyterLiteKernelDisplayName)
+        #expect(Set(labels).count == labels.count, "two languages share a kernel label: \(labels)")
     }
 
     @Test func luaNotebookNormalizesToXlua() throws {

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -24,6 +24,8 @@ import Testing
         #expect(!d.generatedScriptExtension.isEmpty)
         #expect(!d.inputsFileName.isEmpty)
         #expect(!d.kernelEnvironmentFileName.isEmpty)
+        #expect(!d.jupyterLiteKernelName.isEmpty)
+        #expect(!d.jupyterLiteKernelDisplayName.isEmpty)
         #expect(!d.missingDependencyFailureDescription.isEmpty)
         #expect(!d.interpreterProbe.command.isEmpty)
         #expect(!d.interpreterProbe.versionArguments.isEmpty)
@@ -41,6 +43,8 @@ import Testing
             ("generatedScriptExtension", all.map(\.generatedScriptExtension)),
             ("inputsFileName", all.map(\.inputsFileName)),
             ("kernelEnvironmentFileName", all.map(\.kernelEnvironmentFileName)),
+            ("jupyterLiteKernelName", all.map(\.jupyterLiteKernelName)),
+            ("jupyterLiteKernelDisplayName", all.map(\.jupyterLiteKernelDisplayName)),
             ("interpreterProbe.command", all.map(\.interpreterProbe.command)),
         ]
         for (field, values) in unique {

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -393,6 +393,20 @@ One judgement remains, and it replaced three:
   Python resolves by name just the same and does. Verify it, do not assume:
   `lua -e 'print(package.path)'`.
 
+**Facts that used to be sites are now fields.** Three things that were
+hand-written arms per language are read off the descriptor, so writing the
+literal is the whole job:
+
+| field | what stopped being a site |
+|---|---|
+| `jupyterLiteKernelName` / `…DisplayName` | `normalizeNotebookForJupyterLite` iterates `allCases` instead of one `else if` per language — the arm that shipped without a Lua twin |
+| `scriptExtensions` | `contentType(for:)` and the browser's student-module hint both derive from it; the hint is *generated* into the JS (below) |
+| `notebookKernelNames` | resolution, the normalizer, and the browser's kernel sets all read it |
+
+The rule this encodes: **if a fact differs per language, put it on the
+descriptor and loop — do not write an arm.** An arm is invisible to the
+compiler when the next language arrives; a loop is not.
+
 And two behaviours that take arguments and so stay methods: `literal(_:)` (needs
 a new `JSONValue.<x>Literal`) and `renderInputsFile(_:)` (the `_ck_inputs.<x>`
 contract, which must match byte-for-byte what the language's `test_runtime`
@@ -468,6 +482,14 @@ types and so pointed at nothing.
    generated nothing and the browser kept routing its notebooks to Python. So
    this item is now *loud* rather than silent — but you still have to add the
    fenced block, and the script tells you so.
+
+   It also generates `GRADED_SCRIPT_EXTENSIONS` from the union of
+   `scriptExtensions` across the descriptors, which is what decides whether a
+   directly-uploaded file gets a `.chickadee_student_module` hint. That list was
+   hand-written as `.py` / `.r`, so a `.lua` upload got no hint and
+   `test_runtime.lua` — hint-only, because Lua cannot list a directory — could
+   not find it. A new language's extension now reaches the browser the day its
+   descriptor literal lands.
 4. **The vendored browser wasm.** `RoutingExecutor` calls `classifyScript` out
    of `Public/runner-wasm/`, so the browser disagrees with the worker until it
    is rebuilt — and a new RunnerCore export (`extractLua`) simply does not exist
@@ -667,6 +689,11 @@ state this document exists to warn you about:
       message are seen
 - [ ] `LanguageConformanceMatrixTests` is green with the new case **and the
       interpreter actually present**; confirm the executed half did not skip
+- [ ] `LanguagePipelineWalkTests` is green — it starts from a manifest, RESOLVES
+      the language, and walks the resolved answer through the renderers, the
+      inputs file and the editor kernel. The matrix proves each stage works when
+      handed your language; this proves the pipeline *agrees* on it. Every
+      audit defect lived in that joint, not in a stage
 - [ ] `submissionGuaranteeExemption` is answered for every guarantee, and every
       exemption carries a reason you would defend to an instructor
 - [ ] a runner ADVERTISES the language (`interpreterProbe`) and an assignment in

--- a/scripts/generate-js-constants.sh
+++ b/scripts/generate-js-constants.sh
@@ -3,8 +3,10 @@
 # Generate JS constants in Public/browser-runner.js from their canonical Swift
 # declarations, so the browser copy is machine-written instead of hand-synced.
 #
-# The browser cannot import Swift, so it needs a copy of every per-language
-# kernel-alias set on AssignmentLanguage (Sources/Core/AssignmentLanguage.swift).
+# The browser cannot import Swift, so it needs a copy of the per-language facts
+# it routes on: every kernel-alias set on AssignmentLanguage
+# (Sources/Core/AssignmentLanguage.swift), and the union of the graded-script
+# extensions on LanguageDescriptor (Sources/Core/LanguageDescriptor.swift).
 # This script owns those copies. Each lives in a fenced block:
 #
 #   // CHICKADEE_GENERATED:R_KERNEL_NAMES:BEGIN
@@ -37,6 +39,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 swift_src="$repo_root/Sources/Core/AssignmentLanguage.swift"
+descriptor_src="$repo_root/Sources/Core/LanguageDescriptor.swift"
 js_src="$repo_root/Public/browser-runner.js"
 
 mode="write"
@@ -102,12 +105,54 @@ for lang in $langs; do
   mv "$tmp" "$work"
 done
 
+# --- The graded-script extensions, unioned across every descriptor -----------
+#
+# The browser decides whether a directly-uploaded file is gradeable source (and
+# so needs a `.chickadee_student_module` hint) by extension. That list was hand
+# written as `.py` / `.r` and silently omitted `.lua`, so a Lua upload got no
+# hint and test_runtime.lua — which cannot list a directory and is therefore
+# hint-only — could not find it. Generating the union from the descriptors makes
+# a new language's extension appear the day its literal does.
+extensions="$(sed -n 's/.*scriptExtensions: \[\(.*\)\],.*/\1/p' "$descriptor_src" \
+  | grep -o '"[^"]*"' | tr -d '"' | LC_ALL=C sort -u)"
+if [ -z "$extensions" ]; then
+  echo "generate-js-constants: found no scriptExtensions declarations in $descriptor_src" >&2
+  rm -f "$work"; exit 1
+fi
+if printf '%s\n' "$extensions" | grep -q '[A-Z]'; then
+  echo "generate-js-constants: scriptExtensions entries must be lowercase" >&2
+  rm -f "$work"; exit 1
+fi
+
+ext_joined="$(printf '%s\n' "$extensions" \
+  | awk -v q="'" 'NR > 1 { out = out ", " } { out = out q "." $0 q } END { print out }')"
+ext_generated="    const GRADED_SCRIPT_EXTENSIONS = [$ext_joined];"
+ext_begin="CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:BEGIN"
+ext_end="CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:END"
+for marker in "$ext_begin" "$ext_end"; do
+  if ! grep -q "$marker" "$work"; then
+    echo "generate-js-constants: missing $marker marker in $js_src." >&2
+    echo "The browser needs the graded-script extension list to decide which" >&2
+    echo "uploads get a student-module hint. Add the fenced block and re-run." >&2
+    rm -f "$work"; exit 1
+  fi
+done
+
+tmp="$(mktemp)"
+awk -v repl="$ext_generated" -v begin="$ext_begin" -v end="$ext_end" '
+  index($0, begin) { print; print repl; skipping = 1; next }
+  index($0, end)   { skipping = 0; print; next }
+  skipping { next }
+  { print }
+' "$work" > "$tmp"
+mv "$tmp" "$work"
+
 if [ "$mode" = "check" ]; then
   if cmp -s "$work" "$js_src"; then
     rm -f "$work"
-    echo "generate-js-constants: OK (browser kernel-name sets match the Swift declarations)"
+    echo "generate-js-constants: OK (browser language constants match the Swift declarations)"
   else
-    echo "generate-js-constants: Public/browser-runner.js kernel-name sets are stale." >&2
+    echo "generate-js-constants: Public/browser-runner.js language constants are stale." >&2
     echo "Run scripts/generate-js-constants.sh and commit the result." >&2
     diff -u "$js_src" "$work" >&2 || true
     rm -f "$work"
@@ -119,6 +164,6 @@ else
     echo "generate-js-constants: already up to date"
   else
     mv "$work" "$js_src"
-    echo "generate-js-constants: rewrote the kernel-name blocks"
+    echo "generate-js-constants: rewrote the generated language blocks"
   fi
 fi


### PR DESCRIPTION
The structural follow-ups the audit recommended, now that F1–F6 are fixed. Each converts a hand-written per-language arm — **the shape every audit defect had** — into something derived, generated, or tested.

Not a behaviour change: no generated bytes move, no golden changes.

## 1. The JupyterLite kernel is a descriptor field

`normalizeNotebookForJupyterLite` had one `else if` per language reading a free constant, which is exactly how it shipped without a Lua arm. `jupyterLiteKernelName` / `…DisplayName` now live on `LanguageDescriptor`, and the normalizer **iterates `allCases`** — a new language needs no arm at all. `language_info.name` is the raw value, so the two can't drift.

`contentType(for:)` likewise derives `text/plain` from `AssignmentLanguage(scriptExtension:)` instead of hand-listing `py`/`r`/`lua`.

The normalization test now reads the expected kernel **off the descriptor**. My own F6 fix had put a hand-maintained `[AssignmentLanguage: String]` map in the test — the same enumerated shape I was fixing, which would have needed editing for a fourth language exactly when it should have been failing.

## 2. The browser's extension list is generated

`generate-js-constants.sh` already discovered `<lang>KernelNames`; it now also emits **`GRADED_SCRIPT_EXTENSIONS`** from the union of `scriptExtensions` across the descriptors, and `browser-runner.js` uses it to decide which uploads get a `.chickadee_student_module` hint. That list was hand-written and omitted `.lua` (audit F6).

Verified both directions:
- a **stale block** fails `--check`
- a **fourth language's extension** appears in the generated block without touching the JS (probed with a synthetic `.jl`)

## 3. A pipeline walk, not just a matrix

`LanguagePipelineWalkTests` starts from a manifest, **resolves** the language, and feeds that *resolved* answer through the family renderer → check renderer → inputs file → editor kernel.

This is the gap the existing matrix leaves: it proves each stage works when handed `.lua` explicitly, which is necessary and not sufficient. Every audit defect (F1, F5, F6) instead sat in the **joint** between stages, where something asked "which language is this?" and answered Python.

Verified by reverting the F1 and F6 fixes in turn — the walk fails on the resolution leg and the kernel leg respectively, each with a message naming the consequence:

> A manifest whose only graded script is `publictest_walk.lua` resolved to `.python`. Everything downstream — renderers, the inputs file, the expression driver — is handed this answer, so a wrong one grades the assignment as `.python`.

## Docs

The runbook records the new rule — **if a fact differs per language, put it on the descriptor and loop; do not write an arm** — plus the generated extension list and the walk in the done test.

## Verification

68 Swift tests across 10 language/normalizer/golden/conformance suites, full 235-test JS suite, `generate-js-constants --check` clean, SwiftLint (`--strict`) + `swift-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iNSs5MJjkiGcTKx3R19DK

---
_Generated by [Claude Code](https://claude.ai/code/session_019iNSs5MJjkiGcTKx3R19DK)_