### PR TITLE
docs: correct the C++ noexec postmortem to the heterogeneous-fleet finding

### DIFF
--- a/changelog.d/cpp-noexec-doc-correction.md
+++ b/changelog.d/cpp-noexec-doc-correction.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Corrected the C++ `noexec` postmortem in `docs/cpp-support.md`.** It said
+  no C++ assignment could be graded in production. That was true of the moment
+  it was measured — the one runner hardened with a `noexec` `/tmp` was also the
+  only one new enough to advertise `cpp` — but not of the system: a second
+  runner has a writable, exec-capable work root and grades C++ correctly. The
+  bug was claim-order-dependent grading across a non-uniform fleet, which is
+  what `RunnerLanguageGate` exists to eliminate, and is why the fix belongs in
+  capability discovery rather than an operator runbook. The original conclusion
+  came from a probe that filtered the mount table to `/` and `/tmp`; the full
+  table is now recorded, along with the v0.5.33 production confirmation that
+  the hardened runner drops `cpp` from its profile while keeping every other
+  language.

--- a/docs/cpp-support.md
+++ b/docs/cpp-support.md
@@ -143,13 +143,35 @@ elsewhere — because the cause is not permissions at all:
 tmpfs /tmp tmpfs rw,nosuid,nodev,noexec,relatime,size=262144k
 ```
 
-The production runner container mounts `/tmp` **`noexec`**, which is a
-common hardening default, and job workspaces were rooted there. `exec`
-returns EACCES (shell exit 126) no matter what the file mode says. Container
-root is mounted `ro`, so there was no writable exec-capable path in the
-default configuration at all — meaning **no C++ assignment could be graded in
-production**, while the same suites passed in CI, where the workspace is an
-ordinary directory.
+That runner mounts `/tmp` **`noexec`**, which is a common hardening default,
+and job workspaces were rooted there. `exec` returns EACCES (shell exit 126)
+no matter what the file mode says. The same suites passed in CI, where the
+workspace is an ordinary directory.
+
+**The fleet is not uniform, and that is the real shape of the bug.** A
+later probe of the full mount table — the first one filtered it to `/` and
+`/tmp`, which is how this was missed — found the runners disagree:
+
+| runner | `/` | `/tmp` | compiled binary runs? |
+|---|---|---|---|
+| hardened | overlay `ro` | `tmpfs … noexec` | no |
+| default | overlay `rw` | *no separate mount* (on the overlay) | yes |
+
+On the second runner `/data`, `/app`, `/var/tmp`, `/home/chickadee` and the
+job working directory are all writable and exec-capable; only `/dev/shm` is
+`noexec`. So C++ grades correctly there and fails on the hardened host.
+
+The symptom therefore depends on **which runner claims the job**, and only
+looked absolute because for a while the hardened runner was the sole one new
+enough to advertise `cpp` at all — the others predated the language. Once a
+second runner upgraded, the same assignment started passing, with nothing
+about it changed. An earlier revision of this document said no C++ assignment
+could be graded in production; that was true of the moment it was measured,
+not of the system.
+
+Claim-order-dependent grading is precisely what `RunnerLanguageGate` exists
+to eliminate, which is why the fix belongs in capability discovery rather
+than in an operator runbook.
 
 Two changes follow from it, and they are deliberately a pair:
 
@@ -176,3 +198,23 @@ an unconfigured runner simply does not claim C++ work, which is the gate's
 documented fail-closed behaviour; `list_runners` showing no `cpp` capability
 on a host that has g++ is then the signal that its cache directory sits on a
 `noexec` mount.
+
+**Confirmed in production (v0.5.33).** After the hardened runner restarted on
+the release, its advertised profile dropped from
+
+```
+… "cpp 13.3.0", "lua 5.4.6", "octave 8.4.0", "python 3.12.3", "r 4.3.3" …
+```
+
+to
+
+```
+… "lua 5.4.6", "octave 8.4.0", "python 3.12.3", "r 4.3.3" …
+```
+
+g++ is still installed on that host; the probe compiled a binary into the
+work root, could not `exec` it, and the language was withheld. Every other
+capability survived, because no other language executes something it built.
+C++ work now routes deterministically to a runner that can actually run it,
+and the `noexec` mount stays exactly as hardened as it was — a supported
+configuration rather than a silent failure.


### PR DESCRIPTION
Documentation-only follow-up to #1303. No behaviour change.

## What was wrong

`docs/cpp-support.md` (and #1303's commit message) claimed **no C++ assignment could be graded in production**. That was true of the moment it was measured, and not true of the system.

Two things produced the overstatement:

1. The diagnostic probe filtered `/proc/mounts` down to `/` and `/tmp`, so the rest of the mount table was never examined.
2. The gap was filled in from the repo's `docker-compose.yml` ("the runner deliberately mounts NO volumes") — a file that does not describe this deployment at all. Production is containerd-managed with a different container shape entirely.

## What the full mount table showed

The fleet is **not uniform**:

| runner | `/` | `/tmp` | compiled binary runs? |
|---|---|---|---|
| hardened | overlay `ro` | `tmpfs … noexec` | no |
| default | overlay `rw` | *no separate mount* (on the overlay) | **yes** |

On the second runner, `/data`, `/app`, `/var/tmp`, `/home/chickadee` and the job working directory are all writable and exec-capable; only `/dev/shm` is `noexec`. C++ grades correctly there.

It *looked* absolute because the hardened runner was, for a while, the only one new enough to advertise `cpp` at all — the others predated the language, so every C++ job landed on the one host that could not run it. Once a second runner upgraded, the same assignment passed with nothing about it changed.

So the defect was **claim-order-dependent grading across a non-uniform fleet** — precisely what `RunnerLanguageGate` exists to eliminate, and why the fix in #1303 belongs in capability discovery rather than in an operator runbook. The fix itself was right; only its description was wrong.

## Production confirmation added (v0.5.33)

After restarting on the release, the hardened runner's advertised profile went from

```
… "cpp 13.3.0", "lua 5.4.6", "octave 8.4.0", "python 3.12.3", "r 4.3.3" …
```

to

```
… "lua 5.4.6", "octave 8.4.0", "python 3.12.3", "r 4.3.3" …
```

g++ is still installed on that host — the probe compiled a binary, could not `exec` it, and the language was withheld. Every other capability survived, because no other language executes something it built. C++ now routes deterministically to a runner that can run it, and the `noexec` mount stays exactly as hardened as it was: a supported configuration rather than a silent failure.

## Testing

Documentation and a changelog fragment only — no source, no tests touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_017McdDCCdwwNhS4p5Jxzj8f)_