### PR TITLE
docs+test: correct two stale language counts, and guard the CI probe from allCases

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -194,18 +194,26 @@ jobs:
           key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
-        # zip/unzip/python3 are baked into the swift-ci image, so this
-        # normally just verifies and exits.  The apt-get path remains as the
-        # fallback for a stale image (e.g. a toolchain bump before the
-        # swift-ci rebuild — see mirror-images.yml), degrading to the old
-        # per-job install instead of failing the job.
+        # These are baked into the swift-ci image, so this normally just
+        # verifies and exits.  The apt-get path remains as the fallback for a
+        # stale image (e.g. a toolchain bump before the swift-ci rebuild — see
+        # mirror-images.yml), degrading to the old per-job install instead of
+        # failing the job.
+        #
+        # EVERY graded language's interpreter belongs in BOTH the probe and the
+        # install list.  Omitting one is not caught by a red job: the
+        # execution-path suites guard on availability and skip SILENTLY, so the
+        # job stays green having executed nothing in that language.  Rscript was
+        # missing from both here — the identical silent-skip trap that r-base
+        # and lua5.4 each hit on the image itself, recorded in
+        # .github/docker/ci-image/Dockerfile.
         run: |
-          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 lua5.4 octave g++ && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 r-base lua5.4 octave g++ && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -279,18 +287,26 @@ jobs:
           key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
-        # zip/unzip/python3 are baked into the swift-ci image, so this
-        # normally just verifies and exits.  The apt-get path remains as the
-        # fallback for a stale image (e.g. a toolchain bump before the
-        # swift-ci rebuild — see mirror-images.yml), degrading to the old
-        # per-job install instead of failing the job.
+        # These are baked into the swift-ci image, so this normally just
+        # verifies and exits.  The apt-get path remains as the fallback for a
+        # stale image (e.g. a toolchain bump before the swift-ci rebuild — see
+        # mirror-images.yml), degrading to the old per-job install instead of
+        # failing the job.
+        #
+        # EVERY graded language's interpreter belongs in BOTH the probe and the
+        # install list.  Omitting one is not caught by a red job: the
+        # execution-path suites guard on availability and skip SILENTLY, so the
+        # job stays green having executed nothing in that language.  Rscript was
+        # missing from both here — the identical silent-skip trap that r-base
+        # and lua5.4 each hit on the image itself, recorded in
+        # .github/docker/ci-image/Dockerfile.
         run: |
-          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 lua5.4 octave g++ && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 r-base lua5.4 octave g++ && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -367,14 +383,15 @@ jobs:
         # real local HTTP servers (LocalHTTPTestServer) and notebook probes in
         # WorkerDaemonTests / NotebookExtractorTests, which otherwise fail (not
         # skip) when the interpreter is absent.  Both are baked into the
-        # swift-ci image; the apt-get path is the stale-image fallback (see
-        # the api-tests job note).
+        # swift-ci image; the apt-get path is the stale-image fallback.  The
+        # graded-language interpreters follow the same all-of-them-or-silent-
+        # skip rule as the api-tests job — see that job's note.
         run: |
-          if command -v file >/dev/null && command -v python3 >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
+          if command -v file >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
-          apt-get update -qq && apt-get install -y --no-install-recommends file python3 lua5.4 octave g++
+          apt-get update -qq && apt-get install -y --no-install-recommends file python3 r-base lua5.4 octave g++
 
       - name: Run WorkerTests
         # `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` caps Swift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,21 +140,23 @@ directly (no `evaluate` calling-handler trap). Budget one quirk per kernel, not
 the same one. Measurements and the full postmortem:
 `docs/adding-a-xeus-kernel.md` §"What the Lua run actually cost".
 
