### PR TITLE
feat(mcp): set_submission_mode + set_assignment_language, so MCP can author a C++ assignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1035,7 +1035,7 @@ browser (Pyodide/wasm) and native worker grading paths sharing one RunnerCore
 implementation; per-student personalization; pattern-generated test families
 (8 kinds) and notebook checks (10 kinds); achievements; student slip days;
 per-course roles; BrightSpace grade sync (awaiting UW IST prod credentials);
-an MCP authoring surface of 52 tools plus a read-only admin-diagnostics MCP
+an MCP authoring surface of 54 tools plus a read-only admin-diagnostics MCP
 of 19 (`MCPToolCatalog.live` in
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift` is the count's
 source of truth); OIDC SSO; and zero-downtime auto-deploys.

--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -74,6 +74,73 @@ func currentManifestLanguage(_ manifest: String?) -> String? {
     return dict["language"] as? String
 }
 
+/// Sets the test setup's recorded `language` to `language` when it differs.
+/// Returns the effective language.
+///
+/// The recorded field is normally a *memo* of what resolution derived from the
+/// content (`manifestWithRederivedLanguage`), which is why nothing else writes
+/// it directly. An upload-only language is the case that memo cannot reach: C++
+/// has no editor kernel, so no notebook kernelspec implies it, and its generated
+/// tests are extension-free `.sh` wrappers by design — leaving a declaration as
+/// the only signal there is. Hence this setter, and hence its two guards.
+///
+/// Refuses an upload-only language while the setup is still in notebook mode:
+/// the mirror of `setManifestSubmissionMode`'s C++ guard, so the incoherent
+/// combination cannot be authored from either direction.
+///
+/// Refuses any change once generated scripts exist. A language change rewrites
+/// every generated filename (the extension is part of the name), and only the
+/// pattern-family application path knows how to re-render and clean up the old
+/// side. Rather than half-perform that here, the change is confined to a suite
+/// with nothing generated in it yet — which is where an author declares the
+/// language anyway.
+func setManifestLanguage(
+    setup: APITestSetup, to language: String, on db: any Database
+) async throws -> String {
+    guard let parsed = AssignmentLanguage(rawValue: language) else {
+        throw AppError.badRequest(reason: unknownLanguageMessage(language))
+    }
+    let current = currentManifestLanguage(setup.manifest)
+    guard current != language else { return language }
+    if case .uploadOnly = parsed.editorSupport,
+        currentManifestSubmissionMode(setup.manifest) != SubmissionMode.uploadOnly.rawValue
+    {
+        throw AppError.badRequest(reason: cppRequiresUploadOnlyMessage)
+    }
+    if manifestHasGeneratedScripts(setup.manifest) {
+        throw AppError.badRequest(reason: languageChangeAfterGenerationMessage)
+    }
+    try await mutateManifest(setup: setup, on: db) { dict in
+        dict["language"] = language
+    }
+    return language
+}
+
+/// True when the manifest carries any generated test — a pattern-family case or
+/// a notebook check. Read off `generatedBy` rather than the family/check lists
+/// so a family that has produced no enabled case doesn't block a change that
+/// would rewrite nothing.
+func manifestHasGeneratedScripts(_ manifest: String?) -> Bool {
+    guard let manifest,
+        let dict = (try? JSONSerialization.jsonObject(with: Data(manifest.utf8))) as? [String: Any],
+        let suites = dict["testSuites"] as? [[String: Any]]
+    else { return false }
+    return suites.contains { $0["generatedBy"] != nil }
+}
+
+/// Names the languages rather than listing an enum case, so the message stays
+/// correct when a sixth language is added.
+func unknownLanguageMessage(_ given: String) -> String {
+    let known = AssignmentLanguage.allCases.map(\.rawValue).sorted().joined(separator: ", ")
+    return "Unknown assignment language \"\(given)\". Known languages: \(known)."
+}
+
+/// Shared by the MCP tool and any future surface that declares the language.
+let languageChangeAfterGenerationMessage =
+    "This assignment already has generated tests, whose filenames carry the current language's "
+    + "extension. Declare the language before authoring pattern families or notebook checks, or "
+    + "delete the generated families/checks first."
+
 /// Reads the `submissionMode` field straight from a manifest JSON string,
 /// defaulting to "notebook" (TestProperties' own default) when the field is
 /// absent or the manifest can't be parsed.

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -240,6 +240,12 @@ enum MCPServerInstructions {
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \
+        set_submission_mode (notebook editor vs upload-only hand-in), \
+        set_assignment_language (declare python/r/lua/octave/cpp — normally derived from the \
+        notebook kernel or a graded script's extension, but REQUIRED for cpp, which has neither an \
+        in-browser kernel nor a language-bearing script extension; a cpp assignment must be \
+        uploadOnly, and the language must be declared before any pattern family or notebook check \
+        is authored), \
         set_time_limit (the assignment's default per-test timeout in seconds; a per-test \
         timeLimitSeconds override, 1–600s, can be set on a hand-written script via author_script / \
         update_suite, on a pattern family via create_pattern_family / update_pattern_family \
@@ -303,7 +309,8 @@ enum MCPServerInstructions {
         you can see which check failed and why before fixing the suite or solution. It is \
         validation-only: it resolves the instructor's own reference-solution run and never exposes a \
         student submission, identity, or grade. \
-        Metadata-only edits (update_assignment, set_grading_mode, set_time_limit, set_dataset, \
+        Metadata-only edits (update_assignment, set_grading_mode, set_submission_mode, \
+        set_assignment_language, set_time_limit, set_dataset, \
         set_minimum_runner_version, update_achievements, the section-organization tools) never trigger \
         a regrade or a close. \
         update_global_inputs and update_section_variables re-inline the shared inputs into the \

--- a/Sources/APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
@@ -1,0 +1,110 @@
+// APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
+//
+// Write tool: declare the language an assignment is authored and graded in, by
+// assignment public ID. content:write, course-scoped.
+//
+// For the four kernel languages the language is DERIVED, not declared — a
+// notebook's kernelspec or a graded script's extension answers it, and the
+// recorded manifest field is only a memo of that. This tool exists for the case
+// derivation cannot reach: C++ has no editor kernel (so no kernelspec implies
+// it) and its generated tests are deliberately extension-free `.sh` wrappers
+// (so no filename implies it either). Without a declaration there is no way to
+// author a C++ assignment through MCP at all.
+//
+// Declaring one of the derivable languages is still allowed and still useful —
+// it pins an assignment whose suite is all pattern families, with no `.R`/`.lua`
+// script on disk to find — it is simply not the case that motivated the tool.
+
+import Core
+import Fluent
+import Foundation
+
+struct SetAssignmentLanguageTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// An `AssignmentLanguage` raw value: python, r, lua, octave, cpp.
+        let language: String
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let language: String
+        /// Reported because an upload-only language constrains it, so a caller
+        /// sees the assignment's whole resulting shape in one response.
+        let submissionMode: String
+    }
+
+    static let name = "set_assignment_language"
+    static let description =
+        "Declare the language an assignment is authored and graded in by its public ID: python, r, lua, "
+        + "octave, or cpp. For every language except cpp this is normally unnecessary — the language is "
+        + "derived from the starter notebook's kernel or a graded script's extension — but declaring it "
+        + "pins a suite made only of pattern families, which has no script on disk to derive from. For "
+        + "cpp it is required: C++ has no in-browser kernel and its generated tests are extension-free "
+        + "shell wrappers, so nothing implies the language. A cpp assignment must already be uploadOnly "
+        + "(set_submission_mode) — this tool refuses otherwise. Because a language change rewrites every "
+        + "generated filename, declare the language BEFORE authoring pattern families or notebook checks; "
+        + "the tool refuses a change once generated tests exist. Read the current language from "
+        + "get_assignment."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.assignmentPublicID,
+            "language": .object([
+                "type": .string("string"),
+                "enum": .array(
+                    AssignmentLanguage.allCases.map { .string($0.rawValue) }),
+                "description": .string(
+                    "The assignment's language. cpp additionally requires submissionMode uploadOnly."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("language")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.string,
+            "language": MCPSchema.string,
+            "submissionMode": MCPSchema.string,
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("language"), .string("submissionMode"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let raw = input.language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let parsed = AssignmentLanguage(rawValue: raw) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: unknownLanguageMessage(input.language))
+        }
+        // Which language an assignment is decides how every generated test
+        // renders — lifecycle-shaped, so instructor-level like its neighbours.
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
+        // Surface the shared helper's refusals as arguments errors; the helper
+        // keeps its own guards for any path that skips this one.
+        if case .uploadOnly = parsed.editorSupport,
+            currentManifestSubmissionMode(setup.manifest) != SubmissionMode.uploadOnly.rawValue,
+            currentManifestLanguage(setup.manifest) != raw
+        {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: cppRequiresUploadOnlyMessage)
+        }
+        if currentManifestLanguage(setup.manifest) != raw,
+            manifestHasGeneratedScripts(setup.manifest)
+        {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: languageChangeAfterGenerationMessage)
+        }
+        let effective = try await setManifestLanguage(setup: setup, to: raw, on: context.db)
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            language: effective,
+            submissionMode: currentManifestSubmissionMode(setup.manifest))
+    }
+}

--- a/Sources/APIServer/MCP/Tools/SetSubmissionModeTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetSubmissionModeTool.swift
@@ -1,0 +1,103 @@
+// APIServer/MCP/Tools/SetSubmissionModeTool.swift
+//
+// Write tool: set how students hand work in — "notebook" (the embedded editor,
+// with the upload form beside it) or "uploadOnly" (file upload and nothing
+// else) — by assignment public ID. content:write, course-scoped.
+//
+// The web edit page has had this control since the submission-mode slice; this
+// is its MCP twin, so an agent can author the upload-only assignments C++
+// requires without a human visiting the form. Both call the same
+// `setManifestSubmissionMode`, so the two refusals below are enforced once.
+
+import Core
+import Fluent
+import Foundation
+
+struct SetSubmissionModeTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// "notebook" or "uploadOnly".
+        let submissionMode: String
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let submissionMode: String
+        /// The mode the assignment is actually graded in. `uploadOnly` pins
+        /// this to "worker" — reported so a caller that flipped the mode sees
+        /// the grading path move with it rather than discovering it later.
+        let gradingMode: String
+    }
+
+    static let name = "set_submission_mode"
+    static let description =
+        "Set how students hand work in for an assignment by its public ID: \"notebook\" (the embedded "
+        + "editor, with the upload form beside it) or \"uploadOnly\" (file upload only, no editor). Use "
+        + "uploadOnly for a language with no in-browser kernel — C++ assignments must be uploadOnly, and "
+        + "set_assignment_language refuses C++ until they are. An uploadOnly assignment is always graded "
+        + "by the native worker, so switch the grading mode to \"worker\" first (set_grading_mode); this "
+        + "tool refuses the browser combination rather than storing a value that could never execute. "
+        + "Read the current mode from get_assignment."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.assignmentPublicID,
+            "submissionMode": .object([
+                "type": .string("string"),
+                "enum": .array([.string("notebook"), .string("uploadOnly")]),
+                "description": .string(
+                    "\"notebook\" (embedded editor plus upload form) or \"uploadOnly\" (upload only)."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("submissionMode")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.string,
+            "submissionMode": MCPSchema.string,
+            "gradingMode": MCPSchema.string,
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("submissionMode"), .string("gradingMode"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let mode = input.submissionMode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = SubmissionMode(rawValue: mode) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "submissionMode must be \"notebook\" or \"uploadOnly\".")
+        }
+        // How students submit is a lifecycle setting — instructor-level (#417),
+        // matching set_grading_mode.
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
+        // Surface both of the shared helper's refusals as arguments errors, so
+        // an agent reads a fixable message rather than a 400. The helper keeps
+        // its own guards as the backstop for any path that skips this.
+        if parsed == .uploadOnly,
+            currentManifestGradingMode(setup.manifest) == GradingMode.browser.rawValue
+        {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: uploadModeGradingConflictMessage)
+        }
+        if parsed == .notebook,
+            currentManifestLanguage(setup.manifest) == AssignmentLanguage.cpp.rawValue
+        {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: cppRequiresUploadOnlyMessage)
+        }
+        let effective = try await setManifestSubmissionMode(
+            setup: setup, to: mode, on: context.db)
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            submissionMode: effective,
+            gradingMode: effective == SubmissionMode.uploadOnly.rawValue
+                ? GradingMode.worker.rawValue : currentManifestGradingMode(setup.manifest))
+    }
+}

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -22,14 +22,40 @@ import Fluent
 import Foundation
 
 struct UpdateSolutionTool: ContentTool {
+    /// A reference solution supplied as a source FILE rather than a notebook —
+    /// the only shape available to an upload-only language. C++ is the case
+    /// that needs it: it has no notebook workflow, so there is no `.ipynb` to
+    /// extract source from and a notebook solution could never be graded.
+    struct SolutionFile: Decodable, Sendable {
+        let filename: String
+        let content: String
+    }
+
     struct Input: Decodable, Sendable {
         let assignmentPublicID: String
-        let notebook: JSONValue
+        /// Exactly one of `notebook` / `solutionFile` is supplied.
+        let notebook: JSONValue?
+        let solutionFile: SolutionFile?
+
+        /// Spelled out rather than left to the memberwise synthesis so each
+        /// alternative reads as optional at the call site.
+        init(
+            assignmentPublicID: String, notebook: JSONValue? = nil,
+            solutionFile: SolutionFile? = nil
+        ) {
+            self.assignmentPublicID = assignmentPublicID
+            self.notebook = notebook
+            self.solutionFile = solutionFile
+        }
     }
 
     struct Output: Encodable, Sendable {
         let assignmentPublicID: String
+        /// 0 for a source-file solution, which has no cells.
         let cellCount: Int
+        /// The name the solution was stored under — "solution.ipynb" for a
+        /// notebook, the supplied filename for a source file.
+        let solutionFilename: String
         let validationStatus: String?
         /// true when this edit closed a previously-open assignment (re-open with
         /// update_assignment once validation passes).
@@ -50,7 +76,10 @@ struct UpdateSolutionTool: ContentTool {
         + "substituted per validation-seed at grading, which is the supported way to give a seed-agnostic "
         + "answer key a per-student VARIABLE value (a module-level assignment that COMPUTES the value via "
         + "a function call, e.g. reading CHICKADEE_ASSIGNMENT_SEED, is quarantined at import and won't "
-        + "define the variable — see docs/personalization-solution-notebooks.md)."
+        + "define the variable — see docs/personalization-solution-notebooks.md). For a language with "
+        + "no notebook workflow (C++), pass solutionFile instead — a single source file "
+        + "({filename, content}) — since there is no notebook to extract the answer key from; passing "
+        + "a notebook for such an assignment is refused. Supply exactly one of notebook / solutionFile."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -58,11 +87,32 @@ struct UpdateSolutionTool: ContentTool {
             "notebook": .object([
                 "type": .string("object"),
                 "description": .string(
-                    "The full solution notebook as .ipynb JSON (an object containing a \"cells\" array)."
+                    "The full solution notebook as .ipynb JSON (an object containing a \"cells\" array). "
+                        + "Use for a notebook-workflow assignment; omit when passing solutionFile."
                 ),
             ]),
+            "solutionFile": .object([
+                "type": .string("object"),
+                "description": .string(
+                    "The reference solution as ONE source file, for an assignment whose language has no "
+                        + "notebook workflow (C++). Omit when passing notebook."),
+                "properties": .object([
+                    "filename": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Bare filename with no path separators, e.g. \"solution.cpp\". Its extension "
+                                + "must be one the assignment's language recognizes."),
+                    ]),
+                    "content": .object([
+                        "type": .string("string"),
+                        "description": .string("The full file body."),
+                    ]),
+                ]),
+                "required": .array([.string("filename"), .string("content")]),
+                "additionalProperties": .bool(false),
+            ]),
         ]),
-        "required": .array([.string("assignmentPublicID"), .string("notebook")]),
+        "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
     static let outputSchema: JSONValue? = .object([
@@ -70,11 +120,13 @@ struct UpdateSolutionTool: ContentTool {
         "properties": .object([
             "assignmentPublicID": MCPSchema.string,
             "cellCount": MCPSchema.integer,
+            "solutionFilename": MCPSchema.string,
             "validationStatus": MCPSchema.string,
             "assignmentClosed": MCPSchema.boolean,
         ]),
         "required": .array([
-            .string("assignmentPublicID"), .string("cellCount"), .string("assignmentClosed"),
+            .string("assignmentPublicID"), .string("cellCount"), .string("solutionFilename"),
+            .string("assignmentClosed"),
         ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
@@ -82,7 +134,14 @@ struct UpdateSolutionTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        try validateNotebookShape(input.notebook, tool: Self.name)
+        guard (input.notebook == nil) != (input.solutionFile == nil) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "Supply exactly one of notebook / solutionFile.")
+        }
+        if let notebook = input.notebook {
+            try validateNotebookShape(notebook, tool: Self.name)
+        }
 
         let assignment = try await context.authorizedAssignmentForWrite(
             publicID: input.assignmentPublicID, tool: Self.name, atLeast: .ta)
@@ -92,28 +151,77 @@ struct UpdateSolutionTool: ContentTool {
 
         // Content versioning: this tool reaches its setup by id rather than
         // through `authorizedAssignmentAndSetupForWrite`, so it registers for a
-        // snapshot by hand. Replacing the reference solution rewrites
-        // `solution.ipynb` inside the setup zip, which is versioned content.
-        if let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) {
+        // snapshot by hand. Replacing the reference solution rewrites the
+        // solution file inside the setup zip, which is versioned content.
+        let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db)
+        if let setup {
             await context.beginContentWrite(setup: setup)
         }
 
-        let data: Data
-        do {
-            data = try JSONEncoder().encode(input.notebook)
-        } catch {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The notebook could not be serialized to JSON.")
+        // Which shape this assignment's answer key can take is decided by its
+        // language, not by the caller's preference: a language with no notebook
+        // workflow has no `.ipynb` to extract source from, so a notebook
+        // solution would be stored and then grade as an empty submission.
+        let language =
+            setup?.decodedManifest().map {
+                AssignmentLanguage.resolve(manifest: $0, notebookData: nil)
+            } ?? .default
+        let wantsSourceFile: Bool
+        if case .uploadOnly = language.editorSupport {
+            wantsSourceFile = true
+        } else {
+            wantsSourceFile = false
         }
-        let normalized = normalizeNotebookForJupyterLite(data)
+        if wantsSourceFile, input.notebook != nil {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail:
+                    "\(language.rawValue) has no notebook workflow, so a notebook cannot serve as its "
+                    + "reference solution. Pass solutionFile ({filename, content}) instead.")
+        }
+
+        let data: Data
+        let storedFilename: String
+        let cellCount: Int
+        if let file = input.solutionFile {
+            let name = file.filename.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, !name.contains("/"), !name.contains("\\"), name != ".",
+                name != ".."
+            else {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail: "solutionFile.filename must be a bare filename with no path separators.")
+            }
+            let ext = URL(fileURLWithPath: name).pathExtension.lowercased()
+            guard language.scriptExtensions.contains(ext) else {
+                let allowed = language.scriptExtensions.sorted().joined(separator: ", ")
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail:
+                        "solutionFile.filename must end in an extension \(language.rawValue) "
+                        + "recognizes (\(allowed)); got \"\(name)\".")
+            }
+            data = Data(file.content.utf8)
+            storedFilename = name
+            cellCount = 0
+        } else {
+            do {
+                data = normalizeNotebookForJupyterLite(try JSONEncoder().encode(input.notebook))
+            } catch {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name, detail: "The notebook could not be serialized to JSON.")
+            }
+            storedFilename = "solution.ipynb"
+            cellCount = notebookCellCount(input.notebook ?? .null)
+        }
 
         let validationSubmissionID: String
         do {
             validationSubmissionID = try await enqueueRunnerValidationSubmission(
                 req: context.request,
                 setupID: assignment.testSetupID,
-                solutionNotebookData: normalized,
-                filename: "solution.ipynb",
+                solutionNotebookData: data,
+                filename: storedFilename,
                 submitterUserID: subject.id)
         } catch {
             throw MCPToolError.executionFailed(
@@ -135,7 +243,8 @@ struct UpdateSolutionTool: ContentTool {
 
         return Output(
             assignmentPublicID: assignment.publicID,
-            cellCount: notebookCellCount(input.notebook),
+            cellCount: cellCount,
+            solutionFilename: storedFilename,
             validationStatus: assignment.validationStatus,
             assignmentClosed: closed)
     }

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -35,6 +35,8 @@ enum MCPToolCatalog {
             RestoreAssignmentVersionTool().erased(),
             UpdateAssignmentTool().erased(),
             SetGradingModeTool().erased(),
+            SetSubmissionModeTool().erased(),
+            SetAssignmentLanguageTool().erased(),
             SetTimeLimitTool().erased(),
             SetDatasetTool().erased(),
             SetMinimumRunnerVersionTool().erased(),

--- a/Tests/APITests/MCP/MCPContentEditCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPContentEditCoverageTests.swift
@@ -68,6 +68,13 @@ import Testing
         // Grading-mode flip; no regrade/close by design (documented in the
         // server instructions).
         "SetGradingModeTool.swift",
+        // How students hand work in (editor vs upload); the suite grades the
+        // same files either way, so nothing to close or regrade.
+        "SetSubmissionModeTool.swift",
+        // Declares the language generated tests will render in. Refused once
+        // any generated test exists, so it cannot change what an existing suite
+        // grades — the case that would warrant a close cannot arise.
+        "SetAssignmentLanguageTool.swift",
         // Time limits are enforced at run time; no content change.
         "SetTimeLimitTool.swift",
         // Minimum-runner-version gate: changes which runner may grade, not what

--- a/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
+++ b/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
@@ -90,6 +90,7 @@ import Testing
                 UpdateSolutionTool.name, UpdateSolutionTool.outputSchema,
                 UpdateSolutionTool.Output(
                     assignmentPublicID: "abc123", cellCount: 4,
+                    solutionFilename: "solution.ipynb",
                     validationStatus: "pending", assignmentClosed: true)
             ),
             (

--- a/Tests/APITests/MCP/SetSubmissionModeAndLanguageToolTests.swift
+++ b/Tests/APITests/MCP/SetSubmissionModeAndLanguageToolTests.swift
@@ -1,0 +1,230 @@
+// Tests for the two tools that let a C++ assignment be authored through MCP:
+// SetSubmissionModeTool (notebook vs uploadOnly) and SetAssignmentLanguageTool
+// (the declared language). Backed by a real test database.
+//
+// The pair carries an invariant neither half owns alone: cpp ⟺ uploadOnly. Each
+// tool refuses the incoherent combination from its own side, so the suite walks
+// BOTH directions — a C++ assignment cannot be flipped back to the notebook
+// workflow it has no kernel for, and C++ cannot be declared on an assignment
+// still in notebook mode.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct SetSubmissionModeAndLanguageToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let workerManifest =
+        #"{"schemaVersion":1,"gradingMode":"worker","testSuites":[],"timeLimitSeconds":10}"#
+    private let browserManifest =
+        #"{"schemaVersion":1,"gradingMode":"browser","testSuites":[],"timeLimitSeconds":10}"#
+
+    private func fixture(
+        on app: Application, manifest: String, enroll: Bool = true
+    ) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS247", name: "Software Design")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        if enroll {
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        }
+        try await makeTestSetup(on: app, id: "setup_sm", courseID: courseID, manifest: manifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_sm", courseID: courseID, title: "Lab")
+    }
+
+    private func manifest(
+        of assignment: APIAssignment, on app: Application
+    ) async throws
+        -> TestProperties?
+    {
+        let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+        return setup.decodedManifest()
+    }
+
+    // ── set_submission_mode ────────────────────────────────────────────────
+
+    @Test func setsUploadOnlyAndReportsWorkerGrading() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+
+            let out = try await SetSubmissionModeTool().execute(
+                .init(assignmentPublicID: assignment.publicID, submissionMode: "uploadOnly"),
+                context(app))
+            #expect(out.submissionMode == "uploadOnly")
+            // Upload-only pins grading to the native worker; the tool reports
+            // the effective path rather than leaving the caller to infer it.
+            #expect(out.gradingMode == "worker")
+            #expect(try await manifest(of: assignment, on: app)?.submissionMode == .uploadOnly)
+        }
+    }
+
+    @Test func refusesUploadOnlyWhileBrowserGraded() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: browserManifest)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetSubmissionModeTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, submissionMode: "uploadOnly"),
+                    context(app))
+            }
+            // Refusing must leave the assignment untouched, not half-saved.
+            #expect(try await manifest(of: assignment, on: app)?.submissionMode == .notebook)
+        }
+    }
+
+    @Test func rejectsUnknownSubmissionMode() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetSubmissionModeTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, submissionMode: "upload"),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesSubmissionModeWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(
+                on: app, manifest: workerManifest, enroll: false)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetSubmissionModeTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, submissionMode: "uploadOnly"),
+                    context(app))
+            }
+        }
+    }
+
+    // ── set_assignment_language ────────────────────────────────────────────
+
+    @Test func declaresCppOnAnUploadOnlyAssignment() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+            _ = try await SetSubmissionModeTool().execute(
+                .init(assignmentPublicID: assignment.publicID, submissionMode: "uploadOnly"),
+                context(app))
+
+            let out = try await SetAssignmentLanguageTool().execute(
+                .init(assignmentPublicID: assignment.publicID, language: "cpp"), context(app))
+            #expect(out.language == "cpp")
+            #expect(out.submissionMode == "uploadOnly")
+
+            // The declaration is what resolution reads — the whole point of the
+            // tool, since nothing about a C++ assignment implies its language.
+            let props = try #require(try await manifest(of: assignment, on: app))
+            #expect(props.language == .cpp)
+            #expect(AssignmentLanguage.resolve(manifest: props, notebookData: nil) == .cpp)
+        }
+    }
+
+    @Test func refusesCppWhileStillNotebookMode() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetAssignmentLanguageTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, language: "cpp"), context(app))
+            }
+            #expect(try await manifest(of: assignment, on: app)?.language == nil)
+        }
+    }
+
+    /// The invariant from the other side: once an assignment IS C++, it cannot
+    /// be flipped back to a notebook workflow it has no kernel for.
+    @Test func refusesNotebookModeOnACppAssignment() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+            _ = try await SetSubmissionModeTool().execute(
+                .init(assignmentPublicID: assignment.publicID, submissionMode: "uploadOnly"),
+                context(app))
+            _ = try await SetAssignmentLanguageTool().execute(
+                .init(assignmentPublicID: assignment.publicID, language: "cpp"), context(app))
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetSubmissionModeTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, submissionMode: "notebook"),
+                    context(app))
+            }
+            #expect(try await manifest(of: assignment, on: app)?.submissionMode == .uploadOnly)
+        }
+    }
+
+    @Test func refusesALanguageChangeOnceGeneratedTestsExist() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let generated = #"""
+                {"schemaVersion":1,"gradingMode":"worker","timeLimitSeconds":10,\
+                "testSuites":[{"tier":"public","script":"publictest_bmi_01.py","generatedBy":"bmi"}]}
+                """#
+                .replacingOccurrences(of: "\\\n", with: "")
+            let assignment = try await fixture(on: app, manifest: generated)
+
+            // A change would rewrite every generated filename's extension, which
+            // only the family-application path knows how to do.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetAssignmentLanguageTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, language: "r"), context(app))
+            }
+            #expect(try await manifest(of: assignment, on: app)?.language == nil)
+        }
+    }
+
+    /// Declaring the language an assignment already has must stay a no-op
+    /// rather than tripping the generated-scripts guard — otherwise a retry, or
+    /// an agent re-asserting known state, fails on an assignment it cannot fix.
+    @Test func redeclaringTheSameLanguageIsANoOp() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let generated = #"""
+                {"schemaVersion":1,"gradingMode":"worker","timeLimitSeconds":10,"language":"r",\
+                "testSuites":[{"tier":"public","script":"publictest_bmi_01.R","generatedBy":"bmi"}]}
+                """#
+                .replacingOccurrences(of: "\\\n", with: "")
+            let assignment = try await fixture(on: app, manifest: generated)
+
+            let out = try await SetAssignmentLanguageTool().execute(
+                .init(assignmentPublicID: assignment.publicID, language: "r"), context(app))
+            #expect(out.language == "r")
+        }
+    }
+
+    @Test func rejectsUnknownLanguage() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetAssignmentLanguageTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, language: "java"), context(app))
+            }
+        }
+    }
+
+    @Test func deniesLanguageWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(
+                on: app, manifest: workerManifest, enroll: false)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetAssignmentLanguageTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, language: "lua"), context(app))
+            }
+        }
+    }
+}

--- a/Tests/APITests/MCP/UpdateSolutionToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSolutionToolTests.swift
@@ -180,4 +180,115 @@ import Vapor
             }
         }
     }
+
+    // ── Source-file solutions (a language with no notebook workflow) ───────
+    //
+    // C++ has no `.ipynb` to extract source from, so its answer key is a file.
+    // Storing a notebook for such an assignment would grade as an empty
+    // submission — silently, and only at validation time — so the shape is
+    // decided by the assignment's language rather than by the caller.
+
+    private let cppManifest = #"""
+        {"schemaVersion":1,"gradingMode":"worker","submissionMode":"uploadOnly",\
+        "language":"cpp","testSuites":[],"timeLimitSeconds":10}
+        """#
+        .replacingOccurrences(of: "\\\n", with: "")
+
+    private func cppFixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS247", name: "Software Design")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(
+            on: app, id: "setup_cpp", courseID: courseID, manifest: cppManifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_cpp", courseID: courseID, title: "Lab")
+    }
+
+    @Test func storesASourceFileSolutionUnderItsOwnName() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await cppFixture(on: app)
+            let source = "#include <string>\nstd::string f() { return \"ok\"; }\n"
+
+            let output = try await UpdateSolutionTool().execute(
+                UpdateSolutionTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    solutionFile: .init(filename: "solution.cpp", content: source)),
+                context(app))
+
+            #expect(output.solutionFilename == "solution.cpp")
+            #expect(output.cellCount == 0)
+            #expect(output.validationStatus == "pending")
+
+            // Stored verbatim as a validation submission — the bytes the runner
+            // will compile, not a notebook wrapper around them.
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            let subID = try #require(reloaded.validationSubmissionID)
+            let sub = try #require(try await APISubmission.find(subID, on: app.db))
+            #expect(sub.kind == APISubmission.Kind.validation)
+            #expect(sub.filename?.hasSuffix(".cpp") == true)
+        }
+    }
+
+    @Test func refusesANotebookForALanguageWithNoNotebookWorkflow() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await cppFixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSolutionTool().execute(
+                    UpdateSolutionTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        notebook: try json(twoCellSolution)),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func refusesASolutionFilenameTheLanguageDoesNotRecognize() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await cppFixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSolutionTool().execute(
+                    UpdateSolutionTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        solutionFile: .init(filename: "solution.py", content: "x = 1")),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func refusesASolutionFilenameWithAPathSeparator() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await cppFixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSolutionTool().execute(
+                    UpdateSolutionTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        solutionFile: .init(filename: "../solution.cpp", content: "int f();")),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func refusesNeitherShapeAndBothShapes() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSolutionTool().execute(
+                    UpdateSolutionTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            }
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSolutionTool().execute(
+                    UpdateSolutionTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        notebook: try json(twoCellSolution),
+                        solutionFile: .init(filename: "solution.cpp", content: "int f();")),
+                    context(app))
+            }
+        }
+    }
 }

--- a/changelog.d/mcp-submission-mode-language.md
+++ b/changelog.d/mcp-submission-mode-language.md
@@ -1,0 +1,18 @@
+### Added
+
+- **MCP can now author a C++ assignment.** Two new content tools close the gap
+  the C++ language arc left behind: `set_submission_mode` (`notebook` /
+  `uploadOnly`, the MCP twin of the edit page's control) and
+  `set_assignment_language` (declare `python` / `r` / `lua` / `octave` / `cpp`).
+  C++ was previously unreachable through MCP entirely — its language is the one
+  that cannot be derived, since it has no editor kernel for a notebook
+  kernelspec to name and its generated tests are deliberately extension-free
+  `.sh` wrappers — so a C++ assignment could only be created by uploading a
+  hand-written `test.properties.json`. The catalog is now 54 tools.
+
+  Both halves of the `cpp ⟺ uploadOnly` invariant are enforced, each from its
+  own side: declaring C++ on a notebook-mode assignment is refused, and a C++
+  assignment cannot be flipped back to the notebook workflow it has no kernel
+  for. A language change is refused once generated tests exist, since every
+  generated filename carries the current language's extension — declare the
+  language before authoring families, which is the natural order anyway.

--- a/changelog.d/mcp-submission-mode-language.md
+++ b/changelog.d/mcp-submission-mode-language.md
@@ -16,3 +16,12 @@
   for. A language change is refused once generated tests exist, since every
   generated filename carries the current language's extension — declare the
   language before authoring families, which is the natural order anyway.
+
+- **`update_solution` accepts a source-file answer key.** A language with no
+  notebook workflow has no `.ipynb` to extract a solution from, so C++
+  assignments had no way to receive a reference solution — and therefore no way
+  to pass validation — even once their suite could be authored. The tool now
+  takes either `notebook` (unchanged) or `solutionFile` ({filename, content}),
+  and picks which shape is legal from the assignment's language rather than the
+  caller's preference: passing a notebook for C++ is refused, since it would be
+  stored and then grade as an empty submission at validation time.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -590,7 +590,7 @@ refresh; an hourly reaper drops dead OAuth rows.
 
 Lets an agent author course content on an instructor's behalf. Gated by
 `MCP_MODE` (`off` / `read_only` / `read_write`); scopes are clamped to the
-mode ceiling. The catalog holds **52 tools** — `MCPToolCatalog.live` in
+mode ceiling. The catalog holds **54 tools** — `MCPToolCatalog.live` in
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift` is the source
 of truth — covering course/assignment/suite/notebook/solution reads, suite +
 pattern-family + notebook-check + script authoring, course sections and

--- a/docs/compliance/tool-inventory.md
+++ b/docs/compliance/tool-inventory.md
@@ -9,7 +9,7 @@ This is a complete, one-row-per-tool inventory of the MCP capability surface,
 walked from the live registry (`MCPToolCatalog.live`,
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) down to each
 tool's handler. As of the 2026-07 refresh (plus `delete_support_file`) the content catalog
-registers **52 tools** (the table below plus the six-tool addendum), and a second,
+registers **54 tools** (the table below plus the six-tool addendum), and a second,
 admin-only diagnostic surface (`AdminMCPToolCatalog.live`) registers
 **19 read-only tools** — inventoried in the addendum. The registries are the
 source of truth; a census re-count is required whenever either changes
@@ -58,6 +58,8 @@ source of truth; a census re-count is required whenever either changes
 | `clone_assignment` | `CloneAssignmentTool.swift:40` | source + target `assignmentPublicID`/`courseCode` | course-enrol on **both** (`:95`, `:117`) | new `APIAssignment` + `APITestSetup` |
 | `update_assignment` | `UpdateAssignmentTool.swift:47` | `assignmentPublicID` | course-enrol (`:136`) | `APIAssignment` (title/due/open-close) |
 | `set_grading_mode` | `SetGradingModeTool.swift:31` | `assignmentPublicID` | course-enrol (`:73`) | `APIAssignment` grading mode |
+| `set_submission_mode` | `SetSubmissionModeTool.swift:36` | `assignmentPublicID` | course-enrol (`:76`) | `APITestSetup` manifest (submission mode) |
+| `set_assignment_language` | `SetAssignmentLanguageTool.swift:39` | `assignmentPublicID` | course-enrol (`:87`) | `APITestSetup` manifest (declared language) |
 | `update_suite` | `UpdateSuiteTool.swift:46` | `assignmentPublicID` | course-enrol (`:116`) | `APITestSetup` manifest (suite metadata) |
 | `author_script` | `AuthorScriptTool.swift:58` | `assignmentPublicID` + `filename` | course-enrol (`:194`) | **verbatim file into setup zip** (escape hatch — see below) |
 | `delete_suite_item` | `DeleteSuiteItemTool.swift:49` | `assignmentPublicID` + item | course-enrol (`:103`) | `APITestSetup` manifest + zip |

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -52,6 +52,8 @@ The catalog:
 | `restore_assignment_version` | `content:write` | Put an assignment's content back to a recorded version (content only, never metadata); append-only — records a new version, closes + re-grades |
 | `update_assignment` | `content:write` | Metadata: title, due date, visibility (closed/preview/open) |
 | `set_grading_mode` | `content:write` | Set an assignment's grading path (worker vs browser); no regrade/close |
+| `set_submission_mode` | `content:write` | Set how students hand work in (`notebook` editor vs `uploadOnly`); an uploadOnly assignment is worker-graded; no regrade/close |
+| `set_assignment_language` | `content:write` | Declare the assignment's language (python/r/lua/octave/cpp). Required for cpp, which has no kernel and no language-bearing script extension to derive from; refused once generated tests exist; no regrade/close |
 | `set_time_limit` | `content:write` | Set the assignment-wide (or per-test) execution time limit; no regrade/close |
 | `set_dataset` | `content:write` | Mark a support file as a per-student dataset (per-seed row sample under the same filename) or clear the mark; no regrade/close |
 | `set_minimum_runner_version` | `content:write` | Set (or clear) the minimum native-runner version that may grade the assignment (semver); server-side claim-time gate, worker path only; no regrade/close |


### PR DESCRIPTION
## What

Makes it possible to author a **C++ assignment end-to-end through MCP**. Three gaps, found by trying to create one sample assignment per language and getting four of five:

1. **`set_submission_mode`** (new tool) — `notebook` (embedded editor plus upload form) or `uploadOnly`. The MCP twin of the control the instructor edit page has had since the submission-mode slice.
2. **`set_assignment_language`** (new tool) — declare `python` / `r` / `lua` / `octave` / `cpp`.
3. **`update_solution` accepts a source-file answer key** — `solutionFile: {filename, content}` beside the existing `notebook`.

Catalog goes 52 → 54 tools.

## Why

Language is normally **derived**, not declared — from a notebook's kernelspec or a graded script's extension — and C++ is the one language neither signal can reach:

- it has `editorSupport: .uploadOnly`, so no kernelspec ever names it;
- its generated tests are deliberately extension-free `.sh` wrappers, so no filename implies it.

Combined with `submissionMode` having no MCP setter, the only way to create a C++ assignment was to hand-upload a `test.properties.json` declaring both fields — the path `docs/cpp-support.md` §"What an instructor does today" already described.

The solution gap was the subtler one. `update_solution` hard-coded `filename: "solution.ipynb"`, so even once a C++ suite could be authored it could never be *validated*: a notebook stored as a C++ assignment's answer key has no extraction path, so it would grade as an empty submission — silently, and only at validation time. The tool now picks the legal shape from the assignment's language rather than the caller's preference, and refuses the mismatch each way.

Declaring the language is useful beyond C++ too: it pins an assignment whose suite is entirely pattern families, with no `.R`/`.lua` script on disk to derive from.

## Invariants

Both new tools reuse the existing `ManifestFieldEdits` helpers, so `cpp ⟺ uploadOnly` is enforced once and refused from **both** directions:

- declaring `cpp` on a notebook-mode assignment is refused (`cppRequiresUploadOnlyMessage`);
- flipping a C++ assignment back to notebook mode is refused by the guard that already existed.

A language change is refused once generated tests exist — every generated filename carries the current language's extension, and only the pattern-family application path knows how to re-render and clean up the old side. Re-declaring the language an assignment already has stays a no-op, so a retry doesn't trip that guard.

`uploadOnly` still refuses browser grading (pre-existing rule), so the C++ sequence is `set_grading_mode(worker)` → `set_submission_mode(uploadOnly)` → `set_assignment_language(cpp)`, each refusal naming the next step.

## Tests

16 new tests — 11 in `SetSubmissionModeAndLanguageToolTests` (both directions of the invariant, both refusals, the no-op re-declare, enrolment scoping) and 5 added to `UpdateSolutionToolTests` (source file stored under its own name as a validation submission, notebook refused for C++, unrecognized extension refused, path separator refused, neither/both shapes refused). Full suite green: **3,269 tests in 385 suites**.

Four existing drift guards caught the omissions they exist for, and all four are updated rather than relaxed:

- `everyWriteToolIsClassifiedForCloseOnEdit` — both new tools classified non-closing, with justifications;
- `everyCatalogToolIsMentionedInInstructions` — both added to the `initialize` instructions;
- `everyCatalogToolAppearsInTheRoadmapTable` — both added to `docs/mcp-authoring-roadmap.md`;
- `MCPOutputSchemaSyncTests` — `update_solution`'s new `solutionFilename` output field.

Tool count updated in `CLAUDE.md`, `docs/architecture.md`, and `docs/compliance/tool-inventory.md` (a row per new tool, keeping the per-tool compliance inventory complete).

## Verification

The four kernel languages were already confirmed against production 0.5.27 before this PR — one sample assignment each in the `TEST` course, each resolving to its own language (`.py` / `.R` / `.lua` / `.m` generated filenames) and validating green on the native worker. C++ is the fifth, and is what this PR unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hwj5fD2dysDT6iC9RuVF4a