### PR TITLE
feat: a runner only claims a job it can actually grade; language resolution is Optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,31 +229,30 @@ unchanged. R pattern-family / notebook-check renderers and literal-globals
 inlined into hand-authored `.R` scripts shipped in #1207 (v0.4.636);
 `astStructure` remains the one Python-only check kind. See `docs/r-support.md`.
 
-**Gate an assignment on `minimumRunnerVersion` whenever it needs a runner-side
-feature — at authoring time, not after something breaks.** Runners are separate
-hosts that upgrade on their own schedule, so several `chickadee-runner` builds
-poll at once and some predate the release that taught the runner your feature.
-An ungated assignment goes to whichever runner polls first, so whether it grades
-correctly depends on *who answered*: it validates green because a capable runner
-happened to claim it, then fails weeks later for the one student whose job an
-older runner claims — and the symptom (exit 127, "interpreter not found", a
-suite of `error`s) reads as a broken test script and gets debugged as one. This
-has cost us repeatedly; most recently the Octave sample went out ungated against
-a fleet still running a 0.5.23 runner. Set it with MCP
-`set_minimum_runner_version` (metadata-only — no regrade, no close, no
-visibility change) or `minimumRunnerVersion` in the manifest, to the release that
-shipped support: Lua **0.5.23**, Octave **0.5.24**, C++ **0.5.27**.
-Browser-graded assignments need the gate too, because instructor validation is
-enqueued as a `kind == .validation` submission and always runs on the **native
-worker**, as does any browser submission that fails over. Capability
-requirements are **not** a substitute and fail the opposite way:
-`requiredLanguages` matches what a runner *advertises*, and
-`RunnerProfileDetector` hand-lists the interpreters it probes, so a runner built
-before your language never advertises it however the host is provisioned —
-requiring it matches no runner and queues the jobs forever. Use
-`requiredLanguages`/`requiredCapabilities` for "this host lacks a package", and
-`minimumRunnerVersion` for "this build is too old to know the feature". See
-"Authoring rule" in `docs/runner-capability-profiles.md`.
+**A runner only claims a job it can actually grade — enforced, not authored
+(`RunnerLanguageGate`).** Runners are separate hosts that upgrade on their own
+schedule, so several `chickadee-runner` builds poll at once and claim order
+decides which one grades a job. That used to make an assignment in a newer
+language nondeterministic: it validated green because a capable runner happened
+to claim it, then failed for the one student whose job an older runner claimed —
+with a symptom (exit 127, "interpreter not found") that reads as a broken test
+script and gets debugged as one. The claim seam now resolves the assignment's
+language from its manifest and refuses a runner whose advertised profile lacks
+it, so the job waits for a runner that can grade it. No authoring step: the
+manifest already knows the language, and `RunnerProfileDetector` discovers its
+probes from `AssignmentLanguage.allCases`, so every runner advertises every
+language it has and a runner whose *build* predates one advertises a profile
+without it. Two deliberate fail-opens — an assignment with no language (a plain
+`.sh` suite) and a runner advertising no profile at all (discovery switched off,
+an operator's choice; an old runner still has discovery on and is caught by the
+closed path). It catches strictly more than a version gate: a *current* runner
+whose host lacks the interpreter never advertises it either. `minimumRunnerVersion`
+(MCP `set_minimum_runner_version`, metadata-only) survives for the case this
+cannot see — runner behaviour that is not observable as an interpreter — and is
+the wrong tool for "this is a new language". Browser-graded assignments are
+covered too, since instructor validation is enqueued as a `kind == .validation`
+submission and always runs on the **native worker**. See
+`docs/runner-capability-profiles.md`.
 
 **Roles are two-level: a deployment role plus a per-course role (#417).**
 The deployment-global `UserRole` on `APIUser` is just `user` | `admin`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,32 @@ unchanged. R pattern-family / notebook-check renderers and literal-globals
 inlined into hand-authored `.R` scripts shipped in #1207 (v0.4.636);
 `astStructure` remains the one Python-only check kind. See `docs/r-support.md`.
 
+**Gate an assignment on `minimumRunnerVersion` whenever it needs a runner-side
+feature — at authoring time, not after something breaks.** Runners are separate
+hosts that upgrade on their own schedule, so several `chickadee-runner` builds
+poll at once and some predate the release that taught the runner your feature.
+An ungated assignment goes to whichever runner polls first, so whether it grades
+correctly depends on *who answered*: it validates green because a capable runner
+happened to claim it, then fails weeks later for the one student whose job an
+older runner claims — and the symptom (exit 127, "interpreter not found", a
+suite of `error`s) reads as a broken test script and gets debugged as one. This
+has cost us repeatedly; most recently the Octave sample went out ungated against
+a fleet still running a 0.5.23 runner. Set it with MCP
+`set_minimum_runner_version` (metadata-only — no regrade, no close, no
+visibility change) or `minimumRunnerVersion` in the manifest, to the release that
+shipped support: Lua **0.5.23**, Octave **0.5.24**, C++ **0.5.27**.
+Browser-graded assignments need the gate too, because instructor validation is
+enqueued as a `kind == .validation` submission and always runs on the **native
+worker**, as does any browser submission that fails over. Capability
+requirements are **not** a substitute and fail the opposite way:
+`requiredLanguages` matches what a runner *advertises*, and
+`RunnerProfileDetector` hand-lists the interpreters it probes, so a runner built
+before your language never advertises it however the host is provisioned —
+requiring it matches no runner and queues the jobs forever. Use
+`requiredLanguages`/`requiredCapabilities` for "this host lacks a package", and
+`minimumRunnerVersion` for "this build is too old to know the feature". See
+"Authoring rule" in `docs/runner-capability-profiles.md`.
+
 **Roles are two-level: a deployment role plus a per-course role (#417).**
 The deployment-global `UserRole` on `APIUser` is just `user` | `admin`
 (plus the non-human `mcp` service-account role) — the legacy global

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -72,6 +72,9 @@
     // CHICKADEE_GENERATED:OCTAVE_KERNEL_NAMES:BEGIN
     const OCTAVE_KERNEL_NAMES = ['octave', 'xoctave'];
     // CHICKADEE_GENERATED:OCTAVE_KERNEL_NAMES:END
+    // CHICKADEE_GENERATED:PYTHON_KERNEL_NAMES:BEGIN
+    const PYTHON_KERNEL_NAMES = ['python', 'python3', 'xpython'];
+    // CHICKADEE_GENERATED:PYTHON_KERNEL_NAMES:END
 
     // Filename extensions that mark a directly-uploaded file as gradeable
     // source, so it gets a `.chickadee_student_module` hint. A GENERATED copy of
@@ -1006,6 +1009,7 @@
         const isR    = R_KERNEL_NAMES.includes(ksName) || liName === 'r';
         const isLua  = LUA_KERNEL_NAMES.includes(ksName) || liName === 'lua';
         const isOctave = OCTAVE_KERNEL_NAMES.includes(ksName) || liName === 'octave';
+        const isPython = PYTHON_KERNEL_NAMES.includes(ksName) || liName === 'python';
         const stem   = filename.replace(/\.ipynb$/i, '');
 
         const cells = (notebook.cells || []).map(cell => ({
@@ -1061,15 +1065,30 @@
 
         // Python: extract via the shared RunnerCore wasm — the SAME code the
         // native worker runs (Sources/RunnerCore), instead of a JS reimplementation.
-        const result = core.extractPython(cells, filename);
+        function extractAsPython() {
+            const result = core.extractPython(cells, filename);
 
-        files[`${stem}.py`] = result.executableModule;
-        files['.chickadee_student_module'] = `${stem}.py`;
+            files[`${stem}.py`] = result.executableModule;
+            files['.chickadee_student_module'] = `${stem}.py`;
 
-        // Sidecar: the introspectable (un-exec-wrapped) source, so structural /
-        // AST NotebookChecks can read real `def`s via student_source().
-        files[`${stem}.source.py`] = result.introspectableSource;
-        files['.chickadee_student_source'] = `${stem}.source.py`;
+            // Sidecar: the introspectable (un-exec-wrapped) source, so structural /
+            // AST NotebookChecks can read real `def`s via student_source().
+            files[`${stem}.source.py`] = result.introspectableSource;
+            files['.chickadee_student_source'] = `${stem}.source.py`;
+        }
+
+        if (isPython) {
+            return extractAsPython();
+        }
+
+        // Unrecognised kernel. Extraction still has to produce a file in SOME
+        // syntax, so it falls back to Python — the same explicit choice the
+        // native NotebookExtractor makes (`?? .python`). Written as its own
+        // branch rather than left as the shape of the tail, so the fallback is
+        // visible where it happens: "we could not tell" and "this is Python"
+        // are different facts that used to share one code path here, exactly as
+        // they used to share one value in AssignmentLanguage.
+        return extractAsPython();
     }
 
     // Build the _ck_inputs.py source from per-student personalization inputs

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -65,6 +65,15 @@
                     <input class="form-input" type="datetime-local" name="dueAt" id="dueAt" value="#(dueAt)">
                 </label>
                 <label class="form-label field-gap">
+                    Language
+                    <select class="form-input" name="assignmentLanguage" id="assignmentLanguageSelect">
+                        #for(option in assignmentLanguageOptions):
+                        <option value="#(option.value)" #if(option.selected):selected#endif>#(option.label)</option>
+                        #endfor
+                    </select>
+                </label>
+                <p class="card-meta fine-print">Chickadee normally works the language out from the starter notebook's kernel or a test script's extension. Declare it when there is nothing to work it out from — a suite made only of pattern families — or for C++, which has no notebook kernel and whose generated tests are shell wrappers. Declare it before adding pattern families or notebook checks: their filenames carry the language's extension, so it cannot be changed once they exist.</p>
+                <label class="form-label field-gap">
                     Submission Method
                     <select class="form-input" name="submissionMode" id="submissionModeSelect">
                         <option value="notebook" #if(submissionMode == "notebook"):selected#endif>Notebook editor</option>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -51,7 +51,17 @@ Create Assignment
                     </select>
                 </label>
                 #endif
+                <label class="field-inline">
+                    Language
+                    <select class="form-input input-compact" name="assignmentLanguage"
+                            id="assignmentLanguageSelect" required>
+                        #for(option in assignmentLanguageOptions):
+                        <option value="#(option.value)" #if(option.selected):selected#endif>#(option.label)</option>
+                        #endfor
+                    </select>
+                </label>
             </div>
+            <p class="card-meta fine-print">Every generated test renders in this language, so it is stated here rather than worked out later. Pick "None" for a suite of plain shell scripts. Choosing C++ makes the assignment upload-only, since C++ has no notebook editor.</p>
             <div id="uw-date-warning" class="card-meta date-warning" style="display:none"></div>
             <p id="grading-mode-hint" class="card-meta grading-mode-hint" style="display:none"></p>
         </div>

--- a/Sources/APIServer/Compatibility/RunnerLanguageGate.swift
+++ b/Sources/APIServer/Compatibility/RunnerLanguageGate.swift
@@ -1,0 +1,77 @@
+import Core
+import Foundation
+
+/// Server-side gate that keeps a job away from a runner that cannot grade the
+/// assignment's language.
+///
+/// The third sibling at the claim seam, beside `CompatibilityMatcher` (an
+/// explicit `AssignmentRequirementSpec` an instructor opted into) and
+/// `RunnerVersionGate` (the manifest's `minimumRunnerVersion`). Unlike both, this
+/// one is **implicit**: it needs no authoring step, because the assignment's
+/// language is already knowable from its manifest and the runner already
+/// advertises the languages it has.
+///
+/// Why it exists as its own gate rather than as advice to set one of the other
+/// two:
+///
+/// - `requiredLanguages` works, but only if an instructor remembers to set it,
+///   and the failure of forgetting is silent and intermittent.
+/// - `minimumRunnerVersion` is a *proxy* for capability: it excludes a runner
+///   whose build predates the language, but admits a current runner whose HOST
+///   lacks the interpreter, which then fails at grade time. This gate catches
+///   both, because it asks the runner what it actually has.
+///
+/// The failure it prevents: runners upgrade independently of the auto-deployed
+/// server, so several `chickadee-runner` builds poll at once and claim order
+/// decides which one grades a job. An assignment in a language only some of them
+/// can run is graded correctly or not depending on *who answered* — it validates
+/// green on a capable runner and then fails for the next student whose job an
+/// older one claims, with a message (exit 127, "interpreter not found") that
+/// reads as a broken test script.
+///
+/// Only bites the native worker path, like `RunnerVersionGate`: browser grading
+/// runs the server's own vended WASM bundle and has no runner profile to check.
+enum RunnerLanguageGate {
+
+    /// Whether `runnerProfile` advertises the language this assignment is in.
+    ///
+    /// Compatible — with no check performed — in two cases:
+    ///
+    /// 1. **The assignment names no language** (`language == nil`). A suite of
+    ///    plain `.sh` scripts has no interpreter to require; that is the
+    ///    system's original mode and stays claimable by anyone.
+    /// 2. **The runner advertises no profile at all.** That means capability
+    ///    discovery is switched off (`RUNNER_CAPABILITY_DISCOVERY_ENABLED=false`),
+    ///    an explicit operator choice, and treating it as incompatible would
+    ///    silently stop such a runner claiming anything at all. Failing open here
+    ///    costs nothing against the failure this gate is for: a runner too old to
+    ///    know the language still *has* discovery on, so it advertises a profile
+    ///    without the language and is caught by the closed path below.
+    ///
+    /// Everything else is checked: a profile that is present and does not list
+    /// the language is refused, whatever the reason it is missing (build too old
+    /// to probe for it, or host without the interpreter installed).
+    static func evaluate(
+        runnerProfile: RunnerCapabilityProfile?,
+        language: AssignmentLanguage?
+    ) -> CompatibilityResult {
+        guard let language else { return CompatibilityResult(isCompatible: true) }
+        guard let runnerProfile else { return CompatibilityResult(isCompatible: true) }
+
+        let required = normalized(language.capabilityName)
+        let advertised = Set(runnerProfile.languageVersions.map { normalized($0.language) })
+        guard advertised.contains(required) else {
+            return CompatibilityResult(
+                isCompatible: false,
+                reasons: ["runner does not provide \(required) (assignment language)"]
+            )
+        }
+        return CompatibilityResult(isCompatible: true)
+    }
+
+    /// Matches `CompatibilityMatcher`'s own normalization so the two gates agree
+    /// about what counts as the same language token.
+    private static func normalized(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -116,6 +116,29 @@ func setManifestLanguage(
     return language
 }
 
+/// Removes the recorded `language`, returning the assignment to derived
+/// resolution. Returns true when a value was actually removed.
+///
+/// The escape hatch from the one-way door `AssignmentLanguage.rederive`
+/// documents: a recorded language outranks every content signal, so without a
+/// way back an assignment declared wrong once would keep rendering in that
+/// language forever, however its notebook and scripts changed underneath.
+///
+/// Guarded exactly like `setManifestLanguage`, and for the same reason: clearing
+/// changes which language generated tests render in just as setting does, and
+/// only the pattern-family application path knows how to re-render and clean up
+/// the old side.
+func clearManifestLanguage(setup: APITestSetup, on db: any Database) async throws -> Bool {
+    guard currentManifestLanguage(setup.manifest) != nil else { return false }
+    if manifestHasGeneratedScripts(setup.manifest) {
+        throw AppError.badRequest(reason: languageChangeAfterGenerationMessage)
+    }
+    try await mutateManifest(setup: setup, on: db) { dict in
+        dict.removeValue(forKey: "language")
+    }
+    return true
+}
+
 /// True when the manifest carries any generated test — a pattern-family case or
 /// a notebook check. Read off `generatedBy` rather than the family/check lists
 /// so a family that has produced no enabled case doesn't block a change that

--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -116,6 +116,61 @@ func setManifestLanguage(
     return language
 }
 
+/// The wire value meaning "this assignment has no language — its suite is plain
+/// shell scripts". Shared by the web creation/edit selects and the MCP tools so
+/// the two surfaces cannot disagree about how the choice is spelled.
+///
+/// A reserved STRING at the surface, not an `AssignmentLanguage` case: the enum
+/// promises a literal renderer, an inputs file, pattern families and a
+/// personalization driver, none of which a shell suite has. A case would have to
+/// answer "not applicable" to all of them while silently satisfying every
+/// exhaustive switch.
+let noLanguageChoice = "none"
+
+/// Parses a creation-time or edit-time language choice into the language to
+/// record — nil for `noLanguageChoice`.
+func parseLanguageChoice(_ raw: String) throws -> AssignmentLanguage? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if trimmed == noLanguageChoice { return nil }
+    guard let parsed = AssignmentLanguage(rawValue: trimmed) else {
+        throw AppError.badRequest(reason: unknownLanguageMessage(raw))
+    }
+    return parsed
+}
+
+/// Records an author's answer to "what language is this assignment?" — the
+/// language itself, or its declared absence, plus the flag saying the question
+/// was answered at all.
+///
+/// This is the declaration primitive, distinct from `setManifestLanguage`
+/// (which edits a language on an assignment that already has content and guards
+/// accordingly). Two differences matter:
+///
+/// 1. It records `languageDeclared`, so a nil language afterwards means "the
+///    author says there is none" rather than "nobody has been asked".
+/// 2. An upload-only language sets `submissionMode` too, because the language
+///    implies it. That is what makes declare-at-creation possible for C++ at
+///    all: `setManifestLanguage` refuses an upload-only language while the setup
+///    is in notebook mode, and a brand-new assignment always is — so requiring
+///    the declaration up front would otherwise leave C++ uncreatable. It also
+///    collapses the old three-step authoring dance (grading mode, then
+///    submission mode, then language) into one answer.
+func declareManifestLanguage(
+    setup: APITestSetup, to language: AssignmentLanguage?, on db: any Database
+) async throws {
+    try await mutateManifest(setup: setup, on: db) { dict in
+        dict["languageDeclared"] = true
+        guard let language else {
+            dict.removeValue(forKey: "language")
+            return
+        }
+        dict["language"] = language.rawValue
+        if case .uploadOnly = language.editorSupport {
+            dict["submissionMode"] = SubmissionMode.uploadOnly.rawValue
+        }
+    }
+}
+
 /// Removes the recorded `language`, returning the assignment to derived
 /// resolution. Returns true when a value was actually removed.
 ///

--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -159,8 +159,14 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
     // hand-written arms and shipped without a Lua one, leaving a `lua`-named
     // notebook on "unknown → leave unchanged" with no kernel the editor could
     // attach (docs/lua-architecture-audit.md F6).
+    // Python is excluded by name rather than as "the default": it now has its
+    // own `notebookKernelNames`, and matching it here would route a Python
+    // notebook through the destructuring branch instead of the Python branch
+    // below. The two produce the same kernelspec, but only the branch below
+    // also handles a MISSING kernelspec, which is the common case for a
+    // freshly-authored notebook.
     let matched = AssignmentLanguage.allCases.first {
-        $0 != .default && existingName.map($0.notebookKernelNames.contains) == true
+        $0 != .python && existingName.map($0.notebookKernelNames.contains) == true
     }
 
     // A matched language always destructures: `matched` comes from
@@ -185,11 +191,11 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
         // A kernel no language claims → leave unchanged.
         return data
     } else {
-        // Python kernel (or missing kernelspec) → the default's vendored
-        // kernel. The default language always has one (guarded so the
-        // compiler agrees; leaving the notebook unchanged is the safe
-        // degradation if that ever stopped being true).
-        let python = AssignmentLanguage.default
+        // Python kernel (or missing kernelspec) → Python's vendored kernel.
+        // Python always has one (guarded so the compiler agrees; leaving the
+        // notebook unchanged is the safe degradation if that ever stopped
+        // being true).
+        let python = AssignmentLanguage.python
         guard
             case .notebookKernel(_, let kernelName, let kernelDisplayName, _) =
                 python.editorSupport

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -25,6 +25,9 @@ struct CreateAssignmentTool: ContentTool {
         let courseCode: String
         let title: String
         let notebook: JSONValue
+        /// An `AssignmentLanguage` raw value, or `"none"` for a shell-script
+        /// suite. Required — see the schema description.
+        let language: String
     }
 
     struct Output: Encodable, Sendable {
@@ -59,8 +62,21 @@ struct CreateAssignmentTool: ContentTool {
                 "description": .string(
                     "The starter notebook as .ipynb JSON (an object containing a \"cells\" array)."),
             ]),
+            "language": .object([
+                "type": .string("string"),
+                "enum": .array(
+                    AssignmentLanguage.allCases.map { .string($0.rawValue) }
+                        + [.string(noLanguageChoice)]),
+                "description": .string(
+                    "The language this assignment is authored and graded in, or \"none\" for a suite "
+                        + "of plain shell scripts. Required: the language is what every generated test "
+                        + "renders in, so it is stated rather than guessed. Declaring \"cpp\" also sets "
+                        + "submissionMode to uploadOnly, since C++ has no notebook workflow."),
+            ]),
         ]),
-        "required": .array([.string("courseCode"), .string("title"), .string("notebook")]),
+        "required": .array([
+            .string("courseCode"), .string("title"), .string("notebook"), .string("language"),
+        ]),
         "additionalProperties": .bool(false),
     ])
     static let outputSchema: JSONValue? = .object([
@@ -88,6 +104,15 @@ struct CreateAssignmentTool: ContentTool {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "title must not be empty.")
         }
         try validateNotebookShape(input.notebook, tool: Self.name)
+        // Parsed BEFORE the course lookup and the setup write, so an unusable
+        // language fails without leaving a half-created assignment behind.
+        let declaredLanguage: AssignmentLanguage?
+        do {
+            declaredLanguage = try parseLanguageChoice(input.language)
+        } catch {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: unknownLanguageMessage(input.language))
+        }
 
         let code = input.courseCode.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
@@ -120,6 +145,9 @@ struct CreateAssignmentTool: ContentTool {
             }
             throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
         }
