### PR TITLE
fix(tests): stop the harness leaking its temp directories

### DIFF
--- a/Tests/APITests/TestAppTempDirectoryTests.swift
+++ b/Tests/APITests/TestAppTempDirectoryTests.swift
@@ -1,0 +1,86 @@
+// Tests/APITests/TestAppTempDirectoryTests.swift
+//
+// The test harness must not leak its own scratch directories.
+//
+// It did, for a long time and invisibly: `makeTestApp` built its per-app temp
+// path with a trailing slash inside `appendingPathComponent`, and `URL.path`
+// strips that, so the five directories it then created by string concatenation
+// were SIBLINGS of the intended parent rather than children. Nothing created
+// the parent, so `tearDownTestApp`'s `removeItem` deleted a path that never
+// existed — and its `try?` swallowed the error, so cleanup reported success
+// while removing nothing. A full suite run leaked ~1.4 GB across ~6,900
+// entries; a working session filled a 252 GB disk. See issue #1298.
+//
+// These assert the OUTCOME (nothing survives) rather than that cleanup ran,
+// because "cleanup ran" is exactly what was true the whole time it was broken.
+
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct TestAppTempDirectoryTests {
+
+    private var temporaryDirectory: String {
+        FileManager.default.temporaryDirectory.path
+    }
+
+    /// Entries in the system temp directory whose name starts with `prefix`.
+    /// Deliberately a prefix scan of the whole directory rather than a look
+    /// inside the app's own path: the bug produced siblings, which an inside
+    /// look cannot see by construction.
+    private func entries(matching prefix: String) -> [String] {
+        ((try? FileManager.default.contentsOfDirectory(atPath: temporaryDirectory)) ?? [])
+            .filter { $0.hasPrefix(prefix) }
+    }
+
+    @Test func theAppsDirectoriesAreChildrenOfItsTempDirectory() async throws {
+        let prefix = "chickadee-tmptest-\(UUID().uuidString)"
+        let app = try await makeTestApp(prefix: prefix)
+        defer { Task { try? await app.tearDownTestApp() } }
+
+        let root = try #require(app.testDataDirectory)
+        var isDirectory: ObjCBool = false
+        #expect(
+            FileManager.default.fileExists(atPath: root, isDirectory: &isDirectory),
+            "the recorded test data directory must actually exist — it is what teardown removes")
+        #expect(isDirectory.boolValue)
+
+        // Each configured directory must live INSIDE the recorded root. This is
+        // the assertion the sibling bug fails: `.../<uuid>results/` does not
+        // have `.../<uuid>/` as a prefix.
+        for directory in [
+            app.resultsDirectory, app.testSetupsDirectory, app.submissionsDirectory,
+            app.dataExportsDirectory, app.contentFilesDirectory,
+        ] {
+            #expect(
+                directory.hasPrefix(root),
+                "\(directory) is not inside \(root) — teardown will not remove it")
+        }
+        // The two dotfiles are built by the same concatenation and leaked the
+        // same way.
+        #expect(app.workerSecretFilePath.hasPrefix(root))
+        #expect(app.localRunnerAutoStartFilePath.hasPrefix(root))
+    }
+
+    @Test func tearDownLeavesNothingBehind() async throws {
+        let prefix = "chickadee-tmptest-\(UUID().uuidString)"
+        #expect(entries(matching: prefix).isEmpty, "prefix must be unique to this test")
+
+        let app = try await makeTestApp(prefix: prefix)
+        #expect(
+            !entries(matching: prefix).isEmpty,
+            "the app should have created something to clean up")
+
+        try await app.tearDownTestApp()
+
+        #expect(
+            entries(matching: prefix).isEmpty,
+            """
+            \(entries(matching: prefix)) survived teardown. Anything matching the app's prefix \
+            must be removed — the leak this guards against produced SIBLINGS of the directory \
+            teardown deletes, so it cleaned up successfully and left everything behind.
+            """)
+    }
+}

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -307,9 +307,18 @@ func makeTestApp(
         // `appConfig` to exercise specific config branches.
         app.appConfig = appConfig ?? AppConfig.testDefaults(authMode: authMode)
 
-        let tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(prefix)-\(UUID().uuidString)/")
-            .path
+        // The trailing slash is applied AFTER `.path`, not before. `URL.path`
+        // strips a trailing slash, so building it into the path component left
+        // `tmpDir` as `/tmp/<prefix>-<uuid>` and made every concatenation below
+        // a SIBLING of that directory rather than a child
+        // (`/tmp/<prefix>-<uuid>content-files/`). Nothing then created
+        // `tmpDir` itself, so `tearDownTestApp`'s `removeItem` was deleting a
+        // path that never existed — silently, under its `try?` — and every run
+        // leaked ~1.4 GB across ~6,900 entries. See issue #1298.
+        let tmpDir =
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)")
+            .path + "/"
         let dirs = ["results/", "testsetups/", "submissions/", "data-exports/", "content-files/"].map {
             tmpDir + $0
         }

