### PR TITLE
fix(tests): close the two remaining /tmp leaks after #1299 (#1298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -938,8 +938,10 @@ css-vars + design-token guards too — same as the CI `format-lint` job).
     suite needs expensive shared state per-test instance (temp
     directories, Vapor app fixtures). For Vapor apps, store `let app`
     and wrap each `@Test` body in `try await withApp(app) { _ in ... }`
-    so shutdown is deterministic; the next test's `init` builds a
-    fresh app.
+    so teardown is deterministic (`withApp` runs the full
+    `tearDownTestApp`: shutdown plus removal of the app's temp
+    directories and sqlite-kit's fake-memory database file — #1298);
+    the next test's `init` builds a fresh app.
 - **`with*App` helpers** for DB-backed suite clusters
   (`withWebRoutesApp`, `withAssignmentRoutesApp`, `withPatternFamilyFixture`).
   See `Tests/APITests/WebRoutesHelpers.swift` etc. for the pattern.

--- a/Tests/APITests/DatabaseConfigurationTests.swift
+++ b/Tests/APITests/DatabaseConfigurationTests.swift
@@ -240,14 +240,21 @@ struct DatabasePoolSizingTests {
     }
 
     @Test func configureDatabaseAcceptsExplicitPoolSize() async throws {
+        // A file-backed database is the caller's to clean up (`tearDownTestApp`
+        // deliberately only removes sqlite-kit's fake-memory files) — and this
+        // one exists on disk, because `configureDatabase` opens it to set WAL.
+        let dbPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-pool-\(UUID().uuidString).sqlite").path
+        defer {
+            for path in [dbPath, dbPath + "-wal", dbPath + "-shm", dbPath + "-journal"] {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
         let app = try await makeTestingApplication { app in
             try configureDatabase(
                 app,
-                settings: .sqlite(
-                    path: FileManager.default.temporaryDirectory
-                        .appendingPathComponent("chickadee-pool-\(UUID().uuidString).sqlite").path,
-                    maxConnectionsPerEventLoop: 4))
+                settings: .sqlite(path: dbPath, maxConnectionsPerEventLoop: 4))
         }
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     }
 }

--- a/Tests/APITests/JupyterLiteContentsRoutesTests.swift
+++ b/Tests/APITests/JupyterLiteContentsRoutesTests.swift
@@ -44,6 +44,8 @@ import VaporTesting
             atPath: publicDir + "jupyterlite/files/",
             withIntermediateDirectories: true
         )
+        // Recorded so the per-test `withApp` teardown removes the tree (#1298).
+        app.testDataDirectory = tmpRoot
         // The contents routes now resolve the viewer's per-course staff status
         // through `req.db` (#417 Slice G), so the test app needs a database —
         // previously the route was filesystem-only.

--- a/Tests/APITests/MCP/MCPSeedMainPoolTests.swift
+++ b/Tests/APITests/MCP/MCPSeedMainPoolTests.swift
@@ -72,9 +72,9 @@ import Vapor
                 let leaked = try await APIAssignmentPersonalizationSeed.query(on: app.db).count()
                 #expect(leaked == 0, "seed bookkeeping must not touch the content (.mcp) pool")
             }
-            try await seedlessApp.asyncShutdown()
+            try await seedlessApp.tearDownTestApp()
         } catch {
-            try? await seedlessApp.asyncShutdown()
+            try? await seedlessApp.tearDownTestApp()
             throw error
         }
     }
@@ -116,9 +116,9 @@ import Vapor
                 let leaked = try await APIAssignmentPersonalizationSeed.query(on: app.db).count()
                 #expect(leaked == 0, "seed bookkeeping must not touch the content (.mcp) pool")
             }
