### PR TITLE
refactor: LanguageDescriptor editorSupport judgement — slice 2 of first-class C++

### DIFF
--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -163,9 +163,17 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
         $0 != .default && existingName.map($0.notebookKernelNames.contains) == true
     }
 
-    if let language = matched {
-        kernelSpec["name"] = language.descriptor.jupyterLiteKernelName
-        kernelSpec["display_name"] = language.descriptor.jupyterLiteKernelDisplayName
+    // A matched language always destructures: `matched` comes from
+    // `notebookKernelNames`, which is empty for a kernel-less (upload-only)
+    // language, so nothing can match one. If that invariant ever broke, the
+    // combined condition falls through to "leave unchanged" — there is no
+    // kernel to normalize onto.
+    if let language = matched,
+        case .notebookKernel(_, let kernelName, let kernelDisplayName, _) =
+            language.editorSupport
+    {
+        kernelSpec["name"] = kernelName
+        kernelSpec["display_name"] = kernelDisplayName
         metadata["kernelspec"] = kernelSpec
         if (languageInfo["name"] as? String).map({ $0.isEmpty }) != false {
             // The raw value IS the language_info name (`r`, `lua`, `python`), so
@@ -177,10 +185,17 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
         // A kernel no language claims → leave unchanged.
         return data
     } else {
-        // Python kernel (or missing kernelspec) → the default's vendored kernel.
+        // Python kernel (or missing kernelspec) → the default's vendored
+        // kernel. The default language always has one (guarded so the
+        // compiler agrees; leaving the notebook unchanged is the safe
+        // degradation if that ever stopped being true).
         let python = AssignmentLanguage.default
-        kernelSpec["name"] = python.descriptor.jupyterLiteKernelName
-        kernelSpec["display_name"] = python.descriptor.jupyterLiteKernelDisplayName
+        guard
+            case .notebookKernel(_, let kernelName, let kernelDisplayName, _) =
+                python.editorSupport
+        else { return data }
+        kernelSpec["name"] = kernelName
+        kernelSpec["display_name"] = kernelDisplayName
         metadata["kernelspec"] = kernelSpec
         if (languageInfo["name"] as? String)?.isEmpty != false {
             languageInfo["name"] = python.rawValue

--- a/Sources/APIServer/Services/KernelImportGuard.swift
+++ b/Sources/APIServer/Services/KernelImportGuard.swift
@@ -113,12 +113,19 @@ enum KernelImportGuard {
     static func message(
         for unsatisfied: [Unsatisfied], filename: String, language: AssignmentLanguage
     ) -> String {
+        // Unreachable through `check` for a kernel-less language: with no
+        // vendored kernel there is no fixed browser environment, so nothing
+        // is ever unsatisfiable. Kept total so a direct caller gets a
+        // truthful sentence rather than a crash.
+        guard
+            case .notebookKernel(let envFile, _, _, let failure) = language.editorSupport
+        else {
+            return "\(filename) is in a language with no browser grading environment."
+        }
         let names = unsatisfied.map(\.name)
         let list = names.map { "`\($0)`" }.joined(separator: ", ")
         let plural = names.count == 1 ? "it" : "they"
         let locations = unsatisfied.map { "\($0.name) (line \($0.line))" }.joined(separator: ", ")
-        let envFile = language.kernelEnvironmentFileName
-        let failure = language.missingDependencyFailureDescription
         return """
             \(filename) needs \(list), which the browser grading environment does not provide, \
             so \(plural) would fail with \(failure) for every student who submits — even though \

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -380,17 +380,11 @@ extension AssignmentLanguage {
     // exhaustive switch here turns each of those into a compile error naming the
     // decision that has to be made. See docs/language-handling-review.md §4.
 
-    /// The env file a maintainer edits to add a package to this language's
-    /// browser-grading kernel, named in the authoring rejection message.
-    /// See `LanguageDescriptor.kernelEnvironmentFileName`.
-    public var kernelEnvironmentFileName: String { descriptor.kernelEnvironmentFileName }
-
-    /// How a missing dependency presents to a student at grade time, phrased for
-    /// the same rejection message.
-    /// See `LanguageDescriptor.missingDependencyFailureDescription`.
-    public var missingDependencyFailureDescription: String {
-        descriptor.missingDependencyFailureDescription
-    }
+    /// The kernel facts, when this language has a vendored editor kernel —
+    /// see `LanguageDescriptor.editorSupport`. Call sites that presuppose a
+    /// kernel destructure this, so a kernel-less language forces an explicit
+    /// answer there instead of inheriting a blank string.
+    public var editorSupport: EditorSupport { descriptor.editorSupport }
 
     /// See `LanguageDescriptor.interpreterProbe`. Kept as a tuple here because
     /// every call site destructures it.

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -110,6 +110,59 @@ public enum ModuleResolution: Equatable, Sendable {
     case byName(searchPathVariable: String?, interpreterHookModules: Set<String> = [])
 }
 
+/// Whether — and how — a language appears in the embedded editor.
+///
+/// THE SECOND JUDGEMENT, alongside `ModuleResolution`. Four descriptor fields
+/// used to presuppose a vendored JupyterLite kernel (the env file, the kernel
+/// name, its display label, and how a missing package presents at grade
+/// time). That was fine while it was true of every language, but it baked the
+/// assumption into the type: a language without a kernel could not be
+/// expressed at all. This enum makes the assumption a stated answer instead —
+/// and gathers the four facts behind it, so they exist exactly when a kernel
+/// does.
+///
+/// - `notebookKernel`: the language has a vendored xeus kernel; it appears in
+///   the editor's picker, notebooks normalize onto it, and browser grading
+///   can run it. Every current language answers this — which is the vendored-
+///   kernel rule ("a language is supported or it is not present",
+///   docs/adding-a-xeus-kernel.md) expressed in types.
+/// - `uploadOnly`: no kernel is vendored, deliberately. The language's
+///   assignments are upload-only (`SubmissionMode.uploadOnly`) and grade on
+///   the native worker exclusively. This is the shape for compiled languages
+///   graded through the shell-script + makefile path — the browser cannot run
+///   the course's real toolchain, and grading a *different* compiler than the
+///   course teaches is a pedagogy defect no substrate work removes (see
+///   docs/cpp-assignment-language-decision.md §3). Nothing dangles: with no
+///   kernel in the picker, the language cannot be authored in the editor, so
+///   the rule above is satisfied from the other direction.
+public enum EditorSupport: Equatable, Sendable {
+    /// A vendored kernel serves this language in the editor and the browser
+    /// grader.
+    ///
+    /// - `environmentFileName`: the env file a maintainer edits to add a
+    ///   package to the browser-grading kernel, named in the authoring
+    ///   rejection message.
+    /// - `kernelName` / `kernelDisplayName`: the vendored JupyterLite kernel a
+    ///   notebook in this language is normalized onto, and the friendly label
+    ///   shown beside it. `normalizeNotebookForJupyterLite` collapses every
+    ///   alias in `notebookKernelNames` onto `kernelName` so the editor can
+    ///   attach a kernel; the display name deliberately omits the language
+    ///   version the kernelspec carries, so a kernel rebuild does not churn
+    ///   every stored notebook.
+    /// - `missingDependencyFailureDescription`: how a missing dependency
+    ///   presents to a student at grade time, phrased for that same rejection
+    ///   message.
+    case notebookKernel(
+        environmentFileName: String,
+        kernelName: String,
+        kernelDisplayName: String,
+        missingDependencyFailureDescription: String)
+
+    /// No vendored kernel, deliberately — submissions arrive as file uploads
+    /// and grade on the native worker only.
+    case uploadOnly
+}
+
 /// Files the RUNNER writes into every grading workspace, which are therefore
 /// importable in any language that resolves modules by name.
 ///
@@ -171,28 +224,13 @@ public struct LanguageDescriptor: Equatable, Sendable {
     /// the sets would leave the generator with nothing to find.
     public let notebookKernelNames: Set<String>
 
-    /// The env file a maintainer edits to add a package to this language's
-    /// browser-grading kernel, named in the authoring rejection message.
-    public let kernelEnvironmentFileName: String
-
-    /// The vendored JupyterLite kernel a notebook in this language is
-    /// normalized onto, and the friendly label shown beside it.
-    ///
-    /// `normalizeNotebookForJupyterLite` collapses every alias in
-    /// `notebookKernelNames` onto this name, so the editor can attach a kernel.
-    /// It is a descriptor field rather than a per-language constant because the
-    /// normalizer was a hand-written arm per language and shipped without a Lua
-    /// one — a `lua`-named notebook fell through "unknown → leave unchanged"
-    /// and never attached xeus-lua (docs/lua-architecture-audit.md F6).
-    ///
-    /// The display name deliberately omits the language version the kernelspec
-    /// carries, so a kernel rebuild does not churn every stored notebook.
-    public let jupyterLiteKernelName: String
-    public let jupyterLiteKernelDisplayName: String
-
-    /// How a missing dependency presents to a student at grade time, phrased for
-    /// that same rejection message.
-    public let missingDependencyFailureDescription: String
+    /// Whether the language has a vendored editor/browser-grading kernel, and
+    /// the kernel facts when it does — see `EditorSupport`. Was four flat
+    /// fields (`kernelEnvironmentFileName`, `jupyterLiteKernelName` and its
+    /// display name, `missingDependencyFailureDescription`) that presupposed a
+    /// kernel exists; folding them behind this judgement is what lets a
+    /// kernel-less, upload-only language be expressed at all.
+    public let editorSupport: EditorSupport
 
     /// The command a runner probes to decide whether it can grade this
     /// language, with the arguments that make it print a version and exit 0.
@@ -241,10 +279,7 @@ public struct LanguageDescriptor: Equatable, Sendable {
         generatedScriptExtension: String,
         inputsFileName: String,
         notebookKernelNames: Set<String>,
-        kernelEnvironmentFileName: String,
-        jupyterLiteKernelName: String,
-        jupyterLiteKernelDisplayName: String,
-        missingDependencyFailureDescription: String,
+        editorSupport: EditorSupport,
         interpreterProbe: InterpreterProbe,
         moduleResolution: ModuleResolution,
         workingDirectoryIsOnDefaultSearchPath: Bool
@@ -254,10 +289,7 @@ public struct LanguageDescriptor: Equatable, Sendable {
         self.generatedScriptExtension = generatedScriptExtension
         self.inputsFileName = inputsFileName
         self.notebookKernelNames = notebookKernelNames
-        self.kernelEnvironmentFileName = kernelEnvironmentFileName
-        self.jupyterLiteKernelName = jupyterLiteKernelName
-        self.jupyterLiteKernelDisplayName = jupyterLiteKernelDisplayName
-        self.missingDependencyFailureDescription = missingDependencyFailureDescription
+        self.editorSupport = editorSupport
         self.interpreterProbe = interpreterProbe
         self.moduleResolution = moduleResolution
         self.workingDirectoryIsOnDefaultSearchPath = workingDirectoryIsOnDefaultSearchPath
@@ -280,10 +312,11 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "py",
                 inputsFileName: "_ck_inputs.py",
                 notebookKernelNames: [],
-                kernelEnvironmentFileName: "environment-python.yml",
-                jupyterLiteKernelName: "xpython",
-                jupyterLiteKernelDisplayName: "Python (xeus-python)",
-                missingDependencyFailureDescription: "an ImportError",
+                editorSupport: .notebookKernel(
+                    environmentFileName: "environment-python.yml",
+                    kernelName: "xpython",
+                    kernelDisplayName: "Python (xeus-python)",
+                    missingDependencyFailureDescription: "an ImportError"),
                 interpreterProbe: .init(command: "python3", versionArguments: ["--version"]),
                 moduleResolution: .byName(
                     searchPathVariable: "PYTHONPATH",
@@ -300,10 +333,11 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "R",
                 inputsFileName: "_ck_inputs.R",
                 notebookKernelNames: AssignmentLanguage.rKernelNames,
-                kernelEnvironmentFileName: "environment-r.yml",
-                jupyterLiteKernelName: "xr",
-                jupyterLiteKernelDisplayName: "R (xeus-r)",
-                missingDependencyFailureDescription: "an error from library()",
+                editorSupport: .notebookKernel(
+                    environmentFileName: "environment-r.yml",
+                    kernelName: "xr",
+                    kernelDisplayName: "R (xeus-r)",
+                    missingDependencyFailureDescription: "an error from library()"),
                 interpreterProbe: .init(command: "R", versionArguments: ["--version"]),
                 // `source("test_runtime.R")` is a file read, not a module load:
                 // there is no name to resolve, so nothing is importable and no
@@ -318,10 +352,11 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "lua",
                 inputsFileName: "_ck_inputs.lua",
                 notebookKernelNames: AssignmentLanguage.luaKernelNames,
-                kernelEnvironmentFileName: "environment-lua.yml",
-                jupyterLiteKernelName: "xlua",
-                jupyterLiteKernelDisplayName: "Lua (xeus-lua)",
-                missingDependencyFailureDescription: "an error from require()",
+                editorSupport: .notebookKernel(
+                    environmentFileName: "environment-lua.yml",
+                    kernelName: "xlua",
+                    kernelDisplayName: "Lua (xeus-lua)",
+                    missingDependencyFailureDescription: "an error from require()"),
                 // `-v`, not `--version` — see `interpreterProbe`'s note.
                 interpreterProbe: .init(command: "lua", versionArguments: ["-v"]),
                 // `require("test_runtime")` IS a module load — the same shape as
@@ -339,10 +374,11 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "m",
                 inputsFileName: "_ck_inputs.m",
                 notebookKernelNames: AssignmentLanguage.octaveKernelNames,
-                kernelEnvironmentFileName: "environment-octave.yml",
-                jupyterLiteKernelName: "xoctave",
-                jupyterLiteKernelDisplayName: "Octave (xeus-octave)",
-                missingDependencyFailureDescription: "an undefined-function error",
+                editorSupport: .notebookKernel(
+                    environmentFileName: "environment-octave.yml",
+                    kernelName: "xoctave",
+                    kernelDisplayName: "Octave (xeus-octave)",
+                    missingDependencyFailureDescription: "an undefined-function error"),
                 // `octave-cli --version` prints "GNU Octave, version N" and
                 // exits 0 (verified on 8.4.0). The worker invokes the same
                 // binary, so probe and invocation cannot skew.

--- a/Tests/APITests/LanguageConformanceMatrixTests.swift
+++ b/Tests/APITests/LanguageConformanceMatrixTests.swift
@@ -229,13 +229,18 @@ import Testing
     @Test(arguments: AssignmentLanguage.allCases)
     func theKernelEnvironmentFileExists(_ language: AssignmentLanguage) {
         // The authoring rejection message names this file; a name that does not
-        // exist sends an instructor to a path that is not there.
+        // exist sends an instructor to a path that is not there. A kernel-less
+        // (upload-only) language names no file, so there is nothing to check —
+        // expected for that language, hence the silent return.
+        guard
+            case .notebookKernel(let environmentFileName, _, _, _) = language.editorSupport
+        else { return }
         let url = Self.repoRoot
             .appendingPathComponent("Tools/jupyterlite")
-            .appendingPathComponent(language.kernelEnvironmentFileName)
+            .appendingPathComponent(environmentFileName)
         #expect(
             FileManager.default.fileExists(atPath: url.path),
-            "\(language.kernelEnvironmentFileName) does not exist")
+            "\(environmentFileName) does not exist")
     }
 
     /// The defect that shipped with Lua: `.lua` classified to an `env lua`

--- a/Tests/APITests/LanguagePipelineWalkTests.swift
+++ b/Tests/APITests/LanguagePipelineWalkTests.swift
@@ -104,17 +104,22 @@ import Testing
 
         // 5. EDITOR KERNEL — the notebook this language's students open must
         //    normalize onto a kernel the editor can attach. The leg F6 broke.
+        //    A kernel-less (upload-only) language has no notebook workflow, so
+        //    this leg does not apply to it — the walk's earlier legs already
+        //    covered everything such a language does.
+        guard case .notebookKernel(_, let expectedKernel, _, _) = resolved.editorSupport else {
+            return
+        }
         let normalized = normalizeNotebookForJupyterLite(notebook(for: resolved))
         let object = try #require(
             (try? JSONSerialization.jsonObject(with: normalized)) as? [String: Any])
         let kernelspec = try #require(
             (object["metadata"] as? [String: Any])?["kernelspec"] as? [String: Any])
         #expect(
-            kernelspec["name"] as? String == resolved.descriptor.jupyterLiteKernelName,
+            kernelspec["name"] as? String == expectedKernel,
             """
             A \(resolved) notebook normalized to \(kernelspec["name"] as? String ?? "nil") rather \
-            than \(resolved.descriptor.jupyterLiteKernelName), so the editor cannot attach a \
-            kernel to it.
+            than \(expectedKernel), so the editor cannot attach a kernel to it.
             """)
     }
 

--- a/Tests/APITests/NotebookKernelNormalizationTests.swift
+++ b/Tests/APITests/NotebookKernelNormalizationTests.swift
@@ -35,7 +35,14 @@ import Testing
     @Test(arguments: AssignmentLanguage.allCases)
     func everyKernelAliasNormalizesToItsVendoredKernel(_ language: AssignmentLanguage) throws {
         guard language != .default else { return }  // Python has no positive aliases
-        let expected = language.descriptor.jupyterLiteKernelName
+        guard case .notebookKernel(_, let expected, _, _) = language.editorSupport else {
+            // A kernel-less language must claim no aliases at all — an alias
+            // with nothing to normalize onto is exactly the F6 shape.
+            #expect(
+                language.notebookKernelNames.isEmpty,
+                "\(language) claims kernel aliases but vendors no kernel")
+            return
+        }
         for alias in language.notebookKernelNames {
             #expect(
                 try kernelName(afterNormalizing: alias) == expected,
@@ -46,9 +53,14 @@ import Testing
     /// The vendored kernel names must be distinct, or two languages' notebooks
     /// would attach the same kernel — a copied descriptor literal.
     @Test func vendoredKernelNamesAreDistinct() {
-        let names = AssignmentLanguage.allCases.map(\.descriptor.jupyterLiteKernelName)
+        let facts = AssignmentLanguage.allCases.compactMap { language -> (String, String)? in
+            guard case .notebookKernel(_, let name, let display, _) = language.editorSupport
+            else { return nil }
+            return (name, display)
+        }
+        let names = facts.map(\.0)
         #expect(Set(names).count == names.count, "two languages share a vendored kernel: \(names)")
-        let labels = AssignmentLanguage.allCases.map(\.descriptor.jupyterLiteKernelDisplayName)
+        let labels = facts.map(\.1)
         #expect(Set(labels).count == labels.count, "two languages share a kernel label: \(labels)")
     }
 

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -23,14 +23,34 @@ import Testing
         #expect(!d.scriptExtensions.isEmpty)
         #expect(!d.generatedScriptExtension.isEmpty)
         #expect(!d.inputsFileName.isEmpty)
-        #expect(!d.kernelEnvironmentFileName.isEmpty)
-        #expect(!d.jupyterLiteKernelName.isEmpty)
-        #expect(!d.jupyterLiteKernelDisplayName.isEmpty)
-        #expect(!d.missingDependencyFailureDescription.isEmpty)
+        if case .notebookKernel(let env, let name, let display, let failure) = d.editorSupport {
+            #expect(!env.isEmpty)
+            #expect(!name.isEmpty)
+            #expect(!display.isEmpty)
+            #expect(!failure.isEmpty)
+        }
         #expect(!d.interpreterProbe.command.isEmpty)
         #expect(!d.interpreterProbe.versionArguments.isEmpty)
         // notebookKernelNames is deliberately empty for Python — it is the
         // default, reached by falling through — so it is asserted separately.
+    }
+
+    /// Every language shipped so far has a vendored kernel; the type now
+    /// permits `.uploadOnly`, so that fact needs pinning. Admitting a
+    /// kernel-less language is a deliberate act (this list changes in the
+    /// same diff, stating the decision) — not something a copied literal or
+    /// an unfinished descriptor should be able to do quietly.
+    @Test func everyCurrentLanguageVendorsAKernel() {
+        let kernelLess = AssignmentLanguage.allCases.filter {
+            $0.editorSupport == .uploadOnly
+        }
+        #expect(
+            kernelLess.isEmpty,
+            """
+            \(kernelLess) vendor no editor kernel. If that is a real decision \
+            (an upload-only compiled language), update this pin in the same \
+            change; if not, the descriptor is unfinished.
+            """)
     }
 
     /// The fields that must not collide across languages. A copied literal
@@ -38,13 +58,18 @@ import Testing
     /// language's submissions to the other, silently.
     @Test func theIdentifyingFieldsAreUniqueAcrossLanguages() {
         let all = AssignmentLanguage.allCases.map(\.descriptor)
+        let kernels: [(env: String, name: String, display: String)] = all.compactMap {
+            guard case .notebookKernel(let env, let name, let display, _) = $0.editorSupport
+            else { return nil }
+            return (env, name, display)
+        }
         let unique: [(String, [String])] = [
             ("displayName", all.map(\.displayName)),
             ("generatedScriptExtension", all.map(\.generatedScriptExtension)),
             ("inputsFileName", all.map(\.inputsFileName)),
-            ("kernelEnvironmentFileName", all.map(\.kernelEnvironmentFileName)),
-            ("jupyterLiteKernelName", all.map(\.jupyterLiteKernelName)),
-            ("jupyterLiteKernelDisplayName", all.map(\.jupyterLiteKernelDisplayName)),
+            ("kernel environmentFileName", kernels.map(\.env)),
+            ("kernelName", kernels.map(\.name)),
+            ("kernelDisplayName", kernels.map(\.display)),
             ("interpreterProbe.command", all.map(\.interpreterProbe.command)),
         ]
         for (field, values) in unique {
@@ -78,9 +103,7 @@ import Testing
         #expect(language.generatedScriptExtension == d.generatedScriptExtension)
         #expect(language.inputsFileName == d.inputsFileName)
         #expect(language.notebookKernelNames == d.notebookKernelNames)
-        #expect(language.kernelEnvironmentFileName == d.kernelEnvironmentFileName)
-        #expect(
-            language.missingDependencyFailureDescription == d.missingDependencyFailureDescription)
+        #expect(language.editorSupport == d.editorSupport)
         #expect(language.interpreterProbe.command == d.interpreterProbe.command)
         #expect(language.interpreterProbe.versionArguments == d.interpreterProbe.versionArguments)
     }

--- a/changelog.d/editor-support-split.md
+++ b/changelog.d/editor-support-split.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **`LanguageDescriptor` can now express a language with no editor kernel.**
+  The four descriptor facts that presupposed a vendored JupyterLite kernel
+  (the environment file, kernel name, display label, and missing-dependency
+  wording) are folded behind one `editorSupport` judgement:
+  `.notebookKernel(...)` for every current language, `.uploadOnly` for a
+  compiled language graded through the shell-script + makefile path whose
+  submissions arrive as file uploads. Purely internal — every language keeps
+  its kernel and every behaviour is unchanged — but a kernel-less language is
+  now expressible at all, which the compiled-C++ arc requires, and a test pins
+  that admitting one is a deliberate, stated decision rather than an
+  unfinished descriptor.


### PR DESCRIPTION
## What

Folds the four `LanguageDescriptor` fields that presupposed a vendored JupyterLite kernel — `kernelEnvironmentFileName`, `jupyterLiteKernelName`, `jupyterLiteKernelDisplayName`, `missingDependencyFailureDescription` — behind one judgement with the facts as associated values:

```swift
public enum EditorSupport {
    case notebookKernel(environmentFileName:, kernelName:, kernelDisplayName:, missingDependencyFailureDescription:)
    case uploadOnly
}
```

All four current languages answer `.notebookKernel(...)` — **zero behaviour change** — but a kernel-less language is now expressible at all, which the compiled-C++ arc requires (its assignments are `submissionMode: uploadOnly` from #1293 and grade on the native worker only, because the browser cannot run the course's real g++ toolchain).

The two production sites that presuppose a kernel now destructure the case, so each one's no-kernel behaviour is decided *here*, in a diff dedicated to exactly that:

- `normalizeNotebookForJupyterLite` — a kernel-less language can never match (its `notebookKernelNames` is empty), and if the invariant ever broke, the notebook is left unchanged: there is no kernel to attach.
- `KernelImportGuard.message` — kept total with a truthful fallback sentence; unreachable through `check`, since a language with no vendored kernel has no fixed browser environment for anything to be unsatisfiable against.

The `.uploadOnly` case also records *why* it exists in its doc comment: the vendored-kernel rule ("a language is supported or it is not present") forbids authorable-but-not-gradable; a kernel-less upload-only language is the mirror image — gradable but never in the editor's picker — so nothing dangles.

## Tests

- `LanguageDescriptorTests` gains **`everyCurrentLanguageVendorsAKernel`**: the type now permits `.uploadOnly`, so the fact that no current language uses it is pinned — admitting a kernel-less language must be a stated decision in the same diff, not an unfinished descriptor slipping through. The blank-field, cross-language-uniqueness, and forwarding assertions are restated over the destructured facts.
- `NotebookKernelNormalizationTests` — the alias walk now also asserts a kernel-less language claims **no aliases** (an alias with nothing to normalize onto is exactly the F6 shape).
- `LanguagePipelineWalkTests` / `LanguageConformanceMatrixTests` — the editor-kernel legs destructure, skipping (with the reasoning in a comment) for a kernel-less language while every kernel-bearing language keeps the full walk.
- Targeted suites green (descriptor, normalization, pipeline walk, conformance matrix, both import-scanner suites); format/lint/SwiftLint `--strict` and `generate-js-constants.sh --check` green (the JS-constants generator parses the `<lang>KernelNames` statics, which this change deliberately leaves untouched). Full local suite running in parallel; CI gates the merge on the same set regardless.

## Why now

Slice 2 of first-class C++, between #1293 (upload-only submission mode) and the `AssignmentLanguage.cpp` arc — kept separate so the cpp diff carries only cpp decisions, and the "what happens with no kernel" decisions get review attention on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hwj5fD2dysDT6iC9RuVF4a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwj5fD2dysDT6iC9RuVF4a)_