### PR TITLE
feat: add Racket as the sixth assignment language

### DIFF
--- a/.github/docker/ci-image/Dockerfile
+++ b/.github/docker/ci-image/Dockerfile
@@ -45,7 +45,7 @@ FROM ${BASE_IMAGE}
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends file python3 zip unzip curl \
         r-base python3-pandas python3-matplotlib lua5.4 octave \
-        gnuplot-nox fonts-freefont-otf g++ \
+        gnuplot-nox fonts-freefont-otf g++ racket \
         nodejs npm ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 # octave     — provides /usr/bin/octave-cli for the Octave execution-path
@@ -57,6 +57,16 @@ RUN apt-get update -qq \
 # gnuplot-nox + fonts-freefont-otf — headless figure creation for the
 #              figureCount execution tests; without them figure() errors and
 #              the tests would skip or fail for reasons unrelated to the code.
+# racket     — the interpreter for the Racket execution-path suites
+#              (RacketRendererExecutionTests, the conformance matrix's Racket
+#              arm). The Debian package includes the HtDP teaching-language
+#              collections, which is the requirement rather than a bonus:
+#              CS 135/115 submissions are `#lang htdp/bsl` and a minimal
+#              Racket would reject every one of them. Same silent-skip trap as
+#              r-base and lua5.4 — the suites guard on `racket --version` and
+#              pass vacuously without it, which `racketIsPresentInCI` exists to
+#              catch.
+#
 # g++        — the C++ toolchain for the C++ execution-path suites (generated
 #              .sh wrappers compile a single TU per test) and the C++
 #              personalization-driver tests. Same silent-skip trap as the

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -208,12 +208,12 @@ jobs:
         # and lua5.4 each hit on the image itself, recorded in
         # .github/docker/ci-image/Dockerfile.
         run: |
-          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null && command -v racket >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 r-base lua5.4 octave g++ && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 r-base lua5.4 octave g++ racket && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -301,12 +301,12 @@ jobs:
         # and lua5.4 each hit on the image itself, recorded in
         # .github/docker/ci-image/Dockerfile.
         run: |
-          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null && command -v racket >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 r-base lua5.4 octave g++ && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 r-base lua5.4 octave g++ racket && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -387,11 +387,11 @@ jobs:
         # graded-language interpreters follow the same all-of-them-or-silent-
         # skip rule as the api-tests job — see that job's note.
         run: |
-          if command -v file >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null; then
+          if command -v file >/dev/null && command -v python3 >/dev/null && command -v Rscript >/dev/null && command -v lua >/dev/null && command -v octave-cli >/dev/null && command -v g++ >/dev/null && command -v racket >/dev/null; then
             echo "test dependencies already baked into the image; skipping apt-get"
             exit 0
           fi
-          apt-get update -qq && apt-get install -y --no-install-recommends file python3 r-base lua5.4 octave g++
+          apt-get update -qq && apt-get install -y --no-install-recommends file python3 r-base lua5.4 octave g++ racket
 
       - name: Run WorkerTests
         # `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` caps Swift

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         gnuplot-nox \
         fonts-freefont-otf \
         g++ \