-            try await seedlessApp.asyncShutdown()
+            try await seedlessApp.tearDownTestApp()
         } catch {
-            try? await seedlessApp.asyncShutdown()
+            try? await seedlessApp.tearDownTestApp()
             throw error
         }
     }

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -29,6 +29,10 @@ import VaporTesting
 
             try FileManager.default.createDirectory(
                 atPath: tmpRoot, withIntermediateDirectories: true)
+            // Recorded so the per-test `withApp` teardown removes the tree —
+            // one survived per test before #1298 (the `Resources` symlink
+            // inside is removed as a link, its target untouched).
+            app.testDataDirectory = tmpRoot
             try FileManager.default.createSymbolicLink(
                 atPath: tmpRoot + "Resources",
                 withDestinationPath: repoRoot + "/Resources"

--- a/Tests/APITests/PatternFamilyFixtures.swift
+++ b/Tests/APITests/PatternFamilyFixtures.swift
@@ -134,19 +134,19 @@ func withPatternFamilyFixture(_ body: (PFFixture) async throws -> Void) async th
     } catch {
         // Same SIGILL guard as `makeTestingApplication`: any throw before
         // the fixture is fully built leaves a half-initialized Application
-        // that crashes in its sync deinit.  Shutdown explicitly first.
+        // that crashes in its sync deinit.  Tear down explicitly first.
         try? FileManager.default.removeItem(atPath: tmpDir)
-        try? await app.asyncShutdown()
+        try? await app.tearDownTestApp()
         throw error
     }
 
     do {
         try await body(fixture)
         try? FileManager.default.removeItem(atPath: tmpDir)
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     } catch {
         try? FileManager.default.removeItem(atPath: tmpDir)
-        try? await app.asyncShutdown()
+        try? await app.tearDownTestApp()
         throw error
     }
 }

--- a/Tests/APITests/ResultCollectionSideTableTests.swift
+++ b/Tests/APITests/ResultCollectionSideTableTests.swift
@@ -159,9 +159,9 @@ import VaporTesting
                     .first(decoding: AnyRow.self)
             }
         } catch {
-            try? await app.asyncShutdown()
+            try? await app.tearDownTestApp()
             throw error
         }
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     }
 }

--- a/Tests/APITests/TestAppTempDirectoryTests.swift
+++ b/Tests/APITests/TestAppTempDirectoryTests.swift
@@ -11,6 +11,12 @@
 // while removing nothing. A full suite run leaked ~1.4 GB across ~6,900
 // entries; a working session filled a 252 GB disk. See issue #1298.
 //
+// The two smaller leaks the same issue kept open are pinned here too:
+//   - suites route teardown through `withApp`, which used to only shut the
+//     app down — the directory tree survived (~45 MB / ~1,400 entries);
+//   - sqlite-kit backs every `.memory` database with a real file in the
+//     system temp directory and never deletes it (~973 MB / ~1,566 entries).
+//
 // These assert the OUTCOME (nothing survives) rather than that cleanup ran,
 // because "cleanup ran" is exactly what was true the whole time it was broken.
 
