### PR TITLE
docs: teach the add-a-language runbook the authoring UI, and correct its counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ on the default load path in both runners — and the LanguageDescriptor table
 records the correction. Postmortem: `docs/adding-a-xeus-kernel.md` §"What
 the Octave run actually cost".
 
-**C++ is the fifth assignment language — and the first with NO editor kernel.**
+**C++ is the fifth assignment language — and the FIRST with no editor kernel; Racket is the second (see below).**
 `EditorSupport.uploadOnly` (the `LanguageDescriptor` judgement that folded the
 four kernel facts) plus `submissionMode: "uploadOnly"` (a manifest field beside
 `gradingMode`; `notebook` mode deliberately keeps the upload form beside the
@@ -213,8 +213,23 @@ shipped browser-graded R that no isolated engine ever ran.
 and fails on drift in either direction. It currently lists the four grading
 workers (Python, R, Lua, Octave) plus the freeze watchdog.
 
-**Assignments are Python, R, Lua, Octave *or* C++; language is first-class (`AssignmentLanguage`).**
-`AssignmentLanguage` (`.python | .r | .lua | .octave | .cpp`, Core) is resolved from the manifest
+**Racket is the sixth assignment language, and the second upload-only one.**
+No Scheme-family kernel exists on `emscripten-forge-4x` to vendor, so
+`EditorSupport.uploadOnly` — but for a *contingent* reason where C++'s is a
+decision: C++ has no kernel because grading a different compiler than the course
+teaches is a pedagogy defect, Racket has none because nobody built one. It is
+otherwise the cheapest language here: interpreted, so `racket file.rkt` needs no
+`.sh` wrapper, and dynamically typed, so `JSONValue` renders without C++'s
+refusal table. All eight pattern kinds render and execute across both dialects
+CS 135/115 (`#lang htdp/bsl`) and CS 136 (`#lang racket`) write; notebook checks
+are refused categorically, as for C++. The measured trap: a teaching-language
+module EXPORTS NOTHING, so a generated test loads the submission with
+`dynamic-require` + `module->namespace` and evaluates an application form rather
+than a bare identifier. See `docs/multi-language-audit.md` for the two runner
+defects still open against it.
+
+**Assignments are Python, R, Lua, Octave, C++ *or* Racket; language is first-class (`AssignmentLanguage`).**
+`AssignmentLanguage` (`.python | .r | .lua | .octave | .cpp | .racket`, Core) is resolved from the manifest
 (any `.R` graded script → `.r`, any `.lua` → `.lua`, any `.m` → `.octave`; else
 a notebook kernel in that language's `notebookKernelNames` — `{ir,r,webr,xr}`
 for R, `{xlua,lua}` for Lua, `{xoctave,octave}` for Octave; else `.python`) and every language-specific path dispatches through it — literal
@@ -379,6 +394,50 @@ gets. It is a **live-edit** endpoint: like `PUT /suite` and unlike the MCP
 tools, it never changes visibility, so fixing a typo mid-lab does not close the
 assignment out from under students. Re-validation still runs (debounced for the
 starter, always for a solution, since the new solution *is* what validates).
+
+**The authoring UI reads the assignment's language from ONE seed (v0.5.36).**
+The browser editors had no notion of language at all: `pattern-family-editor.js`
+contained the string "language" zero times, and `inputs-editor-core.js` had the
+identical defect, so both parsed instructor input by Python's rules — `True` /
+`False` / `None` plus a Python-repr rewrite — on every assignment. An R author
+typing the boolean true stored the **string**, silently, in a value a generated
+test then compares.
+
+`AuthoringLanguageFacts` is now encoded into an `#assignment-language-seed`
+script tag on both authoring pages, and `Public/authoring-language.js`
+(`window.ChickadeeLanguage`) is the single reader. **Every value in the seed is
+derived, never tabulated:** the scalar spellings come from
+`JSONValue.literal(_:)` — the same call that renders the real generated test, so
+the editor cannot show one spelling while the renderer emits another — kind
+availability from `notebookCheckKindIsSupported` (the predicate the save-time
+refusal uses, so the Add Test menu and the rejection cannot disagree), scan
+support from `notebookFunctionScanSupport`, and evaluation support from
+`PersonalizationEvaluator`.
+
+The consequence worth knowing before touching this: **a seventh language needs
+zero JavaScript edits.** There is no per-language list in any authoring JS, and
+the invariant is greppable (see the runbook's "The authoring UI: what you do NOT
+have to do"). If a new *fact* is needed, add a field to `AuthoringLanguageFacts`
+and derive it from whatever already owns the answer — do not answer it twice.
+Both mistakes were made and undone here: the literals were nearly generated into
+a JS table, and two capability flags shipped as hand-written bools before being
+pointed at their real owners. `AuthoringLanguageFactsTests` asserts the
+derivation.
+
+**Auto-computing a case's expected value runs on the SERVER for every language
+but Python** (`POST /instructor/:id/compute-expected`). The in-page evaluator is
+a Python kernel; on another language it did not fail, it computed a *Python*
+answer for a value compared against that language's result.
+`PersonalizationEvaluator` already evaluates in all six behind an exhaustive
+switch, so the fix was to route to it rather than grow five more kernels into the
+page. Python keeps the in-page path (faster, and its `None`-return and
+non-round-trippable-type handling is behaviour existing assignments rely on).
+Two stated limits: the drivers report values as their language's REPR (base R and
+Lua have no JSON to serialize with), so a scalar round-trips into the Expected
+cell and a composite may not — the client decides, using the same language-aware
+reader hand-typed values go through; and automatic stdout capture is offered
+where one expression expresses it (R's `capture.output`, Octave's `evalc`) and
+reported unavailable where it does not.
 
 **Assignment vanity URLs (v0.4.71).** Each assignment gets a per-course
 unique slug. Student links prefer `/:courseCode/:assignmentSlug` routes while
@@ -1059,7 +1118,8 @@ Full design, runbook, and host steps:
 
 **The 0.4 series is closed.** v0.5.0 marks the conclusion of the first full
 course offering run on Chickadee and the pivot to next year's feature work.
-The system is a working client–server autograder: Python, R and Lua assignments;
+The system is a working client–server autograder: Python, R, Lua, Octave, C++
+and Racket assignments;
 browser (Pyodide/wasm) and native worker grading paths sharing one RunnerCore
 implementation; per-student personalization; pattern-generated test families
 (8 kinds) and notebook checks (10 kinds); achievements; student slip days;
@@ -1257,7 +1317,8 @@ shim); and archived finished-era docs under `docs/archive/`.
 - `docs/xeus-python-grading-spike.md` — whether Python browser grading should move to xeus-python (#1271): measured Pyodide-vs-xeus-python execution and boot cost, the package-set gap, and the accidental CSP dependency that currently makes Pyodide load at all in a classic worker
 - `docs/xeus-python-grading-migration-plan.md` — the executable handoff for that migration: the package-set decision that gates it, the slices, which R lessons do NOT carry over (the stderr trap and the one-expression rule are both xeus-r-only), staged rollout behind the existing failover, and what must be true before `Public/pyodide` can go
 - `docs/cpp-assignment-language-decision.md` — why C++ stays on the shell-script + makefile path rather than becoming an `AssignmentLanguage`: the one-file-one-command invocation mismatch, the typed-literal impossibility, and the Clang-REPL-vs-course-toolchain pedagogy problem; the priced revisit condition
-- `docs/adding-a-xeus-kernel.md` — runbook for teaching Chickadee another in-browser language: which xeus kernels exist on emscripten-forge (with sizes and xeus-ABI pins), why availability is not the same as working, the browser-half steps and the check that proves each, the traps that have cost a day each, and where the irreducible per-language work begins — plus "What the Lua run actually cost", the measured postmortem of doing it once (what held, and which of R's expensive lessons turned out to be xeus-r properties that do not generalise). Now covers BOTH halves end to end: the 26 compiler-named sites measured on the Lua run, the **seven** the compiler cannot see (the fifth being boolean sniffs like `isRNotebook(nb) ? .r : .python`, which type-check forever and route the new language to Python; the sixth runner capability matching, which fails in both directions and whose worse direction queues an assignment's jobs forever; the seventh the submission policy), the browser half's own checklist, the one judgement (`moduleResolution`) that replaced three and the scorecard that sized it against Octave/Java/C++ — including the two axes the model cannot see (interpreted-vs-compiled, and dynamically-vs-statically-typed literals) and the reframe that a language need not be an `AssignmentLanguage` to be graded at all, the submission-guarantee policy (a policy value with named exemptions rather than a protocol, because a protocol makes opting out invisible), and a done test that requires the generated code be executed rather than parsed
+- `docs/multi-language-audit.md` — architecture audit of the Lua→Racket arc and the fixes it produced: the three stacking Racket runner defects (two still open — `.rkt` dispatching to `/bin/sh`, and `racket --version`'s letter-led token defeating the runner's version parser, confirmed against the production fleet), the upload-only rule that generalised at two of five sites, and the recurring shape behind all of them — a hand-written list of languages in a place whose types are language-generic, failing open. Carries a "Status at merge" section separating closed from deliberately open, so a later reader does not chase a fixed defect
+- `docs/adding-a-xeus-kernel.md` — runbook for teaching Chickadee another in-browser language: which xeus kernels exist on emscripten-forge (with sizes and xeus-ABI pins), why availability is not the same as working, the browser-half steps and the check that proves each, the traps that have cost a day each, and where the irreducible per-language work begins — plus "What the Lua run actually cost", the measured postmortem of doing it once (what held, and which of R's expensive lessons turned out to be xeus-r properties that do not generalise). Now covers BOTH halves end to end: the 27 compiler-named switch arms across 17 files, the **nine** the compiler cannot see (the fifth being boolean sniffs like `isRNotebook(nb) ? .r : .python`, which type-check forever and route the new language to Python; the sixth runner capability matching, which fails in both directions and whose worse direction queues an assignment's jobs forever; the seventh the submission policy; the ninth whether the generated scripts DISPATCH at all, which the RunnerCore/Core dependency direction means the compiler probably never will see), the authoring-UI section that exists to stop you working (a seventh language needs ZERO JavaScript edits, and the failure mode is going to look for one), the browser half's own checklist, the one judgement (`moduleResolution`) that replaced three and the scorecard that sized it against Octave/Java/C++ — including the two axes the model cannot see (interpreted-vs-compiled, and dynamically-vs-statically-typed literals) and the reframe that a language need not be an `AssignmentLanguage` to be graded at all, the submission-guarantee policy (a policy value with named exemptions rather than a protocol, because a protocol makes opting out invisible), and a done test that requires the generated code be executed rather than parsed
 - `docs/kernel-boot-cost.md` — what a kernel boot costs, measured per package and per environment; the failure-driven on-demand install design and why predicting the package set cannot work; why cross-user caching is unavailable; why the editor is deliberately excluded
 - `docs/r-support.md` — first-class R support: `AssignmentLanguage` resolution + strategy, per-language personalization (`Rscript` expression driver, base-R `chickadee_seed()`, `_ck_inputs.R` delivery, R-literal notebook substitution), the R grading runtime, and the R renderers for pattern families / notebook checks (#1207; `astStructure` stays Python-only)
 - `docs/language-handling-review.md` — second-opinion design review of the assignment-language dispatch surface: verdicts on R extraction in RunnerCore, the Swift↔JS drift-guard hierarchy, the resolution API surface, the third-language census, and process rules. Written before Lua existed, so §4's prediction is now **scored against the real third language** — what held (bucket A never changed; every bucket-B site failed to compile) and what did not (the compiler-invisible surface is a recurring shape, not a checklist)

--- a/changelog.d/language-runbook-refresh.md
+++ b/changelog.d/language-runbook-refresh.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **The add-a-language runbook covers the authoring UI, and says a seventh
+  language needs no JavaScript at all.** That section exists to stop work: the
+  editors clearly behave per-language, so the failure mode is going looking for
+  the arm to add and re-introducing the per-language table that v0.5.36 removed
+  twice. It records the derivation table, the greppable invariant, and the rule
+  for adding a genuinely new fact.
+- **The compiler-invisible list is nine, not eight.** Capability matching gains
+  the probe's *output format* (Racket's letter-led `v8.10` defeats the version
+  parser even though the probe exits 0), and generated-script dispatch is added
+  as item 9 — which the `RunnerCore`/`Core` dependency direction means the
+  compiler probably never will see. The runtime helper left the list: it is
+  installed from `allCases` now, so omitting it is a compile error.
+- The descriptor field list, the compiler-named site count (27 arms across 17
+  files), and `CLAUDE.md`'s language list are current — Racket is in both, and
+  `CLAUDE.md` records the authoring-language seam and the server-side
+  compute-expected route.

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -366,16 +366,45 @@ estimated. Two notes on why your split may differ:
   sites were all in `Worker`. A language whose extraction is not pre-landed
   pays for it here instead.
 
-**The compiler cannot see eight more**, listed under "What the compiler will not
-tell you" below — those are the ones that have historically shipped broken.
+**The compiler cannot see nine more**, listed under "What the compiler will not
+tell you" below — those are the ones that have historically shipped broken. One
+former member of that list is gone: the runtime helper a language's generated
+tests load is now installed from `allCases` (`runtimeHelperFiles(for:)`), so
+omitting it is a compile error rather than a silent absence. That is the shape to
+aim for whenever an item can be moved.
 
 ### The 26 the compiler names
 
 **`Sources/Core/AssignmentLanguage.swift`** — the hub. The FACTS now live in one
 `LanguageDescriptor` literal per language (`Core/LanguageDescriptor.swift`), so
-most of this is one struct to write rather than eleven arms to find: display
-name, script extensions, generated extension, inputs filename, kernel aliases,
-kernel env file, missing-dependency wording, interpreter probe.
+most of this is one struct to write rather than a dozen arms to find. The
+current fields: display name, script extensions, generated extension, **source
+file extension**, inputs filename, kernel aliases, `editorSupport`, interpreter
+probe, `moduleResolution`, `workingDirectoryIsOnDefaultSearchPath`, and
+`capabilityRequiresExecutableOutput`.
+
+Three of those are worth knowing before you write the literal, because each was
+added when a language broke on it:
+
+- **`sourceFileExtension` is not `generatedScriptExtension`.** The first is what
+  a notebook's code becomes when extracted and what `solution.<ext>` is called;
+  the second is what a *generated test* is named. They differ for C++, whose
+  generated case is a `.sh` wrapper around `.cpp` source. Neither is
+  `scriptExtensions`, which is a `Set` with no deterministic first element.
+- **`editorSupport` is a judgement, not a fact** — `.notebookKernel(...)` with
+  the four kernel facts behind it, or `.uploadOnly`. It is what lets a
+  kernel-less language be expressed at all, and answering it `.uploadOnly` makes
+  the language upload-only and native-worker-only by construction.
+- **`capabilityRequiresExecutableOutput`** — true only when grading *executes*
+  something it just built. `g++ --version` succeeds on a runner whose work
+  directory is mounted `noexec`; the compile then works and the `exec` does not.
+
+The count measured on the Lua run was 26 compiler-named sites. It is now **27
+switch arms across 17 files** — a bigger worklist, but a strictly safer one:
+every one of the additions is a compile error rather than something to discover.
+Most of the growth is the authoring surface described under "The authoring UI"
+below, which a language now gets for free precisely *because* those arms are
+forced.
 
 That file also records why this is a descriptor on a closed enum rather than a
 protocol or a class hierarchy — short version: a closed enum makes a missing
@@ -463,7 +492,7 @@ the three.
 
 ### What the compiler will *not* tell you
 
-**Eight** things, each of which has shipped broken at least once. Numbers 5-7
+**Nine** things, each of which has shipped broken at least once. Numbers 5-7
 were found during the Lua run; 5 is the most dangerous, because it is a shape
 rather than a place, and 6-7 are whole subsystems that needed no change to their
 types and so pointed at nothing. Number 8 came later still, from the audit that
@@ -566,6 +595,28 @@ additions, because prose is the surface no guard reaches.
    python3 and R and **fails on lua**, which exits 1 with a usage message. A
    hardcoded `--version` leaves the language undetectable even after it is added
    to the loop.
+
+   **And its OUTPUT FORMAT matters as much as either.** This is the third link
+   in the same chain and it cost the Racket run: `racket --version` exits 0 and
+   prints a perfectly good banner, and `RunnerProfileDetector.firstNumericVersion`
+   cannot read it. That function takes the first whitespace-token whose *numeric
+   prefix* contains a `.`; Racket's version token is `v8.10`, letter-led, and no
+   other language's is. `detectVersion` returns nil, the language is absent from
+   `languageVersions`, and `RunnerLanguageGate` then refuses every runner — so
+   every job in that language queues forever, instructor validation included,
+   with no error, no failed test and no log line anywhere.
+
+   The existing guard stops one step short: `everyLanguageProbeActuallyReportsAVersion`
+   asserts the probe **exits 0**, which Racket does. Assert instead that its
+   output *parses*:
+
+   ```swift
+   #expect(firstNumericVersion(in: probeOutput) != nil)
+   ```
+
+   Run the probe by hand and read the banner before trusting the loop. Command,
+   arguments, output format — three separate ways to be invisible to capability
+   matching, and all three have now happened.
 7. **The submission policy.** See "The submission policy" below. Nothing fails when a
    language is missing from it; the student just gets silence instead of a
    message.
@@ -588,6 +639,32 @@ additions, because prose is the surface no guard reaches.
    Also make sure the language's REFUSED pattern-family and notebook-check kinds
    are discoverable before a save is attempted, not only via the rejection
    message. See issue #1290.
+9. **Whether the generated scripts DISPATCH.** The newest item, and the most
+   direct: a generated test is only graded if `scriptInvocation` knows how to run
+   it. Racket's generated `.rkt` had no `ScriptInterpreter` case and no extension
+   arm, so it classified `.unknown`, fell back to `/bin/sh`, and exited 2 on its
+   own leading `;` — every generated test reporting `error`, in the only grading
+   path an upload-only language has.
+
+   The compiler cannot see it and, unusually, probably never will:
+   `ScriptClassification.swift` lives in `RunnerCore`, which the browser compiles
+   to wasm and which therefore has **no dependency on `Core`** — so it cannot
+   reach `AssignmentLanguage` to iterate. The dependency direction forbids the
+   obvious fix.
+
+   What closes it is a test in `Worker`, which depends on both:
+
+   ```swift
+   @Test(arguments: AssignmentLanguage.allCases)
+   func generatedScriptsDispatchToTheirOwnInterpreter(_ language: AssignmentLanguage) {
+       // render a family, write it, assert scriptInvocation resolves to this
+       // language's interpreter rather than the /bin/sh fallback
+   }
+   ```
+
+   C++ is the deliberate exception and shows what the test must tolerate: its
+   generated case IS a `.sh` wrapper, so it dispatches as shell on purpose.
+   Every other language's generated extension must reach its own interpreter.
 
 ### What this model cannot see, scored against three languages it does not have
 
@@ -692,12 +769,72 @@ That last pair is the enumeration trap again: `browser-runner.js` destructures
 its shared modules at IIFE start, so every harness that runs it has to load the
 same set the page does. Three files list that set independently.
 
+### The authoring UI: what you do NOT have to do
+
+The section that exists to stop you working. A seventh language needs **zero
+JavaScript edits** for the authoring surface — no arm, no table, no branch — and
+the failure mode this section prevents is someone going to look for one and
+adding it.
+
+That was not true until v0.5.36. `Public/pattern-family-editor.js` contained the
+string "language" zero times: it validated Python identifiers, accepted `True` /
+`False` / `None`, rewrote Python reprs, and named Python in its placeholders — on
+all six languages, while the server rendered the same family correctly in each.
+`inputs-editor-core.js` had the identical defect in the Global/Section Inputs
+panels, which is where per-student `=` expressions are authored. The concrete
+bite: an R instructor typing the boolean true stored the **string**, silently, in
+a value a generated test then compares.
+
+**How it works now.** The server encodes `AuthoringLanguageFacts` into a
+`#assignment-language-seed` script tag on both authoring pages;
+`Public/authoring-language.js` is the single reader
+(`window.ChickadeeLanguage`); every editor asks it. There is no per-language
+list in any of the authoring JS — verify with:
+
+```
+grep -nE "'(r|lua|octave|cpp|racket)'" Public/authoring-language.js Public/inputs-editor-core.js Public/pattern-family-editor.js Public/test-editor-modal.js
+```
+
+An empty result is the invariant. A hit means someone re-added the table.
+
+**Everything in the seed is DERIVED, which is why the UI follows for free:**
+
+| Fact | Derived from | So a new language… |
+|---|---|---|
+| `trueLiteral` / `falseLiteral` / `nullLiteral` | `JSONValue.literal(_:)` | is spelled the way its real generated test is spelled |
+| `unsupportedCheckKinds` | `notebookCheckKindIsSupported` — the predicate the save-time refusal uses | has its unavailable kinds disabled in the Add Test menu, with reasons |
+| `functionScanning` | `notebookFunctionScanSupport(for:)` | is told the solution scan cannot read it, instead of "No functions found." |
+| `expressionEvaluation` | `PersonalizationEvaluator.supportsEvaluation` | gets auto-compute the day its driver arm exists |
+| `displayName` | the descriptor | is named in its own messages, not told about C++ |
+
+**The rule if you need a NEW fact.** Add a field to `AuthoringLanguageFacts` and
+derive it from whatever already owns the answer. Do not tabulate it in JS, and
+do not answer it twice. Both of those were done and both had to be undone: the
+literal spellings were nearly generated into a JS table by
+`generate-js-constants.sh` (a second source of truth for something
+`JSONValue.literal` already answers), and `functionScanning` / `expressionEvaluation`
+shipped as hand-written bools in `AuthoringLanguageFacts` before being pointed at
+their real owners one commit later. `AuthoringLanguageFactsTests` asserts the
+derivation, so a second copy fails the suite.
+
+**What is still hand-written, and correctly so.** The per-language *renderers* —
+pattern families, notebook checks, the personalization driver, the grading
+runtime. Those are the irreducible per-language work this document has always
+been about. The UI is not; it is a projection of them.
+
 ### The done test
 
 The language is supported when all of these are true. Anything less is the
 state this document exists to warn you about:
 
 - [ ] `swift build` is clean with the new case and **no `default:` arm added**
+- [ ] `grep -nE "'(r|lua|octave|cpp|racket)'" Public/*editor*.js Public/authoring-language.js`
+      is empty — the authoring UI still has no per-language table
+- [ ] a generated script in the new language dispatches to its own interpreter,
+      asserted from `allCases` (invisible item 9) — not merely that it parses
+- [ ] `firstNumericVersion` parses the interpreter probe's real banner
+      (invisible item 6) — running the probe by hand is not enough; the parse is
+      the part that failed for Racket
 - [ ] the interpreter is on the runner image, and worker grading of a
       hand-authored test passes
 - [ ] instructor validation of an assignment in the language passes


### PR DESCRIPTION
Follow-up to #1306. Documentation only — `docs/adding-a-xeus-kernel.md` and `CLAUDE.md`.

Written on the assumption Racket's two open defects land next, so the compiler-invisible entries describe the tests that must accompany the fix rather than claiming they already exist.

## The section that exists to stop work

The runbook had **zero** mentions of the authoring UI, because when it was written the UI had no notion of language. That silence is now the dangerous part: after #1306 the editors visibly behave per-language, so the next maintainer goes looking for the arm to add — and re-introduces the per-language JS table that #1306 removed twice.

"The authoring UI: what you do NOT have to do" states the invariant (**a seventh language needs zero JavaScript edits**), gives the grep that proves it, tabulates what each seed field is derived *from*, and records the rule for a genuinely new fact: derive it, don't answer it twice. Both mistakes are named because both were made in #1306 and undone — the literals were nearly generated into a JS table, and two capability flags shipped as hand-written bools before being pointed at their real owners.

## The compiler-invisible list is nine, not eight

- **Capability matching gains the probe's OUTPUT FORMAT.** `racket --version` exits 0 and prints a perfectly good banner, and `firstNumericVersion` cannot read `v8.10` because it is letter-led. Command, arguments, output format — three separate ways to be invisible to capability matching, and all three have now happened. The existing guard asserts exit 0; it should assert the output *parses*.
- **Item 9 is whether generated scripts dispatch at all** — with the note that the compiler probably never will see it. `ScriptClassification` lives in `RunnerCore`, which compiles to wasm and cannot depend on `Core`, so the dependency direction forbids the obvious fix; a `Worker`-side `allCases` test is what closes it. C++ is the deliberate exception the test must tolerate, since its generated case really is a `.sh` wrapper.
- **One item left the list**, which is the shape to aim for: the runtime helper is installed from `allCases` now, so omitting it is a compile error rather than a silent absence.

## Counts, measured not estimated

27 switch arms across 17 files (the runbook said 26, measured on the Lua run). 11 descriptor fields, with the three that bite called out: `sourceFileExtension` is not `generatedScriptExtension`, `editorSupport` is a judgement rather than a fact, and `capabilityRequiresExecutableOutput` is about `exec` rather than about owning a compiler. The done test gains the two assertions the invisible items need.

Every number in the diff was verified against the tree rather than carried over, including the greppable invariant the new section asks a maintainer to run.

## CLAUDE.md

Racket exists in it now — it described five languages and mentioned Racket zero times. Plus the authoring-language seam, the `compute-expected` route with its two stated limits (language reprs don't always round-trip; stdout capture is offered only where one expression expresses it), and a reference entry for `docs/multi-language-audit.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4dLGw94C2mGzveMq1MYNU)_