+
+        try await declareManifestLanguage(
+            setup: created.setup, to: declaredLanguage, on: context.db)
 
         await AuditLogger.recordAssignmentLifecycle(
             .assignmentCreated, assignment: created.assignment,

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -162,10 +162,13 @@ struct UpdateSolutionTool: ContentTool {
         // language, not by the caller's preference: a language with no notebook
         // workflow has no `.ipynb` to extract source from, so a notebook
         // solution would be stored and then grade as an empty submission.
+        // An assignment with no language signal keeps the notebook workflow:
+        // only `.uploadOnly` languages need a source file, and nothing that has
+        // not named itself is upload-only.
         let language =
-            setup?.decodedManifest().map {
+            setup?.decodedManifest().flatMap {
                 AssignmentLanguage.resolve(manifest: $0, notebookData: nil)
-            } ?? .default
+            } ?? .python
         let wantsSourceFile: Bool
         if case .uploadOnly = language.editorSupport {
             wantsSourceFile = true

--- a/Sources/APIServer/Migrations/BackfillDeclaredLanguage.swift
+++ b/Sources/APIServer/Migrations/BackfillDeclaredLanguage.swift
@@ -1,0 +1,97 @@
+// APIServer/Migrations/BackfillDeclaredLanguage.swift
+//
+// One-time backfill so every assignment already on disk carries an ANSWER to
+// "what language is this?", rather than leaving that to be re-derived forever.
+
+import Core
+import Fluent
+import Foundation
+
+/// Records a declared language on every existing test setup.
+///
+/// Declaring the language at creation is what lets the rest of the system stop
+/// guessing: once `languageDeclared` is set, nil `language` means "the author
+/// says this has no language" rather than "nobody has been asked", and a worker
+/// can refuse a job it cannot identify instead of falling back to Python. That
+/// only holds if EXISTING content carries the flag too — otherwise every
+/// pre-existing assignment looks undeclared forever and the guessing paths can
+/// never be removed.
+///
+/// The backfill is deterministic: it runs the same resolution the server runs
+/// today (recorded language, then a graded script's extension, then the starter
+/// notebook's kernel) and writes the answer down. An assignment that resolves to
+/// nothing is recorded as declared-with-no-language, which is the truthful
+/// answer for a plain `.sh` suite — the case that resolution has always returned
+/// nothing for and that the system has always supported.
+///
+/// It is idempotent by construction: a setup that already carries
+/// `languageDeclared` is skipped, so a re-run (or a revert-then-reapply) cannot
+/// overwrite an author's later choice with a re-derived one.
+struct BackfillDeclaredLanguage: ChickadeeMigration {
+
+    func prepare(on database: Database) async throws {
+        // A full model query is safe HERE specifically because this migration is
+        // registered last, after every `Create*` — the #1077 hazard is a
+        // migration full-querying a model whose columns a LATER migration adds.
+        let setups = try await APITestSetup.query(on: database).all()
+        var declared = 0
+        var withoutLanguage = 0
+
+        for setup in setups {
+            guard let manifest = setup.decodedManifest() else { continue }
+            // Already answered — by an author on the edit page, or by an earlier
+            // run of this migration. Never re-derive over a real answer.
+            guard manifest.languageDeclared != true else { continue }
+
+            let resolved = AssignmentLanguage.resolve(for: setup, manifest: manifest)
+            guard let updated = manifestWithDeclaredLanguage(setup.manifest, language: resolved)
+            else { continue }
+            setup.manifest = updated
+            try await setup.save(on: database)
+
+            declared += 1
+            if resolved == nil { withoutLanguage += 1 }
+        }
+
+        database.logger.info(
+            """
+            backfill_declared_language: \(declared) test setup(s) stamped \
+            (\(withoutLanguage) with no language, i.e. shell-script suites)
+            """)
+    }
+
+    /// Deliberately a no-op rather than stripping the field.
+    ///
+    /// Reverting would put every assignment back to undeclared, which is not the
+    /// state it was in before — an author may have declared a language through
+    /// the edit page since. There is nothing to undo: the flag records that the
+    /// question has an answer, and it does.
+    func revert(on database: Database) async throws {}
+
+    /// Rewrites the manifest JSON with `languageDeclared` set, and `language`
+    /// set or removed to match `language`.
+    ///
+    /// Works on the raw JSON rather than re-encoding a decoded `TestProperties`,
+    /// so a manifest carrying fields this build does not know keeps them. A
+    /// round-trip through the type would silently drop anything newer, which on
+    /// a rollback would mean the migration ate content the newer build wrote.
+    private func manifestWithDeclaredLanguage(
+        _ manifestJSON: String, language: AssignmentLanguage?
+    ) -> String? {
+        guard
+            var dict = (try? JSONSerialization.jsonObject(with: Data(manifestJSON.utf8)))
+                as? [String: Any]
+        else { return nil }
+        dict["languageDeclared"] = true
+        if let language {
+            dict["language"] = language.rawValue
+        } else {
+            dict.removeValue(forKey: "language")
+        }
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: dict, options: [.sortedKeys])
+        else { return nil }
+        return String(bytes: data, encoding: .utf8)
+    }
+}

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -180,6 +180,9 @@ struct BrowserRunnerRoutes: RouteCollection {
         var language: AssignmentLanguage?
         if let manifest = setup.decodedManifest() {
             let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+            // nil language yields no grading inputs (there is no syntax to
+            // render them in); datasets below are language-independent and
+            // still resolve.
             let resolved = AssignmentLanguage.resolve(for: setup, manifest: manifest)
             language = resolved
             personalizedInputs = await PersonalizationSubstitution.gradingInputs(

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -261,20 +261,23 @@ struct AssignmentLanguageOption: Encodable {
     let selected: Bool
 
     /// Builds the whole list for an assignment whose manifest records
-    /// `recorded` (nil when nothing is recorded).
+    /// `recorded` (nil when no language is recorded).
     ///
-    /// The empty-valued first entry is not cosmetic: it is what lets an author
-    /// undo a declaration. `AssignmentLanguage.resolve` treats a recorded value
-    /// as authoritative over the notebook and the suite, so a select offering
-    /// only the five real languages would make the first choice permanent.
+    /// The first entry is a DECLARATION that the assignment has no language —
+    /// a plain shell-script suite — not a request to go and detect one. That
+    /// distinction is the point of the whole change: an author picking it is
+    /// answering the question, so nothing downstream has to guess afterwards.
+    /// It doubles as the way to undo a declaration, since
+    /// `AssignmentLanguage.resolve` treats a recorded value as authoritative
+    /// over the notebook and the suite.
     static func options(recorded: String?) -> [AssignmentLanguageOption] {
         let normalized = recorded?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let auto = AssignmentLanguageOption(
-            value: "",
-            label: "Detect from the notebook or test scripts",
+        let noLanguage = AssignmentLanguageOption(
+            value: noLanguageChoice,
+            label: "None — plain shell scripts",
             selected: normalized == nil || AssignmentLanguage(rawValue: normalized ?? "") == nil
         )
-        return [auto]
+        return [noLanguage]
             + AssignmentLanguage.allCases.map { language in
                 AssignmentLanguageOption(
                     value: language.rawValue,

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -79,6 +79,9 @@ struct NewAssignmentContext: Encodable {
     let requiredCapabilitiesCSV: String
     let detectedLanguages: [String]
     let detectedCapabilities: [String]
+    /// The required Language select's options, same builder the edit page
+    /// uses. Declared at creation so nothing downstream has to derive it.
+    let assignmentLanguageOptions: [AssignmentLanguageOption]
     let detectedLanguagesCSV: String
     let detectedCapabilitiesCSV: String
     let notice: String?

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -10,6 +10,7 @@
 // site).  Nesting is deferred — Leaf templates reference these fields
 // flat via `#(field)`, so nesting would force a template-side rewrite.
 
+import Core
 import Foundation
 
 struct NewAssignmentContext: Encodable {
@@ -227,6 +228,12 @@ struct EditAssignmentContext: Encodable {
     /// "notebook" | "uploadOnly" from the manifest — renders the Submission
     /// select's current value in the name/due-date edit block.
     let submissionMode: String
+    /// The Language select's options, in `AssignmentLanguage.allCases` order
+    /// behind the "detect automatically" entry. Built from `allCases` rather
+    /// than written out in the template so a sixth language needs no Leaf edit —
+    /// the same discovered-not-enumerated rule the kernel-alias generator and
+    /// the runner's capability probe follow.
+    let assignmentLanguageOptions: [AssignmentLanguageOption]
     /// The per-assignment secret-reveal toggle: whether students may spend
     /// their one reveal token here.  Renders the "Student Options" checkbox.
     let secretRevealEnabled: Bool
@@ -244,4 +251,36 @@ struct EditAssignmentContext: Encodable {
     /// "Open workbench" link (the workbench must not link to itself).
     /// `nil` on the standalone `/edit` render.
     let embedded: Bool?
+}
+
+/// One entry in the edit page's Language select.
+struct AssignmentLanguageOption: Encodable {
+    /// An `AssignmentLanguage` raw value, or "" for the derive-it entry.
+    let value: String
+    let label: String
+    let selected: Bool
+
+    /// Builds the whole list for an assignment whose manifest records
+    /// `recorded` (nil when nothing is recorded).
+    ///
+    /// The empty-valued first entry is not cosmetic: it is what lets an author
+    /// undo a declaration. `AssignmentLanguage.resolve` treats a recorded value
+    /// as authoritative over the notebook and the suite, so a select offering
+    /// only the five real languages would make the first choice permanent.
+    static func options(recorded: String?) -> [AssignmentLanguageOption] {
+        let normalized = recorded?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let auto = AssignmentLanguageOption(
+            value: "",
+            label: "Detect from the notebook or test scripts",
+            selected: normalized == nil || AssignmentLanguage(rawValue: normalized ?? "") == nil
+        )
+        return [auto]
+            + AssignmentLanguage.allCases.map { language in
+                AssignmentLanguageOption(
+                    value: language.rawValue,
+                    label: language.displayName,
+                    selected: normalized == language.rawValue
+                )
+            }
+    }
 }

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
@@ -423,6 +423,27 @@ private func importBundledTestSetups(
             courseID: courseID
         )
         try await setup.save(on: db)
+
+        // A bundle exported by an older build carries no language declaration,
+        // so declare one on the way in — the same thing
+        // `BackfillDeclaredLanguage` does for content already on disk, applied
+        // at the one other door assignments come through.
+        //
+        // Without this, import is a permanent source of undeclared assignments,
+        // and "undeclared" is exactly the state the worker must be able to
+        // refuse rather than guess at. A refusal that legitimate imports can
+        // trip is a refusal that has to be watered down.
+        //
+        // The notebook is already on disk above, so resolution can consult its
+        // kernel; an assignment nothing identifies is declared as having no
+        // language, which is the truthful answer for a shell-script suite.
+        if let imported = setup.decodedManifest(), imported.languageDeclared != true {
+            try await declareManifestLanguage(
+                setup: setup,
+                to: AssignmentLanguage.resolve(for: setup, manifest: imported),
+                on: db)
+        }
+
         setupIDMap[bundledSetup.bundleID] = newSetupID
         tally.testSetupsImported += 1
     }

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -93,6 +93,8 @@ extension DraftAssignmentRoutes {
                 : storedState.requiredCapabilitiesCSV,
             detectedLanguages: detected.languages,
             detectedCapabilities: detected.capabilities,
+            assignmentLanguageOptions: AssignmentLanguageOption.options(
+                recorded: setup.flatMap { currentManifestLanguage($0.manifest) }),
             detectedLanguagesCSV: detected.languages.joined(separator: ", "),
             detectedCapabilitiesCSV: detected.capabilities.joined(separator: ", "),
             notice: q?.notice,
@@ -133,6 +135,23 @@ extension DraftAssignmentRoutes {
         )
         guard let setupID = setup.id else {
             throw WebAssignmentError.internalFailure(reason: "Draft test setup persisted without an id")
+        }
+
+        // Declared BEFORE the draft service runs, so pattern families and
+        // notebook checks authored in the same save render in the language the
+        // author chose rather than in one derived from a suite that does not
+        // exist yet. Empty means the field was absent (a form predating it);
+        // the select is `required`, so a real submission always carries one.
+        if !payload.assignmentLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            do {
+                try await declareManifestLanguage(
+                    setup: setup, to: try parseLanguageChoice(payload.assignmentLanguage),
+                    on: req.db)
+            } catch {
+                throw WebAssignmentError.unprocessable(
+                    reason: (error as? any AbortError)?.reason
+                        ?? unknownLanguageMessage(payload.assignmentLanguage))
+            }
         }
 
         var formState = loadDraftFormState(req: req, draftID: setupID)
@@ -230,6 +249,10 @@ extension DraftAssignmentRoutes {
             try multipartTextField(named: ["requiredCapabilitiesCSV"], from: req)
             ?? body.requiredCapabilitiesCSV
             ?? ""
+        let assignmentLanguage =
+            try multipartTextField(named: ["assignmentLanguage"], from: req)
+            ?? body.assignmentLanguage
+            ?? ""
 
         return NewAssignmentDraftPayload(
             assignmentName: assignmentName,
@@ -245,7 +268,8 @@ extension DraftAssignmentRoutes {
             requiredPlatform: requiredPlatform,
             requiredArchitecture: requiredArchitecture,
             requiredLanguagesCSV: requiredLanguagesCSV,
-            requiredCapabilitiesCSV: requiredCapabilitiesCSV
+            requiredCapabilitiesCSV: requiredCapabilitiesCSV,
+            assignmentLanguage: assignmentLanguage
         )
     }
 
@@ -378,6 +402,7 @@ extension DraftAssignmentRoutes {
         var requiredArchitecture: String?
         var requiredLanguagesCSV: String?
         var requiredCapabilitiesCSV: String?
+        var assignmentLanguage: String?
     }
 
     // MARK: - saveNewAssignment helpers

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -667,6 +667,11 @@ struct InstructorDashboardRoutes: RouteCollection {
             brightspaceGradeObjectID: assignment.brightspaceGradeObjectID,
             submissionMode: manifest?.submissionMode.rawValue
                 ?? SubmissionMode.notebook.rawValue,
+            // Read straight off the manifest JSON, not from resolution: the
+            // select shows what is DECLARED, and resolution would fill the box
+            // in with a derived answer the author never chose.
+            assignmentLanguageOptions: AssignmentLanguageOption.options(
+                recorded: currentManifestLanguage(setup.manifest)),
             secretRevealEnabled: assignment.secretRevealEnabled == true,
             timeLimitSeconds: manifest?.timeLimitSeconds ?? 10,
             notice: q?.notice,

--- a/Sources/APIServer/Routes/Web/NewAssignmentDraftPayload.swift
+++ b/Sources/APIServer/Routes/Web/NewAssignmentDraftPayload.swift
@@ -31,4 +31,9 @@ struct NewAssignmentDraftPayload {
     let requiredArchitecture: String
     let requiredLanguagesCSV: String
     let requiredCapabilitiesCSV: String
+    /// The Language select's value: an `AssignmentLanguage` raw value, or
+    /// `noLanguageChoice` for a plain shell-script suite. Empty when the form
+    /// omitted it, which the publish path treats as "not answered" and
+    /// refuses rather than guessing.
+    let assignmentLanguage: String
 }

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -217,10 +217,10 @@ extension PublishedAssignmentRoutes {
     /// user-facing refusal reason or nil when it succeeded or there was nothing
     /// to do.
     ///
-    /// `requested` distinguishes three states that must not be collapsed: nil is
-    /// the field being absent (a form posted from a tab opened before it
-    /// existed) and leaves the declaration alone; "" is the author picking
-    /// "detect automatically" and clears it; anything else declares it.
+    /// `requested` nil means the field was absent — a form posted from a tab
+    /// opened before it existed — and leaves the declaration alone. Anything
+    /// else is an answer, including `noLanguageChoice` ("none"), which declares
+    /// the assignment has no language rather than asking for one to be detected.
     ///
     /// The reason is the thrown error's own, not one fixed message: the shared
     /// helpers have three distinct refusals — unknown language, C++ outside
@@ -229,13 +229,20 @@ extension PublishedAssignmentRoutes {
     fileprivate func persistDeclaredLanguage(
         requested: String?, setup: APITestSetup, on db: any Database
     ) async -> String? {
-        guard let requested else { return nil }
+        guard let requested,
+            !requested.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
         do {
-            if requested.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                _ = try await clearManifestLanguage(setup: setup, on: db)
-            } else {
-                _ = try await setManifestLanguage(setup: setup, to: requested, on: db)
+            let language = try parseLanguageChoice(requested)
+            // Changing the language rewrites every generated filename, so the
+            // existing guard still applies to an edit even though a declaration
+            // at creation has nothing generated to protect.
+            if manifestHasGeneratedScripts(setup.manifest),
+                currentManifestLanguage(setup.manifest) != language?.rawValue
+            {
+                throw AppError.badRequest(reason: languageChangeAfterGenerationMessage)
             }
+            try await declareManifestLanguage(setup: setup, to: language, on: db)
             return nil
         } catch {
             // `any AbortError` rather than `AppError`, so a Vapor `Abort` thrown

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -76,18 +76,24 @@ extension PublishedAssignmentRoutes {
         // row: `setManifestSubmissionMode` refuses the upload + browser
         // combination, and refusing must leave the assignment entirely
         // unmodified — not half-saved.
-        if let requestedMode = form.submissionMode,
-            requestedMode == SubmissionMode.notebook.rawValue
-                || requestedMode == SubmissionMode.uploadOnly.rawValue
+        if let refusal = await persistSubmissionMode(
+            requested: form.submissionMode, setup: setup, on: req.db)
         {
-            do {
-                _ = try await setManifestSubmissionMode(
-                    setup: setup, to: requestedMode, on: req.db)
-            } catch {
-                let q =
-                    "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(form.dueAtRaw ?? ""))\(startsAtQuery)&error=\(urlEncode(uploadModeGradingConflictMessage))"
-                return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
-            }
+            let q =
+                "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(form.dueAtRaw ?? ""))\(startsAtQuery)&error=\(urlEncode(refusal))"
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
+        }
+
+        // Then the declared language, in that order deliberately: an upload-only
+        // language (C++) is refused while the setup is still in notebook mode,
+        // so a save that switches both at once has to apply the mode first or
+        // the pair would be rejected on its way to a coherent state.
+        if let refusal = await persistDeclaredLanguage(
+            requested: form.assignmentLanguage, setup: setup, on: req.db)
+        {
+            let q =
+                "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(form.dueAtRaw ?? ""))\(startsAtQuery)&error=\(urlEncode(refusal))"
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
 
         try persistAssignmentNotebook(
@@ -166,6 +172,12 @@ extension PublishedAssignmentRoutes {
         /// form predates the field (a stale open tab) so the stored mode is
         /// left untouched rather than reset to the default.
         let submissionMode: String?
+        /// An `AssignmentLanguage` raw value from the Language select, "" for
+        /// "detect automatically", or nil when the form predates the field (a
+        /// stale open tab) so the stored language is left untouched.  The empty
+        /// string and nil mean different things here and must stay distinct:
+        /// one clears a declaration, the other is silence.
+        let assignmentLanguage: String?
         /// Set by the assignment workbench's embedded form.  Suppresses the
         /// close-on-save below; see the comment at that call site.
         let liveEdit: Bool
@@ -177,6 +189,62 @@ extension PublishedAssignmentRoutes {
         let isNotebook: Bool
     }
 
+    /// Applies the Submission select's value to the manifest, returning a
+    /// user-facing refusal reason or nil when it succeeded or there was nothing
+    /// to do.
+    ///
+    /// An unrecognised value is ignored rather than refused, which is what keeps
+    /// a stale tab posting a mode this build no longer has from failing the
+    /// whole save. The refusal it CAN produce has one cause — the upload +
+    /// browser combination — hence the single fixed message, unlike the language
+    /// helper below.
+    fileprivate func persistSubmissionMode(
+        requested: String?, setup: APITestSetup, on db: any Database
+    ) async -> String? {
+        guard let requested,
+            requested == SubmissionMode.notebook.rawValue
+                || requested == SubmissionMode.uploadOnly.rawValue
+        else { return nil }
+        do {
+            _ = try await setManifestSubmissionMode(setup: setup, to: requested, on: db)
+            return nil
+        } catch {
+            return uploadModeGradingConflictMessage
+        }
+    }
+
+    /// Applies the Language select's value to the manifest, returning a
+    /// user-facing refusal reason or nil when it succeeded or there was nothing
+    /// to do.
+    ///
+    /// `requested` distinguishes three states that must not be collapsed: nil is
+    /// the field being absent (a form posted from a tab opened before it
+    /// existed) and leaves the declaration alone; "" is the author picking
+    /// "detect automatically" and clears it; anything else declares it.
+    ///
+    /// The reason is the thrown error's own, not one fixed message: the shared
+    /// helpers have three distinct refusals — unknown language, C++ outside
+    /// upload-only mode, and a change once generated tests exist — and which one
+    /// applies is exactly what the author needs in order to act.
+    fileprivate func persistDeclaredLanguage(
+        requested: String?, setup: APITestSetup, on db: any Database
+    ) async -> String? {
+        guard let requested else { return nil }
+        do {
+            if requested.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                _ = try await clearManifestLanguage(setup: setup, on: db)
+            } else {
+                _ = try await setManifestLanguage(setup: setup, to: requested, on: db)
+            }
+            return nil
+        } catch {
+            // `any AbortError` rather than `AppError`, so a Vapor `Abort` thrown
+            // deeper in the manifest write surfaces its reason too.
+            return (error as? any AbortError)?.reason
+                ?? "Could not set the assignment language."
+        }
+    }
+
     fileprivate func parseSaveEditedAssignmentForm(req: Request) throws -> SaveEditedAssignmentForm {
         struct SaveBody: Content {
             var assignmentName: String?
@@ -186,6 +254,7 @@ extension PublishedAssignmentRoutes {
             var solutionNotebookFile: File?
             var gradeObjectID: String?
             var submissionMode: String?
+            var assignmentLanguage: String?
             var liveEdit: String?
         }
 
@@ -205,6 +274,8 @@ extension PublishedAssignmentRoutes {
             gradeObjectID: try multipartTextField(named: ["gradeObjectID"], from: req) ?? body.gradeObjectID,
             submissionMode: try multipartTextField(named: ["submissionMode"], from: req)
                 ?? body.submissionMode,
+            assignmentLanguage: try multipartTextField(named: ["assignmentLanguage"], from: req)
+                ?? body.assignmentLanguage,
             liveEdit: (try multipartTextField(named: ["liveEdit"], from: req) ?? body.liveEdit) != nil
         )
     }

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -528,17 +528,28 @@ extension WorkerJobRoutes {
                 runnerProfile: runnerProfile,
                 requirements: requirementSpec
             )
-            // Fold the manifest's optional `minimumRunnerVersion` gate into the
-            // same verdict so a version block rides the existing diagnostics /
-            // guard / blocked-candidate path.  Use the *merged* result below,
-            // not `capabilityResult`, or the diagnostics would report
-            // "compatible" while the job is actually blocked on version.
+            // Fold the manifest's optional `minimumRunnerVersion` gate and the
+            // implicit language gate into the same verdict so either block rides
+            // the existing diagnostics / guard / blocked-candidate path.  Use
+            // the *merged* result below, not `capabilityResult`, or the
+            // diagnostics would report "compatible" while the job is actually
+            // blocked.
+            //
+            // The language gate needs no authoring step: the manifest already
+            // knows what language the assignment is in and the runner already
+            // advertises what it has, so a runner that cannot grade this
+            // assignment leaves it for one that can instead of failing it.
+            let versionResult = RunnerVersionGate.evaluate(
+                runnerVersion: body.runnerVersion,
+                minimumRunnerVersion: manifest.minimumRunnerVersion
+            )
+            let languageResult = RunnerLanguageGate.evaluate(
+                runnerProfile: runnerProfile,
+                language: AssignmentLanguage.resolve(for: setup, manifest: manifest)
+            )
             let compatibilityResult = RunnerVersionGate.combine(
-                capabilityResult,
-                RunnerVersionGate.evaluate(
-                    runnerVersion: body.runnerVersion,
-                    minimumRunnerVersion: manifest.minimumRunnerVersion
-                )
+                RunnerVersionGate.combine(capabilityResult, versionResult),
+                languageResult
             )
             await req.application.diagnostics.recordCompatibilityDecision(
                 submission: submission,

--- a/Sources/APIServer/Services/GlobalInputsService.swift
+++ b/Sources/APIServer/Services/GlobalInputsService.swift
@@ -213,13 +213,23 @@ enum GlobalInputsService {
         manifest: TestProperties,
         inputs: Inputs,
         testSetupsDirectory: String,
-        language: AssignmentLanguage = .python,
+        // Defaulted to nil, not to `.python`. The old `= .python` default meant
+        // an omitted argument produced a confident wrong answer for an R or Lua
+        // assignment; omitting it now produces "unknown", which lands on the
+        // same explicit fallback below as any other unknown. (Both callers pass
+        // it explicitly regardless; the default is here so the parameter count
+        // stays inside the lint threshold.)
+        language: AssignmentLanguage? = nil,
         seedDB: any Database
     ) async throws {
         guard !inputs.expressions.isEmpty,
             let userID = actingUserID,
             let assignmentID = assignment.id
         else { return }
+        // See the matching line in `SectionInputsService.evaluateForActingSeed`:
+        // evaluation needs an interpreter, so a language-less assignment
+        // evaluates as Python rather than refusing.
+        let language = language ?? .python
         let seedHex = try await AssignmentSeedStore.ensureSeed(
             userID: userID, assignmentID: assignmentID, on: seedDB)
         // Combine globals + section vars so expressions can reference the same

--- a/Sources/APIServer/Services/PersonalizationSubstitution.swift
+++ b/Sources/APIServer/Services/PersonalizationSubstitution.swift
@@ -34,13 +34,25 @@ enum PersonalizationSubstitution {
     /// `language` selects how literals are rendered (`pythonLiteral` vs
     /// `rLiteral`) and which interpreter evaluates the `=` expressions, so an R
     /// notebook's `{{name}}` placeholders receive R literals and a Python one
-    /// stays byte-for-byte identical (the default is `.python`).
+    /// stays byte-for-byte identical.
+    ///
+    /// A nil `language` renders as Python. Rendering is not the same question as
+    /// resolution: "what language is this assignment?" can honestly answer
+    /// nothing, but "what syntax do I write this literal in?" cannot — there is
+    /// no literal without a syntax. So the fallback lives HERE, one visible line
+    /// at the site that needs it, instead of inside resolution where every
+    /// caller inherited it and none could see it.
+    ///
+    /// It fires only for an assignment that names no language at all. A real R,
+    /// Lua, Octave or C++ assignment resolves positively and never reaches it —
+    /// which is the property the Optional buys.
     static func resolve(
         manifest: TestProperties,
         seedHex: String?,
         supportFilesDirectory: String?,
-        language: AssignmentLanguage = .python
+        language: AssignmentLanguage?
     ) async -> Resolution {
+        let language = language ?? .python
         // Combined static name pool — global first, then sections, so a
         // same-named section variable shadows a global (matches the runner).
         var staticVars: [FamilyVariable] = manifest.globalVariables
@@ -105,7 +117,7 @@ enum PersonalizationSubstitution {
         manifest: TestProperties,
         seedHex: String?,
         supportFilesDirectory: String?,
-        language: AssignmentLanguage = .python
+        language: AssignmentLanguage?
     ) async -> [String: String]? {
         guard let seedHex, !seedHex.isEmpty else { return nil }
         guard manifest.hasExpressions else { return nil }

--- a/Sources/APIServer/Services/SectionInputsService.swift
+++ b/Sources/APIServer/Services/SectionInputsService.swift
@@ -163,13 +163,20 @@ enum SectionInputsService {
         sectionID: String,
         inputs: Inputs,
         seed: SeedContext,
-        language: AssignmentLanguage = .python,
+        language: AssignmentLanguage?,
         seedDB: any Database
     ) async throws {
         guard !inputs.expressions.isEmpty,
             let userID = seed.actingUserID,
             let assignmentID = seed.assignmentID
         else { return }
+        // An assignment that names no language evaluates its `=` expressions as
+        // Python — the same explicit render-site fallback as
+        // `PersonalizationSubstitution.resolve`, and for the same reason:
+        // evaluation needs an interpreter, so this question cannot answer
+        // "none". Refusing instead would be circular, since inputs are often
+        // authored before the first graded script exists.
+        let language = language ?? .python
 
         let seedHex = try await AssignmentSeedStore.ensureSeed(
             userID: userID, assignmentID: assignmentID, on: seedDB)

--- a/Sources/APIServer/Utilities/AssignmentLanguageResolution.swift
+++ b/Sources/APIServer/Utilities/AssignmentLanguageResolution.swift
@@ -23,7 +23,10 @@ extension AssignmentLanguage {
     /// The notebook is only read when the manifest can't answer on its own
     /// (see the `@autoclosure` on the Core overload), so this stays cheap on
     /// the worker-job and suite-save paths.
-    static func resolve(for setup: APITestSetup, manifest: TestProperties) -> AssignmentLanguage {
+    ///
+    /// nil means no signal names a language — a legal state for a plain `.sh`
+    /// suite. Callers that need a language refuse; callers that don't, ignore it.
+    static func resolve(for setup: APITestSetup, manifest: TestProperties) -> AssignmentLanguage? {
         resolve(
             manifest: manifest,
             notebookData: setup.notebookPath.flatMap { FileManager.default.contents(atPath: $0) })

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -407,4 +407,10 @@ func registerMigrations(on app: Application) {
     // in place. New table; FKs reference `users`, `courses`, `assignments`,
     // all created above, so no additional ordering constraint.
     app.migrations.add(CreateSlipDaySpends())
+
+    // Data backfill, registered LAST on purpose: it full-queries `APITestSetup`,
+    // which is only safe once every migration that adds a column to
+    // `test_setups` has already run (the #1077 boot-order hazard, inverted —
+    // here the model query is the late one rather than the column).
+    app.migrations.add(BackfillDeclaredLanguage())
 }

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -313,29 +313,46 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     // extension it gets. Prefer the authored items when supplied — they carry
     // the edit being applied, which may be the very first `.R` test — and fall
     // back to the stored manifest (which records the language once known).
-    // Defaults to `.python`, so a Python assignment renders byte-for-byte as
-    // before.
     let previousLanguage = AssignmentLanguage.resolve(for: setup, manifest: props)
-    let assignmentLanguage: AssignmentLanguage = {
+    let resolvedLanguage: AssignmentLanguage? = {
         // The authored items carry the edit being applied, which may be the very
         // first non-Python graded script — the `.R` or `.lua` that establishes
         // the language before the manifest has recorded anything. Resolve it
         // from the extension so the families/checks render in the right language
-        // at that moment. Any non-default language wins, in `allCases` order
+        // at that moment. Any non-Python language wins, in `allCases` order
         // (R before Lua) for a deterministic answer on a mixed edit. Checking
         // only `.r` here is what made the first `.lua` script save as Python.
+        //
+        // Python is excluded by name so that adding a `.py` helper to an R
+        // assignment cannot flip the render language; the stored manifest stays
+        // authoritative in that case.
         var authoredLanguages: Set<AssignmentLanguage> = []
         for item in authoredItems ?? [] {
             guard case .script(let raw) = item,
                 let language = AssignmentLanguage(
                     scriptExtension: URL(fileURLWithPath: raw.script).pathExtension),
-                language != .default
+                language != .python
             else { continue }
             authoredLanguages.insert(language)
         }
         return AssignmentLanguage.allCases.first { authoredLanguages.contains($0) }
             ?? previousLanguage
     }()
+    // Authoring falls back to Python, deliberately and locally — this is NOT the
+    // old resolution default leaking back in.
+    //
+    // Refusing here would be circular: a pattern family is frequently the FIRST
+    // thing authored on an assignment, and generating its scripts is how the
+    // suite acquires a graded script in the first place. "Add a graded script
+    // before you can add a family" asks the instructor for the output as a
+    // precondition of the input. So when nothing names a language yet, author in
+    // Python — and note that the save RECORDS the choice into the manifest, so
+    // the ambiguity exists for exactly one save and never silently again.
+    //
+    // What the Optional buys is upstream of this line: an `.R`/`.lua`/`.m`
+    // assignment can no longer arrive here as Python by fallthrough, because
+    // those signals now resolve positively and nil means only "nothing said".
+    let assignmentLanguage = resolvedLanguage ?? .python
 
     try validateNotebookChecks(
         resolvedChecks,
@@ -369,14 +386,19 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     // when the assignment changes language, under the new one too, or the
     // old-extension scripts would be stranded in the setup forever. Listing
     // only these two keeps `deletedFiles` free of names that were never written.
+    // `previousLanguage` is optional (an assignment that had no language yet),
+    // so the pair is built explicitly rather than as a set literal — which also
+    // keeps the two comprehensions below inside the type-checker's budget.
+    var oldFilenameLanguages: Set<AssignmentLanguage> = [assignmentLanguage]
+    if let previousLanguage { oldFilenameLanguages.insert(previousLanguage) }
     let oldGeneratedFilenames = Set(
-        Set([previousLanguage, assignmentLanguage]).flatMap { language in
+        oldFilenameLanguages.flatMap { language in
             props.patternFamilies.flatMap {
                 patternFamilyAllGeneratedFilenames($0, language: language)
             }
         }
     ).union(
-        Set([previousLanguage, assignmentLanguage]).flatMap { language in
+        oldFilenameLanguages.flatMap { language in
             props.notebookChecks.flatMap {
                 notebookCheckAllGeneratedFilenames($0, language: language)
             }

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -24,15 +24,17 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
     /// build strategy enters Swift.
     case cpp
 
-    /// What an assignment resolves to when nothing about it says otherwise.
+    /// Kernelspec `name` values that mark a Python notebook. `xpython` is the
+    /// vendored xeus-python kernel; `python3` is what classic Jupyter writes and
+    /// `python` is what `language_info.name` reports.
     ///
-    /// Named rather than written as `.python` at the comparison sites, because
-    /// those sites are asking "did resolution fall back?" and not "is this
-    /// Python?". The two questions have the same answer today and would diverge
-    /// the moment a third language existed: `manifestOnly == .python` would
-    /// stop consulting the notebook kernelspec for a Julia assignment that had
-    /// resolved positively, which is the opposite of what that guard wants.
-    public static let `default`: AssignmentLanguage = .python
+    /// Python used to have NO aliases and no positive script match, because it
+    /// was the resolution default — which made "this is Python" and "we could
+    /// not tell" the same answer, and every silent-misroute bug in this area
+    /// descended from that. Resolution is Optional now (see `resolve`), so
+    /// Python resolves positively like any other language and "we could not
+    /// tell" is `nil`.
+    public static let pythonKernelNames: Set<String> = ["python", "python3", "xpython"]
 
     /// Kernelspec `name` values (and `language_info.name`) that mark an R
     /// notebook. The single source of truth for the sniff: every Swift consumer
@@ -110,31 +112,35 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
         self = match
     }
 
-    /// The non-default language whose graded script appears in `manifest`'s
-    /// suite, in `allCases` order (so a mixed R+Lua suite resolves R-first,
-    /// matching `manifestOwningLanguage`), or nil when only default-language
-    /// (or no) graded scripts are present.
+    /// The language whose graded script appears in `manifest`'s suite, in
+    /// `allCases` order (so a mixed R+Lua suite resolves R-first, matching
+    /// `manifestOwningLanguage`), or nil when the suite carries no
+    /// language-bearing script at all — a suite of plain `.sh` scripts, or an
+    /// empty one.
     ///
     /// The strongest resolution signal — the graded suite is what actually runs
     /// — and the single implementation of it, so `resolve` and `rederive` cannot
-    /// disagree about which language a `.lua`/`.R` script implies. Python is the
-    /// default and is never matched positively here; it is reached by falling
-    /// through, which is what keeps every existing Python assignment unchanged.
+    /// disagree about which language a `.lua`/`.R` script implies.
+    ///
+    /// Python is matched positively here like every other language. It used to
+    /// be skipped (`language != .default`) so that it was only ever reached by
+    /// falling through, which meant a `.py` suite and a suite with no language
+    /// at all produced the same answer. `.sh`-only suites are the case that
+    /// distinction was really protecting, and nil now says so directly.
     static func gradedScriptLanguage(in manifest: TestProperties) -> AssignmentLanguage? {
         allCases.first { language in
-            language != .default
-                && manifest.testSuites.contains {
-                    AssignmentLanguage(scriptExtension: URL(fileURLWithPath: $0.script).pathExtension)
-                        == language
-                }
+            manifest.testSuites.contains {
+                AssignmentLanguage(scriptExtension: URL(fileURLWithPath: $0.script).pathExtension)
+                    == language
+            }
         }
     }
 
     /// The language a notebook kernel name (`kernelspec.name` then
     /// `language_info.name`) declares, or nil when neither is recognised. The
     /// string-argument form of `fromNotebookMetadata`, matched against every
-    /// language's `notebookKernelNames` — Python's set is empty, so it is never
-    /// matched positively and remains the fallthrough default.
+    /// language's `notebookKernelNames` — including Python's, which is why a
+    /// Python notebook now resolves positively rather than by fallthrough.
     private static func languageFromKernelNames(
         _ kernelName: String?, _ languageInfoName: String?
     ) -> AssignmentLanguage? {
@@ -154,13 +160,24 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
     ///      answer always beats sniffing, and it is what lets a suite made up
     ///      only of pattern families (no graded script to find) keep its
     ///      language;
-    ///   1. any non-default graded test script (`.R` → `.r`, `.lua` → `.lua`),
-    ///      in `allCases` order — the graded suite is the strongest signal,
-    ///      it's what actually runs;
+    ///   1. any graded test script (`.R` → `.r`, `.lua` → `.lua`, `.py` →
+    ///      `.python`), in `allCases` order — the graded suite is the strongest
+    ///      signal, it's what actually runs;
     ///   2. else a notebook kernel whose `kernelspec.name` / `language_info.name`
     ///      is in some language's `notebookKernelNames`;
-    ///   3. else `.python` — the default, so every existing assignment resolves
-    ///      exactly as today and its generated bytes stay byte-for-byte identical.
+    ///   3. else **nil** — no signal says this assignment has a language.
+    ///
+    /// nil is a legal, supported answer, NOT an error: an assignment whose suite
+    /// is plain `.sh` scripts is the system's original mode and has no language
+    /// in the `AssignmentLanguage` sense. It means "no language-specific
+    /// machinery applies" — refuse only at the operations that genuinely need a
+    /// language (rendering a literal, evaluating a per-student `=` expression,
+    /// generating a pattern family, picking an editor kernel).
+    ///
+    /// This used to answer `.python` instead of nil, which made "this is
+    /// Python" and "nothing here says anything" indistinguishable. Every silent
+    /// misroute in this area descended from that, Lua shipping green while
+    /// resolving to Python among them.
     ///
     /// Deliberately not public (docs/language-handling-review.md §3): the
     /// defaulted parameters made `resolve(manifest: props)` an easy spelling
@@ -172,10 +189,10 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
         manifest: TestProperties,
         notebookKernelName: String? = nil,
         notebookLanguageInfoName: String? = nil
-    ) -> AssignmentLanguage {
+    ) -> AssignmentLanguage? {
         if let recorded = manifest.language { return recorded }
         if let scriptLanguage = gradedScriptLanguage(in: manifest) { return scriptLanguage }
-        return languageFromKernelNames(notebookKernelName, notebookLanguageInfoName) ?? .python
+        return languageFromKernelNames(notebookKernelName, notebookLanguageInfoName)
     }
 }
 
@@ -205,13 +222,14 @@ extension AssignmentLanguage {
     ///
     /// This is the only signal a *brand-new* notebook assignment has. Its suite
     /// is still empty and nothing has recorded a language yet, so
-    /// `resolve(manifest:)` alone answers `.python` — which meant an
-    /// instructor's first R `=` expression was evaluated by `python3` and
-    /// rejected with a Python `SyntaxError`, before any `.R` script existed to
-    /// give the game away.
+    /// `resolve(manifest:)` alone answers nil — and used to answer `.python`,
+    /// which meant an instructor's first R `=` expression was evaluated by
+    /// `python3` and rejected with a Python `SyntaxError`, before any `.R`
+    /// script existed to give the game away.
     ///
-    /// Falls back to the manifest-only resolution when the notebook is absent
-    /// or unparseable, so nothing regresses for assignments without one.
+    /// Returns nil when neither the manifest nor the notebook names a language;
+    /// see `resolve(manifest:notebookKernelName:notebookLanguageInfoName:)` for
+    /// why that is a legal answer rather than a failure.
     /// `notebookData` is an autoclosure because only step 2 of the precedence
     /// needs it: a recorded language or an `.R` script in the suite both
     /// outrank the kernelspec, so callers on hot paths (the worker job payload,
@@ -220,17 +238,15 @@ extension AssignmentLanguage {
     public static func resolve(
         manifest: TestProperties,
         notebookData: @autoclosure () -> Data?
-    ) -> AssignmentLanguage {
-        let manifestOnly = resolve(manifest: manifest)
-        // `== .default`, not `== .python`: the question is whether resolution
-        // fell back, so that the kernelspec is only consulted when the manifest
-        // said nothing. See the `default` declaration.
-        guard manifest.language == nil, manifestOnly == .default else { return manifestOnly }
+    ) -> AssignmentLanguage? {
+        // The kernelspec is consulted only when the manifest said nothing at
+        // all — a manifest answer of any kind outranks it.
+        if let manifestOnly = resolve(manifest: manifest) { return manifestOnly }
         guard let data = notebookData(),
             let notebook = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
             let metadata = notebook["metadata"] as? [String: Any]
         else {
-            return manifestOnly
+            return nil
         }
         return resolve(
             manifest: manifest,
@@ -249,25 +265,25 @@ extension AssignmentLanguage {
     /// rendering `.py` forever, because the sticky `.python` outranks the new R
     /// notebook. When the starter notebook is *replaced* the recorded value is a
     /// stale memo, not a declaration, so re-derivation must skip it. Precedence
-    /// is otherwise identical to `resolve`: a non-default graded script wins
-    /// (`.R` → `.r`, `.lua` → `.lua`), else the notebook's own kernel via
-    /// `fromNotebookMetadata`, else `.python`.
+    /// is otherwise identical to `resolve`: a graded script wins (`.R` → `.r`,
+    /// `.lua` → `.lua`, `.py` → `.python`), else the notebook's own kernel via
+    /// `fromNotebookMetadata`, else nil.
     public static func rederive(
         manifest: TestProperties,
         notebookData: @autoclosure () -> Data?
-    ) -> AssignmentLanguage {
+    ) -> AssignmentLanguage? {
         if let scriptLanguage = gradedScriptLanguage(in: manifest) { return scriptLanguage }
         guard let data = notebookData(),
             let notebook = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
             let metadata = notebook["metadata"] as? [String: Any]
         else {
-            return .python
+            return nil
         }
         // `fromNotebookMetadata`, not `isRNotebookMetadata(…) ? .r : .python`: the
         // ternary compiles forever and routes every non-R notebook to Python, so
         // a Lua notebook re-derived as Python. The general form returns the
-        // language it recognised, or nil to mean "use the default".
-        return fromNotebookMetadata(metadata) ?? .python
+        // language it recognised, or nil when it recognised none.
+        return fromNotebookMetadata(metadata)
     }
 }
 

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -311,7 +311,7 @@ extension AssignmentLanguage {
                 scriptExtensions: ["py"],
                 generatedScriptExtension: "py",
                 inputsFileName: "_ck_inputs.py",
-                notebookKernelNames: [],
+                notebookKernelNames: AssignmentLanguage.pythonKernelNames,
                 editorSupport: .notebookKernel(
                     environmentFileName: "environment-python.yml",
                     kernelName: "xpython",

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -373,11 +373,29 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// cases. "We inferred Python" and "this is a Python assignment" are also
     /// genuinely different states, and only one of them is safe to act on.
     ///
-    /// Nil means "written before the language was recorded" — every manifest
-    /// on disk today. `AssignmentLanguage.resolve(manifest:)` falls back to
-    /// sniffing for those, so they keep behaving exactly as before until their
-    /// next save stamps a value.
+    /// Nil means either "the author declared this assignment has no language"
+    /// or "nobody has declared anything yet" — `languageDeclared` is what
+    /// separates those. `AssignmentLanguage.resolve(manifest:)` falls back to
+    /// sniffing when nothing is recorded.
     public let language: AssignmentLanguage?
+
+    /// True when an author has actually answered "what language is this?" —
+    /// including answering "none, it is a plain shell-script suite", which is
+    /// recorded as `language == nil` alongside this flag.
+    ///
+    /// A SECOND field rather than a reserved `"none"` string in `language`,
+    /// deliberately. `language` is decoded as an `AssignmentLanguage`, and an
+    /// unrecognised enum case THROWS, so a reserved string would make every
+    /// manifest carrying it undecodable by any runner built before the string
+    /// existed — the whole manifest, not just the field. An unknown *key* is
+    /// ignored by Swift's synthesized decoding, so an old runner reads a new
+    /// manifest exactly as it reads an old one.
+    ///
+    /// Nil means undeclared: a manifest written before the field, or a
+    /// `.chickadee` bundle exported by an older build. Those keep deriving.
+    /// Everything on disk is backfilled by `BackfillDeclaredLanguage`, so an
+    /// undeclared manifest after that point came from outside this deployment.
+    public let languageDeclared: Bool?
 
     /// Optional minimum `chickadee-runner` version required to grade this
     /// assignment on the native worker path.  When set, the server only hands a
@@ -405,6 +423,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         makefile: MakefileConfig? = nil,
         starterNotebook: String? = nil,
         language: AssignmentLanguage? = nil,
+        languageDeclared: Bool? = nil,
         minimumRunnerVersion: String? = nil,
         patternFamilies: [PatternFamily] = [],
         notebookChecks: [NotebookCheck] = [],
@@ -427,6 +446,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         self.makefile = makefile
         self.starterNotebook = starterNotebook
         self.language = language
+        self.languageDeclared = languageDeclared
         self.minimumRunnerVersion = minimumRunnerVersion
         // `testItems` wins when supplied; otherwise synthesize it from the
         // legacy `patternFamilies` / `notebookChecks` arguments (families
@@ -461,6 +481,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         // Absent on every manifest written before the language became
         // first-class; nil falls back to sniffing the suite.
         language = try c.decodeIfPresent(AssignmentLanguage.self, forKey: .language)
+        languageDeclared = try c.decodeIfPresent(Bool.self, forKey: .languageDeclared)
         minimumRunnerVersion = try c.decodeIfPresent(String.self, forKey: .minimumRunnerVersion)
         // `testItems` is the canonical unified list when present.  A legacy
         // manifest carries the separate `patternFamilies` / `notebookChecks`
@@ -504,6 +525,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         case makefile
         case starterNotebook
         case language
+        case languageDeclared
         case minimumRunnerVersion
         case testItems
         case patternFamilies
@@ -531,6 +553,11 @@ public struct TestProperties: Codable, Equatable, Sendable {
         // encodeIfPresent, not encode: an assignment with no recorded language
         // must produce the exact bytes it always has.
         try c.encodeIfPresent(language, forKey: .language)
+        // Also encodeIfPresent, and for a second reason beyond byte-stability:
+        // a `false` here would be meaningless. The flag records that the
+        // question was ANSWERED, so its absence is the only "not answered"
+        // state and writing `false` would be a third state nothing reads.
+        try c.encodeIfPresent(languageDeclared, forKey: .languageDeclared)
         try c.encodeIfPresent(minimumRunnerVersion, forKey: .minimumRunnerVersion)
         try c.encode(testItems, forKey: .testItems)
         // Mirror the legacy arrays (derived from `testItems`, so they can
@@ -574,6 +601,11 @@ public struct TestProperties: Codable, Equatable, Sendable {
             // manifest that silently lost it here would resolve differently on
             // any path that re-sniffs from the runner-facing copy.
             language: language,
+            // Kept for the same reason, plus one of its own: it is what lets the
+            // runner tell "declared to have no language" from "nobody has
+            // declared one", which is the distinction a runner needs before it
+            // can refuse a job rather than guess at Python.
+            languageDeclared: languageDeclared,
             patternFamilies: [],
             notebookChecks: [],
             // Expressions are a server-side authoring concern — both global

--- a/Sources/Worker/NotebookExtractor.swift
+++ b/Sources/Worker/NotebookExtractor.swift
@@ -117,11 +117,17 @@ private func resolveNotebookForExtraction(
     // extracted as PYTHON — a silent wrong answer the compiler could not flag,
     // because `?:` on two cases type-checks perfectly well however many cases
     // exist. The general form returns the language it recognised, or nil to
-    // mean "nothing recognisable, use the default".
+    // mean "nothing recognisable".
+    //
+    // Python is named explicitly as the extraction fallback rather than
+    // inherited from a resolution default. Unlike resolution, extraction cannot
+    // answer "no language" — it has to write a file in some syntax — so an
+    // unrecognised kernel is extracted as Python, which is what this has always
+    // done. Stating it here keeps that a local, visible choice.
     let language =
         forcedLanguage
         ?? (lenient?["metadata"] as? [String: Any]).flatMap(AssignmentLanguage.fromNotebookMetadata)
-        ?? .default
+        ?? .python
 
     // For the student's own notebook the policy THROWS a message they can act
     // on; for anything else it stays lenient and merely warns, because failing

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -564,9 +564,9 @@ extension WorkerDaemon {
                     preferredStudentModuleFilename(
                         submissionFilename: job.submissionFilename,
                         // nil means the extractor trusted the notebook's own
-                        // metadata, which for an unrecognised kernel resolves to
-                        // the default — so the hint has to agree.
-                        language: forcedLanguage ?? .default)
+                        // metadata, which for an unrecognised kernel falls back
+                        // to Python — so the hint has to agree.
+                        language: forcedLanguage ?? .python)
                 )
             }
         }

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -216,10 +216,15 @@ func manifestOwningLanguage(_ manifest: TestProperties) -> AssignmentLanguage? {
     // The RECORDED language is the strongest ownership signal, and for C++ it
     // is the only one: a C++ suite's generated scripts are `.sh` wrappers, so
     // there is no extension to sniff — exactly the "suite made up only of
-    // pattern families" blindness the recorded field exists to fix. Python is
-    // the default and never claims by record (nil-recorded manifests keep the
-    // sniffing behaviour below unchanged).
-    if let recorded = manifest.language, recorded != .default { return recorded }
+    // pattern families" blindness the recorded field exists to fix.
+    //
+    // Python is excluded by NAME here, not because it is a resolution default:
+    // this function is about submission-normalization *precedence*, and a
+    // recorded `.python` must keep falling through to the Python-exclusion
+    // rules below rather than claiming ownership outright. Resolution now
+    // records `.python` positively, so spelling this `!= .python` is what keeps
+    // the routing identical.
+    if let recorded = manifest.language, recorded != .python { return recorded }
     func suiteContains(_ language: AssignmentLanguage) -> Bool {
         manifest.testSuites.contains {
             AssignmentLanguage(scriptExtension: URL(fileURLWithPath: $0.script).pathExtension)
@@ -231,7 +236,7 @@ func manifestOwningLanguage(_ manifest: TestProperties) -> AssignmentLanguage? {
     }
     guard !suiteContains(.python), !hasRequiredPython else { return nil }
     return AssignmentLanguage.allCases
-        .filter { $0 != .default }
+        .filter { $0 != .python }
         .first(where: suiteContains)
 }
 
@@ -274,12 +279,15 @@ func submissionNormalization(
     }
 
     // 3. No Python suite, and the submission itself positively declares a
-    //    non-default language: honour that rather than treating any `.ipynb` as
+    //    non-Python language: honour that rather than treating any `.ipynb` as
     //    Python at step 4. Generalised from the old `submissionIsRNotebook`.
+    //    Python is excluded by name because steps 4-6 are Python's own
+    //    heuristics — letting a `python3` kernelspec short-circuit to
+    //    `.extractToSource(.python)` here would skip them.
     if !hasPythonSuite,
         let declared = submissionNotebookLanguage(
             submissionDirectory: submissionDirectory, submissionFilename: submissionFilename),
-        declared != .default
+        declared != .python
     {
         return .extractToSource(forcedLanguage: declared)
     }

--- a/Tests/APITests/AssignmentLanguageEditorTests.swift
+++ b/Tests/APITests/AssignmentLanguageEditorTests.swift
@@ -35,11 +35,11 @@ import VaporTesting
 
     // MARK: - Option construction (pure)
 
-    @Test func nothingRecordedSelectsTheDeriveEntry() {
+    @Test func nothingRecordedSelectsTheNoLanguageEntry() {
         let options = AssignmentLanguageOption.options(recorded: nil)
         let selected = options.filter(\.selected)
         #expect(selected.count == 1)
-        #expect(selected.first?.value.isEmpty == true)
+        #expect(selected.first?.value == noLanguageChoice)
     }
 
     @Test func aRecordedLanguageIsTheSelectedOption() {
@@ -50,10 +50,10 @@ import VaporTesting
 
     /// Defensive: a manifest carrying a language this build does not know must
     /// still render a coherent select rather than one with nothing selected.
-    @Test func anUnknownRecordedLanguageFallsBackToTheDeriveEntry() {
+    @Test func anUnknownRecordedLanguageFallsBackToTheNoLanguageEntry() {
         let selected = AssignmentLanguageOption.options(recorded: "fortran").filter(\.selected)
         #expect(selected.count == 1)
-        #expect(selected.first?.value.isEmpty == true)
+        #expect(selected.first?.value == noLanguageChoice)
     }
 
     /// Discovered, not enumerated: a sixth language appears in the select with
@@ -66,7 +66,9 @@ import VaporTesting
                 values.contains(language.rawValue),
                 "\(language) is missing from the Language select")
         }
-        #expect(values.contains(""), "the derive-it entry must always be offered")
+        #expect(
+            values.contains(noLanguageChoice),
+            "the no-language declaration must always be offered")
     }
 
     @Test func optionLabelsAreTheLanguagesDisplayNames() {
@@ -165,7 +167,7 @@ import VaporTesting
     /// The escape hatch. `resolve` treats a recorded language as authoritative
     /// over the notebook and the suite, so without this the first choice would
     /// be permanent.
-    @Test func editSaveClearsADeclarationWithTheDeriveEntry() async throws {
+    @Test func editSaveDeclaresNoLanguage() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsInstructor(on: app)
             let instructor = try #require(
@@ -176,12 +178,17 @@ import VaporTesting
 
             let status = try await postEdit(
                 assignment: a,
-                fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": ""],
+                fields: [
+                    "assignmentName": "Lab", "dueAt": "", "assignmentLanguage": noLanguageChoice,
+                ],
                 cookie: cookie, on: app)
             #expect(status == .seeOther)
 
             let reloaded = try #require(try await APITestSetup.find("lang_save2", on: app.db))
             #expect(currentManifestLanguage(reloaded.manifest) == nil)
+            // The flag is the point: "no language" is now an ANSWER, so this is
+            // distinguishable from an assignment nobody has declared.
+            #expect(reloaded.decodedManifest()?.languageDeclared == true)
         }
     }
 
@@ -207,9 +214,14 @@ import VaporTesting
         }
     }
 
-    // MARK: - Refusals, each with its own reason
+    // MARK: - The upload-only implication
 
-    @Test func editSaveRefusesCppWhileInNotebookMode() async throws {
+    /// Declaring C++ SETS upload-only rather than refusing without it. The
+    /// language implies the mode — C++ has no notebook workflow — and making the
+    /// declaration carry it is what lets an author answer one question instead
+    /// of performing the old three-step dance (grading mode, then submission
+    /// mode, then language, each refusal naming the next step).
+    @Test func declaringCppAlsoSetsUploadOnly() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsInstructor(on: app)
             let instructor = try #require(
@@ -218,15 +230,15 @@ import VaporTesting
             let a = try await saveableAssignment(
                 id: "lang_save4", manifest: Self.plainManifest, title: "Lab", on: app)
 
-            _ = try await postEdit(
+            let status = try await postEdit(
                 assignment: a,
                 fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": "cpp"],
                 cookie: cookie, on: app)
+            #expect(status == .seeOther)
 
             let reloaded = try #require(try await APITestSetup.find("lang_save4", on: app.db))
-            #expect(
-                currentManifestLanguage(reloaded.manifest) == nil,
-                "a refused declaration must leave the manifest unchanged")
+            #expect(currentManifestLanguage(reloaded.manifest) == "cpp")
+            #expect(reloaded.decodedManifest()?.submissionMode == .uploadOnly)
         }
     }
 

--- a/Tests/APITests/AssignmentLanguageEditorTests.swift
+++ b/Tests/APITests/AssignmentLanguageEditorTests.swift
@@ -1,0 +1,306 @@
+// Tests/APITests/AssignmentLanguageEditorTests.swift
+//
+// The Language select on the assignment edit page:
+//
+//   * option construction (discovered from `AssignmentLanguage.allCases`, with
+//     the derive-it entry that keeps a declaration from being a one-way door),
+//   * the edit page rendering the stored declaration,
+//   * the edit-save path declaring a language, clearing it, and leaving it
+//     alone when the field is absent (a stale tab),
+//   * and the three refusals surfacing their own distinct reasons rather than
+//     one generic message.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct AssignmentLanguageEditorTests {
+
+    static let plainManifest = """
+        {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+        """
+    static let rDeclaredManifest = """
+        {"schemaVersion":1,"gradingMode":"worker","language":"r","requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+        """
+    static let generatedManifest = """
+        {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_bmi_01.py","generatedBy":"bmi"}],"timeLimitSeconds":10}
+        """
+    static let sampleNotebookJSON = """
+        {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[{"cell_type":"code","source":["x = 1"],"metadata":{},"outputs":[],"execution_count":null}]}
+        """
+
+    // MARK: - Option construction (pure)
+
+    @Test func nothingRecordedSelectsTheDeriveEntry() {
+        let options = AssignmentLanguageOption.options(recorded: nil)
+        let selected = options.filter(\.selected)
+        #expect(selected.count == 1)
+        #expect(selected.first?.value.isEmpty == true)
+    }
+
+    @Test func aRecordedLanguageIsTheSelectedOption() {
+        let selected = AssignmentLanguageOption.options(recorded: "r").filter(\.selected)
+        #expect(selected.count == 1)
+        #expect(selected.first?.value == "r")
+    }
+
+    /// Defensive: a manifest carrying a language this build does not know must
+    /// still render a coherent select rather than one with nothing selected.
+    @Test func anUnknownRecordedLanguageFallsBackToTheDeriveEntry() {
+        let selected = AssignmentLanguageOption.options(recorded: "fortran").filter(\.selected)
+        #expect(selected.count == 1)
+        #expect(selected.first?.value.isEmpty == true)
+    }
+
+    /// Discovered, not enumerated: a sixth language appears in the select with
+    /// no template edit, which is the rule the kernel-alias generator and the
+    /// runner capability probe already follow.
+    @Test func everyLanguageIsOffered() {
+        let values = Set(AssignmentLanguageOption.options(recorded: nil).map(\.value))
+        for language in AssignmentLanguage.allCases {
+            #expect(
+                values.contains(language.rawValue),
+                "\(language) is missing from the Language select")
+        }
+        #expect(values.contains(""), "the derive-it entry must always be offered")
+    }
+
+    @Test func optionLabelsAreTheLanguagesDisplayNames() {
+        let options = AssignmentLanguageOption.options(recorded: nil)
+        let byValue = Dictionary(uniqueKeysWithValues: options.map { ($0.value, $0.label) })
+        for language in AssignmentLanguage.allCases {
+            #expect(byValue[language.rawValue] == language.displayName)
+        }
+    }
+
+    // MARK: - Render
+
+    @Test func editPageRendersTheStoredLanguage() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            try await wrInsertSetup(id: "lang_edit1", manifest: Self.rDeclaredManifest, on: app)
+            let a = try await wrInsertAssignment(
+                testSetupID: "lang_edit1", title: "R Lab", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(a.publicID)/edit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("assignmentLanguageSelect"))
+                    #expect(
+                        html.contains(#"value="r" selected"#),
+                        "the select should show the declared language")
+                })
+        }
+    }
+
+    // MARK: - Save
+
+    /// Sets up an assignment the save handler will actually reach the language
+    /// write on: it requires a solution draft and an openable zip first.
+    private func saveableAssignment(
+        id: String, manifest: String, title: String, on app: Application
+    ) async throws -> APIAssignment {
+        let setup = try await wrInsertSetup(id: id, manifest: manifest, on: app)
+        try Data([0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18))
+            .write(to: URL(fileURLWithPath: setup.zipPath))
+        let assignment = try await wrInsertAssignment(
+            testSetupID: id, title: title, isOpen: false, on: app)
+        let draftPath =
+            try ensureDraftNotebookDirectory(
+                testSetupsDirectory: app.testSetupsDirectory, setupID: id) + "solution.ipynb"
+        try Data(Self.sampleNotebookJSON.utf8).write(to: URL(fileURLWithPath: draftPath))
+        return assignment
+    }
+
+    private func postEdit(
+        assignment: APIAssignment, fields: [String: String], cookie: String, on app: Application
+    ) async throws -> HTTPStatus {
+        let (csrf, sessionCookie) = try await csrfFields(
+            for: "/instructor", cookie: cookie, on: app)
+        var status = HTTPStatus.internalServerError
+        var body = fields
+        body["_csrf"] = csrf
+        try await app.asyncTest(
+            .POST, "/instructor/\(assignment.publicID)/edit/save",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                try req.content.encode(body, as: .urlEncodedForm)
+            },
+            afterResponse: { res in status = res.status })
+        return status
+    }
+
+    @Test func editSaveDeclaresALanguage() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save1", manifest: Self.plainManifest, title: "Lab", on: app)
+
+            let status = try await postEdit(
+                assignment: a,
+                fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": "lua"],
+                cookie: cookie, on: app)
+            #expect(status == .seeOther)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save1", on: app.db))
+            #expect(currentManifestLanguage(reloaded.manifest) == "lua")
+        }
+    }
+
+    /// The escape hatch. `resolve` treats a recorded language as authoritative
+    /// over the notebook and the suite, so without this the first choice would
+    /// be permanent.
+    @Test func editSaveClearsADeclarationWithTheDeriveEntry() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save2", manifest: Self.rDeclaredManifest, title: "Lab", on: app)
+
+            let status = try await postEdit(
+                assignment: a,
+                fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": ""],
+                cookie: cookie, on: app)
+            #expect(status == .seeOther)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save2", on: app.db))
+            #expect(currentManifestLanguage(reloaded.manifest) == nil)
+        }
+    }
+
+    /// A form posted from a tab opened before the field existed carries no
+    /// `assignmentLanguage` at all. That is silence, not "detect
+    /// automatically", and must leave the declaration untouched.
+    @Test func anAbsentFieldLeavesTheDeclarationAlone() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save3", manifest: Self.rDeclaredManifest, title: "Lab", on: app)
+
+            let status = try await postEdit(
+                assignment: a, fields: ["assignmentName": "Lab", "dueAt": ""],
+                cookie: cookie, on: app)
+            #expect(status == .seeOther)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save3", on: app.db))
+            #expect(currentManifestLanguage(reloaded.manifest) == "r")
+        }
+    }
+
+    // MARK: - Refusals, each with its own reason
+
+    @Test func editSaveRefusesCppWhileInNotebookMode() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save4", manifest: Self.plainManifest, title: "Lab", on: app)
+
+            _ = try await postEdit(
+                assignment: a,
+                fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": "cpp"],
+                cookie: cookie, on: app)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save4", on: app.db))
+            #expect(
+                currentManifestLanguage(reloaded.manifest) == nil,
+                "a refused declaration must leave the manifest unchanged")
+        }
+    }
+
+    /// Setting the mode and the language in ONE save has to work, which is why
+    /// the handler applies submissionMode first — the C++ guard reads the mode
+    /// the same request just set.
+    @Test func editSaveAcceptsCppTogetherWithUploadOnlyInOneRequest() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save5", manifest: Self.plainManifest, title: "Lab", on: app)
+
+            let status = try await postEdit(
+                assignment: a,
+                fields: [
+                    "assignmentName": "Lab", "dueAt": "",
+                    "submissionMode": "uploadOnly", "assignmentLanguage": "cpp",
+                ],
+                cookie: cookie, on: app)
+            #expect(status == .seeOther)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save5", on: app.db))
+            #expect(currentManifestLanguage(reloaded.manifest) == "cpp")
+            #expect(reloaded.decodedManifest()?.submissionMode == .uploadOnly)
+        }
+    }
+
+    @Test func editSaveRefusesAChangeOnceGeneratedTestsExist() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save6", manifest: Self.generatedManifest, title: "Lab", on: app)
+
+            _ = try await postEdit(
+                assignment: a,
+                fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": "r"],
+                cookie: cookie, on: app)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save6", on: app.db))
+            #expect(
+                currentManifestLanguage(reloaded.manifest) == nil,
+                "generated filenames carry the language's extension, so the change is refused")
+        }
+    }
+
+    /// Clearing is guarded exactly like setting: it changes how generated tests
+    /// would render just as much.
+    @Test func clearingIsAlsoRefusedOnceGeneratedTestsExist() async throws {
+        try await withWebRoutesApp { app in
+            let generatedAndDeclared = """
+                {"schemaVersion":1,"gradingMode":"worker","language":"python","requiredFiles":[],\
+                "testSuites":[{"tier":"public","script":"publictest_bmi_01.py","generatedBy":"bmi"}],\
+                "timeLimitSeconds":10}
+                """
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let a = try await saveableAssignment(
+                id: "lang_save7", manifest: generatedAndDeclared, title: "Lab", on: app)
+
+            _ = try await postEdit(
+                assignment: a,
+                fields: ["assignmentName": "Lab", "dueAt": "", "assignmentLanguage": ""],
+                cookie: cookie, on: app)
+
+            let reloaded = try #require(try await APITestSetup.find("lang_save7", on: app.db))
+            #expect(currentManifestLanguage(reloaded.manifest) == "python")
+        }
+    }
+}

--- a/Tests/APITests/AssignmentLanguageResolutionTests.swift
+++ b/Tests/APITests/AssignmentLanguageResolutionTests.swift
@@ -36,13 +36,15 @@ import Vapor
     }
 
     /// The gap this closes.  With an empty suite and no recorded language the
-    /// manifest says `.python`; the `xr` kernel is the only thing that knows
-    /// better, and it has to reach the save path or the assignment is recorded
-    /// as Python forever.
+    /// manifest names no language at all; the `xr` kernel is the only thing that
+    /// knows better, and it has to reach the save path or the assignment is
+    /// recorded wrong forever.
     @Test func firstSaveOfAnRNotebookAssignmentRecordsR() async throws {
         try await withPatternFamilyFixture { fixture in
             let manifest = try pfDecodeManifest(fixture.setup.manifest)
-            #expect(AssignmentLanguage.resolve(manifest: manifest, notebookData: nil) == .python)
+            // nil, not `.python`: an empty suite says nothing about the
+            // language, and saying nothing used to be spelled "Python".
+            #expect(AssignmentLanguage.resolve(manifest: manifest, notebookData: nil) == nil)
 
             try await attachNotebook(fixture, kernel: "xr")
             #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == .r)
@@ -71,13 +73,13 @@ import Vapor
         }
     }
 
-    /// A setup with no notebook resolves exactly as it did before, so nothing
-    /// regresses for script-only assignments.
+    /// A setup with no notebook resolves from the manifest alone: a language
+    /// when the suite names one, nil when nothing does.
     @Test func setupWithoutANotebookResolvesFromTheManifestAlone() async throws {
         try await withPatternFamilyFixture { fixture in
             #expect(fixture.setup.notebookPath == nil)
             let manifest = try pfDecodeManifest(fixture.setup.manifest)
-            #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == .python)
+            #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == nil)
 
             let rSuite = TestProperties(testSuites: [TestSuiteEntry(tier: .pub, script: "publictest_a.R")])
             #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: rSuite) == .r)
@@ -91,12 +93,12 @@ import Vapor
             let manifest = try pfDecodeManifest(fixture.setup.manifest)
 
             fixture.setup.notebookPath = fixture.app.testSetupsDirectory + "does-not-exist.ipynb"
-            #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == .python)
+            #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == nil)
 
             let junk = fixture.app.testSetupsDirectory + "junk.ipynb"
             try Data("not a notebook".utf8).write(to: URL(fileURLWithPath: junk))
             fixture.setup.notebookPath = junk
-            #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == .python)
+            #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == nil)
         }
     }
 }

--- a/Tests/APITests/BackfillDeclaredLanguageTests.swift
+++ b/Tests/APITests/BackfillDeclaredLanguageTests.swift
@@ -1,0 +1,159 @@
+// Tests/APITests/BackfillDeclaredLanguageTests.swift
+//
+// The one-time backfill that gives every existing assignment a DECLARED
+// language, which is what lets the rest of the system stop guessing: it runs
+// today's resolution, writes the answer down, records "no language" truthfully
+// for a shell-script suite, never overwrites a real answer, and preserves
+// manifest fields it does not know about.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct BackfillDeclaredLanguageTests {
+
+    private func manifest(_ setup: APITestSetup) throws -> TestProperties {
+        try #require(setup.decodedManifest())
+    }
+
+    private func rawManifest(_ setup: APITestSetup) throws -> [String: Any] {
+        try #require(
+            (try? JSONSerialization.jsonObject(with: Data(setup.manifest.utf8)))
+                as? [String: Any])
+    }
+
+    @Test func aGradedScriptsLanguageIsRecorded() async throws {
+        try await withWebRoutesApp { app in
+            try await wrInsertSetup(
+                id: "bf_r",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.R"}],"timeLimitSeconds":10}
+                    """,
+                on: app)
+
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+
+            let reloaded = try #require(try await APITestSetup.find("bf_r", on: app.db))
+            let props = try manifest(reloaded)
+            #expect(props.language == .r)
+            #expect(props.languageDeclared == true)
+        }
+    }
+
+    /// Python is recorded like any other language now. Before resolution became
+    /// Optional it could not be: it was reached only by falling through, so
+    /// there was no way to tell a Python assignment from an unidentified one and
+    /// nothing safe to write down.
+    @Test func aPythonSuiteIsRecordedAsPython() async throws {
+        try await withWebRoutesApp { app in
+            try await wrInsertSetup(
+                id: "bf_py",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.py"}],"timeLimitSeconds":10}
+                    """,
+                on: app)
+
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+
+            let props = try manifest(
+                try #require(try await APITestSetup.find("bf_py", on: app.db)))
+            #expect(props.language == .python)
+            #expect(props.languageDeclared == true)
+        }
+    }
+
+    /// The case the whole design turns on. A `.sh`-only suite genuinely has no
+    /// language, and saying so is what makes nil meaningful: after this runs,
+    /// nil `language` WITH the flag means "declared none", not "we could not
+    /// tell", so a worker can refuse the latter without breaking the former.
+    @Test func aShellOnlySuiteIsDeclaredToHaveNoLanguage() async throws {
+        try await withWebRoutesApp { app in
+            try await wrInsertSetup(
+                id: "bf_sh",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test_a.sh"}],"timeLimitSeconds":10}
+                    """,
+                on: app)
+
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+
+            let reloaded = try #require(try await APITestSetup.find("bf_sh", on: app.db))
+            let props = try manifest(reloaded)
+            #expect(props.language == nil)
+            #expect(props.languageDeclared == true)
+            // Absent, not `null`: the field means "no language", and the flag
+            // beside it is what says that was a decision.
+            #expect(try rawManifest(reloaded)["language"] == nil)
+        }
+    }
+
+    @Test func anAlreadyDeclaredManifestIsLeftAlone() async throws {
+        try await withWebRoutesApp { app in
+            // Declares Lua while the suite says R — an author's explicit answer
+            // disagreeing with what derivation would say. The backfill must not
+            // "correct" it.
+            try await wrInsertSetup(
+                id: "bf_declared",
+                manifest: """
+                    {"schemaVersion":1,"language":"lua","languageDeclared":true,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.R"}],"timeLimitSeconds":10}
+                    """,
+                on: app)
+
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+
+            let props = try manifest(
+                try #require(try await APITestSetup.find("bf_declared", on: app.db)))
+            #expect(props.language == .lua)
+        }
+    }
+
+    /// Running twice must be a no-op the second time, so a re-applied migration
+    /// cannot overwrite a choice an author made in between.
+    @Test func theBackfillIsIdempotent() async throws {
+        try await withWebRoutesApp { app in
+            try await wrInsertSetup(
+                id: "bf_twice",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test_a.sh"}],"timeLimitSeconds":10}
+                    """,
+                on: app)
+
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+            let afterFirst = try #require(try await APITestSetup.find("bf_twice", on: app.db))
+                .manifest
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+            let afterSecond = try #require(try await APITestSetup.find("bf_twice", on: app.db))
+                .manifest
+
+            #expect(afterFirst == afterSecond)
+        }
+    }
+
+    /// The manifest is rewritten as raw JSON rather than round-tripped through
+    /// `TestProperties`, so a field written by a NEWER build survives. A
+    /// round-trip would drop it, which on a rollback would mean this migration
+    /// silently ate content.
+    @Test func unknownManifestFieldsSurvive() async throws {
+        try await withWebRoutesApp { app in
+            try await wrInsertSetup(
+                id: "bf_unknown",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.lua"}],"timeLimitSeconds":10,"somethingNewerWrote":{"keep":"me"}}
+                    """,
+                on: app)
+
+            try await BackfillDeclaredLanguage().prepare(on: app.db)
+
+            let reloaded = try #require(try await APITestSetup.find("bf_unknown", on: app.db))
+            let raw = try rawManifest(reloaded)
+            #expect(raw["languageDeclared"] as? Bool == true)
+            #expect(raw["language"] as? String == "lua")
+            let preserved = raw["somethingNewerWrote"] as? [String: Any]
+            #expect(preserved?["keep"] as? String == "me")
+        }
+    }
+}

--- a/Tests/APITests/CourseBundleTests.swift
+++ b/Tests/APITests/CourseBundleTests.swift
@@ -442,6 +442,36 @@ import VaporTesting
         }
     }
 
+    /// A bundle exported by an older build carries no language declaration.
+    /// Import must supply one, because import is otherwise a permanent source of
+    /// undeclared assignments — and "undeclared" is precisely the state the
+    /// worker has to be able to refuse rather than guess at. A refusal that
+    /// legitimate imports can trip is one that has to be watered down.
+    @Test func importDeclaresALanguageForAnUndeclaredBundle() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+            let zipData = try await makeMinimalBundleZip(courseCode: "IMP_LANG")
+
+            let (status, body) = try await postImport(cookie: cookie, zipData: zipData)
+            #expect(status != .badRequest, "Import failed: \(body.prefix(200))")
+
+            let course = try #require(
+                try await APICourse.query(on: app.db).filter(\.$code == "IMP_LANG").first())
+            let setup = try #require(
+                try await APITestSetup.query(on: app.db)
+                    .filter(\.$courseID == course.requireID()).first())
+            let manifest = try #require(setup.decodedManifest())
+
+            #expect(
+                manifest.languageDeclared == true,
+                "an imported setup must carry a declaration, whatever the bundle said")
+            // The fixture's suite is `.sh`, so the truthful declaration is "no
+            // language" — recorded as the flag with no `language` beside it,
+            // which is exactly what distinguishes it from never having asked.
+            #expect(manifest.language == nil)
+        }
+    }
+
     @Test func importMatchesExistingUser() async throws {
         try await withApp(app) { _ in
             let cookie = try await loginAsAdmin()

--- a/Tests/APITests/LanguageConformanceMatrixTests.swift
+++ b/Tests/APITests/LanguageConformanceMatrixTests.swift
@@ -439,15 +439,16 @@ import Testing
                 .map(\.source).joined(separator: "\n")
                 perLanguage[language] = Set(vocabulary.filter { source.contains($0) })
             }
-            guard let reference = perLanguage[.default] else { continue }
-            for (language, used) in perLanguage where language != .default {
+            // Python is the reference wording every other language is compared
+            // against — named directly, since it is no longer "the default".
+            guard let reference = perLanguage[.python] else { continue }
+            for (language, used) in perLanguage where language != .python {
                 #expect(
                     used == reference,
                     """
-                    \(kind) uses different failure wording in \(language) than in \
-                    \(AssignmentLanguage.default). Only in \(AssignmentLanguage.default): \
-                    \(reference.subtracting(used).sorted()). Only in \(language): \
-                    \(used.subtracting(reference).sorted()).
+                    \(kind) uses different failure wording in \(language) than in Python. \
+                    Only in Python: \(reference.subtracting(used).sorted()). \
+                    Only in \(language): \(used.subtracting(reference).sorted()).
                     """)
             }
         }

--- a/Tests/APITests/LanguagePipelineWalkTests.swift
+++ b/Tests/APITests/LanguagePipelineWalkTests.swift
@@ -69,7 +69,13 @@ import Testing
         //    `resolved`, never `expected`, so a resolution that answers Python
         //    fails the legs below rather than quietly grading as Python.
         let props = try manifest(gradedScriptIn: expected)
-        let resolved = AssignmentLanguage.resolve(manifest: props, notebookData: nil)
+        let resolved = try #require(
+            AssignmentLanguage.resolve(manifest: props, notebookData: nil),
+            """
+            A manifest whose only graded script is a \(expected) script resolved to NO language. \
+            Resolution is Optional, and nil means "nothing here names a language" — a graded \
+            script in the language is exactly the signal that must not produce it.
+            """)
         #expect(
             resolved == expected,
             """
@@ -157,7 +163,8 @@ import Testing
     /// notebook assignment has (empty suite, nothing recorded).
     @Test(arguments: AssignmentLanguage.allCases)
     func aBrandNewNotebookAssignmentResolvesFromItsKernel(_ expected: AssignmentLanguage) throws {
-        guard expected != .default else { return }  // no positive aliases by design
+        // Python is included now — it has its own aliases. A language with no
+        // kernel at all (C++, upload-only) has an empty set and asserts nothing.
         let empty = try JSONDecoder().decode(
             TestProperties.self,
             from: Data(

--- a/Tests/APITests/MCP/CreateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/CreateAssignmentToolTests.swift
@@ -43,7 +43,7 @@ import Vapor
             try await enrolledCourse(on: app)
             let output = try await CreateAssignmentTool().execute(
                 CreateAssignmentTool.Input(
-                    courseCode: "CS246", title: "  New Lab  ", notebook: try json(twoCellNotebook)),
+                    courseCode: "CS246", title: "  New Lab  ", notebook: try json(twoCellNotebook), language: "python"),
                 context(app))
 
             #expect(output.title == "New Lab")
@@ -77,7 +77,7 @@ import Vapor
             await #expect(throws: MCPToolError.self) {
                 _ = try await CreateAssignmentTool().execute(
                     CreateAssignmentTool.Input(
-                        courseCode: "CS246", title: "   ", notebook: try json(twoCellNotebook)),
+                        courseCode: "CS246", title: "   ", notebook: try json(twoCellNotebook), language: "python"),
                     context(app))
             }
         }
@@ -90,7 +90,7 @@ import Vapor
             await #expect(throws: MCPToolError.self) {
                 _ = try await CreateAssignmentTool().execute(
                     CreateAssignmentTool.Input(
-                        courseCode: "NOPE99", title: "Lab", notebook: try json(twoCellNotebook)),
+                        courseCode: "NOPE99", title: "Lab", notebook: try json(twoCellNotebook), language: "python"),
                     context(app))
             }
         }
@@ -104,7 +104,7 @@ import Vapor
                 _ = try await CreateAssignmentTool().execute(
                     CreateAssignmentTool.Input(
                         courseCode: "CS246", title: "Lab",
-                        notebook: try json(#"{"nbformat":4,"metadata":{}}"#)),
+                        notebook: try json(#"{"nbformat":4,"metadata":{}}"#), language: "python"),
                     context(app))
             }
         }
@@ -119,7 +119,7 @@ import Vapor
             await #expect(throws: MCPToolError.self) {
                 _ = try await CreateAssignmentTool().execute(
                     CreateAssignmentTool.Input(
-                        courseCode: "CS246", title: "Lab", notebook: try json(twoCellNotebook)),
+                        courseCode: "CS246", title: "Lab", notebook: try json(twoCellNotebook), language: "python"),
                     context(app))
             }
         }

--- a/Tests/APITests/NewAssignmentDraftServiceTests.swift
+++ b/Tests/APITests/NewAssignmentDraftServiceTests.swift
@@ -79,7 +79,8 @@ import VaporTesting
             requiredPlatform: "",
             requiredArchitecture: "",
             requiredLanguagesCSV: "",
-            requiredCapabilitiesCSV: ""
+            requiredCapabilitiesCSV: "",
+            assignmentLanguage: "python"
         )
     }
 
@@ -296,7 +297,8 @@ import VaporTesting
                 assignmentNotebookFile: nil, solutionNotebookFile: nil,
                 suiteFiles: [], suiteConfigRaw: nil,
                 requiredPlatform: "", requiredArchitecture: "",
-                requiredLanguagesCSV: "", requiredCapabilitiesCSV: "")
+                requiredLanguagesCSV: "", requiredCapabilitiesCSV: "",
+                assignmentLanguage: "python")
             let service = NewAssignmentDraftService(
                 req: makeSyntheticRequest(),
                 setup: APITestSetup(id: "x", manifest: "{}", zipPath: "/tmp/x", courseID: UUID()),
@@ -316,7 +318,8 @@ import VaporTesting
                 assignmentNotebookFile: nil, solutionNotebookFile: nil,
                 suiteFiles: [], suiteConfigRaw: nil,
                 requiredPlatform: "", requiredArchitecture: "",
-                requiredLanguagesCSV: "", requiredCapabilitiesCSV: "")
+                requiredLanguagesCSV: "", requiredCapabilitiesCSV: "",
+                assignmentLanguage: "python")
             let service = NewAssignmentDraftService(
                 req: makeSyntheticRequest(),
                 setup: APITestSetup(id: "x", manifest: "{}", zipPath: "/tmp/x", courseID: UUID()),

--- a/Tests/APITests/NotebookKernelNormalizationTests.swift
+++ b/Tests/APITests/NotebookKernelNormalizationTests.swift
@@ -34,7 +34,8 @@ import Testing
     /// language exactly when it should be failing instead.
     @Test(arguments: AssignmentLanguage.allCases)
     func everyKernelAliasNormalizesToItsVendoredKernel(_ language: AssignmentLanguage) throws {
-        guard language != .default else { return }  // Python has no positive aliases
+        // Python is included: it has its own aliases now, and they must
+        // normalize onto the vendored xeus-python kernel like everyone else.
         guard case .notebookKernel(_, let expected, _, _) = language.editorSupport else {
             // A kernel-less language must claim no aliases at all — an alias
             // with nothing to normalize onto is exactly the F6 shape.

--- a/Tests/APITests/RunnerLanguageGateTests.swift
+++ b/Tests/APITests/RunnerLanguageGateTests.swift
@@ -1,0 +1,114 @@
+// Tests/APITests/RunnerLanguageGateTests.swift
+//
+// Unit tests for the implicit assignment-language gate (RunnerLanguageGate):
+// the two fail-open short-circuits (no language, no runner profile), the
+// closed path when a profile is present without the language, token
+// normalization, and the allCases-driven pin that every language is gated —
+// including Python, which used to be unrepresentable here because resolution
+// could not tell "this is Python" from "we could not tell".
+
+import Core
+import Testing
+
+@testable import APIServer
+
+@Suite struct RunnerLanguageGateTests {
+
+    private func profile(languages: [String]) -> RunnerCapabilityProfile {
+        RunnerCapabilityProfile(
+            platform: "linux",
+            architecture: "x86_64",
+            languageVersions: languages.map { LanguageVersion(language: $0, version: "1.0") },
+            capabilities: []
+        )
+    }
+
+    // MARK: - Fail-open short-circuits
+
+    /// A `.sh`-only suite has no interpreter to require. This is the system's
+    /// original mode and must stay claimable by any runner.
+    @Test func anAssignmentWithNoLanguageIsClaimableByAnyone() {
+        let result = RunnerLanguageGate.evaluate(
+            runnerProfile: profile(languages: []), language: nil)
+        #expect(result.isCompatible)
+        #expect(result.reasons.isEmpty)
+    }
+
+    /// No profile means capability discovery is switched off, which is an
+    /// operator's explicit choice. Treating it as incompatible would stop such a
+    /// runner claiming anything at all.
+    @Test func aRunnerWithNoProfileIsNotBlocked() {
+        for language in AssignmentLanguage.allCases {
+            #expect(
+                RunnerLanguageGate.evaluate(runnerProfile: nil, language: language).isCompatible,
+                "a profile-less runner must not be blocked from \(language) work")
+        }
+    }
+
+    // MARK: - The closed path
+
+    @Test func aProfileWithoutTheLanguageIsRefused() {
+        let result = RunnerLanguageGate.evaluate(
+            runnerProfile: profile(languages: ["python"]), language: .octave)
+        #expect(!result.isCompatible)
+        #expect(result.reasons.count == 1)
+        #expect(result.reasons.first?.contains("octave") == true)
+    }
+
+    @Test func aProfileWithTheLanguageIsAdmitted() {
+        #expect(
+            RunnerLanguageGate.evaluate(
+                runnerProfile: profile(languages: ["python", "octave"]), language: .octave
+            ).isCompatible)
+    }
+
+    /// The scenario the gate exists for: a runner whose BUILD predates the
+    /// language advertises a profile that simply lacks it, so it leaves the job
+    /// for a runner that can grade it instead of failing it with exit 127.
+    @Test func anOlderRunnerLeavesANewLanguagesJobAlone() {
+        let old = profile(languages: ["python", "r"])
+        let current = profile(languages: ["python", "r", "lua", "octave", "cpp"])
+        #expect(!RunnerLanguageGate.evaluate(runnerProfile: old, language: .octave).isCompatible)
+        #expect(RunnerLanguageGate.evaluate(runnerProfile: current, language: .octave).isCompatible)
+    }
+
+    /// The case a `minimumRunnerVersion` gate cannot catch: the runner is new
+    /// enough, but its HOST has no interpreter, so it never advertises one.
+    @Test func aCurrentRunnerMissingTheInterpreterIsAlsoRefused() {
+        #expect(
+            !RunnerLanguageGate.evaluate(
+                runnerProfile: profile(languages: ["python", "r", "lua"]), language: .octave
+            ).isCompatible)
+    }
+
+    // MARK: - Normalization
+
+    @Test func languageTokensMatchCaseAndWhitespaceInsensitively() {
+        #expect(
+            RunnerLanguageGate.evaluate(
+                runnerProfile: profile(languages: ["  OCTAVE "]), language: .octave
+            ).isCompatible)
+    }
+
+    // MARK: - allCases-driven
+
+    /// Every language is gated, Python included. Python could not be gated
+    /// before: it was the resolution default, so "this is a Python assignment"
+    /// and "nothing named a language" were the same value and a gate on it would
+    /// have fired on every un-identified assignment.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func everyLanguageIsGatedBothWays(_ language: AssignmentLanguage) {
+        let withIt = profile(languages: [language.capabilityName])
+        #expect(
+            RunnerLanguageGate.evaluate(runnerProfile: withIt, language: language).isCompatible,
+            "a runner advertising \(language.capabilityName) must be admitted for \(language)")
+
+        let withoutIt = profile(
+            languages: AssignmentLanguage.allCases
+                .filter { $0 != language }
+                .map(\.capabilityName))
+        #expect(
+            !RunnerLanguageGate.evaluate(runnerProfile: withoutIt, language: language).isCompatible,
+            "a runner advertising every language BUT \(language.capabilityName) must be refused")
+    }
+}

--- a/Tests/CoreTests/AssignmentLanguageStrategyTests.swift
+++ b/Tests/CoreTests/AssignmentLanguageStrategyTests.swift
@@ -64,10 +64,10 @@ import Testing
 
     /// The reason the field exists: a suite made up only of pattern families
     /// has no `.R` script to sniff, so without a recorded language it would
-    /// resolve back to Python on every save.
+    /// resolve to nothing on every save.
     @Test func recordedLanguageWinsOverSniffingAnEmptySuite() {
         let sniffed = TestProperties(testSuites: [])
-        #expect(AssignmentLanguage.resolve(manifest: sniffed) == .python)
+        #expect(AssignmentLanguage.resolve(manifest: sniffed) == nil)
 
         let recorded = TestProperties(testSuites: [], language: .r)
         #expect(AssignmentLanguage.resolve(manifest: recorded) == .r)
@@ -136,7 +136,9 @@ import Testing
         let xrNotebook = try notebook(kernel: "xr", languageInfo: nil)
         let rInfoNotebook = try notebook(kernel: nil, languageInfo: "R")
         let pythonNotebook = try notebook(kernel: "python3", languageInfo: nil)
-        #expect(AssignmentLanguage.resolve(manifest: manifest) == .python)
+        // Manifest alone: nothing names a language. The `python3` notebook two
+        // lines down is what resolves Python POSITIVELY.
+        #expect(AssignmentLanguage.resolve(manifest: manifest) == nil)
         #expect(AssignmentLanguage.resolve(manifest: manifest, notebookData: xrNotebook) == .r)
         #expect(AssignmentLanguage.resolve(manifest: manifest, notebookData: rInfoNotebook) == .r)
         #expect(AssignmentLanguage.resolve(manifest: manifest, notebookData: pythonNotebook) == .python)
@@ -153,7 +155,7 @@ import Testing
         #expect(
             AssignmentLanguage.resolve(
                 manifest: TestProperties(testSuites: []), notebookData: Data("not json".utf8))
-                == .python)
+                == nil)
     }
 
     /// A recorded language still wins over the notebook.
@@ -169,6 +171,6 @@ import Testing
         let decoded = try JSONDecoder().decode(
             TestProperties.self, from: try #require(legacy.data(using: .utf8)))
         #expect(decoded.language == nil)
-        #expect(AssignmentLanguage.resolve(manifest: decoded) == .python)
+        #expect(AssignmentLanguage.resolve(manifest: decoded) == nil)
     }
 }

--- a/Tests/CoreTests/AssignmentLanguageTests.swift
+++ b/Tests/CoreTests/AssignmentLanguageTests.swift
@@ -38,7 +38,9 @@ import Testing
         #expect(AssignmentLanguage.resolve(manifest: m, notebookKernelName: "xr") == .r)
         #expect(AssignmentLanguage.resolve(manifest: m, notebookKernelName: "ir") == .r)
         #expect(AssignmentLanguage.resolve(manifest: m, notebookLanguageInfoName: "r") == .r)
-        #expect(AssignmentLanguage.resolve(manifest: m) == .python)
+        // No suite and no kernel name: nothing names a language, which is nil
+        // rather than Python. Conflating those two was the whole defect class.
+        #expect(AssignmentLanguage.resolve(manifest: m) == nil)
     }
 
     // MARK: - rederive (ignores the recorded language memo)
@@ -74,11 +76,15 @@ import Testing
         #expect(AssignmentLanguage.rederive(manifest: m, notebookData: ipynb(kernel: "python")) == .python)
     }
 