-**Octave is the fourth assignment language.** `AssignmentLanguage` is now
-`.python | .r | .lua | .octave`: `.m` scripts grade natively (`octave-cli`;
+**Octave is the fourth assignment language.** `AssignmentLanguage` gained
+`.octave`: `.m` scripts grade natively (`octave-cli`;
 the `octave` package plus `gnuplot-nox` + `fonts-freefont-otf` for headless
 figures are on both images) and in the browser via the vendored `xeus-octave`
 kernel (`chickadee-octave`, 142 MB on disk — the largest env — xeus 6.0.5,
 ~5–12 s boot, no per-statement cost). All eight pattern kinds render and
-execute; notebook checks cover seven of ten — `figureCount` and regex
-`cellContains` are SUPPORTED (both of Lua's opposite answers, re-measured:
-plotting is core Octave and Octave's regexp is PCRE), while the four
-data-frame kinds (no data-frame type in core Octave, no packages on the
-channel) and `astStructure` are refused at save time. The literal rule is the
-language's one silent trap: `[65, "bc"]` is the char array `"Abc"`, so
-`JSONValue.octaveLiteral` renders arrays as `[...]` only when every element
-is a numeric/boolean scalar (null → `NA`) and everything else — any string,
-mixed kinds, nesting, objects, empty — as cells, with objects as
+execute; notebook checks cover five of ten — `variableExists`,
+`functionExists`, `numericArrayClose`, `cellContains` and `figureCount`, the
+last two being Lua's opposite answers re-measured (plotting is core Octave,
+and Octave's regexp is PCRE so `cellContains` takes `regex: true` where Lua
+refuses it) — while the four data-frame kinds (no data-frame type in core
+Octave, no packages on the channel) and `astStructure` are refused at save
+time. The literal rule is the language's one silent trap: `[65, "bc"]` is the
+char array `"Abc"`, so `JSONValue.octaveLiteral` renders arrays as `[...]`
+only when every element is a numeric/boolean scalar (null → `NA`) and
+everything else — any string, mixed kinds, nesting, objects, empty — as
+cells, with objects as
 `containers.Map` calls. Equality is `isequaln`-based (NA/NaN match
 themselves; Octave is already type-blind across logical/int/double) plus a
 both-empty rule and shape-blind numeric comparison. `test_runtime.m` loads

--- a/Tests/APITests/LanguageConformanceMatrixTests.swift
+++ b/Tests/APITests/LanguageConformanceMatrixTests.swift
@@ -27,8 +27,16 @@
 // skipped when it is absent, following the existing `hasRscript` pattern —
 // silently, because a missing R on a contributor's laptop is not a defect. The
 // STRUCTURAL half never skips, so a language can never be entirely unexamined.
-// CI has python3, r-base and lua5.4 on the image, so the executed half runs
-// there; `theRunnerImageProvidesEveryInterpreter` is what keeps that true.
+//
+// The executed half therefore only means anything where every interpreter is
+// present, which is CI. That makes the CI image a load-bearing part of this
+// matrix and a silent one: a language missing from it does not go red, it
+// stops being executed. So both images are asserted from `allCases` rather
+// than described here — `theRunnerImageProvidesEveryInterpreter` for the
+// production Dockerfile, `theCIImageAndItsProbeProvideEveryInterpreter` for the
+// swift-ci image and the swift-tests.yml probe that falls back to installing
+// it. Neither can drift; this comment deliberately names no package list,
+// because a list in prose is the thing that was wrong.
 
 import Core
 import Foundation
@@ -67,6 +75,17 @@ import Testing
         let versionArguments: [String]
         /// The Debian package that provides it, as the Dockerfile installs it.
         let debianPackage: String
+        /// The command whose presence proves this language's toolchain is
+        /// installed, as CI's dependency probe spells it.
+        ///
+        /// NOT always `interpreter`, and C++ is why it is a field rather than a
+        /// derivation: C++ is spawned through `sh`, which exists on every
+        /// machine and would make the probe vacuously true. What actually has
+        /// to be there is `g++`. It equals `debianPackage` for that one
+        /// language, which is a coincidence — deriving it from either
+        /// neighbour is the sort of "the other four agree, so" reasoning this
+        /// file exists to stop.
+        let toolchainProbeCommand: String
         /// Source that parses `path` WITHOUT executing it, exiting non-zero on
         /// a syntax error. A parse check, not a run: generated scripts expect a
         /// student submission and a runtime beside them.
@@ -96,6 +115,7 @@ import Testing
                 evalFlag: "-c",
                 versionArguments: ["-c", "g++ --version"],
                 debianPackage: "g++",
+                toolchainProbeCommand: "g++",
                 parseOnlyProgram: { path in
                     "sh -n '\(path)'"
                 },
@@ -116,6 +136,7 @@ import Testing
                 evalFlag: "-c",
                 versionArguments: ["--version"],
                 debianPackage: "python3",
+                toolchainProbeCommand: "python3",
                 parseOnlyProgram: { path in
                     "import ast,sys;ast.parse(open(\(pythonString(path))).read())"
                 },
@@ -129,6 +150,7 @@ import Testing
                 evalFlag: "-e",
                 versionArguments: ["--version"],
                 debianPackage: "r-base",
+                toolchainProbeCommand: "Rscript",
                 parseOnlyProgram: { path in "invisible(parse(\(rString(path))))" },
                 readInputsProgram: { key in
                     // Mirrors chickadee_inputs(): source into a fresh env, read
@@ -145,6 +167,7 @@ import Testing
                 evalFlag: "-e",
                 versionArguments: ["-v"],
                 debianPackage: "lua5.4",
+                toolchainProbeCommand: "lua",
                 // `loadfile` compiles without running, which is exactly the
                 // parse check wanted here — `dofile` would execute a script
                 // that expects a submission and a runtime beside it.
@@ -172,6 +195,7 @@ import Testing
                 evalFlag: "--eval",
                 versionArguments: ["--version"],
                 debianPackage: "octave",
+                toolchainProbeCommand: "octave-cli",
                 // `__parse_file__` compiles a file without executing it —
                 // verified: a script whose body prints does not print, a
                 // mid-script `function` definition parses, and a syntax error
@@ -298,6 +322,75 @@ import Testing
             The Dockerfile does not install \(package), which provides \
             \(Self.adapter(for: language).interpreter) for \(language) assignments. \
             Without it every test exits 127 and instructor validation cannot pass.
+            """)
+    }
+
+    /// Non-comment lines only, so a guard cannot be satisfied by the prose that
+    /// documents it.
+    ///
+    /// Not hypothetical tidiness: `.github/docker/ci-image/Dockerfile` names
+    /// `r-base` in four comments and one install line, so a plain
+    /// `contains("r-base")` would pass on a file that had stopped installing
+    /// it. That is the "drift guard matched its own documentation" failure
+    /// CLAUDE.md records having shipped twice, and this file's own new comments
+    /// name every package — so writing the naive check here would have
+    /// reproduced it a third time.
+    static func codeLines(of text: String) -> [Substring] {
+        text.split(separator: "\n").filter {
+            !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#")
+        }
+    }
+
+    /// The CI image and its probe have to know every language too — and unlike
+    /// the production image, this one fails SILENTLY. The executed assertions
+    /// guard on interpreter availability and skip when it is absent, so a
+    /// language missing from the swift-ci image (or from the probe that would
+    /// otherwise apt-get it) leaves CI green having executed nothing in that
+    /// language.
+    ///
+    /// R is why this exists. It was absent from both the probe and the fallback
+    /// install list in swift-tests.yml for the entire time Lua, Octave and C++
+    /// were being added to them, and nothing went red — invisible precisely
+    /// because the only symptom is a test that does not run.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theCIImageAndItsProbeProvideEveryInterpreter(_ language: AssignmentLanguage) throws {
+        let adapter = Self.adapter(for: language)
+
+        let ciImage = try String(
+            contentsOf: Self.repoRoot.appendingPathComponent(
+                ".github/docker/ci-image/Dockerfile"), encoding: .utf8)
+        #expect(
+            Self.codeLines(of: ciImage).contains { $0.contains(adapter.debianPackage) },
+            """
+            .github/docker/ci-image/Dockerfile does not install \
+            \(adapter.debianPackage), so the swift-ci image has no \
+            \(adapter.toolchainProbeCommand) and every \(language) execution-path \
+            assertion skips. CI stays green having run none of them.
+            """)
+
+        let lines = try Self.codeLines(
+            of: String(
+                contentsOf: Self.repoRoot.appendingPathComponent(
+                    ".github/workflows/swift-tests.yml"), encoding: .utf8))
+
+        let probes = lines.filter { $0.contains("command -v ") }
+        #expect(!probes.isEmpty, "swift-tests.yml has no dependency probe to check.")
+        #expect(
+            probes.allSatisfy { $0.contains("command -v \(adapter.toolchainProbeCommand) ") },
+            """
+            A dependency probe in swift-tests.yml does not check for \
+            \(adapter.toolchainProbeCommand), so a stale swift-ci image missing \
+            \(adapter.debianPackage) goes undetected, the apt-get fallback never runs, \
+            and every \(language) execution-path assertion skips silently.
+            """)
+
+        let installs = lines.filter { $0.contains("--no-install-recommends") }
+        #expect(!installs.isEmpty, "swift-tests.yml has no fallback install to check.")
+        #expect(
+            installs.allSatisfy { $0.contains(adapter.debianPackage) },
+            """
+            A fallback install in swift-tests.yml omits \(adapter.debianPackage), so a \
+            stale swift-ci image leaves \(language) untested rather than failing.
             """)
     }
 


### PR DESCRIPTION
Started as a one-digit CLAUDE.md correction; a follow-up question ("is Python in the test matrix? C++?") turned up a real gap next to it.

Both languages **are** in the matrix — `adapter(for:)` is exhaustive, so all five have arms and none could be missing. The problems were around it.

## 1. `swift-tests.yml` never probed for R

Its three "install system test dependencies" steps `command -v` for `python3`, `lua`, `octave-cli`, `g++` and apt-get the matching packages. R was in neither list.

It works today only because `r-base` is baked into the swift-ci image. If that image were rebuilt without it, the probe would pass, the fallback wouldn't install R, and every R execution-path suite would **skip** — not fail. They guard on interpreter availability, so CI would stay green having executed no R at all.

That's the same silent-skip trap `r-base` and `lua5.4` each hit on the image itself, both recorded in `.github/docker/ci-image/Dockerfile`. R was simply the language never retrofitted into the pattern the later three established.

## 2. The matrix file's header comment undercounted

It said "CI has python3, r-base and lua5.4 on the image" — written when Lua was the third language, so it omitted octave and g++. Code right, prose stale. Same class as the CLAUDE.md error in the first commit.

## The fix is a guard, not a comment

`theCIImageAndItsProbeProvideEveryInterpreter` reads both images from `allCases`: the swift-ci Dockerfile installs each language's package, every probe line checks its command, every fallback install lists its package. The header now names no package list at all — a list in prose is what was wrong.

`toolchainProbeCommand` is a new `Adapter` field rather than a derivation, and **C++ is why**: it's spawned through `sh`, which exists everywhere and would make the probe vacuously true. What must be present is `g++`. It equals `debianPackage` for that one language, which is a coincidence — deriving it from either neighbour is exactly the reasoning this file exists to stop.

**The guard skips comment lines, which is load-bearing rather than tidy.** The CI Dockerfile names `r-base` in four comments and one install line, so a naive `contains("r-base")` passes on a file that has stopped installing it. That's the "drift guard matched its own documentation" failure CLAUDE.md records shipping twice — and this PR's own new comments name every package, so the naive check would have reproduced it a third time.

## Verification

**Mutation-tested.** Reintroducing the exact bug — dropping `Rscript` from the probes and `r-base` from the installs — fails the guard for `.r` on both assertions:

```
✘ A dependency probe in swift-tests.yml does not check for Rscript, so a stale
  swift-ci image missing r-base goes undetected, the apt-get fallback never runs,
  and every .r execution-path assertion skips silently.
✘ A fallback install in swift-tests.yml omits r-base, so a stale swift-ci image
  leaves .r untested rather than failing.
```

Restored, all five pass. APITests: 2,695 tests green. swift-format, SwiftLint `--strict` (0 violations), style guards clean.

## Also in this PR (first commit)

CLAUDE.md said Octave's notebook checks "cover seven of ten"; the code supports **five** (`NotebookCheckRendererOctave.swift:37`). Only the digit was wrong — the same sentence's refusal list already implied five, which is why it survived review. The fix names all five supported kinds so the count is checkable in place. Also drops a stale present-tense `AssignmentLanguage` enum list that C++ falsified.

Verified unchanged and correct: Lua's four of ten, C++'s all-ten-refused, R's `astStructure`-only exclusion, and the 54/19 MCP tool counts.

No changelog fragment: CLAUDE.md is maintainer context and the rest is CI/test plumbing — neither is shipped behaviour.