### PR TITLE
fix(worker): refuse per-student inputs with no language rather than guessing

### DIFF
--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -400,10 +400,28 @@ extension WorkerDaemon {
             // owns the exact bytes (the Python form is byte-for-byte the historical
             // writer, so existing Python jobs are unchanged). The filename is
             // reserved (excluded from student-module candidates in the runtimes), so
-            // it can't be mistaken for the submission. Language is nil on payloads
-            // from an older server → `.python`, preserving legacy behaviour.
+            // it can't be mistaken for the submission.
+            //
+            // A job carrying inputs but naming no language is REFUSED rather than
+            // rendered as Python. This used to default, on the reasoning that nil
+            // meant an older server — but the two states it conflated are not
+            // equally harmless. The values arrive as source literals already
+            // rendered in the assignment's language (`repr` / `deparse`), so
+            // writing them into `_ck_inputs.py` for an R assignment does not
+            // produce an error at the boundary: it produces a file whose contents
+            // are wrong, and every personalized test then fails somewhere inside
+            // the student's own code, with a traceback that reads as their
+            // mistake and persists as their grade. Guessing is only safe where
+            // being wrong is loud, and here it is silent.
+            //
+            // Nothing legitimate reaches this. Personalization is resolved
+            // per-language on the server, so an assignment with inputs has a
+            // language by construction; a plain `.sh` suite has no language and
+            // no inputs, and never enters this branch.
             if let inputs = job.personalizedInputs, !inputs.isEmpty {
-                let language = job.language ?? .python
+                guard let language = job.language else {
+                    throw WorkerDaemonError.personalizedInputsWithoutLanguage(inputCount: inputs.count)
+                }
                 let source = language.renderInputsFile(inputs)
                 // A failed write here would make every personalized test error with
                 // a confusing missing-file traceback that looks like a student

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -292,7 +292,8 @@ actor WorkerDaemon {
                         return classifyHTTPRetry(statusCode: statusCode, body: body)
                     case .downloadFailed(let failedURL):
                         return .terminal("Failed to download \(failedURL.absoluteString)")
-                    case .makeFailed, .makeTimedOut, .insufficientDiskSpace, .unsafePersonalizedFilename:
+                    case .makeFailed, .makeTimedOut, .insufficientDiskSpace, .unsafePersonalizedFilename,
+                        .personalizedInputsWithoutLanguage:
                         return .terminal(String(describing: workerError))
                     }
                 }

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -361,6 +361,7 @@ enum WorkerDaemonError: Error, LocalizedError {
     case makeTimedOut(target: String?, limitSeconds: Int)
     case insufficientDiskSpace(path: String, freeMB: Int, requiredMB: Int)
     case unsafePersonalizedFilename(String)
+    case personalizedInputsWithoutLanguage(inputCount: Int)
 
     var errorDescription: String? {
         switch self {
@@ -378,6 +379,15 @@ enum WorkerDaemonError: Error, LocalizedError {
                 "Runner workspace at \(path) has \(freeMB) MB free; need at least \(requiredMB) MB before accepting a job"
         case .unsafePersonalizedFilename(let name):
             return "Personalized file name '\(name)' is not a bare filename; refusing to write it"
+        case .personalizedInputsWithoutLanguage(let inputCount):
+            return """
+                This job carries \(inputCount) per-student input value\(inputCount == 1 ? "" : "s") \
+                but names no assignment language, so there is no way to know what syntax to write \
+                them in. Refusing rather than guessing: the values are already source literals in \
+                the assignment's language, and rendering them into the wrong one would make every \
+                personalized test fail in a way that reads as a student mistake. Re-save the \
+                assignment so its language is recorded, then retest.
+                """
         }
     }
 }

--- a/Tests/WorkerTests/PersonalizedInputsLanguageRefusalTests.swift
+++ b/Tests/WorkerTests/PersonalizedInputsLanguageRefusalTests.swift
@@ -1,0 +1,67 @@
+// Tests/WorkerTests/PersonalizedInputsLanguageRefusalTests.swift
+//
+// A job that carries per-student input values but names no assignment language
+// is refused, not rendered as Python.
+//
+// The values arrive already rendered as source literals in the assignment's
+// language (`repr` / `deparse`), so writing them into `_ck_inputs.py` for an R
+// assignment produces no error at the boundary — it produces a file whose
+// CONTENTS are wrong. Every personalized test then fails somewhere inside the
+// student's own code, with a traceback that reads as their mistake, and that
+// persists as their grade. Guessing is only safe where being wrong is loud.
+//
+// The old default was justified by "nil means an older server", a premise the
+// declare-at-creation work falsified: personalization is resolved per-language
+// on the server, so an assignment with inputs has a language by construction.
+
+import Core
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite struct PersonalizedInputsLanguageRefusalTests {
+
+    // The retry classification (terminal — retrying cannot make a language
+    // appear) is deliberately NOT covered here. It lives inline in
+    // `RunnerDaemon.download`'s `shouldRetry` closure, and the only way to
+    // assert it would be to extract that closure for the test's benefit alone.
+    // The compiler already enforces the case is handled: adding it made the
+    // switch non-exhaustive and failed the build until it was classified.
+
+    @Test func theMessageNamesTheCauseAndTheFix() throws {
+        let message = try #require(
+            WorkerDaemonError.personalizedInputsWithoutLanguage(inputCount: 3).errorDescription)
+
+        // This text reaches an instructor as `compilerOutput` on a failed
+        // collection, so it has to say what happened and what to do — not just
+        // that something was nil.
+        #expect(message.contains("3"), "the count tells the reader this is not a nil-guard misfire")
+        #expect(message.lowercased().contains("language"))
+        #expect(
+            message.lowercased().contains("retest") || message.lowercased().contains("re-save"),
+            "an instructor needs the recovery step, not just the diagnosis")
+    }
+
+    @Test func singularAndPluralBothReadCorrectly() throws {
+        let one = try #require(
+            WorkerDaemonError.personalizedInputsWithoutLanguage(inputCount: 1).errorDescription)
+        let many = try #require(
+            WorkerDaemonError.personalizedInputsWithoutLanguage(inputCount: 2).errorDescription)
+        #expect(one.contains("1 per-student input value "))
+        #expect(many.contains("2 per-student input values "))
+    }
+
+    /// Every language renders its own inputs file, which is the property that
+    /// makes a wrong guess silent rather than loud: each is valid source in ITS
+    /// language, so nothing downstream can tell it was written for another one.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func eachLanguageRendersADistinctInputsFile(language: AssignmentLanguage) {
+        let inputs = ["threshold": "42"]
+        let rendered = language.renderInputsFile(inputs)
+        #expect(!rendered.isEmpty, "\(language.rawValue) must render something")
+        #expect(
+            rendered.contains("threshold"),
+            "\(language.rawValue) must bind the input name the tests reference")
+    }
+}