-    @Test func rederive_noNotebookDefaultsPython() throws {
+    /// `rederive` ignores the recorded memo by design, so a manifest that
+    /// records R but has no suite and no notebook re-derives to NOTHING — the
+    /// memo is the only thing that claimed a language, and re-derivation is
+    /// exactly the operation that refuses to trust it.
+    @Test func rederive_noNotebookResolvesToNoLanguage() throws {
         let m = try manifest(
             #"{"schemaVersion":1,"language":"r","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
         )
-        #expect(AssignmentLanguage.rederive(manifest: m, notebookData: nil) == .python)
+        #expect(AssignmentLanguage.rederive(manifest: m, notebookData: nil) == nil)
     }
 
     // MARK: - Lua resolution (the F1 regression: resolve/rederive were R-only,
@@ -123,12 +129,14 @@ import Testing
         // wrappers, and `.sh` must carry NO language signal (every hand-written
         // shell suite would sniff as C++ otherwise). Its resolution signal is
         // the RECORDED manifest language — asserted here, along with the
-        // no-signal pin for the bare script.
+        // no-signal pin for the bare script. That pin is now nil rather than
+        // Python: a `.sh`-only suite is the canonical language-less assignment,
+        // and saying so is the point of the Optional.
         guard language != .cpp else {
             let bare = try manifest(
                 #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_x.sh"}],"timeLimitSeconds":10}"#
             )
-            #expect(AssignmentLanguage.resolve(manifest: bare) == .python)
+            #expect(AssignmentLanguage.resolve(manifest: bare) == nil)
             let recorded = try manifest(
                 #"{"schemaVersion":1,"language":"cpp","requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_x.sh"}],"timeLimitSeconds":10}"#
             )
@@ -145,10 +153,10 @@ import Testing
     }
 
     @Test(arguments: AssignmentLanguage.allCases)
-    func everyNonDefaultLanguageResolvesFromItsOwnKernel(_ language: AssignmentLanguage) throws {
-        // Python's kernel set is deliberately empty (it is the default, reached
-        // by falling through), so only the positively-detected languages apply.
-        guard language != .default else { return }
+    func everyLanguageResolvesFromItsOwnKernel(_ language: AssignmentLanguage) throws {
+        // Python is included: it has its own `notebookKernelNames` now and
+        // resolves positively like every other language. A language with no
+        // kernel at all (C++, upload-only) has an empty set and asserts nothing.
         let m = try manifest(
             #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
         )

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -118,7 +118,9 @@ import Testing
         #expect(AssignmentLanguage.r.descriptor.notebookKernelNames == AssignmentLanguage.rKernelNames)
         #expect(
             AssignmentLanguage.lua.descriptor.notebookKernelNames == AssignmentLanguage.luaKernelNames)
-        #expect(AssignmentLanguage.python.descriptor.notebookKernelNames.isEmpty)
+        #expect(
+            AssignmentLanguage.python.descriptor.notebookKernelNames
+                == AssignmentLanguage.pythonKernelNames)
     }
 
     /// `capabilityName` is deliberately NOT a descriptor field: it is the token