--- a/changelog.d/fix-test-temp-dir-leak.md
+++ b/changelog.d/fix-test-temp-dir-leak.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **The test harness no longer leaks its scratch directories.** `makeTestApp`
+  built its per-app temp path with a trailing slash inside
+  `appendingPathComponent`, and `URL.path` strips that — so the five directories
+  it then created by string concatenation were *siblings* of the intended
+  parent rather than children (`…/<uuid>content-files/`). Nothing created the
+  parent, so `tearDownTestApp`'s `removeItem` deleted a path that never existed,
+  and its `try?` swallowed the error: cleanup reported success while removing
+  nothing. A full suite run leaked ~1.4 GB across ~6,900 `/tmp` entries, enough
+  to fill a 252 GB disk over a working session. Measured after the fix, the same
+  run leaves 45 MB. Two regression tests assert the outcome — that the
+  configured directories are inside the recorded root, and that nothing matching
+  the app's prefix survives teardown — rather than asserting that cleanup ran,
+  which is what was true the whole time it was broken. (#1298)


### PR DESCRIPTION
Fixes the root cause in #1298. Tests only; no production code.

## The bug

`makeTestApp` built its per-app temp path as

```swift
.appendingPathComponent("\(prefix)-\(UUID().uuidString)/").path
```

`URL.path` strips a trailing slash, so `tmpDir` came out as `/tmp/<prefix>-<uuid>` and every concatenation below it produced a **sibling** rather than a child:

```
/tmp/<prefix>-<uuid>content-files/     ← note: no separator
/tmp/<prefix>-<uuid>results/
…plus testsetups, submissions, data-exports, .worker-secret, .local-runner-autostart
```

Nothing ever created `/tmp/<prefix>-<uuid>` itself. `tearDownTestApp` then removed exactly that path — under a `try?`, so the "no such file" error was discarded and cleanup reported success while removing nothing.

That is why it went unseen for so long: **the only operation that failed was the one whose failure was thrown away.**

## Measured

| | per full `swift test` run |
|---|---|
| before | **~1.4 GB**, ~6,900 `/tmp` entries |
| after | **45 MB** |

Over one working session this reached 17 GB / 148,489 entries and filled a 252 GB disk, at which point unrelated commands started failing with `ENOSPC` — on a disk whose `df` "Used" column looked fine.

## The fix

Move the slash outside `.path`. The five directories become real children, `withIntermediateDirectories: true` creates the parent, and teardown finally has something to delete.

## Tests

Two regression tests that assert the **outcome**, not that cleanup ran — "cleanup ran" is exactly what was true the whole time this was broken:

- every configured directory is inside the recorded root (the assertion the sibling shape fails by construction — an inside-out check could never have caught this, since the leak was *outside* the directory being inspected);
- create an app, tear it down, scan the temp directory for anything matching its prefix.

Both were confirmed to fail against the old path construction before being kept. The failure output names the leaked siblings directly:

```
["…-<uuid>data-exports", "…-<uuid>content-files", "…-<uuid>submissions",
 "…-<uuid>results", "…-<uuid>testsetups"] survived teardown
```

Full suite: 3,271 tests pass.

## What this does NOT fix

Two smaller leaks remain, with different causes. Both are recorded on #1298 rather than folded in here:

- **~45 MB / ~1,400 entries per run** from apps whose tests never call `tearDownTestApp`. These now have the *correct* shape (one parent containing its five children), so each such app leaks one directory instead of seven — but it still leaks.
- **~973 MB / ~1,566 entries per run** of `sqlite-kit_memory*`, which comes from SQLKit rather than this codebase and wants its own look. This is now the dominant consumer.

I deliberately left the `try?` on the teardown remove in place. Dropping it was the other suggestion on the issue, but a throw in teardown risks masking a real test failure, and the second regression test above asserts the same property directly with no flake risk — a stronger guard for less cost.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwj5fD2dysDT6iC9RuVF4a)_