@@ -38,30 +44,33 @@ import VaporTesting
     @Test func theAppsDirectoriesAreChildrenOfItsTempDirectory() async throws {
         let prefix = "chickadee-tmptest-\(UUID().uuidString)"
         let app = try await makeTestApp(prefix: prefix)
-        defer { Task { try? await app.tearDownTestApp() } }
-
-        let root = try #require(app.testDataDirectory)
-        var isDirectory: ObjCBool = false
-        #expect(
-            FileManager.default.fileExists(atPath: root, isDirectory: &isDirectory),
-            "the recorded test data directory must actually exist — it is what teardown removes")
-        #expect(isDirectory.boolValue)
-
-        // Each configured directory must live INSIDE the recorded root. This is
-        // the assertion the sibling bug fails: `.../<uuid>results/` does not
-        // have `.../<uuid>/` as a prefix.
-        for directory in [
-            app.resultsDirectory, app.testSetupsDirectory, app.submissionsDirectory,
-            app.dataExportsDirectory, app.contentFilesDirectory,
-        ] {
+        // withApp, not `defer { Task { tearDownTestApp } }`: a fire-and-forget
+        // task races test-runner exit and sometimes never ran, leaking the very
+        // directory this suite is about.
+        try await withApp(app) { app in
+            let root = try #require(app.testDataDirectory)
+            var isDirectory: ObjCBool = false
             #expect(
-                directory.hasPrefix(root),
-                "\(directory) is not inside \(root) — teardown will not remove it")
+                FileManager.default.fileExists(atPath: root, isDirectory: &isDirectory),
+                "the recorded test data directory must actually exist — it is what teardown removes")
+            #expect(isDirectory.boolValue)
+
+            // Each configured directory must live INSIDE the recorded root. This is
+            // the assertion the sibling bug fails: `.../<uuid>results/` does not
+            // have `.../<uuid>/` as a prefix.
+            for directory in [
+                app.resultsDirectory, app.testSetupsDirectory, app.submissionsDirectory,
+                app.dataExportsDirectory, app.contentFilesDirectory,
+            ] {
+                #expect(
+                    directory.hasPrefix(root),
+                    "\(directory) is not inside \(root) — teardown will not remove it")
+            }
+            // The two dotfiles are built by the same concatenation and leaked the
+            // same way.
+            #expect(app.workerSecretFilePath.hasPrefix(root))
+            #expect(app.localRunnerAutoStartFilePath.hasPrefix(root))
         }