--- a/changelog.d/gate-assignments-on-runner-version.md
+++ b/changelog.d/gate-assignments-on-runner-version.md
@@ -1,15 +1,34 @@
 ### Changed
 
-- **Documented the rule that an assignment needing a runner-side feature must
-  be gated on `minimumRunnerVersion` at authoring time.** Runners upgrade
-  independently of the auto-deployed server, so claim order decides which build
-  grades a job: an ungated assignment validates green whenever a capable runner
-  polls first, then fails for the next student whose job an older runner claims
-  — with a symptom (exit 127, "interpreter not found") that reads as a broken
-  test script. `docs/runner-capability-profiles.md` gains an authoring rule with
-  the landing versions (Lua 0.5.23, Octave 0.5.24, C++ 0.5.27), a note that
-  browser-graded assignments are not exempt because validation always runs on the
-  native worker, and why capability requirements are not a substitute — they fail
-  the opposite way, matching no runner and queueing jobs forever. Cross-linked
-  from `CLAUDE.md` and the new-language checklist in
-  `docs/adding-a-xeus-kernel.md`.
+- **Language resolution is Optional, and Python resolves positively.**
+  `AssignmentLanguage.resolve` answered `.python` when nothing named a
+  language, so "this is Python" and "nothing here says anything" were the same
+  value — Python was defined by absence at both ends to make that work
+  (`gradedScriptLanguage` skipped it, so a `.py` script never matched; its
+  `notebookKernelNames` was empty, so a `python3` kernelspec never matched
+  either). That conflation is upstream of the silent-misroute defects in this
+  area, Lua shipping green while resolving to Python among them. `resolve` and
+  `rederive` now return `AssignmentLanguage?`, nil meaning "no signal names a
+  language" — a legal state, since a suite of plain `.sh` scripts is the
+  system's original mode. `AssignmentLanguage.default` is gone; every site that
+  used it was really asking "is this Python?" and now says so, with identical
+  behaviour. Sites that must produce a language regardless (notebook
+  extraction, literal rendering, expression evaluation, pattern-family
+  authoring) state that locally instead of inheriting it.
+
+### Added
+
+- **A runner only claims a job it can actually grade (`RunnerLanguageGate`).**
+  Runners upgrade independently of the auto-deployed server, so several builds
+  poll at once and claim order decided which one graded a job: an assignment in
+  a newer language validated green on a capable runner, then failed for the
+  next student whose job an older one claimed — with a symptom (exit 127,
+  "interpreter not found") that reads as a broken test script. The claim seam
+  now resolves the assignment's language and refuses a runner whose advertised
+  profile lacks it, so the job waits for one that can grade it. No authoring
+  step is involved, and it catches strictly more than a `minimumRunnerVersion`
+  gate: a current runner whose *host* lacks the interpreter never advertises it
+  either. Fails open for an assignment with no language and for a runner
+  advertising no profile at all (capability discovery switched off).
+  `minimumRunnerVersion` remains for runner behaviour that is not observable as
+  an interpreter.