+        racket \
     && rm -rf /var/lib/apt/lists/*
+# racket — the interpreter generated .rkt tests are handed to, and the one the
+# Racket personalization driver runs under. The Debian package carries the HtDP
+# teaching-language collections (`#lang htdp/bsl`), which is what CS 135/115
+# submissions are written in — a minimal Racket would grade full Racket and
+# reject every teaching-language file, so the full package is the requirement.
+#
 # g++ — the C++ toolchain the generated .sh wrappers and the C++
 # personalization driver invoke. On the SERVER image because
 # `PersonalizationEvaluator` compiles a driver per `=`-expression evaluation

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -83,7 +83,7 @@
     // them here is what omitted `.lua`, leaving a Lua upload with no hint and
     // test_runtime.lua (which cannot list a directory) unable to find it.
     // CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:BEGIN
-    const GRADED_SCRIPT_EXTENSIONS = ['.cpp', '.h', '.hpp', '.lua', '.m', '.py', '.r'];
+    const GRADED_SCRIPT_EXTENSIONS = ['.cpp', '.h', '.hpp', '.lua', '.m', '.py', '.r', '.rkt'];
     // CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:END
 
     // -------------------------------------------------------------------------

--- a/Sources/APIServer/Services/KernelEnvironment.swift
+++ b/Sources/APIServer/Services/KernelEnvironment.swift
@@ -100,6 +100,10 @@ struct KernelEnvironment: Sendable {
         // so `load(publicDirectory:)`'s try? skips it, which is the correct
         // outcome: no inventory, no import guard, nothing to check.
         case .cpp: return "chickadee-cpp"
+        // Same outcome as C++, different reason: no Scheme-family kernel
+        // exists on the channel to vendor. Resolves to a path that is not
+        // there, so no inventory loads and nothing is checked.
+        case .racket: return "chickadee-racket"
         }
     }
 

--- a/Sources/APIServer/Services/KernelImportGuard.swift
+++ b/Sources/APIServer/Services/KernelImportGuard.swift
@@ -62,12 +62,17 @@ enum KernelImportGuard {
             return RLibraryScanner.referencedPackages(in: source)
                 .filter { !environment.provides($0.package) && !localModules.contains($0.package) }
                 .map { Unsatisfied(name: $0.package, line: $0.line) }
-        case .cpp:
-            // Unreachable twice over: `language(forFile:)` returns nil for
-            // C++ extensions, and no chickadee-cpp inventory exists to load —
-            // a kernel-less language has no fixed browser environment for
+        case .cpp, .racket:
+            // Unreachable twice over for both: `language(forFile:)` returns nil
+            // for their extensions, and no inventory exists to load — a
+            // kernel-less language has no fixed browser environment for
             // anything to be unsatisfiable against. Reporting nothing is the
             // direction this guard resolves ambiguity by design.
+            //
+            // Racket would decline anyway even with an inventory, for Lua's
+            // reason: `require` there names collections that ship with the
+            // distribution, so a guard built from a package list would reject
+            // the standard library.
             return []
         case .lua:
             // Unreachable in practice — `language(forFile:)` returns nil for

--- a/Sources/APIServer/Services/PersonalizationEvaluator.swift
+++ b/Sources/APIServer/Services/PersonalizationEvaluator.swift
@@ -283,6 +283,14 @@ enum PersonalizationEvaluator {
             )
             filename = "personalize_driver.R"
             interpreter = "Rscript"
+        case .racket:
+            source = RacketPersonalizationDriver.render(
+                staticVariables: staticVariables,
+                expressions: expressions,
+                supportFiles: supportEntries
+            )
+            filename = "personalize_driver.rkt"
+            interpreter = "racket"
         case .lua:
             source = renderLuaDriverScript(
                 staticVariables: staticVariables,
@@ -340,6 +348,11 @@ enum PersonalizationEvaluator {
             }.sorted()
         case .r:
             return entries.filter { (($0 as NSString).pathExtension).lowercased() == "r" }.sorted()
+        case .racket:
+            // Loaded by FILE like R and Lua — the driver `dynamic-require`s each
+            // helper and copies its bindings into the expression namespace, so
+            // there is no module identifier to validate.
+            return entries.filter { (($0 as NSString).pathExtension).lowercased() == "rkt" }.sorted()
         case .lua:
             // Like R, the driver loads these by FILE (`dofile`), not by module
             // name, so there is no identifier to validate — any `.lua` beside

--- a/Sources/APIServer/Services/RacketPersonalizationDriver.swift
+++ b/Sources/APIServer/Services/RacketPersonalizationDriver.swift
@@ -1,0 +1,167 @@
+// APIServer/Services/RacketPersonalizationDriver.swift
+//
+// The Racket sibling of the Python/R/Lua/Octave/C++ personalization drivers:
+// a script the evaluator runs with `racket` that evaluates each `=` expression
+// server-side and prints, as its LAST stdout line, a JSON map
+// `name → <value rendered as Racket source>`.
+//
+// The Swift return path parses that last line identically for every language,
+// so only the bytes below differ.
+
+import Core
+import Foundation
+
+enum RacketPersonalizationDriver {
+
+    /// The shared seed fold — Horner base-16 over the hex digits of
+    /// CHICKADEE_ASSIGNMENT_SEED, mod 2^31−1 — matching `chickadee_seed()` in
+    /// the R/Lua/Octave runtimes and `ck_seed()` in the C++ driver digit for
+    /// digit, so a student's seed is one number in every language.
+    static let seedSource = #"""
+        (define (ck-seed)
+          (define raw (getenv "CHICKADEE_ASSIGNMENT_SEED"))
+          (cond
+            [(not raw) 0]
+            [else
+             (define modulus 2147483647)
+             (define-values (acc any)
+               (for/fold ([acc 0] [any #f]) ([ch (in-string (string-downcase raw))])
+                 (define digit
+                   (cond [(char<=? #\0 ch #\9) (- (char->integer ch) (char->integer #\0))]
+                         [(char<=? #\a ch #\f) (+ 10 (- (char->integer ch) (char->integer #\a)))]
+                         [else #f]))
+                 (if digit
+                     (values (modulo (+ (* acc 16) digit) modulus) #t)
+                     (values acc any))))
+             (if any acc 0)]))
+        """#
+
+    /// `ck-literal` renders a runtime value as Racket SOURCE, mirroring
+    /// `JSONValue.racketLiteral` so a value round-trips into a generated test
+    /// unchanged. `ck-json-string` is the JSON encoder the output map rides in.
+    static let literalSource = #"""
+        (define (ck-literal v)
+          (cond
+            [(eq? v 'null) "'null"]
+            [(boolean? v) (if v "#t" "#f")]
+            [(and (number? v) (exact-integer? v)) (number->string v)]
+            [(and (real? v) (nan? v)) "+nan.0"]
+            [(and (real? v) (infinite? v)) (if (negative? v) "-inf.0" "+inf.0")]
+            [(real? v) (let ([s (number->string (exact->inexact v))]) s)]
+            [(string? v) (ck-json-string v)]
+            [(list? v)
+             (if (null? v) "(list)"
+                 (string-append "(list " (string-join (map ck-literal v) " ") ")"))]
+            [(vector? v) (ck-literal (vector->list v))]
+            [(hash? v)
+             (if (zero? (hash-count v)) "(hash)"
+                 (string-append
+                  "(hash "
+                  (string-join
+                   (for/list ([k (in-list (sort (hash-keys v) string<? #:key (lambda (x) (format "~a" x))))])
+                     (string-append (ck-json-string (format "~a" k)) " " (ck-literal (hash-ref v k))))
+                   " ")
+                  ")"))]
+            [else (ck-json-string (format "~a" v))]))
+
+        (define (ck-json-string s)
+          (string-append
+           "\""
+           (apply string-append
+                  (for/list ([ch (in-string s)])
+                    (cond [(char=? ch #\") "\\\""]
+                          [(char=? ch #\\) "\\\\"]
+                          [(char=? ch #\newline) "\\n"]
+                          [(char=? ch #\return) "\\r"]
+                          [(char=? ch #\tab) "\\t"]
+                          [(char<? ch #\space)
+                           (let* ([h (number->string (char->integer ch) 16)]
+                                  [pad (make-string (max 0 (- 4 (string-length h))) #\0)])
+                             (string-append "\\u" pad h))]
+                          [else (string ch)])))
+           "\""))
+        """#
+
+    /// The whole driver.
+    ///
+    /// Expressions evaluate in a namespace seeded with `racket` plus `seed`,
+    /// the support helpers and the static variables — the same scope model the
+    /// other drivers build. Each expression's own result is bound before the
+    /// next runs, so a later expression can reference an earlier one.
+    static func render(
+        staticVariables: [FamilyVariable],
+        expressions: [PersonalizationExpression],
+        supportFiles: [String]
+    ) -> String {
+        var lines: [String] = []
+        lines.append("#lang racket")
+        lines.append(";; Auto-generated personalization driver. Do not edit.")
+        lines.append("(require racket/string racket/list)")
+        lines.append("")
+        lines.append(seedSource)
+        lines.append("")
+        lines.append(literalSource)
+        lines.append("")
+        lines.append(";; The scope every expression is evaluated in.")
+        lines.append("(define ns (make-base-namespace))")
+        lines.append("(namespace-set-variable-value! 'seed (ck-seed) #t ns)")
+        lines.append("")
+        if !supportFiles.isEmpty {
+            lines.append(";; Auto-loaded support files (instructor .rkt helpers).")
+            lines.append(";; A broken helper is ignored here; a missing name surfaces as an")
+            lines.append(";; error only if an expression actually references it.")
+            for name in supportFiles {
+                let literal = JSONValue.string(name).racketLiteral
+                lines.append("(with-handlers ([(lambda (_) #t) void])")
+                lines.append("  (let* ([mp `(file ,(path->string (path->complete-path \(literal))))])")
+                lines.append("    (dynamic-require mp #f)")
+                lines.append("    (let ([sns (module->namespace mp)])")
+                lines.append("      (for ([sym (in-list (namespace-mapped-symbols sns))])")
+                lines.append("        (with-handlers ([(lambda (_) #t) void])")
+                lines.append(
+                    "          (namespace-set-variable-value! sym (eval sym sns) #t ns))))))")
+            }
+            lines.append("")
+        }
+        if !staticVariables.isEmpty {
+            lines.append(";; Static globals + section variables (in scope for expressions).")
+            for v in staticVariables {
+                lines.append(
+                    "(namespace-set-variable-value! '\(racketArgumentName(v.name)) \(v.value.racketLiteral) #t ns)")
+            }
+            lines.append("")
+        }
+        lines.append(";; Per-student expressions, evaluated in declared order.")
+        lines.append("(define ck-results '())")
+        for e in expressions {
+            let nameLiteral = JSONValue.string(e.name).racketLiteral
+            // The expression text is embedded as a Racket STRING literal and
+            // read at run time, so an instructor's quotes and backslashes
+            // cannot break out of the driver's own source.
+            let bodyLiteral = JSONValue.string(e.expression).racketLiteral
+            lines.append("(let* ([ck-src \(bodyLiteral)]")
+            lines.append("       [ck-form (with-handlers")
+            lines.append("                  ([(lambda (_) #t)")
+            lines.append("                    (lambda (ex)")
+            lines.append("                      (error 'chickadee \"expression ~a: ~a\" \(nameLiteral) ex))])")
+            lines.append("                  (read (open-input-string ck-src)))]")
+            lines.append("       [ck-value (eval ck-form ns)])")
+            lines.append(
+                "  (namespace-set-variable-value! '\(racketArgumentName(e.name)) ck-value #t ns)")
+            lines.append("  (set! ck-results (cons (cons \(nameLiteral) ck-value) ck-results)))")
+        }
+        lines.append("")
+        lines.append(";; The LAST stdout line: a JSON map name -> Racket-source literal.")
+        lines.append(";; Earlier instructor output is ignored by the Swift reader.")
+        lines.append("(displayln")
+        lines.append("  (string-append")
+        lines.append("   \"{\"")
+        lines.append("   (string-join")
+        lines.append("    (for/list ([pair (in-list (reverse ck-results))])")
+        lines.append("      (string-append (ck-json-string (car pair)) \":\"")
+        lines.append("                     (ck-json-string (ck-literal (cdr pair)))))")
+        lines.append("    \",\")")
+        lines.append("   \"}\"))")
+        return lines.joined(separator: "\n") + "\n"
+    }
+}

--- a/Sources/APIServer/Utilities/NotebookCheckKindHandler.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckKindHandler.swift
@@ -97,6 +97,7 @@ private func isValidIdentifier(_ value: String, language: AssignmentLanguage) ->
     case .lua: return isValidLuaIdentifier(value)
     case .octave: return isValidOctaveIdentifier(value)
     case .cpp: return isValidCppIdentifier(value)
+    case .racket: return isValidRacketIdentifier(value)
     }
 }
 
@@ -108,6 +109,7 @@ private func identifierKindName(_ language: AssignmentLanguage) -> String {
     case .lua: return "Lua identifier"
     case .octave: return "Octave identifier"
     case .cpp: return "C++ identifier"
+    case .racket: return "Racket identifier"
     }
 }
 

--- a/Sources/APIServer/Utilities/NotebookCheckRenderer.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckRenderer.swift
@@ -76,6 +76,15 @@ func renderNotebookCheck(
             echo "Notebook checks are not available for C++ assignments." 1>&2
             exit 2
             """
+    case .racket:
+        // Unreachable for the same reason as C++, and kept total the same
+        // way — but as a `.rkt` module, since Racket's generated extension is
+        // its own and the runner hands this file to `racket`.
+        source = """
+            #lang racket/base
+            (eprintf "Notebook checks are not available for Racket assignments.\\n")
+            (exit 2)
+            """
     }
     let displayName = check.name ?? handler.defaultLabel(check)
     let sidecars = handler.sidecars(check)

--- a/Sources/APIServer/Utilities/NotebookCheckValidator.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckValidator.swift
@@ -153,6 +153,20 @@ private func validateKindSupport(_ check: NotebookCheck, language: AssignmentLan
                 + "C++ assignments: C++ assignments are upload-only, so there is no submitted "
                 + "notebook to check. Use a pattern family or a hand-written .sh test instead."
         )
+    case .racket:
+        // Categorical for the same structural reason as C++ — upload-only, so
+        // no submitted notebook exists for any kind to inspect. The refusal is
+        // NOT a statement about Racket's expressiveness: several kinds would
+        // render fine against a notebook if one existed. If a Scheme-family
+        // kernel ever lands on the channel, this arm is what to revisit.
+        throw Abort(
+            .unprocessableEntity,
+            reason:
+                "Notebook check '\(check.id)' (\(check.kind.rawValue)) is not available for "
+                + "Racket assignments: Racket assignments are upload-only, so there is no "
+                + "submitted notebook to check. Use a pattern family or a hand-written .rkt "
+                + "test instead."
+        )
     }
 }
 

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
@@ -134,62 +134,43 @@ func existenceGuard(
     let label = "\(family.functionName) is defined"
     // Exhaustive so a future language cannot silently receive Python bytes
     // (docs/language-handling-review.md §4).
+    //
+    // Only the SOURCE differs per language — every arm built an identical
+    // `GeneratedScript` around it, so the shared construction is hoisted below.
+    // That kept this function inside the body-length limit at the sixth
+    // language, and makes a seventh one line rather than thirteen.
+    let source: String
     switch language {
-    case .lua:
-        return GeneratedScript(
-            filename: generatedScriptFilename(
-                familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier,
-                language: .lua),
-            source: renderLuaExistenceGuard(family: family, specHash: hash),
-            tier: tier,
-            points: 0,
-            displayName: label,
-            caseKey: patternExistenceGuardCaseKey,
-            familyID: family.id,
-            timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
-        )
-    case .r:
-        return GeneratedScript(
-            filename: generatedScriptFilename(
-                familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier,
-                language: .r),
-            source: renderRExistenceGuard(family: family, specHash: hash),
-            tier: tier,
-            points: 0,
-            displayName: label,
-            caseKey: patternExistenceGuardCaseKey,
-            familyID: family.id,
-            timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
-        )
-    case .octave:
-        return GeneratedScript(
-            filename: generatedScriptFilename(
-                familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier,
-                language: .octave),
-            source: renderOctaveExistenceGuard(family: family, specHash: hash),
-            tier: tier,
-            points: 0,
-            displayName: label,
-            caseKey: patternExistenceGuardCaseKey,
-            familyID: family.id,
-            timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
-        )
-    case .cpp:
-        return GeneratedScript(
-            filename: generatedScriptFilename(
-                familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier,
-                language: .cpp),
-            source: renderCppExistenceGuard(family: family, specHash: hash),
-            tier: tier,
-            points: 0,
-            displayName: label,
-            caseKey: patternExistenceGuardCaseKey,
-            familyID: family.id,
-            timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
-        )
-    case .python:
-        break
+    case .racket: source = renderRacketExistenceGuard(family: family, specHash: hash)
+    case .lua: source = renderLuaExistenceGuard(family: family, specHash: hash)
+    case .r: source = renderRExistenceGuard(family: family, specHash: hash)
+    case .octave: source = renderOctaveExistenceGuard(family: family, specHash: hash)
+    case .cpp: source = renderCppExistenceGuard(family: family, specHash: hash)
+    case .python: source = pythonExistenceGuardSource(family: family, specHash: hash, label: label)
     }
+    return GeneratedScript(
+        filename: generatedScriptFilename(
+            familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier,
+            language: language),
+        source: source,
+        tier: tier,
+        points: 0,
+        displayName: label,
+        caseKey: patternExistenceGuardCaseKey,
+        familyID: family.id,
+        // The guard applies to all the family's generated entries, so it
+        // inherits the family-level limit (the cases inherit it too unless
+        // they set their own).
+        timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
+    )
+}
+
+/// The Python existence guard's bytes. Extracted from `existenceGuard` when the
+/// sixth language arrived — unchanged text, so every pinned `spec_hash` and
+/// golden still matches.
+private func pythonExistenceGuardSource(
+    family: PatternFamily, specHash hash: String, label: String
+) -> String {
     let nameLiteral = "\"" + escapeForPythonStringLiteral(family.functionName) + "\""
     // Mirrors the `getattr(..., _MISSING)` sentinel that `variableEquality`
     // (and the function_exists notebook check) already use — `_MISSING`
@@ -212,20 +193,7 @@ func existenceGuard(
             failed(f"`{function_name}` is defined but is not a function (got {type(target).__name__}).")
         passed(f"`{function_name}` is defined")
         """
-    return GeneratedScript(
-        filename: generatedScriptFilename(
-            familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier),
-        source: source,
-        tier: tier,
-        points: 0,
-        displayName: label,
-        caseKey: patternExistenceGuardCaseKey,
-        familyID: family.id,
-        // The guard applies to all the family's generated entries, so it
-        // inherits the family-level limit (the cases inherit it too unless
-        // they set their own).
-        timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
-    )
+    return source
 }
 
 /// Stable filename for one case.  Format:
@@ -289,6 +257,11 @@ private func renderCase(
             perStudentNames: perStudentNames)
     case .lua:
         source = renderLuaPatternCase(
+            family: family, case: c,
+            sectionVariables: sectionVariables, specHash: specHash,
+            perStudentNames: perStudentNames)
+    case .racket:
+        source = renderRacketPatternCase(
             family: family, case: c,
             sectionVariables: sectionVariables, specHash: specHash,
             perStudentNames: perStudentNames)

--- a/Sources/APIServer/Utilities/PatternFamilyRendererRacket.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRendererRacket.swift
@@ -1,0 +1,431 @@
+// APIServer/Utilities/PatternFamilyRendererRacket.swift
+//
+// The Racket half of the pattern-family renderer: every `PatternKind` rendered
+// as a `.rkt` test script.
+//
+// Structured like PatternFamilyRendererLua.swift — one switch over the kinds,
+// small bodies, a shared call-context helper — and reading its student-facing
+// wording from `GeneratedMessage` rather than restating it.
+//
+// THE ONE THING THAT MAKES RACKET DIFFERENT FROM THE OTHER FIVE.
+// A generated test never `require`s the submission. An HtDP teaching-language
+// module (`#lang htdp/bsl`, what CS 135/115 write) exports nothing, so a
+// `require` binds nothing at all — silently. Every body below goes through the
+// runtime's three-step access instead: `chickadee-load-student` for a namespace,
+// `chickadee-defined?` to test a binding, `chickadee-call` to apply one. The
+// full reasoning, with the measurements behind each step, is in the header of
+// `Tools/runner-support/test_runtime.rkt`.
+//
+// The generated test is always `#lang racket/base` even when the submission is
+// BSL, which is what lets one rendered file grade both dialects: the test gets
+// full-Racket syntax, the submission keeps its own semantics, and neither
+// constrains the other.
+//
+// GAPS ARE DROPPED, NOT PASSED AS A HOLE. Lua renders an omitted argument as a
+// positional `nil` because that is how Lua spells a default. Racket has no such
+// notion — BSL has no optional parameters at all — so an omitted argument is
+// simply not passed, and an arity error surfaces as an ordinary test failure.
+
+import Core
+import Foundation
+
+// MARK: - Header
+
+private func racketGeneratedCaseHeader(
+    family: PatternFamily, case c: PatternCase, specHash: String
+) -> String {
+    let label = c.label.isEmpty ? "\(family.functionName) case \(c.key)" : c.label
+    return """
+        ; Test: \(racketComment(label))
+        ; Generated from pattern family "\(racketComment(family.name))" [\(family.id)] spec_hash=\(specHash) — edit the family, not this file.
+        """
+}
+
+/// Strips anything that would end the `; Test:` line the runner reads the label
+/// from. Newlines only — a comment cannot be escaped out of.
+func racketComment(_ text: String) -> String {
+    text.replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "\r", with: " ")
+}
+
+// MARK: - Call context
+
+struct RacketCallContext {
+    /// `(define name <literal>)` lines, or "" when the case takes no arguments.
+    let declBlock: String
+    /// The argument list as a Racket list expression: `(list a b)` / `(list)`.
+    let argList: String
+    /// Fragment for the `input:` line of a failure message.
+    let inputPreview: String
+}
+
+func racketCallContext(for family: PatternFamily, case c: PatternCase) -> RacketCallContext {
+    let argNames: [String] = {
+        if !family.paramNames.isEmpty { return family.paramNames }
+        return c.args.indices.map { "arg-\($0 + 1)" }
+    }()
+    let provided: [Bool] = {
+        guard !c.argsProvided.isEmpty else { return Array(repeating: true, count: argNames.count) }
+        return (0..<argNames.count).map { i in i < c.argsProvided.count ? c.argsProvided[i] : true }
+    }()
+    let varRefs: [String?] = {
+        guard !c.argVarRefs.isEmpty else { return Array(repeating: nil, count: argNames.count) }
+        return (0..<argNames.count).map { i in i < c.argVarRefs.count ? c.argVarRefs[i] : nil }
+    }()
+
+    var declLines: [String] = []
+    var callParts: [String] = []
+    var previewParts: [String] = []
+    for (idx, name) in argNames.enumerated() {
+        guard idx < provided.count ? provided[idx] : true else { continue }
+        let local = racketArgumentName(name)
+        if let refName = idx < varRefs.count ? varRefs[idx] : nil {
+            declLines.append("(define \(local) \(racketArgumentName(refName)))")
+        } else if idx < c.args.count {
+            declLines.append("(define \(local) \(c.args[idx].racketLiteral))")
+        } else {
+            continue
+        }
+        callParts.append(local)
+        previewParts.append("\"\(name)=\" (chickadee-format \(local))")
+    }
+    return RacketCallContext(
+        declBlock: declLines.joined(separator: "\n"),
+        argList: callParts.isEmpty ? "(list)" : "(list " + callParts.joined(separator: " ") + ")",
+        inputPreview: previewParts.isEmpty
+            ? "\"(no arguments)\"" : "(string-append " + previewParts.joined(separator: " \" \" ") + ")"
+    )
+}
+
+/// Author-chosen names reach source here, and Racket's identifier grammar is
+/// permissive enough that almost anything passes — but a name carrying a reader
+/// delimiter would end the identifier early and corrupt the rest of the form.
+/// Such names are already refused at save time; this is the backstop, and it
+/// renders an obviously-wrong identifier rather than plausible source.
+func racketArgumentName(_ name: String) -> String {
+    isValidRacketIdentifier(name) ? name : "ck-invalid-name"
+}
+
+// MARK: - Per-case rendering
+
+/// Renders one enabled case of `family` as a Racket test script.
+func renderRacketPatternCase(
+    family: PatternFamily,
+    case c: PatternCase,
+    sectionVariables: [FamilyVariable],
+    specHash: String,
+    perStudentNames: Set<String> = []
+) -> String {
+    let header = racketGeneratedCaseHeader(family: family, case: c, specHash: specHash)
+    let variableBlock = TestScriptVariablePrepender.emit(
+        sectionVariables + family.variables, language: .racket)
+    let preamble = racketPersonalizationPreamble(c, perStudentNames: perStudentNames)
+    let prelude = [
+        header,
+        "#lang racket/base",
+        "(require \"test_runtime.rkt\")",
+        variableBlock,
+        preamble,
+    ].filter { !$0.isEmpty }.joined(separator: "\n\n")
+
+    switch family.kind {
+    case .boundaryEquality:
+        return racketEqualityCase(family: family, case: c, prelude: prelude, unordered: false)
+    case .unorderedEquality:
+        return racketEqualityCase(family: family, case: c, prelude: prelude, unordered: true)
+    case .approximateEquality:
+        return racketApproximateCase(family: family, case: c, prelude: prelude)
+    case .variableEquality:
+        return racketVariableEqualityCase(family: family, case: c, prelude: prelude)
+    case .returnTypeCheck:
+        return racketReturnTypeCase(family: family, case: c, prelude: prelude)
+    case .exceptionExpected:
+        return racketExceptionCase(family: family, case: c, prelude: prelude)
+    case .performanceThreshold:
+        return racketPerformanceCase(family: family, case: c, prelude: prelude)
+    case .stdoutEquality:
+        return racketStdoutCase(family: family, case: c, prelude: prelude)
+    }
+}
+
+/// Binds each per-student input referenced by this case to a local, so the case
+/// bodies read the same whether a value is a literal or a `$name` reference.
+private func racketPersonalizationPreamble(
+    _ c: PatternCase, perStudentNames: Set<String>
+) -> String {
+    var names: [String] = []
+    for ref in c.argVarRefs.compactMap({ $0 }) where perStudentNames.contains(ref) {
+        names.append(ref)
+    }
+    if let expectedRef = c.expectedVarRef, perStudentNames.contains(expectedRef) {
+        names.append(expectedRef)
+    }
+    guard !names.isEmpty else { return "" }
+    var seen = Set<String>()
+    let lines = names.filter { seen.insert($0).inserted }.map {
+        "(define \(racketArgumentName($0)) (hash-ref (chickadee-inputs) \(JSONValue.string($0).racketLiteral) #f))"
+    }
+    return lines.joined(separator: "\n")
+}
+
+/// The expected value: a per-student reference when the case names one,
+/// otherwise the authored literal.
+private func racketExpected(_ c: PatternCase) -> String {
+    if let ref = c.expectedVarRef, !ref.isEmpty { return racketArgumentName(ref) }
+    return c.expected.racketLiteral
+}
+
+private func racketLoadAndGuard(_ family: PatternFamily) -> String {
+    """
+    (define ns (chickadee-load-student))
+    (unless (chickadee-defined? ns '\(racketArgumentName(family.functionName)))
+      (chickadee-failed \(JSONValue.string("`\(family.functionName)` is not defined").racketLiteral)))
+    """
+}
+
+// MARK: - Kind bodies
+
+private func racketEqualityCase(
+    family: PatternFamily, case c: PatternCase, prelude: String, unordered: Bool
+) -> String {
+    let ctx = racketCallContext(for: family, case: c)
+    let compare = unordered ? "chickadee-unordered-equal?" : "chickadee-equal?"
+    // Python names "wrong value" for boundaryEquality and not for
+    // unorderedEquality; the conformance matrix pins that a kind uses the same
+    // vocabulary in every language, so the difference is carried here rather
+    // than invented.
+    let mismatchPrefix =
+        unordered ? "" : JSONValue.string(GeneratedMessage.wrongValue).racketLiteral + " \"\\n\""
+    return """
+        \(prelude)
+
+        \(ctx.declBlock)
+        (define expected \(racketExpected(c)))
+        \(racketLoadAndGuard(family))
+
+        (define actual
+          (with-handlers ([exn:fail? (lambda (e)
+              (chickadee-failed (string-append \(JSONValue.string(GeneratedMessage.unexpectedException).racketLiteral) "\\n"
+                                 \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                                 \(JSONValue.string(GeneratedMessage.error).racketLiteral) (exn-message e))))])
+            (chickadee-call ns '\(racketArgumentName(family.functionName)) \(ctx.argList))))
+
+        (if (\(compare) actual expected)
+            (chickadee-passed (string-append "Returned " (chickadee-format actual)))
+            (chickadee-failed (string-append \(mismatchPrefix)
+                               \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                               \(JSONValue.string(GeneratedMessage.expected).racketLiteral) (chickadee-format expected) "\\n"
+                               \(JSONValue.string(GeneratedMessage.got).racketLiteral) (chickadee-format actual))))
+        """ + "\n"
+}
+
+private func racketApproximateCase(
+    family: PatternFamily, case c: PatternCase, prelude: String
+) -> String {
+    let ctx = racketCallContext(for: family, case: c)
+    let tolerance = JSONValue.double(family.defaults.tolerance ?? 1e-6).racketLiteral
+    return """
+        \(prelude)
+
+        \(ctx.declBlock)
+        (define expected \(racketExpected(c)))
+        (define tolerance \(tolerance))
+        \(racketLoadAndGuard(family))
+
+        (define actual
+          (with-handlers ([exn:fail? (lambda (e)
+              (chickadee-failed (string-append \(JSONValue.string(GeneratedMessage.unexpectedException).racketLiteral) "\\n"
+                                 \(JSONValue.string(GeneratedMessage.error).racketLiteral) (exn-message e))))])
+            (chickadee-call ns '\(racketArgumentName(family.functionName)) \(ctx.argList))))
+
+        (unless (and (real? actual) (real? expected))
+          (chickadee-failed (string-append                              \(JSONValue.string(GeneratedMessage.expected).racketLiteral) (chickadee-format expected) "\\n"
+                             \(JSONValue.string(GeneratedMessage.got).racketLiteral) (chickadee-format actual))))
+        (define delta (abs (- actual expected)))
+        (if (<= delta tolerance)
+            (chickadee-passed (string-append "Returned " (chickadee-format actual)))
+            (chickadee-failed (string-append                                \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                               \(JSONValue.string(GeneratedMessage.expected).racketLiteral) (chickadee-format expected) "\\n"
+                               \(JSONValue.string(GeneratedMessage.got).racketLiteral) (chickadee-format actual) "\\n"
+                               \(JSONValue.string(GeneratedMessage.delta).racketLiteral) (chickadee-format delta))))
+        """ + "\n"
+}
+
+/// `variableEquality` names a module-level VALUE rather than a function, so it
+/// reads the binding with `chickadee-value`. Safe to evaluate bare even under
+/// BSL: the operator-position restriction applies to procedures, not data.
+private func racketVariableEqualityCase(
+    family: PatternFamily, case c: PatternCase, prelude: String
+) -> String {
+    let target = racketArgumentName(family.functionName)
+    return """
+        \(prelude)
+
+        (define expected \(racketExpected(c)))
+        (define ns (chickadee-load-student))
+        (unless (chickadee-defined? ns '\(target))
+          (chickadee-failed \(JSONValue.string("`\(family.functionName)` is not defined").racketLiteral)))
+
+        (define actual
+          (with-handlers ([exn:fail? (lambda (e)
+              (chickadee-failed (string-append "the variable could not be read" "\\n"
+                                 \(JSONValue.string(GeneratedMessage.error).racketLiteral) (exn-message e))))])
+            (chickadee-value ns '\(target))))
+
+        (if (chickadee-equal? actual expected)
+            (chickadee-passed (string-append "\(racketComment(family.functionName)) = " (chickadee-format actual)))
+            (chickadee-failed (string-append \(JSONValue.string(GeneratedMessage.wrongValue).racketLiteral) "\\n"
+                                                              \(JSONValue.string(GeneratedMessage.expected).racketLiteral) (chickadee-format expected) "\\n"
+                               \(JSONValue.string(GeneratedMessage.got).racketLiteral) (chickadee-format actual))))
+        """ + "\n"
+}
+
+private func racketReturnTypeCase(
+    family: PatternFamily, case c: PatternCase, prelude: String
+) -> String {
+    let ctx = racketCallContext(for: family, case: c)
+    let expectedType: String = {
+        if case .string(let s) = c.expected { return s }
+        return ""
+    }()
+    return """
+        \(prelude)
+
+        \(ctx.declBlock)
+        (define expected-type \(JSONValue.string(expectedType).racketLiteral))
+        \(racketLoadAndGuard(family))
+
+        (define actual
+          (with-handlers ([exn:fail? (lambda (e)
+              (chickadee-failed (string-append \(JSONValue.string(GeneratedMessage.unexpectedException).racketLiteral) "\\n"
+                                 \(JSONValue.string(GeneratedMessage.error).racketLiteral) (exn-message e))))])
+            (chickadee-call ns '\(racketArgumentName(family.functionName)) \(ctx.argList))))
+
+        (define actual-type (chickadee-type-name actual))
+        (if (string=? actual-type expected-type)
+            (chickadee-passed (string-append "Returned a " actual-type))
+            (chickadee-failed (string-append                                \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                               \(JSONValue.string(GeneratedMessage.expected).racketLiteral) expected-type "\\n"
+                               \(JSONValue.string(GeneratedMessage.got).racketLiteral) actual-type)))
+        """ + "\n"
+}
+
+/// Racket has no exception TYPES in the Python sense that a student would name,
+/// so the expectation is matched against the message — the same posture the Lua
+/// renderer takes for the same reason.
+private func racketExceptionCase(
+    family: PatternFamily, case c: PatternCase, prelude: String
+) -> String {
+    let ctx = racketCallContext(for: family, case: c)
+    let expectedText: String = {
+        if case .string(let s) = c.expected { return s }
+        return ""
+    }()
+    return """
+        \(prelude)
+
+        \(ctx.declBlock)
+        (define expected-error \(JSONValue.string(expectedText).racketLiteral))
+        \(racketLoadAndGuard(family))
+
+        (define outcome
+          (with-handlers ([exn:fail? (lambda (e) (cons 'raised (exn-message e)))])
+            (cons 'returned (chickadee-call ns '\(racketArgumentName(family.functionName)) \(ctx.argList)))))
+
+        (cond
+          [(eq? (car outcome) 'returned)
+           (chickadee-failed (string-append "expected an error\\n"
+                              \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                              \(JSONValue.string(GeneratedMessage.expected).racketLiteral) expected-error "\\n"
+                              \(JSONValue.string(GeneratedMessage.got).racketLiteral) (chickadee-format (cdr outcome))))]
+          [(or (string=? expected-error "")
+               (regexp-match? (regexp (regexp-quote expected-error)) (cdr outcome)))
+           (chickadee-passed "Raised the expected error")]
+          [else
+           (chickadee-failed (string-append                               \(JSONValue.string(GeneratedMessage.expected).racketLiteral) expected-error "\\n"
+                              \(JSONValue.string(GeneratedMessage.error).racketLiteral) (cdr outcome)))])
+        """ + "\n"
+}
+
+private func racketPerformanceCase(
+    family: PatternFamily, case c: PatternCase, prelude: String
+) -> String {
+    let ctx = racketCallContext(for: family, case: c)
+    let budgetMs: Double = {
+        switch c.expected {
+        case .double(let d): return d
+        case .int(let i): return Double(i)
+        default: return 1000
+        }
+    }()
+    return """
+        \(prelude)
+
+        \(ctx.declBlock)
+        (define budget-ms \(budgetMs))
+        \(racketLoadAndGuard(family))
+
+        (define start (current-inexact-milliseconds))
+        (with-handlers ([exn:fail? (lambda (e)
+            (chickadee-failed (string-append \(JSONValue.string(GeneratedMessage.unexpectedException).racketLiteral) "\\n"
+                               \(JSONValue.string(GeneratedMessage.performanceError).racketLiteral) (exn-message e))))])
+          (chickadee-call ns '\(racketArgumentName(family.functionName)) \(ctx.argList)))
+        (define elapsed (- (current-inexact-milliseconds) start))
+
+        (if (<= elapsed budget-ms)
+            (chickadee-passed (format "Completed in ~ams" (round elapsed)))
+            (chickadee-failed (string-append "too slow\\n"
+                               \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                               \(JSONValue.string(GeneratedMessage.threshold).racketLiteral) (format "~ams" budget-ms) "\\n"
+                               \(JSONValue.string(GeneratedMessage.elapsed).racketLiteral) (format "~ams" (round elapsed)))))
+        """ + "\n"
+}
+
+private func racketStdoutCase(
+    family: PatternFamily, case c: PatternCase, prelude: String
+) -> String {
+    let ctx = racketCallContext(for: family, case: c)
+    return """
+        \(prelude)
+
+        \(ctx.declBlock)
+        (define expected \(racketExpected(c)))
+        \(racketLoadAndGuard(family))
+
+        (define printed
+          (with-handlers ([exn:fail? (lambda (e)
+              (chickadee-failed (string-append \(JSONValue.string(GeneratedMessage.unexpectedException).racketLiteral) "\\n"
+                                 \(JSONValue.string(GeneratedMessage.error).racketLiteral) (exn-message e))))])
+            (let-values ([(out _) (chickadee-call/capture ns '\(racketArgumentName(family.functionName)) \(ctx.argList))])
+              out)))
+
+        (if (chickadee-stdout-matches? printed expected)
+            (chickadee-passed "Printed the expected output")
+            (chickadee-failed (string-append                                \(JSONValue.string(GeneratedMessage.input).racketLiteral) \(ctx.inputPreview) "\\n"
+                               \(JSONValue.string(GeneratedMessage.expected).racketLiteral) (chickadee-format expected) "\\n"
+                               \(JSONValue.string(GeneratedMessage.got).racketLiteral) (chickadee-format printed))))
+        """ + "\n"
+}
+
+// MARK: - Existence guard
+
+/// The cases `dependsOn` this, so a missing target fails once here and the cases
+/// skip through the runner's dependency gate. `failed` (exit 1), never `errored`
+/// (exit 2) — the gate keys on a failure, and an error would leave the dependent
+/// cases running against a function that is not there.
+func renderRacketExistenceGuard(family: PatternFamily, specHash: String) -> String {
+    let name = family.functionName
+    return """
+        ; Test: \(racketComment(name)) is defined
+        ; Generated from pattern family "\(racketComment(family.name))" [\(family.id)] spec_hash=\(specHash) — edit the family, not this file.
+        ; Existence guard: the family's cases depend on this test, so a missing
+        ; target fails once here and the cases skip instead of erroring one by one.
+        #lang racket/base
+        (require "test_runtime.rkt")
+
+        (define ns (chickadee-load-student))
+        (if (chickadee-defined? ns '\(racketArgumentName(name)))
+            (chickadee-passed \(JSONValue.string("`\(name)` is defined").racketLiteral))
+            (chickadee-failed \(JSONValue.string("`\(name)` is not defined — define it in your submission.").racketLiteral)))
+        """ + "\n"
+}

--- a/Sources/APIServer/Utilities/RacketScriptHelpers.swift
+++ b/Sources/APIServer/Utilities/RacketScriptHelpers.swift
@@ -1,0 +1,53 @@
+// APIServer/Utilities/RacketScriptHelpers.swift
+//
+// Racket-side helpers for generated scripts: the identifier grammar, and the
+// module-path form a generated test uses to reach the submission.
+
+import Core
+import Foundation
+
+/// Characters that end an identifier in Racket's reader. Everything else is
+/// fair game — `set!`, `list->vector`, `char<=?`, `+` and `1+` are all legal
+/// names — which is why this is a denylist rather than the alphanumeric
+/// allowlist the other five languages use.
+private let racketDelimiters: Set<Character> = [
+    "(", ")", "[", "]", "{", "}", "\"", ",", "'", "`", ";", "|", "\\",
+]
+
+/// Whether `name` is a legal Racket identifier.
+///
+/// Deliberately permissive, because Racket is: rejecting `bmi-category` or
+/// `valid?` would refuse the names a CS 135 student is taught to write, and
+/// hyphenated names are the house style throughout the HtDP curriculum. The
+/// three things actually excluded are the ones that would misparse:
+///
+///   * anything containing a reader delimiter or whitespace — it would end the
+///     identifier early and turn the rest into stray source;
+///   * a name the reader would take as a NUMBER (`42`, `-1.5`, `+inf.0`), which
+///     cannot be a variable;
+///   * a leading `#`, which begins a reader macro (`#t`, `#lang`, `#(`).
+func isValidRacketIdentifier(_ name: String) -> Bool {
+    guard !name.isEmpty else { return false }
+    guard !name.hasPrefix("#") else { return false }
+    for character in name {
+        if character.isWhitespace || racketDelimiters.contains(character) { return false }
+    }
+    // `Double(_:)` accepts "42", "-1.5", "1e3" and "inf"/"nan" spellings, which
+    // is the same set the reader would claim. A name it parses is a number, not
+    // an identifier.
+    if Double(name) != nil { return false }
+    if name == "+inf.0" || name == "-inf.0" || name == "+nan.0" || name == "-nan.0" {
+        return false
+    }
+    return true
+}
+
+/// The `(file "…")` module path a generated test hands to `dynamic-require`.
+///
+/// A quoted relative path rather than a bare identifier: `(require student)`
+/// would look up a COLLECTION named `student` on the collection path, not the
+/// file beside the test, and would fail with a confusing "collection not found"
+/// rather than a missing-submission message.
+func racketSubmissionModulePath(_ filename: String) -> String {
+    "(file \(JSONValue.string(filename).racketLiteral))"
+}

--- a/Sources/APIServer/Utilities/TestScriptVariablePrepender.swift
+++ b/Sources/APIServer/Utilities/TestScriptVariablePrepender.swift
@@ -76,6 +76,15 @@ enum TestScriptVariablePrepender {
                     }
                 }
                 .joined(separator: "\n")
+        case .racket:
+            // `(define name value)` — top-level definitions in the generated
+            // test's own module. Unlike C++'s shell arm there is no scalar
+            // restriction: every JSONValue has a Racket rendering, so a list
+            // or hash global inlines as faithfully as an integer.
+            return
+                variables
+                .map { "(define \($0.name) \($0.value.racketLiteral))" }
+                .joined(separator: "\n")
         }
     }
 

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -24,6 +24,32 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
     /// build strategy enters Swift.
     case cpp
 
+    /// Racket — the second upload-only language, and the first that is
+    /// upload-only WITHOUT being compiled.
+    ///
+    /// No xeus kernel exists on `emscripten-forge-4x` (measured against the
+    /// channel's repodata, which carries cpp/haskell/javascript/lfortran/lua/
+    /// ocaml/octave/python/r/sqlite and no Scheme family at all), so
+    /// `EditorSupport.uploadOnly` — but for a different reason than C++. C++
+    /// has no kernel because grading a different compiler than the course
+    /// teaches is a pedagogy defect; Racket has none because nobody has built
+    /// one. That distinction matters if a kernel ever appears: Racket's
+    /// upload-only answer is contingent, C++'s is a decision.
+    ///
+    /// It is otherwise the CHEAPEST language here: interpreted, so
+    /// `racket file.rkt` needs no build step and no `.sh` wrapper; and
+    /// dynamically typed, so `JSONValue` renders without C++'s refusal table.
+    ///
+    /// The one thing measurement changed: a generated test cannot `require`
+    /// the student's module, because an HtDP teaching-language module
+    /// (`#lang htdp/bsl`, what CS 135/115 write) exports nothing. Tests load
+    /// the submission with `dynamic-require` + `module->namespace` and
+    /// evaluate a CALL FORM rather than a bare identifier — Beginner Student
+    /// Language rejects a function reference that is not in operator position.
+    /// One mechanism serves `#lang htdp/bsl` and `#lang racket` alike, so a
+    /// generated test is byte-identical across the CS 135 and CS 136 dialects.
+    case racket
+
     /// Kernelspec `name` values that mark a Python notebook. `xpython` is the
     /// vendored xeus-python kernel; `python3` is what classic Jupyter writes and
     /// `python` is what `language_info.name` reports.
@@ -304,6 +330,7 @@ extension AssignmentLanguage {
         case .lua: return value.luaLiteral
         case .octave: return value.octaveLiteral
         case .cpp: return value.cppLiteral
+        case .racket: return value.racketLiteral
         }
     }
 
@@ -340,6 +367,11 @@ extension AssignmentLanguage {
         case .lua: commentLeader = "--"
         case .octave: commentLeader = "%"
         case .cpp: commentLeader = "//"
+        // Racket's line comment. `#` is NOT one — `#` begins a reader macro
+        // (`#t`, `#lang`, `#(`), so a `#`-led header is a read error, not an
+        // ignored line. Same class of trap as Lua's shebang accommodation
+        // noted above, failing louder.
+        case .racket: commentLeader = ";"
         case .python, .r: commentLeader = "#"
         }
         let header =
@@ -413,6 +445,26 @@ extension AssignmentLanguage {
                 + "namespace ck_inputs {\n"
                 + definitions.map { "    \($0)\n" }.joined()
                 + "}\n"
+        case .racket:
+            // A MODULE that provides one hash, which is the shape Racket makes
+            // natural and the one the runtime can read with `dynamic-require`.
+            //
+            // `#lang racket/base`, not `racket`: this file is loaded on every
+            // generated test, and `racket/base` is the small language — the
+            // full `racket` language pulls in a much larger set for values that
+            // are, by construction, literals.
+            //
+            // Unlike the student's submission, this file is OURS, so it can
+            // `provide` — the export problem that shapes everything else about
+            // Racket support does not apply here.
+            let entries = keys.map {
+                "   \(JSONValue.string($0).racketLiteral) \(values[$0] ?? "'null")"
+            }
+            let body =
+                keys.isEmpty
+                ? "(define ck-inputs (hash))"
+                : "(define ck-inputs\n  (hash\n" + entries.joined(separator: "\n") + "))"
+            return "#lang racket/base\n\(header)\n(provide ck-inputs)\n\(body)\n"
         }
     }
 

--- a/Sources/Core/JSONValueRacketLiteral.swift
+++ b/Sources/Core/JSONValueRacketLiteral.swift
@@ -1,0 +1,97 @@
+// Core/JSONValueRacketLiteral.swift
+//
+// Rendering a JSONValue as a Racket expression, for generated pattern-family
+// tests. Split from JSONValue.swift for length; same shape as the other five
+// literal renderers.
+
+import Foundation
+
+extension JSONValue {
+
+    /// Render this value as a Racket expression.
+    ///
+    /// This is the OPPOSITE of the C++ renderer's problem, and the reason
+    /// Racket was the cheapest language to add. C++ is statically typed, so
+    /// `[1, "two"]` has no honest rendering and a refusal table
+    /// (`cppRenderabilityIssue`) had to exist. Racket is dynamically typed:
+    /// heterogeneous lists, nesting and mixed-value hashes are all ordinary
+    /// values, so **nothing is unrenderable** and there is no companion
+    /// `racketRenderabilityIssue`. Its absence is the point, not an omission.
+    ///
+    /// The literals land in the GENERATED TEST, which is always `#lang racket`
+    /// — never in the student's file, which may be an HtDP teaching language.
+    /// So full-Racket syntax is available here even when grading `#lang
+    /// htdp/bsl` submissions, and that asymmetry is what keeps one generated
+    /// test working across both dialects.
+    public var racketLiteral: String {
+        switch self {
+        case .null:
+            // Racket's own `json` library reads JSON null as the symbol
+            // `'null` (the default of the `json-null` parameter), so an
+            // instructor who writes null gets the value Racket itself would
+            // have produced. `'()` would be wrong — that is the empty list, a
+            // different value that an expectation could legitimately want —
+            // and `#f` would collide with boolean false for the same reason.
+            return "'null"
+        case .bool(let b):
+            return b ? "#t" : "#f"
+        case .int(let i):
+            // Racket integers are arbitrary precision, so no suffix or width
+            // question arises — the C++ renderer's `LL` problem has no analogue.
+            return String(i)
+        case .double(let d):
+            // Racket's own reader syntax for the non-finite flonums. `(/ 0. 0.)`
+            // would also produce them but reads as a computation rather than a
+            // value.
+            if d.isNaN { return "+nan.0" }
+            if d.isInfinite { return d < 0 ? "-inf.0" : "+inf.0" }
+            let s = String(d)
+            // Keep it a flonum: `2.0` must not render as `2`, which Racket
+            // reads as an exact integer and which `equal?` then distinguishes.
+            return (s.contains(".") || s.contains("e") || s.contains("E")) ? s : s + ".0"
+        case .string(let s):
+            return encodeRacketString(s)
+        case .array(let a):
+            // `(list ...)` rather than a quoted `'(...)`: quote would suppress
+            // evaluation of the elements, so a nested `(hash ...)` or a
+            // `$name` reference inside would render as literal source text
+            // instead of the value it names.
+            return a.isEmpty ? "(list)" : "(list " + a.map(\.racketLiteral).joined(separator: " ") + ")"
+        case .object(let o):
+            // An immutable hash with string keys, which is what Racket's json
+            // reader produces for a JSON object modulo key type, and which
+            // `equal?` compares structurally.
+            guard !o.isEmpty else { return "(hash)" }
+            let pairs = o.sorted { $0.key < $1.key }
+                .map { "\(encodeRacketString($0.key)) \($0.value.racketLiteral)" }
+            return "(hash " + pairs.joined(separator: " ") + ")"
+        }
+    }
+}
+
+/// Racket string syntax. The escape set is Racket's, not JSON's — they agree on
+/// the common cases but Racket has no `\/`, and a literal backslash must be
+/// doubled before anything else is considered.
+private func encodeRacketString(_ s: String) -> String {
+    var out = "\""
+    for scalar in s.unicodeScalars {
+        switch scalar {
+        case "\\": out += "\\\\"
+        case "\"": out += "\\\""
+        case "\n": out += "\\n"
+        case "\r": out += "\\r"
+        case "\t": out += "\\t"
+        default:
+            // Racket source is UTF-8, so printable non-ASCII needs no escape.
+            // Control characters do: they would otherwise be embedded raw and
+            // make the generated file unreadable (and, for a stray NUL,
+            // unparseable).
+            if scalar.value < 0x20 || scalar.value == 0x7F {
+                out += String(format: "\\u%04X", scalar.value)
+            } else {
+                out.unicodeScalars.append(scalar)
+            }
+        }
+    }
+    return out + "\""
+}

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -472,6 +472,53 @@ extension AssignmentLanguage {
                 // directory — not merely own a g++. See the property's doc.
                 capabilityRequiresExecutableOutput: true
             )
+        case .racket:
+            return LanguageDescriptor(
+                displayName: "Racket",
+                // `.rkt` only. `.ss` and `.scm` are Scheme's historical
+                // extensions and DrRacket still opens them, but no Waterloo
+                // course submits them and claiming an extension is how a
+                // language steals another's files — the uniqueness invariant
+                // exists for exactly that.
+                scriptExtensions: ["rkt"],
+                // Unlike C++, the generated test IS the language: Racket is
+                // interpreted, so `racket test.rkt` runs it directly under the
+                // ordinary shell-script contract. No wrapper, no build step.
+                generatedScriptExtension: "rkt",
+                inputsFileName: "_ck_inputs.rkt",
+                // No kernel exists to claim aliases for. Empty for the same
+                // reason as C++ — nothing to detect — not Python's
+                // default-by-fallthrough.
+                notebookKernelNames: [],
+                // No xeus kernel on the channel, so no editor and no notebook
+                // workflow. Contingent rather than principled: see the enum
+                // case's doc for why that difference is worth keeping.
+                editorSupport: .uploadOnly,
+                // `racket --version` prints "Welcome to Racket v8.10 [cs]."
+                // and exits 0 (measured on 8.10). The generated tests invoke
+                // the same binary, and — unlike C++ — nothing is produced to
+                // execute afterwards, so probe and invocation genuinely cannot
+                // skew here.
+                interpreterProbe: .init(command: "racket", versionArguments: ["--version"]),
+                // `(require "student.rkt")` is a FILE path, resolved relative
+                // to the requiring module — R's shape, not Python's. Nothing
+                // is name-addressable and no search-path variable applies.
+                //
+                // The test does not actually `require` the submission (an HtDP
+                // module exports nothing; see the enum case), but the
+                // resolution MECHANISM this field describes is still file
+                // reading — `dynamic-require` takes a `(file ...)` path too.
+                moduleResolution: .fileRead,
+                // Racket resolves a relative module path against the enclosing
+                // module's own directory, so a test and the submission beside
+                // it find each other with nothing set. Verified, not assumed —
+                // this is the field the Octave run proved you cannot reason
+                // your way to.
+                workingDirectoryIsOnDefaultSearchPath: true,
+                // Interpreted: the runner hands a file to `racket`. Nothing is
+                // built, so there is no second capability to prove.
+                capabilityRequiresExecutableOutput: false
+            )
         }
     }
 }

--- a/Sources/RunnerCore/NotebookExtraction.swift
+++ b/Sources/RunnerCore/NotebookExtraction.swift
@@ -144,6 +144,22 @@ public func extractCpp(cells: [NotebookCell], filename: String) -> ExtractedRNot
     extractWithCellMarkers(cells: cells, filename: filename, comment: "//")
 }
 
+/// Extract Racket from a notebook's cells — the fifth marker-based extractor,
+/// `;` being Racket's comment leader.
+///
+/// Racket assignments are upload-only, so this path is as rare as C++'s: a
+/// student sending an `.ipynb` through the upload form. It carries the same
+/// caveat, for the same reason — the flattened file is NOT directly runnable,
+/// because a `.rkt` module needs `#lang` on its first line and this emits the
+/// provenance header there. Nothing prepends one, deliberately: guessing the
+/// dialect is exactly the silent-wrong-answer this codebase keeps paying for,
+/// and a BSL submission flattened under `#lang racket` would grade against
+/// different semantics than the student wrote. The guarantee that holds is the
+/// universal one: the notebook extracts or errors, never silently vanishes.
+public func extractRacket(cells: [NotebookCell], filename: String) -> ExtractedRNotebook {
+    extractWithCellMarkers(cells: cells, filename: filename, comment: ";")
+}
+
 /// The shared body of the marker-based extractors. Emits each non-empty code
 /// cell verbatim (trailing whitespace trimmed) behind a boundary comment whose
 /// number is the cell's 1-based position in the ORIGINAL notebook — a markdown

--- a/Sources/Worker/NotebookExtractor.swift
+++ b/Sources/Worker/NotebookExtractor.swift
@@ -222,6 +222,7 @@ func extractNotebooksToCode(
         case .lua: ext = "lua"
         case .octave: ext = "m"
         case .cpp: ext = "cpp"
+        case .racket: ext = "rkt"
         }
         let stem = item.deletingPathExtension().lastPathComponent
         let outURL = directory.appendingPathComponent("\(stem).\(ext)")
@@ -239,7 +240,7 @@ private func assembleExtractedSource(
     language: AssignmentLanguage, cells: [[String: Any]], filename: String
 ) -> String {
     switch language {
-    case .r, .lua, .octave, .cpp:
+    case .r, .lua, .octave, .cpp, .racket:
         // Flattening concatenates cells, which loses the boundaries a
         // source-level check (`.cellContains`) needs.  Python keeps them
         // because `wrapCellForResilientLoad` labels each cell; the others get
@@ -262,6 +263,7 @@ private func assembleExtractedSource(
         case .lua: extracted = extractLua(cells: inputCells, filename: filename)
         case .octave: extracted = extractOctave(cells: inputCells, filename: filename)
         case .cpp: extracted = extractCpp(cells: inputCells, filename: filename)
+        case .racket: extracted = extractRacket(cells: inputCells, filename: filename)
         case .r, .python: extracted = extractR(cells: inputCells, filename: filename)
         }
         return extracted.source

--- a/Sources/Worker/SubmissionPolicy.swift
+++ b/Sources/Worker/SubmissionPolicy.swift
@@ -82,14 +82,14 @@ func submissionGuaranteeExemption(
         // a corrupt notebook is corrupt whatever kernel wrote it, and a student
         // who gets silence cannot act on it in any language.
         switch language {
-        case .python, .r, .lua, .octave, .cpp: return nil
+        case .python, .r, .lua, .octave, .cpp, .racket: return nil
         }
 
     case .introspectableSidecar:
         switch language {
         case .python:
             return nil
-        case .r, .lua, .octave, .cpp:
+        case .r, .lua, .octave, .cpp, .racket:
             // A genuine language-shaped exemption rather than unbuilt work. The
             // sidecar exists so `astStructure` notebook checks can introspect
             // real module-level definitions, and `astStructure` is Python-only

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -128,6 +128,7 @@ func preferredStudentModuleFilename(
         case .lua: sourceExtension = "lua"
         case .octave: sourceExtension = "m"
         case .cpp: sourceExtension = "cpp"
+        case .racket: sourceExtension = "rkt"
         }
         return (submittedName as NSString).deletingPathExtension + "." + sourceExtension
     }

--- a/Tests/APITests/LanguageConformanceMatrixTests.swift
+++ b/Tests/APITests/LanguageConformanceMatrixTests.swift
@@ -95,9 +95,16 @@ import Testing
         let readInputsProgram: (_ key: String) -> String
     }
 
+    // swiftlint:disable function_body_length
     /// EXHAUSTIVE ON PURPOSE. A new `AssignmentLanguage` case does not compile
     /// until it supplies its glue here, which is what stops the matrix from
     /// quietly covering one fewer language than exists.
+    ///
+    /// Long by construction — a table of literals that grows ~25 lines per
+    /// language — so `function_body_length` is disabled for it locally rather
+    /// than raised for all of Tests/. Splitting it would put one language's
+    /// glue somewhere other than beside its neighbours, and this file's whole
+    /// premise is that they are readable side by side.
     static func adapter(for language: AssignmentLanguage) -> Adapter {
         switch language {
         case .cpp:
@@ -127,6 +134,31 @@ import Testing
                     int main() { std::cout << ck_inputs::\(key) << "\\n"; }
                     CK_READ_EOF
                     g++ -std=c++20 -O0 .ck_read_inputs.cpp -o .ck_read_inputs && ./.ck_read_inputs
+                    """
+                }
+            )
+        case .racket:
+            // Racket parses with `raco make`? No — that COMPILES, and would
+            // need the submission present. `racket -e` with `read` over the
+            // file's port parses it and nothing more, which is what this field
+            // asks for. The `#lang` line is part of the syntax, so the read
+            // goes through `read-language` first.
+            return Adapter(
+                interpreter: "racket",
+                evalFlag: "-e",
+                versionArguments: ["--version"],
+                debianPackage: "racket",
+                toolchainProbeCommand: "racket",
+                parseOnlyProgram: { path in
+                    """
+                    (let ([in (open-input-file \"\(path)\")])
+                      (read-language in)
+                      (let loop () (unless (eof-object? (read in)) (loop))))
+                    """
+                },
+                readInputsProgram: { key in
+                    """
+                    (displayln (hash-ref (dynamic-require \"_ck_inputs.rkt\" 'ck-inputs) \"\(key)\"))
                     """
                 }
             )
@@ -228,6 +260,7 @@ import Testing
             )
         }
     }
+    // swiftlint:enable function_body_length
 
     // MARK: - Structural invariants (never skipped)
 

--- a/Tests/APITests/PatternFamilyRendererRacketTests.swift
+++ b/Tests/APITests/PatternFamilyRendererRacketTests.swift
@@ -1,0 +1,268 @@
+// Tests/APITests/PatternFamilyRendererRacketTests.swift
+//
+// The Racket renderer's bytes, EXECUTED: every pattern kind rendered by the
+// real renderer and run through a real `racket` against a correct and a wrong
+// submission. This is the done test the runbook demands — a renderer whose
+// output is only ever parsed can ship a comparison that answers backwards or
+// an exit code that maps to the wrong status and stay green.
+//
+// It also pins the property the whole design rests on: the SAME rendered
+// bytes grade a `#lang htdp/bsl` submission (CS 135/115) and a `#lang racket`
+// one (CS 136+). Every kind below is exercised against both dialects.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite(.timeLimit(.minutes(5))) struct RacketRendererExecutionTests {
+
+    static var racketAvailable: Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["racket", "--version"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+
+    /// The did-not-skip proof for the APITests job. Without it, a CI image
+    /// missing `racket` turns every test below into a silent pass — the exact
+    /// shape that let R's suites skip everywhere for a whole release series.
+    @Test func racketIsPresentInCI() {
+        guard ProcessInfo.processInfo.environment["CI"] != nil else { return }
+        #expect(
+            Self.racketAvailable,
+            "racket absent: every Racket renderer execution test skipped silently")
+    }
+
+    /// Runs a rendered test in a workspace holding the canonical runtime, the
+    /// submission and the student hint. Returns (exitCode, stdout).
+    static func execute(
+        script: String, submission: String, inputs: String? = nil
+    ) throws -> (code: Int32, stdout: String) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-rktrender-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let repoRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let runtime = repoRoot.appendingPathComponent("Tools/runner-support/test_runtime.rkt")
+        try FileManager.default.copyItem(
+            at: runtime, to: dir.appendingPathComponent("test_runtime.rkt"))
+        try submission.write(
+            to: dir.appendingPathComponent("solution.rkt"), atomically: true, encoding: .utf8)
+        try "solution.rkt".write(
+            to: dir.appendingPathComponent(".chickadee_student_module"),
+            atomically: true, encoding: .utf8)
+        if let inputs {
+            try inputs.write(
+                to: dir.appendingPathComponent("_ck_inputs.rkt"), atomically: true, encoding: .utf8)
+        }
+        // Named `case.rkt`, not `test.rkt`: the runtime's submission scan
+        // excludes anything matching "test" so it cannot grade a test file, and
+        // a name that collides would make this harness measure the wrong thing.
+        try script.write(
+            to: dir.appendingPathComponent("case.rkt"), atomically: true, encoding: .utf8)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["racket", "case.rkt"]
+        process.currentDirectoryURL = dir
+        let out = Pipe()
+        process.standardOutput = out
+        process.standardError = Pipe()
+        try process.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (process.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+    }
+
+    static func family(
+        _ kind: PatternKind, function: String = "f", expected: JSONValue,
+        args: [JSONValue] = [.int(3)], paramNames: [String] = ["x"]
+    ) -> PatternFamily {
+        PatternFamily(
+            id: "fam", name: "Family", kind: kind,
+            functionName: function, paramNames: paramNames,
+            defaults: PatternDefaults(tier: .pub, points: 1, hint: nil),
+            cases: [PatternCase(key: "01", label: "case", args: args, expected: expected)])
+    }
+
+    static func render(_ family: PatternFamily, perStudent: Set<String> = []) -> String {
+        renderRacketPatternCase(
+            family: family, case: family.cases[0],
+            sectionVariables: [], specHash: "h", perStudentNames: perStudent)
+    }
+
+    /// The same body in both dialects, so one rendered script can be run
+    /// against each.
+    static func bothDialects(_ body: String) -> [String] {
+        ["#lang htdp/bsl\n\(body)\n", "#lang racket\n\(body)\n"]
+    }
+
+    // MARK: - The property the design rests on
+
+    @Test func oneRenderedTestGradesBothDialects() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.boundaryEquality, expected: .int(9)))
+        for submission in Self.bothDialects("(define (f x) (* x x))") {
+            let result = try Self.execute(script: script, submission: submission)
+            #expect(result.code == 0, "dialect failed: \(submission)\n\(result.stdout)")
+        }
+    }
+
+    // MARK: - Per-kind, pass AND fail
+
+    @Test func boundaryEqualityPassesAndFails() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.boundaryEquality, expected: .int(9)))
+        for submission in Self.bothDialects("(define (f x) (* x x))") {
+            #expect(try Self.execute(script: script, submission: submission).code == 0)
+        }
+        for submission in Self.bothDialects("(define (f x) (+ x x))") {
+            let bad = try Self.execute(script: script, submission: submission)
+            #expect(bad.code == 1)
+            #expect(bad.stdout.contains("wrong value"))
+        }
+    }
+
+    /// The exact-vs-inexact trap: BSL reads `18.5` as the exact rational 37/2,
+    /// so `equal?` would answer #f against a rendered flonum and mark a correct
+    /// student wrong. The runtime compares numbers with `=` for this reason.
+    @Test func exactAndInexactNumbersCompareEqual() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(
+            Self.family(.boundaryEquality, expected: .double(18.5), args: [.int(1)]))
+        for submission in Self.bothDialects("(define (f x) 18.5)") {
+            let result = try Self.execute(script: script, submission: submission)
+            #expect(result.code == 0, "exactness mismatch marked a correct answer wrong")
+        }
+    }
+
+    /// A list argument is what BSL's `quote` refusal would have broken — the
+    /// runtime binds arguments into the namespace instead.
+    @Test func listArgumentsSurviveTheBSLQuoteRestriction() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(
+            Self.family(
+                .boundaryEquality, function: "total", expected: .int(6),
+                args: [.array([.int(1), .int(2), .int(3)])], paramNames: ["lst"]))
+        let body = """
+            (define (total lst)
+              (cond [(empty? lst) 0] [else (+ (first lst) (total (rest lst)))]))
+            """
+        for submission in Self.bothDialects(body) {
+            let result = try Self.execute(script: script, submission: submission)
+            #expect(result.code == 0, "list argument did not reach the student: \(result.stdout)")
+        }
+    }
+
+    @Test func unorderedEqualityIgnoresOrderOnly() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(
+            Self.family(
+                .unorderedEquality, expected: .array([.int(1), .int(2), .int(3)])))
+        let reversed = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) (list 3 2 1))\n")
+        #expect(reversed.code == 0, "\(reversed.stdout)")
+        let wrong = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) (list 1 2 4))\n")
+        #expect(wrong.code == 1)
+    }
+
+    @Test func approximateEqualityHonoursTolerance() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.approximateEquality, expected: .double(1.0)))
+        let close = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) 1.0000001)\n")
+        #expect(close.code == 0, "\(close.stdout)")
+        let far = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) 1.5)\n")
+        #expect(far.code == 1)
+    }
+
+    @Test func variableEqualityReadsAModuleLevelValue() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(
+            Self.family(.variableEquality, function: "threshold", expected: .int(42), args: []))
+        for submission in Self.bothDialects("(define threshold 42)") {
+            let result = try Self.execute(script: script, submission: submission)
+            #expect(result.code == 0, "\(result.stdout)")
+        }
+        let wrong = try Self.execute(
+            script: script, submission: "#lang racket\n(define threshold 7)\n")
+        #expect(wrong.code == 1)
+    }
+
+    @Test func returnTypeCheckNamesTheNeutralType() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.returnTypeCheck, expected: .string("str")))
+        let good = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) \"hello\")\n")
+        #expect(good.code == 0, "\(good.stdout)")
+        let bad = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) 5)\n")
+        #expect(bad.code == 1)
+    }
+
+    @Test func exceptionExpectedMatchesTheMessage() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.exceptionExpected, expected: .string("boom")))
+        let raises = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) (error \"boom\"))\n")
+        #expect(raises.code == 0, "\(raises.stdout)")
+        let returns = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) 1)\n")
+        #expect(returns.code == 1)
+    }
+
+    @Test func performanceThresholdBoundsRuntime() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.performanceThreshold, expected: .int(5000)))
+        let fast = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) x)\n")
+        #expect(fast.code == 0, "\(fast.stdout)")
+    }
+
+    @Test func stdoutEqualityComparesPrintedOutput() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.stdoutEquality, expected: .string("hi")))
+        let good = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) (display \"hi\"))\n")
+        #expect(good.code == 0, "\(good.stdout)")
+        let bad = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) (display \"bye\"))\n")
+        #expect(bad.code == 1)
+    }
+
+    // MARK: - Existence guard
+
+    @Test func existenceGuardFailsRatherThanErrors() throws {
+        guard Self.racketAvailable else { return }
+        let script = renderRacketExistenceGuard(
+            family: Self.family(.boundaryEquality, expected: .int(1)), specHash: "h")
+        let present = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) x)\n")
+        #expect(present.code == 0, "\(present.stdout)")
+        let missing = try Self.execute(
+            script: script, submission: "#lang racket\n(define (g x) x)\n")
+        // Exit 1, never 2: the dependency gate keys on a failure, and an error
+        // would leave the dependent cases running against a missing function.
+        #expect(missing.code == 1)
+    }
+
+    /// A submission that does not compile is the STUDENT's finding, so it is a
+    /// failure of the test rather than a runner error.
+    @Test func aBrokenSubmissionFailsWithAReadableMessage() throws {
+        guard Self.racketAvailable else { return }
+        let script = Self.render(Self.family(.boundaryEquality, expected: .int(9)))
+        let broken = try Self.execute(
+            script: script, submission: "#lang racket\n(define (f x) (+ x\n")
+        #expect(broken.code == 1)
+        #expect(broken.stdout.contains("could not be loaded"))
+    }
+}

--- a/Tests/APITests/SubmissionModeRoutesTests.swift
+++ b/Tests/APITests/SubmissionModeRoutesTests.swift
@@ -38,7 +38,7 @@ import VaporTesting
         // Every assignment language's extensions plus the two formats every
         // assignment takes.  Adding a fifth language changes this string
         // without anyone editing a template.
-        #expect(submissionAcceptAttribute(manifest: nil) == ".cpp,.h,.hpp,.ipynb,.lua,.m,.py,.r,.zip")
+        #expect(submissionAcceptAttribute(manifest: nil) == ".cpp,.h,.hpp,.ipynb,.lua,.m,.py,.r,.rkt,.zip")
     }
 
     @Test func acceptAttributeIncludesRequiredFileExtensions() throws {
@@ -48,7 +48,7 @@ import VaporTesting
         // AssignmentLanguage claims, which is the upload-mode C++ case.
         #expect(
             submissionAcceptAttribute(manifest: manifest)
-                == ".cpp,.h,.hpp,.ipynb,.lua,.m,.py,.r,.zip")
+                == ".cpp,.h,.hpp,.ipynb,.lua,.m,.py,.r,.rkt,.zip")
     }
 
     @Test func acceptAttributeSkipsExtensionlessRequiredFiles() throws {
@@ -170,7 +170,7 @@ import VaporTesting
                     #expect(res.status == .ok)
                     let html = res.body.string
                     #expect(html.contains("main.cpp, util.h"))
-                    #expect(html.contains(#"accept=".cpp,.h,.hpp,.ipynb,.lua,.m,.py,.r,.zip""#))
+                    #expect(html.contains(#"accept=".cpp,.h,.hpp,.ipynb,.lua,.m,.py,.r,.rkt,.zip""#))
                 })
         }
     }

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -35,18 +35,25 @@ import Testing
         // default, reached by falling through — so it is asserted separately.
     }
 
-    /// The kernel-less languages, pinned by name. C++ is the one deliberate
-    /// `.uploadOnly` case — no editor kernel exists because the browser
-    /// cannot run the course's real g++ toolchain, and its assignments are
-    /// upload-only by construction (docs/cpp-support.md). Any OTHER language
-    /// appearing here is an unfinished descriptor, not a decision — update
-    /// this pin in the same diff that makes it one.
-    @Test func onlyCppIsDeliberatelyKernelLess() {
+    /// The kernel-less languages, pinned by name. Two are deliberate, for
+    /// DIFFERENT reasons, and the difference is the point of pinning them:
+    ///
+    ///   * C++ — no editor kernel because the browser cannot run the course's
+    ///     real g++ toolchain, and grading a different compiler than the course
+    ///     teaches is a pedagogy defect (docs/cpp-support.md). A kernel
+    ///     appearing on the channel would NOT change this answer.
+    ///   * Racket — no Scheme-family kernel exists on emscripten-forge to
+    ///     vendor. Contingent, not principled: if one lands, this is the
+    ///     decision to revisit.
+    ///
+    /// Any OTHER language appearing here is an unfinished descriptor, not a
+    /// decision — update this pin in the same diff that makes it one.
+    @Test func kernelLessLanguagesArePinned() {
         let kernelLess = AssignmentLanguage.allCases.filter {
             $0.editorSupport == .uploadOnly
         }
         #expect(
-            kernelLess == [.cpp],
+            kernelLess == [.cpp, .racket],
             """
             The kernel-less language set changed: \(kernelLess). Vendoring or \
             dropping a kernel is a stated decision — update this pin in the \

--- a/Tests/Fixtures/generated-source/racket/_ck_inputs.rkt
+++ b/Tests/Fixtures/generated-source/racket/_ck_inputs.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+; Auto-generated per-student grading inputs (issue #461). Do not edit.
+(provide ck-inputs)
+(define ck-inputs
+  (hash
+   "label" "high"
+   "threshold" 42
+   "weights" (list 0.5 1.5)))

--- a/Tests/Fixtures/generated-source/racket/check/ast_structure.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/ast_structure.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/ast_structure/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/ast_structure/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/cell_contains.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/cell_contains.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/cell_contains/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/cell_contains/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/data_frame_columns.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/data_frame_columns.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/data_frame_columns/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/data_frame_columns/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/data_frame_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/data_frame_equality.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/data_frame_equality/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/data_frame_equality/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/data_frame_shape.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/data_frame_shape.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/data_frame_shape/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/data_frame_shape/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/figure_count.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/figure_count.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/figure_count/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/figure_count/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/function_exists.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/function_exists.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/function_exists/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/function_exists/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/numeric_array_close.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/numeric_array_close.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/numeric_array_close/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/numeric_array_close/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/series_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/series_equality.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/series_equality/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/series_equality/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/check/variable_exists.manifest
+++ b/Tests/Fixtures/generated-source/racket/check/variable_exists.manifest
@@ -1,0 +1,1 @@
+publiccheck_chk.rkt	tier=public

--- a/Tests/Fixtures/generated-source/racket/check/variable_exists/publiccheck_chk.rkt
+++ b/Tests/Fixtures/generated-source/racket/check/variable_exists/publiccheck_chk.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(eprintf "Notebook checks are not available for Racket assignments.\n")
+(exit 2)

--- a/Tests/Fixtures/generated-source/racket/pattern/approximate_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/approximate_equality.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/approximate_equality/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/approximate_equality/publictest_fam_01.rkt
@@ -1,0 +1,30 @@
+; Test: b
+; Generated from pattern family "Family" [fam] spec_hash=8fff023f74a1087a — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x 18.49)
+(define expected 1)
+(define tolerance 1e-06)
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define actual
+  (with-handlers ([exn:fail? (lambda (e)
+      (chickadee-failed (string-append "unexpected exception" "\n"
+                         "  error:    " (exn-message e))))])
+    (chickadee-call ns 'classify (list x))))
+
+(unless (and (real? actual) (real? expected))
+  (chickadee-failed (string-append                              "  expected: " (chickadee-format expected) "\n"
+                     "  got:      " (chickadee-format actual))))
+(define delta (abs (- actual expected)))
+(if (<= delta tolerance)
+    (chickadee-passed (string-append "Returned " (chickadee-format actual)))
+    (chickadee-failed (string-append                                "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                       "  expected: " (chickadee-format expected) "\n"
+                       "  got:      " (chickadee-format actual) "\n"
+                       "  delta:    " (chickadee-format delta))))

--- a/Tests/Fixtures/generated-source/racket/pattern/boundary_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/boundary_equality.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/boundary_equality/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/boundary_equality/publictest_fam_01.rkt
@@ -1,0 +1,26 @@
+; Test: b
+; Generated from pattern family "Family" [fam] spec_hash=567149c178ff72bc — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x 18.49)
+(define expected 1)
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define actual
+  (with-handlers ([exn:fail? (lambda (e)
+      (chickadee-failed (string-append "unexpected exception" "\n"
+                         "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                         "  error:    " (exn-message e))))])
+    (chickadee-call ns 'classify (list x))))
+
+(if (chickadee-equal? actual expected)
+    (chickadee-passed (string-append "Returned " (chickadee-format actual)))
+    (chickadee-failed (string-append "wrong value" "\n"
+                       "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                       "  expected: " (chickadee-format expected) "\n"
+                       "  got:      " (chickadee-format actual))))

--- a/Tests/Fixtures/generated-source/racket/pattern/exception_expected.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/exception_expected.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/exception_expected/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/exception_expected/publictest_fam_01.rkt
@@ -1,0 +1,29 @@
+; Test: e
+; Generated from pattern family "Family" [fam] spec_hash=af181e8a5562a736 — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x -1)
+(define expected-error "ValueError")
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define outcome
+  (with-handlers ([exn:fail? (lambda (e) (cons 'raised (exn-message e)))])
+    (cons 'returned (chickadee-call ns 'classify (list x)))))
+
+(cond
+  [(eq? (car outcome) 'returned)
+   (chickadee-failed (string-append "expected an error\n"
+                      "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                      "  expected: " expected-error "\n"
+                      "  got:      " (chickadee-format (cdr outcome))))]
+  [(or (string=? expected-error "")
+       (regexp-match? (regexp (regexp-quote expected-error)) (cdr outcome)))
+   (chickadee-passed "Raised the expected error")]
+  [else
+   (chickadee-failed (string-append                               "  expected: " expected-error "\n"
+                      "  error:    " (cdr outcome)))])

--- a/Tests/Fixtures/generated-source/racket/pattern/performance_threshold.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/performance_threshold.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/performance_threshold/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/performance_threshold/publictest_fam_01.rkt
@@ -1,0 +1,26 @@
+; Test: p
+; Generated from pattern family "Family" [fam] spec_hash=373c736715269bba — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x 1)
+(define budget-ms 0.5)
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define start (current-inexact-milliseconds))
+(with-handlers ([exn:fail? (lambda (e)
+    (chickadee-failed (string-append "unexpected exception" "\n"
+                       "  error:     " (exn-message e))))])
+  (chickadee-call ns 'classify (list x)))
+(define elapsed (- (current-inexact-milliseconds) start))
+
+(if (<= elapsed budget-ms)
+    (chickadee-passed (format "Completed in ~ams" (round elapsed)))
+    (chickadee-failed (string-append "too slow\n"
+                       "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                       "  threshold: " (format "~ams" budget-ms) "\n"
+                       "  elapsed:   " (format "~ams" (round elapsed)))))

--- a/Tests/Fixtures/generated-source/racket/pattern/return_type_check.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/return_type_check.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/return_type_check/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/return_type_check/publictest_fam_01.rkt
@@ -1,0 +1,25 @@
+; Test: t
+; Generated from pattern family "Family" [fam] spec_hash=8adb8f0c701a46e7 — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x 1)
+(define expected-type "int")
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define actual
+  (with-handlers ([exn:fail? (lambda (e)
+      (chickadee-failed (string-append "unexpected exception" "\n"
+                         "  error:    " (exn-message e))))])
+    (chickadee-call ns 'classify (list x))))
+
+(define actual-type (chickadee-type-name actual))
+(if (string=? actual-type expected-type)
+    (chickadee-passed (string-append "Returned a " actual-type))
+    (chickadee-failed (string-append                                "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                       "  expected: " expected-type "\n"
+                       "  got:      " actual-type)))

--- a/Tests/Fixtures/generated-source/racket/pattern/stdout_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/stdout_equality.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/stdout_equality/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/stdout_equality/publictest_fam_01.rkt
@@ -1,0 +1,25 @@
+; Test: s
+; Generated from pattern family "Family" [fam] spec_hash=fc8371b5e923b61d — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x 1)
+(define expected "hello")
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define printed
+  (with-handlers ([exn:fail? (lambda (e)
+      (chickadee-failed (string-append "unexpected exception" "\n"
+                         "  error:    " (exn-message e))))])
+    (let-values ([(out _) (chickadee-call/capture ns 'classify (list x))])
+      out)))
+
+(if (chickadee-stdout-matches? printed expected)
+    (chickadee-passed "Printed the expected output")
+    (chickadee-failed (string-append                                "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                       "  expected: " (chickadee-format expected) "\n"
+                       "  got:      " (chickadee-format printed))))

--- a/Tests/Fixtures/generated-source/racket/pattern/unordered_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/unordered_equality.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/unordered_equality/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/unordered_equality/publictest_fam_01.rkt
@@ -1,0 +1,26 @@
+; Test: u
+; Generated from pattern family "Family" [fam] spec_hash=742f48b545094cfb — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define x 1)
+(define expected (list 1 2))
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define actual
+  (with-handlers ([exn:fail? (lambda (e)
+      (chickadee-failed (string-append "unexpected exception" "\n"
+                         "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                         "  error:    " (exn-message e))))])
+    (chickadee-call ns 'classify (list x))))
+
+(if (chickadee-unordered-equal? actual expected)
+    (chickadee-passed (string-append "Returned " (chickadee-format actual)))
+    (chickadee-failed (string-append 
+                       "  input:    " (string-append "x=" (chickadee-format x)) "\n"
+                       "  expected: " (chickadee-format expected) "\n"
+                       "  got:      " (chickadee-format actual))))

--- a/Tests/Fixtures/generated-source/racket/pattern/variable_equality.manifest
+++ b/Tests/Fixtures/generated-source/racket/pattern/variable_equality.manifest
@@ -1,0 +1,1 @@
+publictest_fam_01.rkt	tier=public	points=1

--- a/Tests/Fixtures/generated-source/racket/pattern/variable_equality/publictest_fam_01.rkt
+++ b/Tests/Fixtures/generated-source/racket/pattern/variable_equality/publictest_fam_01.rkt
@@ -1,0 +1,23 @@
+; Test: v
+; Generated from pattern family "Family" [fam] spec_hash=3e7d072c983cd304 — edit the family, not this file.
+
+#lang racket/base
+
+(require "test_runtime.rkt")
+
+(define expected 3)
+(define ns (chickadee-load-student))
+(unless (chickadee-defined? ns 'classify)
+  (chickadee-failed "`classify` is not defined"))
+
+(define actual
+  (with-handlers ([exn:fail? (lambda (e)
+      (chickadee-failed (string-append "the variable could not be read" "\n"
+                         "  error:    " (exn-message e))))])
+    (chickadee-value ns 'classify)))
+
+(if (chickadee-equal? actual expected)
+    (chickadee-passed (string-append "classify = " (chickadee-format actual)))
+    (chickadee-failed (string-append "wrong value" "\n"
+                                                      "  expected: " (chickadee-format expected) "\n"
+                       "  got:      " (chickadee-format actual))))

--- a/Tests/WorkerTests/SubmissionNormalizationStrategyTests.swift
+++ b/Tests/WorkerTests/SubmissionNormalizationStrategyTests.swift
@@ -57,7 +57,7 @@ import Testing
         switch language {
         case .python:
             #expect(result == .pythonModule)
-        case .r, .lua, .octave, .cpp:
+        case .r, .lua, .octave, .cpp, .racket:
             #expect(
                 result == .extractToSource(forcedLanguage: language),
                 """
@@ -88,7 +88,7 @@ import Testing
 
         switch language {
         case .python: #expect(result == .pythonModule)
-        case .r, .lua, .octave, .cpp:
+        case .r, .lua, .octave, .cpp, .racket:
             #expect(result == .extractToSource(forcedLanguage: language))
         }
     }

--- a/Tests/WorkerTests/SubmissionPolicyTests.swift
+++ b/Tests/WorkerTests/SubmissionPolicyTests.swift
@@ -72,6 +72,7 @@ import Testing
             exempted.sorted() == [
                 "cpp/introspectableSidecar", "lua/introspectableSidecar",
                 "octave/introspectableSidecar", "r/introspectableSidecar",
+                "racket/introspectableSidecar",
             ],
             "the exemption list changed: \(exempted.sorted())")
     }

--- a/Tools/runner-support/test_runtime.rkt
+++ b/Tools/runner-support/test_runtime.rkt
@@ -1,0 +1,285 @@
+#lang racket/base
+;; test_runtime.rkt — Chickadee's Racket grading runtime.
+;;
+;; The Racket member of the test_runtime family (.py/.R/.lua/.m/.hpp). Its shape
+;; is dictated by one fact that no other language in the family has:
+;;
+;;   A STUDENT MODULE EXPORTS NOTHING.
+;;
+;; CS 135 and CS 115 submissions are HtDP teaching languages (`#lang htdp/bsl`
+;; and friends), and such a module has no `provide` — so `(require "student.rkt")`
+;; binds nothing at all. Everything below follows from working around that, and
+;; each workaround was measured against a real `racket` before it was written,
+;; because the obvious spelling fails in each case:
+;;
+;;   1. LOADING. `dynamic-require` the module for its side effect, then take
+;;      `module->namespace` to reach its internal definitions. Requiring it
+;;      normally yields an empty set of bindings, not an error — the silent kind.
+;;
+;;   2. DEFINEDNESS. Ask `namespace-mapped-symbols`, never
+;;      `namespace-variable-value`. The latter returns its failure thunk for a
+;;      perfectly good BSL binding (measured), so a defined function reads as
+;;      missing and every case skips behind a guard that should have passed.
+;;
+;;   3. CALLING. Evaluate an APPLICATION FORM, never a bare identifier. BSL
+;;      rejects a function reference outside operator position — the error reads
+;;      "expected a function call, but there is no open parenthesis before this
+;;      function" — so you cannot extract the procedure and apply it.
+;;
+;;   4. ARGUMENTS. Bind each value into the namespace and pass it BY NAME.
+;;      Quoting is the natural spelling and BSL refuses it: `(quote (1 2 3))`
+;;      fails with "expected the name of a symbol or () after the quote, but
+;;      found a part". That is measured, and it would have broken silently for
+;;      exactly the list-valued arguments a CS 135 assignment is made of.
+;;
+;; The payoff for all four: ONE generated test works unchanged against
+;; `#lang htdp/bsl` and `#lang racket`, so the CS 135 and CS 136 dialects need
+;; no separate authoring path.
+
+(require racket/list racket/string racket/path)
+
+(provide chickadee-load-student
+         chickadee-defined?
+         chickadee-call
+         chickadee-passed
+         chickadee-failed
+         chickadee-errored
+         chickadee-equal?
+         chickadee-unordered-equal?
+         chickadee-format
+         chickadee-inputs
+         chickadee-label
+         chickadee-value
+         chickadee-call/capture
+         chickadee-type-name
+         chickadee-stdout-matches?)
+
+;; --- Test label ------------------------------------------------------------
+;; The runner reads the label off the generated file's first `; Test:` line, and
+;; results echo it back. Reading our own source keeps one source of truth.
+
+(define (chickadee-label)
+  (define path (find-system-path 'run-file))
+  (with-handlers ([exn:fail? (lambda (_) "test")])
+    (define line
+      (for/first ([l (in-lines (open-input-file (current-test-path)))]
+                  #:when (regexp-match #rx"^;+ *Test:" l))
+        l))
+    (if line
+        (string-trim (regexp-replace #rx"^;+ *Test: *" line ""))
+        (path->string (file-name-from-path path)))))
+
+(define (current-test-path)
+  (find-system-path 'run-file))
+
+;; --- Result reporting ------------------------------------------------------
+;; The shell-script contract: exit 0/1/2, and the LAST non-empty stdout line is
+;; read as JSON. Detail goes to stderr, which the runner captures as longResult.
+
+(define (emit status short [err #f])
+  (printf "{\"status\":~a,\"shortResult\":~a,\"test\":~a~a}\n"
+          (json-string status)
+          (json-string short)
+          (json-string (chickadee-label))
+          (if err (format ",\"error\":~a" (json-string err)) "")))
+
+;; Hand-rolled rather than `json`'s `write-json`: this file is loaded by every
+;; generated test, and the strings it emits are short. Escapes cover what a
+;; failure message can actually contain.
+(define (json-string s)
+  (define str (if (string? s) s (format "~a" s)))
+  (string-append
+   "\""
+   (apply string-append
+          (for/list ([ch (in-string str)])
+            (cond [(char=? ch #\") "\\\""]
+                  [(char=? ch #\\) "\\\\"]
+                  [(char=? ch #\newline) "\\n"]
+                  [(char=? ch #\return) "\\r"]
+                  [(char=? ch #\tab) "\\t"]
+                  [(char<? ch #\space) (format "\\u~a" (~hex (char->integer ch)))]
+                  [else (string ch)])))
+   "\""))
+
+(define (~hex n)
+  (define s (number->string n 16))
+  (string-append (make-string (max 0 (- 4 (string-length s))) #\0) s))
+
+(define (chickadee-passed [message #f])
+  (emit "pass" (or message (format "~a: passed" (chickadee-label))))
+  (exit 0))
+
+(define (chickadee-failed [message "failed"])
+  (emit "fail" (format "~a: ~a" (chickadee-label) message) message)
+  (eprintf "~a\n" message)
+  (exit 1))
+
+(define (chickadee-errored [message "error"])
+  (emit "error" (format "~a: ~a" (chickadee-label) message) message)
+  (eprintf "~a\n" message)
+  (exit 2))
+
+;; --- Locating and loading the submission -----------------------------------
+
+;; Names that are never the student's module.
+(define (reserved-name? base)
+  (or (string=? base "test_runtime.rkt")
+      (string=? base "_ck_inputs.rkt")
+      (regexp-match? #rx"test" base)))
+
+;; The runner writes `.chickadee_student_module` on every job. Unlike Lua, we
+;; CAN list a directory, so a scan backs the hint up — same posture as R and
+;; Python.
+(define (chickadee-student-file)
+  (define hinted
+    (and (file-exists? ".chickadee_student_module")
+         (let ([named (string-trim (file->line ".chickadee_student_module"))])
+           (and (not (string=? named ""))
+                (let ([base (path->string (file-name-from-path (string->path named)))])
+                  (and (regexp-match? #rx"[.]rkt$" base)
+                       (not (reserved-name? base))
+                       (file-exists? base)
+                       base))))))
+  (or hinted
+      (and (file-exists? "solution.rkt") "solution.rkt")
+      (let ([candidates
+             (sort (for/list ([p (in-list (directory-list))]
+                              #:when (let ([b (path->string p)])
+                                       (and (regexp-match? #rx"[.]rkt$" b)
+                                            (not (reserved-name? b)))))
+                     (path->string p))
+                   string<?)])
+        (and (pair? candidates) (first candidates)))))
+
+(define (file->line path)
+  (call-with-input-file path (lambda (in) (or (read-line in) ""))))
+
+;; Returns the submission's namespace. Errors (rather than fails) when there is
+;; nothing to grade — a missing submission is not a wrong answer.
+(define (chickadee-load-student)
+  (define file (chickadee-student-file))
+  (unless file
+    (chickadee-errored "No Racket submission file was found to grade."))
+  (define complete (path->string (path->complete-path file)))
+  (with-handlers
+      ([exn:fail?
+        (lambda (e)
+          ;; A submission that does not compile is a FAILURE of the test, not a
+          ;; runner error: the student's own syntax error is the finding.
+          (chickadee-failed
+           (format "Your submission could not be loaded: ~a" (exn-message e))))])
+    (define mp `(file ,complete))
+    (dynamic-require mp #f)
+    (module->namespace mp)))
+
+;; See note 2 in the header: this is the only definedness test that works for a
+;; teaching-language module.
+(define (chickadee-defined? ns name)
+  (and (memq name (namespace-mapped-symbols ns)) #t))
+
+;; See notes 3 and 4: application form, arguments bound by name.
+(define (chickadee-call ns name args)
+  (define arg-names
+    (for/list ([i (in-range (length args))])
+      (string->symbol (format "ck-arg~a" i))))
+  (for ([n (in-list arg-names)] [v (in-list args)])
+    (namespace-set-variable-value! n v #t ns))
+  (eval (cons name arg-names) ns))
+
+;; A module-level VALUE (not a function). Safe to evaluate bare: BSL's
+;; operator-position restriction applies to procedures, not to data bindings —
+;; `(define x 5)` then `x` is legal there. Used by `variableEquality`.
+(define (chickadee-value ns name)
+  (eval name ns))
+
+;; Calls the student's function with stdout captured, for `stdoutEquality`.
+;; Returns (values printed-string result).
+(define (chickadee-call/capture ns name args)
+  (define out (open-output-string))
+  (define result (parameterize ([current-output-port out]) (chickadee-call ns name args)))
+  (values (get-output-string out) result))
+
+;; The neutral type names pattern families use, mapped onto Racket's predicates.
+;; Racket has no "int" distinct from a whole flonum in the way Python does, so
+;; `integer?` deliberately accepts 5.0 — a student who computed a whole number
+;; by division has not made a type error.
+(define (chickadee-type-name v)
+  (cond [(and (number? v) (integer? v)) "int"]
+        [(number? v) "float"]
+        [(string? v) "str"]
+        [(boolean? v) "bool"]
+        [(list? v) "list"]
+        [(hash? v) "dict"]
+        [else (format "~a" (let-values ([(t _) (values (object-name v) #f)]) (or t "value")))]))
+
+;; --- Per-student inputs ----------------------------------------------------
+
+(define (chickadee-inputs)
+  (if (file-exists? "_ck_inputs.rkt")
+      (with-handlers ([exn:fail? (lambda (_) (hash))])
+        (dynamic-require `(file ,(path->string (path->complete-path "_ck_inputs.rkt")))
+                         'ck-inputs))
+      (hash)))
+
+;; --- Comparison ------------------------------------------------------------
+
+;; `equal?` is WRONG for grading numbers: Racket distinguishes exact from
+;; inexact, so `(equal? 25 25.0)` is #f and a student returning a flonum where
+;; the expectation is an integer would be marked wrong for being right. `=`
+;; compares across the exactness boundary, so numbers take that path.
+;;
+;; NaN matches NaN, matching Octave's `isequaln` posture: an expectation of NaN
+;; is asking "is this not-a-number", and `=` alone answers #f to that.
+(define (chickadee-equal? a b)
+  (cond
+    [(and (real? a) (real? b))
+     (cond [(and (nan? a) (nan? b)) #t]
+           [(or (nan? a) (nan? b)) #f]
+           [else (= a b)])]
+    [(and (list? a) (list? b))
+     (and (= (length a) (length b)) (andmap chickadee-equal? a b))]
+    [(and (hash? a) (hash? b))
+     (and (= (hash-count a) (hash-count b))
+          (for/and ([(k v) (in-hash a)])
+            (and (hash-has-key? b k) (chickadee-equal? v (hash-ref b k)))))]
+    [(and (vector? a) (vector? b))
+     (chickadee-equal? (vector->list a) (vector->list b))]
+    [else (equal? a b)]))
+
+(define (nan? x) (and (real? x) (not (= x x))))
+
+;; Order-insensitive comparison for `unorderedEquality`. Quadratic, which is the
+;; right trade at test sizes and avoids requiring the elements be sortable.
+(define (chickadee-unordered-equal? a b)
+  (and (list? a) (list? b)
+       (= (length a) (length b))
+       (let loop ([remaining b] [items a])
+         (cond
+           [(null? items) #t]
+           [else
+            (define idx
+              (for/first ([(v i) (in-indexed remaining)]
+                          #:when (chickadee-equal? (car items) v))
+                i))
+            (and idx
+                 (loop (append (take remaining idx) (drop remaining (add1 idx)))
+                       (cdr items)))]))))
+
+;; Compares captured stdout against an expectation, ignoring surrounding
+;; whitespace. A runtime helper rather than inline `string-trim` in the
+;; generated test: generated tests are `#lang racket/base`, which does NOT
+;; export `string-trim` — that lives in `racket/string`. Keeping the comparison
+;; here means a generated case needs exactly one require.
+(define (chickadee-stdout-matches? printed expected)
+  (define (trim s)
+    (define str (if (string? s) s (format "~a" s)))
+    (define chars (string->list str))
+    (define (drop-ws lst) (if (and (pair? lst) (char-whitespace? (car lst))) (drop-ws (cdr lst)) lst))
+    (list->string (reverse (drop-ws (reverse (drop-ws chars))))))
+  (string=? (trim printed) (trim expected)))
+
+;; One-line, student-readable rendering. `~s` is the write form, so strings keep
+;; their quotes and a returned "25" is distinguishable from 25 in a failure
+;; message — the whole point of showing the value back.
+(define (chickadee-format v)
+  (format "~s" v))

--- a/changelog.d/racket-assignment-language.md
+++ b/changelog.d/racket-assignment-language.md
@@ -1,0 +1,40 @@
+### Added
+
+- **Racket is the sixth assignment language.** `AssignmentLanguage.racket`
+  covers the courses Waterloo's first-year CS stream actually runs — CS 135 and
+  CS 115 (`#lang htdp/bsl`) and CS 136 (`#lang racket`) — with all eight pattern
+  kinds rendering and executing. It is upload-only like C++, because no
+  Scheme-family kernel exists on `emscripten-forge-4x` to vendor; unlike C++
+  that answer is contingent rather than principled, so a kernel appearing is a
+  reason to revisit it. Notebook checks are refused categorically for the same
+  structural reason as C++ (no submitted notebook exists). `racket` is on the
+  server, runner and CI images; the Debian package carries the HtDP
+  teaching-language collections, which is a requirement and not a bonus.
+
+  Four things were measured before any Swift was written, each because the
+  obvious spelling fails silently:
+
+  - A teaching-language module **exports nothing**, so a generated test cannot
+    `require` the submission. Tests load it with `dynamic-require` +
+    `module->namespace`.
+  - Definedness must ask `namespace-mapped-symbols`;
+    `namespace-variable-value` reports a perfectly good BSL binding as missing.
+  - Calls must evaluate an **application form**, never a bare identifier — BSL
+    rejects a function reference outside operator position.
+  - Arguments must be **bound into the namespace and passed by name**. Quoting
+    is the natural spelling and BSL refuses it (`(quote (1 2 3))` is an error),
+    which would have broken exactly the list-valued arguments a CS 135
+    assignment is made of.
+
+  The payoff is that one rendered test grades both dialects unchanged, which
+  `PatternFamilyRendererRacketTests` pins by running every kind against each.
+  Numeric comparison uses `=` rather than `equal?` because BSL reads `18.5` as
+  the exact rational `37/2`, and `equal?` would mark a correct student wrong.
+
+### Changed
+
+- **`existenceGuard` builds its `GeneratedScript` once.** Every per-language arm
+  constructed an identical value around a different source string; the shared
+  construction is hoisted and Python's bytes moved to a helper unchanged (the
+  goldens verify). A seventh language is now one line there rather than
+  thirteen.


### PR DESCRIPTION
Proof of concept for the languages Waterloo's first-year CS stream actually runs. **CS 135** and **CS 115** write `#lang htdp/bsl`; **CS 136** writes `#lang racket`. One rendered test grades both, unchanged.

All eight pattern kinds render **and execute**. Notebook checks are refused categorically (upload-only, so no submitted notebook exists) — the same structural reason as C++.

## Why upload-only, and why that's different from C++

No Scheme-family kernel exists on `emscripten-forge-4x`. Measured against the channel's repodata rather than assumed — it carries cpp, haskell, javascript, lfortran, lua, ocaml, octave, python, r, sqlite, and nothing Scheme.

That makes Racket `EditorSupport.uploadOnly` like C++, but the two answers are **not the same kind of answer**, and the descriptor says so: C++ has no kernel because grading a different compiler than the course teaches is a pedagogy defect — a kernel appearing would not change it. Racket has none because nobody built one. If one lands, Racket's answer is the one to revisit.

It's otherwise the cheapest language here: interpreted (no build step, no `.sh` wrapper) and dynamically typed (so `JSONValue` renders with **no** refusal table — the absence of a `racketRenderabilityIssue` is the point, not an omission).

## Four things measured before any Swift was written

Each because the obvious spelling fails, and three of them fail *silently*:

| | Obvious spelling | What actually happens | What the runtime does |
|---|---|---|---|
| Load | `(require "student.rkt")` | binds **nothing** — an HtDP module has no `provide` — without erroring | `dynamic-require` + `module->namespace` |
| Definedness | `namespace-variable-value` | reports a good BSL binding as **missing** | `namespace-mapped-symbols` |
| Call | extract the procedure, apply it | BSL rejects a function reference outside operator position | evaluate an **application form** |
| Arguments | `(quote (1 2 3))` | BSL: *"expected the name of a symbol or () after the quote"* | bind into the namespace, pass **by name** |

That last one would have broken exactly the list-valued arguments a CS 135 assignment is made of.

A fifth, found by a test rather than reasoning: **BSL reads `18.5` as the exact rational `37/2`**, so `equal?` against a rendered flonum marks a correct student wrong. The runtime compares numbers with `=`. Pinned by `exactAndInexactNumbersCompareEqual`.

## Demonstrated end to end

Real renderer output (the committed golden) against real `racket` 8.10:

```
CS 135 submission (#lang htdp/bsl)   → {"status":"pass","shortResult":"Returned 1"}   exit=0
CS 136 submission (#lang racket)     → {"status":"pass","shortResult":"Returned 1"}   exit=0   ← same file, unchanged
wrong boundary                       → {"status":"fail",... "expected: 1  got: 2"}    exit=1
function missing                     → {"status":"fail","`classify` is not defined"}  exit=1
```

## Testing

- `PatternFamilyRendererRacketTests` — 14 tests, every kind **executed** against a correct and a wrong submission, the equality kinds against **both dialects**. This is the runbook's done test; a renderer whose output is only parsed can ship a backwards comparison and stay green.
- `racketIsPresentInCI` — the did-not-skip proof. Without it a CI image lacking `racket` turns the whole suite into a silent pass, which is how R's suites skipped everywhere for a release series.
- Conformance matrix gains its Racket arm; goldens generated; `swift build` clean **with no `default:` arm added**.
- `scripts/format.sh`, `lint.sh`, `swiftlint.sh --strict`: 0 violations across 952 files.

## Also in this diff

`existenceGuard` built an identical `GeneratedScript` in every per-language arm. The construction is hoisted and Python's bytes moved to a helper **unchanged** (goldens verify). A seventh language is one line there rather than thirteen.

`racket` added to the server, runner and CI images. The Debian package carries the HtDP collections — a requirement, not a bonus: a minimal Racket would reject every CS 135 submission.

## What this does NOT include

- **No live assignment yet.** Production runs `0.5.33`, which predates this branch, so `create_assignment` would reject `language: "racket"`. The acceptance test that caught the C++ failure — author a real assignment, watch it validate on a real runner — has to wait for a deploy. Everything above is local execution against real Racket.
- **Personalization is implemented but only unit-exercised**; no live per-student run.
- **CS 136 is "Racket *and* C"** — C is a separate language decision and roughly C++-sized, not a flag on this.

---
_Generated by [Claude Code](https://claude.ai/code/session_017McdDCCdwwNhS4p5Jxzj8f)_