-        // The two dotfiles are built by the same concatenation and leaked the
-        // same way.
-        #expect(app.workerSecretFilePath.hasPrefix(root))
-        #expect(app.localRunnerAutoStartFilePath.hasPrefix(root))
     }
 
     @Test func tearDownLeavesNothingBehind() async throws {
@@ -82,5 +91,77 @@ import VaporTesting
             must be removed — the leak this guards against produced SIBLINGS of the directory \
             teardown deletes, so it cleaned up successfully and left everything behind.
             """)
+    }
+
+    /// `withApp` is how nearly every suite ends its app, so it must be a FULL
+    /// teardown. It used to only call `asyncShutdown()`: every class suite
+    /// following the documented `makeTestApp` + `withApp` pattern leaked its
+    /// directory tree, ~1,400 of them per run.
+    @Test func withAppLeavesNothingBehind() async throws {
+        let prefix = "chickadee-tmptest-\(UUID().uuidString)"
+        let app = try await makeTestApp(prefix: prefix)
+
+        // In the sqlite lane the app's "in-memory" database is secretly a real
+        // file; require the discovery so a silent break (e.g. sqlite-kit
+        // renaming its temp files) fails here instead of quietly re-leaking.
+        let backend = try await withAsyncEnvLock {
+            try testDatabaseSettingsFromEnvironment().backend
+        }
+        var sqliteFiles: [String] = []
+        if backend == .sqlite {
+            sqliteFiles = await app.sqliteFakeMemoryDatabaseFiles()
+            try #require(
+                !sqliteFiles.isEmpty,
+                """
+                could not locate the file backing the fake in-memory database. If sqlite-kit \
+                changed how `.memory` storage is materialized, update \
+                `sqliteFakeMemoryDatabaseFiles()` — until then every test app leaks that file \
+                again.
+                """)
+            for file in sqliteFiles {
+                #expect(FileManager.default.fileExists(atPath: file))
+            }
+        }
+
+        try await withApp(app) { _ in }
+
+        #expect(
+            entries(matching: prefix).isEmpty,
+            "\(entries(matching: prefix)) survived withApp — it must tear down, not just shut down")
+        for file in sqliteFiles {
+            #expect(
+                !FileManager.default.fileExists(atPath: file),
+                "the sqlite-kit fake-memory database file survived withApp: \(file)")
+        }
+    }
+
+    /// Apps built without `makeTestApp` (bare `Application.make` plus a direct
+    /// `configureDatabase(.sqliteInMemory())`) materialize the same hidden
+    /// file; `tearDownTestApp` must find and remove it for them too. Runs in
+    /// both database lanes — the settings here are explicit, not env-derived.
+    @Test func tearDownRemovesTheFakeMemoryDatabaseFileOfABareApp() async throws {
+        let app = try await makeTestingApplication { app in
+            try configureDatabase(app, settings: .sqliteInMemory())
+        }
+
+        // Discovery opens the pool's first connection, which is also what
+        // materializes the file — asserting existence right after is
+        // deterministic.
+        let sqliteFiles = await app.sqliteFakeMemoryDatabaseFiles()
+        try #require(
+            !sqliteFiles.isEmpty,
+            "could not locate the file backing the fake in-memory database (see withAppLeavesNothingBehind)"
+        )
+        for file in sqliteFiles {
+            #expect(FileManager.default.fileExists(atPath: file))
+        }
+
+        try await app.tearDownTestApp()
+
+        for file in sqliteFiles {
+            #expect(
+                !FileManager.default.fileExists(atPath: file),
+                "the sqlite-kit fake-memory database file survived tearDownTestApp: \(file)")
+        }
     }
 }

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -219,20 +219,24 @@ func demoteToStudentEverywhere(username: String, on app: Application) async thro
 
 // MARK: - Async app lifecycle
 
-/// Runs an async test body with a Vapor application and always shuts it down.
+/// Runs an async test body with a Vapor application and always tears it down:
+/// shutdown plus removal of any temp state the harness created for it (the
+/// `makeTestApp` directory tree, the file sqlite-kit secretly backs an
+/// "in-memory" database with, the per-test Postgres schema). Safe for bare
+/// apps too — each cleanup step is a no-op when there is nothing to clean.
 func withApp(_ app: Application, _ body: (Application) async throws -> Void) async throws {
     do {
         try await body(app)
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     } catch {
-        try? await app.asyncShutdown()
+        try? await app.tearDownTestApp()
         throw error
     }
 }
 
 /// Creates a `.testing` Vapor Application and runs `setup`, returning the
 /// fully-configured app to the caller.  If `setup` throws, the partial
-/// Application is `asyncShutdown`-d before the error is rethrown.
+/// Application is torn down before the error is rethrown.
 ///
 /// This is the safe replacement for the bare pattern
 ///
@@ -253,7 +257,10 @@ func makeTestingApplication(
         try await setup(app)
         return app
     } catch {
-        try? await app.asyncShutdown()
+        // Full teardown, not just shutdown: `setup` may have configured a
+        // database (and thereby materialized sqlite-kit's fake-memory temp
+        // file) before throwing.
+        try? await app.tearDownTestApp()
         throw error
     }
 }
@@ -264,23 +271,91 @@ private struct TestDataDirectoryKey: StorageKey {
     typealias Value = String
 }
 
+private struct LeafViewsSymlinkKey: StorageKey {
+    typealias Value = String
+}
+
 extension Application {
-    /// Filesystem directory created by `makeTestApp` for this app's
-    /// results/testsetups/submissions trees. Nil if the app wasn't built
-    /// via `makeTestApp`.
+    /// Filesystem directory created for this app's results/testsetups/
+    /// submissions trees; `tearDownTestApp` removes it. `makeTestApp` sets it;
+    /// suites that build a bespoke tree instead (e.g. a fake working
+    /// directory) should record it here so their `withApp` teardown removes
+    /// the tree too. Nil for apps with no on-disk state.
     var testDataDirectory: String? {
-        storage[TestDataDirectoryKey.self]
+        get { storage[TestDataDirectoryKey.self] }
+        set { storage[TestDataDirectoryKey.self] = newValue }
     }
 
-    /// Shuts the app down and removes the temp directory created by
-    /// `makeTestApp`. Use in tearDown for any app obtained from
-    /// `makeTestApp`.
+    /// The on-disk files secretly backing this app's "in-memory" SQLite
+    /// databases. Usually zero (postgres lane, no database) or one; a test
+    /// that registers a second in-memory pool (e.g. a stand-in `.mcp` pool)
+    /// has two.
+    ///
+    /// sqlite-kit fakes `.memory` storage with a real file in the system temp
+    /// directory — SQLiteNIO is built with `SQLITE_OMIT_SHARED_CACHE`, so it
+    /// cannot offer genuinely shared in-memory databases — and acknowledges in
+    /// a comment that the file outlives the last connection. Nothing upstream
+    /// ever deletes it, so each per-test Application leaks one ~600 KB file
+    /// (#1298: ~973 MB per full suite run). We ask SQLite itself for the path
+    /// (`PRAGMA database_list`) rather than mirroring sqlite-kit's private
+    /// filename scheme, then accept only files that scheme plainly produced —
+    /// so a real `.file(path:)` database can never be swept up, even one that
+    /// happens to live in the temp directory.
+    func sqliteFakeMemoryDatabaseFiles() async -> [String] {
+        struct DatabaseListRow: Decodable {
+            let name: String
+            let file: String
+        }
+        let systemTempDir = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath().path
+        var files: [String] = []
+        for id in databases.ids() {
+            // Dialect metadata is static — checking it opens no connection, so
+            // a registered-but-unreachable Postgres pool costs nothing here.
+            guard let sql = db(id) as? SQLDatabase, sql.dialect.name == "sqlite" else { continue }
+            guard
+                let rows = try? await sql.raw("PRAGMA database_list")
+                    .all(decoding: DatabaseListRow.self)
+            else { continue }
+            for row in rows where row.name == "main" {
+                let file = URL(fileURLWithPath: row.file).resolvingSymlinksInPath()
+                guard
+                    file.lastPathComponent.hasPrefix("sqlite-kit_memorydb-"),
+                    file.path.hasPrefix(systemTempDir)
+                else { continue }
+                files.append(file.path)
+            }
+        }
+        return files
+    }
+
+    /// Tears the app down completely: drops the per-test Postgres schema (if
+    /// any), shuts the app down, and removes every piece of temp state created
+    /// on its behalf — the `makeTestApp` directory tree, sqlite-kit's
+    /// fake-memory database files, and the Leaf views symlink. Every step is a
+    /// no-op when there is nothing to clean, so this is safe for any test app
+    /// however it was built. `withApp` calls this; use it directly only for
+    /// apps whose lifecycle `withApp` doesn't own.
     func tearDownTestApp() async throws {
+        // Collect everything that needs a live app before shutting down.
         let dir = storage[TestDataDirectoryKey.self]
+        let leafSymlink = storage[LeafViewsSymlinkKey.self]
+        let sqliteFiles = await sqliteFakeMemoryDatabaseFiles()
         try? await dropPostgresTestSchema(self)
         try await asyncShutdown()
         if let dir {
             try? FileManager.default.removeItem(atPath: dir)
+        }
+        for file in sqliteFiles {
+            // The fake-memory databases run the default rollback journal, so
+            // the sidecars exist only transiently — but removal is cheap and a
+            // crash can strand them.
+            for path in [file, file + "-journal", file + "-wal", file + "-shm"] {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+        if let leafSymlink {
+            try? FileManager.default.removeItem(atPath: leafSymlink)
         }
     }
 }
@@ -290,10 +365,11 @@ extension Application {
 /// in-memory sessions, the production migration list, Leaf views, and
 /// the full route tree mounted.
 ///
-/// Caller owns the lifecycle — pair with `app.tearDownTestApp()` in
-/// tearDown.  For unit tests that need a bare app (single-middleware
-/// isolation, custom auth modes, custom database configuration), use
-/// `Application.make(.testing)` directly.
+/// Caller owns the lifecycle — wrap the test body in `withApp(app) { ... }`
+/// (which tears the app down, temp state included) or pair the call with
+/// `app.tearDownTestApp()`.  For unit tests that need a bare app
+/// (single-middleware isolation, custom auth modes, custom database
+/// configuration), use `Application.make(.testing)` directly.
 func makeTestApp(
     prefix: String = "chickadee-test",
     authMode: AuthMode = .local,
@@ -464,6 +540,9 @@ func configureLeaf(_ app: Application) {
         try? FileManager.default.removeItem(atPath: cleanPath)
         try? FileManager.default.createSymbolicLink(atPath: cleanPath, withDestinationPath: viewsDir)
         app.leaf.configuration = LeafConfiguration(rootDirectory: cleanPath + "/")
+        // Recorded so tearDownTestApp removes the symlink — one per app adds
+        // up across a worktree session (#1298's leak class, in miniature).
+        app.storage[LeafViewsSymlinkKey.self] = cleanPath
     }
     app.views.use(.leaf)
     app.leaf.tags["csrfFormField"] = CSRFFormFieldTag()

--- a/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
+++ b/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
@@ -20,7 +20,7 @@ import VaporTesting
             app.migrations.add(CreateWorkerNonces())
             try await app.autoMigrate()
         } catch {
-            try? await app.asyncShutdown()
+            try? await app.tearDownTestApp()
             throw error
         }
         app.workerSecretStore = WorkerSecretStore(initialOverride: sharedSecret)

--- a/changelog.d/issue-1298-remaining-leaks.md
+++ b/changelog.d/issue-1298-remaining-leaks.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **The test suite no longer leaks the ~1 GB per run that remained after
+  #1299 (#1298).** Both residual causes are closed. `withApp` — the teardown
+  route nearly every suite uses — now performs the full `tearDownTestApp`
+  instead of a bare shutdown, so per-app temp directory trees are removed
+  (~45 MB / ~1,400 entries per run). And teardown now discovers, via
+  `PRAGMA database_list`, the real temp file sqlite-kit secretly backs every
+  "in-memory" test database with — upstream never deletes it — and removes it
+  (~973 MB / ~1,566 entries per run). Regression tests pin both outcomes,
+  including a loud failure if sqlite-kit's temp-file scheme ever changes out
+  from under the discovery.


### PR DESCRIPTION
Closes #1298 — the two leaks that remained after #1299, plus three smaller ones of the same class found on the way.

## The `sqlite-kit_memory*` files (~973 MB/run) — answered and fixed

The issue asked whether the in-memory driver materializing something in `/tmp` is our bug or upstream's. Answer: it is **deliberate upstream behavior with no cleanup, still present on sqlite-kit `main`**. SQLiteNIO builds sqlite with `SQLITE_OMIT_SHARED_CACHE`, so sqlite-kit cannot provide the multi-connection shared in-memory databases Fluent relies on; it fakes them with a real file — `sqlite-kit_memorydb-<pid>-<uuid>.sqlite3` in the system temp directory — and its own comment admits this "violat[es] the 'when the last connection … is closed, it is immediately deleted' semantics". Nothing ever deletes the file, so every per-test `Application` leaked one (~600 KB each).

`tearDownTestApp` now discovers the file **before shutdown** by asking SQLite itself (`PRAGMA database_list` on every registered pool whose SQL dialect is sqlite) and removes it after — no dependence on sqlite-kit's private filename scheme for *finding* the file. The scheme appears only as a safety filter (basename must start with `sqlite-kit_memorydb-`, resolved path must be inside the system temp directory), so a real `.file(path:)` database — including the deliberately shared one in `withTwoAppsOnSharedDatabase` — can never be swept up. Sweeping all registered pools also covers tests that stand up a second in-memory database (e.g. the stand-in `.mcp` pool in `MCPSeedMainPoolTests`).

## Apps that never reached `tearDownTestApp` (~45 MB, ~1,400 dirs/run) — fixed at the lifecycle helper

The issue's preferred shape ("a helper that owns the lifecycle … would prevent the next one") turned out to already exist: nearly every suite ends its app through `withApp` (directly or via `withWebRoutesApp` / `withAssignmentRoutesApp`), and `withApp` only called `asyncShutdown()`. It now runs the full `tearDownTestApp`, which is a strict superset — each cleanup step is guarded and a no-op for apps that don't have that state. That one change covers every prefix on the issue's list except `chickadee-notebook-w`, with no per-suite edits.

Two side effects of routing `withApp` through the full teardown:

- **The real-Postgres lane stops accumulating schemas.** `withApp`-only suites never dropped their per-test `test_<uuid>` schema; now they do.
- The `chickadee-leaf-*` views symlink (created per app in worktree checkouts) is recorded and removed too.

## The stragglers, found by measuring

- `NotebookWebRoutesTests` (`chickadee-notebook-w`, 47/run) and `JupyterLiteContentsRoutesTests` build bespoke working-directory trees in `init` and never removed them. `testDataDirectory` is now settable so bespoke suites record their tree into the same slot teardown removes.
- `MCPSeedMainPoolTests`, `ResultCollectionBackfillMigrationTests`, `WorkerHMACAuthMiddlewareTests`, `withPatternFamilyFixture` tore down via bare `asyncShutdown()`; converted to `tearDownTestApp` (which also gains `withPatternFamilyFixture` the Postgres schema drop it was missing).
- `configureDatabaseAcceptsExplicitPoolSize` leaked its file-backed `chickadee-pool-*.sqlite` (created by the WAL pragma at configure time); it now removes its own file — deliberately not `tearDownTestApp`'s job, since file-backed databases are caller-owned by design.
- #1299's own `theAppsDirectoriesAreChildrenOfItsTempDirectory` tore down via `defer { Task { … } }` — a fire-and-forget task that races runner exit and sometimes never ran (observed leaking during this work). It now uses `withApp`.

## Regression tests

`TestAppTempDirectoryTests` gains two tests, both confirmed to fail against the old `withApp` first (they report exactly the two leak classes):

- `withAppLeavesNothingBehind` — after `withApp`, neither the directory tree nor the sqlite file survives. In the sqlite lane it `#require`s that discovery finds the fake-memory file at all, so if sqlite-kit ever changes how `.memory` is materialized the suite fails loudly instead of silently re-leaking.
- `tearDownRemovesTheFakeMemoryDatabaseFileOfABareApp` — the same guarantee for apps built without `makeTestApp` (bare `configureDatabase(.sqliteInMemory())`), in both database lanes.

The `try?` on the removals stays, per the issue's note — the regression tests assert the outcome directly.

## Measured

CI-style APITests run on this branch (sqlite lane, Linux 4-core, `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4`, `/tmp` zeroed first): **2,694 tests in 328 suites passed, and 0 entries matching any leak pattern survived** — against ~1 GB across ~2,970 entries for the same surface when the issue was filed. Sampled mid-run, the live-entry count oscillated between 0 and 9 while suites completed, i.e. teardown keeps pace with app creation instead of accumulating. CoreTests (294) and WorkerTests pass with their CI invocations too.

One note from the way here: running **all** targets in a single unbounded `swift test` — an invocation CI deliberately never uses — hit the AsyncKit pool-timeout wedge already documented in `swift-tests.yml` (the reason for the `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` cap) and ended in a segfault with ~1,100 apps concurrently live, zero test failures before the crash. I did not rerun that invocation on `main` to bisect; the workflow comments describe the same failure mode predating this change, and the CI-shaped invocations above all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127Nnk2r3WMXamgVpxQn57N

---
_Generated by [Claude Code](https://claude.ai/code/session_0127Nnk2r3WMXamgVpxQn57N)_