--- a/changelog.d/gate-assignments-on-runner-version.md
+++ b/changelog.d/gate-assignments-on-runner-version.md
@@ -14,7 +14,11 @@
   used it was really asking "is this Python?" and now says so, with identical
   behaviour. Sites that must produce a language regardless (notebook
   extraction, literal rendering, expression evaluation, pattern-family
-  authoring) state that locally instead of inheriting it.
+  authoring) state that locally instead of inheriting it. The browser's
+  generated copy of the kernel-alias sets gains `PYTHON_KERNEL_NAMES` to match,
+  so `browser-runner.js` identifies a Python notebook positively and its
+  unrecognised-kernel fallback is a visible branch rather than the shape of the
+  tail.
 
 ### Added
 

--- a/changelog.d/gate-assignments-on-runner-version.md
+++ b/changelog.d/gate-assignments-on-runner-version.md
@@ -36,3 +36,14 @@
   advertising no profile at all (capability discovery switched off).
   `minimumRunnerVersion` remains for runner behaviour that is not observable as
   an interpreter.
+
+- **A Language dropdown on the assignment edit page.** Sits above Submission
+  Method and declares the language explicitly, for the cases derivation cannot
+  reach: a suite made only of pattern families has no script on disk to sniff,
+  and C++ has neither a notebook kernel nor a language-bearing generated
+  extension. It writes through the same shared helpers the MCP
+  `set_assignment_language` tool uses, so both surfaces share one policy and its
+  three refusals. Options are built from `AssignmentLanguage.allCases`, and the
+  list leads with "detect from the notebook or test scripts" — a recorded
+  language outranks every content signal, so without a way back the first
+  choice would be permanent.