--- a/changelog.d/worker-refuses-inputs-without-language.md
+++ b/changelog.d/worker-refuses-inputs-without-language.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **The runner now refuses a job that carries per-student inputs but names no
+  assignment language, instead of rendering them as Python.** The values arrive
+  already rendered as source literals in the assignment's language (`repr` /
+  `deparse`), so writing them into `_ck_inputs.py` for an R assignment raised no
+  error at the boundary — it produced a file whose *contents* were wrong, and
+  every personalized test then failed somewhere inside the student's own code,
+  with a traceback that read as their mistake and persisted as their grade. The
+  old default was justified by "nil means an older server", a premise the
+  declare-at-creation work falsified: personalization is resolved per-language
+  on the server, so an assignment with inputs has a language by construction,
+  and a plain `.sh` suite has neither. The refusal reports `buildStatus: failed`
+  with a message naming the cause and the fix, and classifies as terminal so it
+  is not retried.


### PR DESCRIPTION
The follow-up #1297 said it was leaving for a fresh pass: make the worker refuse rather than guess. It turned out to be one site, not the sweep the plan predicted — and the reason why is the more useful half of this PR.

## The change

A job carrying personalized input values but naming no assignment language rendered them as Python:

```swift
let language = job.language ?? .python   // "Language is nil on payloads from an older server"
```

That comment's premise is now false. Personalization is resolved per-language **on the server**, so an assignment with inputs has a language by construction, and a plain `.sh` suite has neither inputs nor a language and never enters the branch.

But the stale premise isn't really why this needed changing. **It's where being wrong lands.** The values arrive already rendered as source literals in the assignment's language (`repr` / `deparse`), so writing them into `_ck_inputs.py` for an R assignment raises nothing at the boundary — it writes a file whose *contents* are wrong. Every personalized test then fails somewhere inside the student's own code, with a traceback that reads as their mistake, and that persists as their grade.

Guessing is defensible where being wrong is loud. Here it is silent, which is the whole argument.

The refusal throws, which the existing machinery already reports as `buildStatus: failed` with the message as `compilerOutput` and leaves retestable — the same shape as the neighbouring personalized-file write failures, and for the reason stated in their comments. The compiler then required it be classified for retry (adding the case made the `shouldRetry` switch non-exhaustive): terminal, since retrying cannot make a language appear.

## What I did NOT change, having checked each

The plan called the remaining `?? .python` sites "now-unreachable fallbacks to remove". Reading them says otherwise, and I'd rather record that than force a removal to match a prediction:

| site | why it stays |
|---|---|
| `PersonalizationSubstitution` | rendering a literal needs a syntax — there is no literal without one |
| `GlobalInputsService`, `SectionInputsService` | evaluating an `=` expression needs an interpreter |
| `NotebookExtractor` | extraction has to write a file in *some* syntax |
| `PatternFamilyApplication` | refusing is circular — a family is often the first thing authored, and generating its scripts is how the suite acquires a graded script at all |
| the module-name hint in `RunnerDaemon+JobProcessing` | it must agree with what the extractor did; changing it alone points it at a file that was never written |

Each is a documented "this question cannot honestly answer *none*" choice established by #1297, which had already pushed every **inherited** default down into a **local, visible** one. What remained was a single site whose local choice rested on a premise that had since gone stale — which is a much smaller and more specific thing than "remove the fallbacks."

## Tests

Three new, covering the message rather than the plumbing: it names the input count (so a reader can tell it isn't a nil-guard misfire), names the language as the cause, and gives the recovery step — that text reaches an instructor as `compilerOutput`, so being diagnostic is the feature. Plus a parameterized check that every language renders a distinct, name-binding inputs file, which is the property that makes a wrong guess silent: each output is valid source in *its* language, so nothing downstream can tell it was written for another.

The retry classification is deliberately not tested — it lives inline in `download`'s closure, and asserting it would mean extracting that closure for the test's benefit alone. The compiler already enforces the case is handled; that's what failed the build until it was classified.

3,302 tests pass; `swift-format`, SwiftLint `--strict` (0 violations), and the style guards are clean.

## Note

Two full-suite runs crashed mid-way here (SIGSEGV, then SIGILL) before I checked the environment: the sandbox disk was at 100%, from the `sqlite-kit_memory*` leak still open on #1298 (~973 MB per suite run). Cleared it and the suite ran green. Flagging it because the symptom looks nothing like the cause, and the next person to hit it will reach for the diff first, as I did.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwj5fD2dysDT6iC9RuVF4a)_