--- a/changelog.d/gate-assignments-on-runner-version.md
+++ b/changelog.d/gate-assignments-on-runner-version.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Documented the rule that an assignment needing a runner-side feature must
+  be gated on `minimumRunnerVersion` at authoring time.** Runners upgrade
+  independently of the auto-deployed server, so claim order decides which build
+  grades a job: an ungated assignment validates green whenever a capable runner
+  polls first, then fails for the next student whose job an older runner claims
+  — with a symptom (exit 127, "interpreter not found") that reads as a broken
+  test script. `docs/runner-capability-profiles.md` gains an authoring rule with
+  the landing versions (Lua 0.5.23, Octave 0.5.24, C++ 0.5.27), a note that
+  browser-graded assignments are not exempt because validation always runs on the
+  native worker, and why capability requirements are not a substitute — they fail
+  the opposite way, matching no runner and queueing jobs forever. Cross-linked
+  from `CLAUDE.md` and the new-language checklist in
+  `docs/adding-a-xeus-kernel.md`.

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -727,6 +727,14 @@ state this document exists to warn you about:
       it SUGGESTS a requirement — capability matching fails in both directions
       and the second is worse: requiring a language no runner advertises queues
       the assignment's jobs forever
+- [ ] every assignment authored in the new language carries
+      `minimumRunnerVersion` set to the release that ships this work. The fleet
+      is mixed and claim order picks the runner, so an ungated assignment
+      validates green on a new runner and then fails for the student whose job
+      an old one claims — with a message that reads as a broken test script.
+      This is the version gate, NOT a capability requirement; the two fail in
+      opposite directions. See "Authoring rule" in
+      [runner-capability-profiles.md](runner-capability-profiles.md)
 - [ ] the MCP guide is true for this language — see item 8 above
 - [ ] **the instructor walkthrough below passes, by hand, on a real server**
 

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -727,13 +727,14 @@ state this document exists to warn you about:
       it SUGGESTS a requirement — capability matching fails in both directions
       and the second is worse: requiring a language no runner advertises queues
       the assignment's jobs forever
-- [ ] every assignment authored in the new language carries
-      `minimumRunnerVersion` set to the release that ships this work. The fleet
-      is mixed and claim order picks the runner, so an ungated assignment
-      validates green on a new runner and then fails for the student whose job
-      an old one claims — with a message that reads as a broken test script.
-      This is the version gate, NOT a capability requirement; the two fail in
-      opposite directions. See "Authoring rule" in
+- [ ] a mixed fleet routes the new language correctly WITHOUT any per-assignment
+      gate. `RunnerLanguageGate` refuses a runner whose profile lacks the
+      assignment's language, so a build that predates your case leaves the job
+      alone instead of failing it with exit 127. That protection is only as good
+      as the item above — it derives entirely from what the runner advertises,
+      so a language the detector cannot probe is a language the gate cannot see,
+      and both halves fail open together. Verify with a runner that does NOT
+      have the interpreter, not only with one that does. See
       [runner-capability-profiles.md](runner-capability-profiles.md)
 - [ ] the MCP guide is true for this language — see item 8 above
 - [ ] **the instructor walkthrough below passes, by hand, on a real server**

--- a/docs/runner-capability-profiles.md
+++ b/docs/runner-capability-profiles.md
@@ -154,14 +154,47 @@ metadata-only edit — no regrade or close), or include it in the uploaded manif
 / a `.chickadee` course bundle. A malformed value is rejected at upload time.
 `get_suite` and `get_assignment` report the current value.
 
-### Authoring rule: gate on the release that shipped the feature
+### The language gate: enforced, not authored
 
-**Every assignment that depends on runner-side behaviour added in release *X*
-must carry `minimumRunnerVersion: X`, set when the assignment is authored.**
-This is written down rather than left to judgement because it is a mistake this
-project keeps repeating.
+**An assignment's language is gated automatically. There is nothing to
+remember.** `RunnerLanguageGate` runs at the claim seam beside the two gates
+above: it resolves the assignment's language from its manifest, and a runner
+whose advertised profile does not list that language does not claim the job —
+it leaves it for one that does.
 
-Why it is not optional, and why testing does not catch it:
+This needs no authoring step because both halves were already there. The
+manifest knows the language (`AssignmentLanguage.resolve`), and
+`RunnerProfileDetector` discovers its probes from `AssignmentLanguage.allCases`,
+so every runner already advertises every language it has, and a runner whose
+*build* predates a language advertises a profile without it.
+
+Two fail-open cases, both deliberate:
+
+- **The assignment names no language** — a suite of plain `.sh` scripts. There
+  is no interpreter to require, and that is the system's original mode.
+- **The runner advertises no profile at all** — capability discovery is off
+  (`RUNNER_CAPABILITY_DISCOVERY_ENABLED=false`), an explicit operator choice.
+  Blocking it would stop that runner claiming anything. It costs nothing here:
+  a runner too old to know a language still has discovery on, so it is caught
+  by the closed path.
+
+Everything else is checked, and the check catches strictly more than a version
+gate would: a runner that is new enough but whose *host* lacks the interpreter
+never advertises it either, and is refused for the same reason.
+
+### `minimumRunnerVersion`: for runner behaviour that is not a language
+
+The version gate remains for the case the language gate cannot see — a suite
+that depends on runner behaviour added in release *X* which is not observable
+as an interpreter. Set `minimumRunnerVersion: X` when authoring such an
+assignment.
+
+It is **not** the right tool for "this assignment is in a new language": it is
+only a proxy for capability, and it admits a current runner on a host with no
+interpreter. The language gate handles that case directly and automatically.
+
+Why the distinction is worth keeping straight, and why testing does not catch
+getting it wrong:
 
 - **The fleet is mixed by construction.** The server auto-deploys on merge
   ([docs/zero-downtime-deploy.md](zero-downtime-deploy.md)); runners are separate
@@ -180,33 +213,26 @@ Why it is not optional, and why testing does not catch it:
   regardless of `gradingMode`, and a browser submission that fails over to the
   worker backstop lands there too.
 
-Support landed in:
+Language support landed in Lua `0.5.23`, Octave `0.5.24`, C++ `0.5.27` — recorded
+for reference, not as gates to set by hand. The language gate derives the same
+exclusion from what each runner advertises.
 
-| Feature | Gate at |
+### Which of the three to reach for
+
+| Situation | Mechanism |
 |---|---|
-| Lua assignments | `0.5.23` |
-| Octave assignments | `0.5.24` |
-| C++ assignments | `0.5.27` |
+| The assignment is in a language some runners cannot run | **Nothing — `RunnerLanguageGate` handles it** |
+| The host needs a package or toolchain (numpy, a shell) | `requiredCapabilities` / `requiredLanguages` |
+| The suite needs runner behaviour that is not an interpreter | `minimumRunnerVersion` |
 
-### Why capability requirements are not a substitute
-
-The two mechanisms fail in opposite directions, and only the version gate is
-reliable for "this runner build is too old":
-
-- `requiredLanguages` matches what a runner **advertises**.
-  `RunnerProfileDetector` hand-lists the interpreters it probes, so a runner
-  built before the language existed never advertises it *however the host is
-  provisioned*. Requiring the language therefore matches **no** runner and queues
-  the assignment's jobs forever — the worse of the two failures, and the one the
-  Lua audit sweep had to fix.
-- `minimumRunnerVersion` compares against `runnerVersion`, which every runner has
-  always advertised. An old runner is excluded correctly without having to know
-  anything about the feature.
-
-Use capability requirements for "this host lacks a package or toolchain" and the
-version gate for "this build predates the feature". A new language wants the
-version gate; adding a language requirement as well is safe only once every
-runner in the fleet advertises it.
+A note on the middle row, since it used to be the recommended answer for the
+top row and is not: `requiredLanguages` matches what a runner *advertises*, and
+before the detector discovered its probes from `AssignmentLanguage.allCases` a
+runner never advertised a newly-added language however the host was provisioned
+— so requiring one matched **no** runner and queued the assignment's jobs
+forever. The Lua audit sweep fixed the detector; the language gate now applies
+the same matching automatically, so declaring the assignment's own language as
+a requirement is redundant rather than dangerous.
 
 ## Rollout And Backwards Compatibility
 

--- a/docs/runner-capability-profiles.md
+++ b/docs/runner-capability-profiles.md
@@ -154,6 +154,60 @@ metadata-only edit — no regrade or close), or include it in the uploaded manif
 / a `.chickadee` course bundle. A malformed value is rejected at upload time.
 `get_suite` and `get_assignment` report the current value.
 
+### Authoring rule: gate on the release that shipped the feature
+
+**Every assignment that depends on runner-side behaviour added in release *X*
+must carry `minimumRunnerVersion: X`, set when the assignment is authored.**
+This is written down rather than left to judgement because it is a mistake this
+project keeps repeating.
+
+Why it is not optional, and why testing does not catch it:
+
+- **The fleet is mixed by construction.** The server auto-deploys on merge
+  ([docs/zero-downtime-deploy.md](zero-downtime-deploy.md)); runners are separate
+  hosts upgraded on their own schedule. Several `chickadee-runner` versions are
+  polling at any moment.
+- **The failure is nondeterministic, so validation does not surface it.** Claim
+  order decides which runner grades a job. An ungated assignment validates green
+  whenever a capable runner happens to poll first, and the identical assignment
+  fails for the next student whose job an older runner claims.
+- **The failure does not look like a version problem.** An old runner has no
+  interpreter for the new language, so the symptom is exit 127 / "not found" / a
+  suite of `error` outcomes. It reads as a broken test script and gets debugged
+  as one, on the assignment rather than on the fleet.
+- **Browser-graded assignments are not exempt.** Instructor validation is
+  enqueued as a `kind == .validation` submission and graded by the native worker
+  regardless of `gradingMode`, and a browser submission that fails over to the
+  worker backstop lands there too.
+
+Support landed in:
+
+| Feature | Gate at |
+|---|---|
+| Lua assignments | `0.5.23` |
+| Octave assignments | `0.5.24` |
+| C++ assignments | `0.5.27` |
+
+### Why capability requirements are not a substitute
+
+The two mechanisms fail in opposite directions, and only the version gate is
+reliable for "this runner build is too old":
+
+- `requiredLanguages` matches what a runner **advertises**.
+  `RunnerProfileDetector` hand-lists the interpreters it probes, so a runner
+  built before the language existed never advertises it *however the host is
+  provisioned*. Requiring the language therefore matches **no** runner and queues
+  the assignment's jobs forever — the worse of the two failures, and the one the
+  Lua audit sweep had to fix.
+- `minimumRunnerVersion` compares against `runnerVersion`, which every runner has
+  always advertised. An old runner is excluded correctly without having to know
+  anything about the feature.
+
+Use capability requirements for "this host lacks a package or toolchain" and the
+version gate for "this build predates the feature". A new language wants the
+version gate; adding a language requirement as well is safe only once every
+runner in the fleet advertises it.
+
 ## Rollout And Backwards Compatibility
 
 The rollout rules are:


### PR DESCRIPTION
Started as a docs note asking authors to remember `minimumRunnerVersion`. That was the wrong instrument — the server can check the capability directly — and looking for the seam turned up a deeper problem underneath it. The arc since has been: stop treating "we don't know the language" as an answer, then close every door that produced that state.

## 1. `.python` was a sentinel for "we don't know"

`AssignmentLanguage.resolve` answered `.python` when nothing named a language, and Python was defined by *absence* at both ends to make that work:

- `gradedScriptLanguage` explicitly skipped it (`language != .default`), so a `.py` graded script never matched positively.
- Its `notebookKernelNames` was `[]`, so a `python3` kernelspec never matched either.

Python was only ever reachable by falling through — which means "this is a Python assignment" and "nothing here says anything" were the same value. Every silent-misroute defect in this area descends from that, Lua shipping green while resolving to Python among them.

It also meant no downstream check could distinguish a real Python assignment from an unidentified one — which is what made the gate in part 2 impossible to write correctly. My first sketch of it excluded Python "because those already resolve positively"; they don't, and it would have shipped with a Python-shaped hole.

**Now:** `resolve` / `rederive` return `AssignmentLanguage?`. Python resolves positively (`.py` scripts match; `pythonKernelNames` = python / python3 / xpython, hoisted from the private copy in `NotebookContentHelpers`). `AssignmentLanguage.default` is gone — every site that used it was really asking *"is this Python?"* (submission-normalization precedence, kernel normalization, the authored-script sniff) and now says so, with identical behaviour.

**nil is a legal state, not an error.** A suite of plain `.sh` scripts is the system's original mode and has no language in this sense. Sites that must produce a language regardless state it locally in one visible line instead of inheriting it — notebook extraction (it has to write a file in *some* syntax), literal rendering and expression evaluation, and pattern-family authoring.

That last one is a deliberate non-refusal, and I got it wrong first: refusing there is **circular**, because a pattern family is frequently the first thing authored on an assignment and generating its scripts is how the suite acquires a graded script at all. "Add a graded script before you can add a family" asks for the output as a precondition of the input. The save records the language, so the ambiguity exists for exactly one save.

## 2. `RunnerLanguageGate`

Claim order decides which runner grades a job, so an assignment in a language only some runners can run was nondeterministic — green on validation, failing later for whichever student's job an older runner claimed, with a symptom that reads as a broken test script.

The gate resolves the assignment's language at the claim seam and refuses a runner whose advertised profile lacks it. **No authoring step**, because both halves already existed: the manifest knows the language, and `RunnerProfileDetector` discovers its probes from `AssignmentLanguage.allCases`, so every runner advertises what it has and a runner whose *build* predates a language advertises a profile without it.

It catches **strictly more** than a version gate, which is only a proxy for capability:

| | old runner (build predates language) | current runner, host lacks interpreter |
|---|---|---|
| `minimumRunnerVersion` | refused | **admitted, then fails at grade time** |
| `RunnerLanguageGate` | refused | refused |

Two deliberate fail-opens: an assignment naming no language, and a runner advertising no profile at all (discovery switched off is an operator's choice; blocking it would stop that runner claiming anything, and an old runner still has discovery on so the closed path catches it).

`minimumRunnerVersion` survives for runner behaviour that isn't observable as an interpreter — and is now documented as the *wrong* tool for "this is a new language".

## 3. "Undeclared" becomes sayable: `TestProperties.languageDeclared`

Making `nil` legal creates a second problem: `nil` now means both "declared as having no language" and "nobody has been asked". Only the first is an answer.

`languageDeclared` is a **separate boolean**, deliberately not a reserved `"none"` string in the `language` field. That field decodes as an `AssignmentLanguage`, and an unrecognised enum case **throws** — so a reserved string would make the whole manifest undecodable by any runner built before it. An unknown *key* is ignored. It rides `runnerSanitized()` precisely so a worker can eventually refuse rather than guess.

## 4. Closing every door that produces an undeclared assignment

A refusal that legitimate content can trip is one that gets watered down until it stops being worth having. So all four entry points now declare:

- **`BackfillDeclaredLanguage`** stamps everything already on disk by running today's resolution and writing the answer down. A `.sh` suite is recorded as declared-with-no-language — the truthful answer. It skips anything already declared, and rewrites raw JSON rather than round-tripping `TestProperties`, so a field written by a newer build survives a rollback.
- **MCP `create_assignment`** takes a required `language` (an `AssignmentLanguage` raw value, or `"none"`). This is a breaking schema change for agents, which is the point: a default is the thing being removed.
- **The web new-assignment page** has a required Language select. The declaration is applied *before* the draft service runs, so families and checks authored in the same save render in the chosen language rather than one derived from a suite that doesn't exist yet — that ordering is what makes declare-at-creation actually remove the guess instead of relocating it.
- **Course-bundle import** declares on the way in. A bundle exported by an older build carries no declaration and import copied its manifest verbatim, which made import a permanent source of exactly the state the worker needs to refuse.

Declaring an upload-only language **sets** `submissionMode` rather than refusing without it. It had to: `setManifestLanguage` refuses C++ in notebook mode and a brand-new assignment always is, so requiring the declaration would have left C++ uncreatable. The upshot is that the old three-step dance (grading mode → submission mode → language, each refusal naming the next) collapses to one answer.

`parseLanguageChoice` / `declareManifestLanguage` are shared by both surfaces, so the web form and MCP cannot disagree about how `"none"` is spelled or what declaring implies.

## Verification

- **3,297 tests pass**, all lint gates clean (`swift-format`, SwiftLint `--strict` at 0 violations, style/CSS/design-token guards, and the JS-constants drift check).
- All 27 CI checks green on `339f99a7`.
- One `smoke (webkit)` failure along the way was the Family 3 wasm flake (`Out of bounds memory access` inside xeus-python's embind invoker) — the identical probe passed twice in the same job minutes earlier, and it went green on re-run with no code change. Likewise the `WorkerDaemonTests` / `AsyncKit Connection request timed out` failures seen locally: the known pool-saturation family, clean on re-run.

## Docs

`docs/runner-capability-profiles.md` now describes what's enforced rather than what to remember, with a table of which of the three mechanisms to reach for. `CLAUDE.md` matches. The new-language checklist in `docs/adding-a-xeus-kernel.md` asks for verification against a runner that does **not** have the interpreter — the gate derives entirely from the detector, so a language the detector can't probe is one the gate can't see, and both halves fail open together.

## Still to come (why this is a draft)

The point of parts 3 and 4 is to make the **worker refuse rather than guess** — fail the collection with a named reason when an assignment is undeclared *and* nothing is derivable, and remove the `?? .python` fallbacks that are now reachable only defensively. Every prerequisite for that is in this PR; the change itself lands in the grading path, where a wrong call silently mis-grades submissions rather than erroring, so it is deliberately a separate careful pass.

## Note on scope

This changes a core type and `TestProperties`' wire format. Worth a careful look at part 1 in particular — the `.default` removal touches submission-normalization precedence in the worker, where I kept behaviour identical by naming Python explicitly at each site rather than changing the ordering.