### PR TITLE
fix: Racket dispatch and the runner version parse (audit F1 and F3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,10 @@ CS 135/115 (`#lang htdp/bsl`) and CS 136 (`#lang racket`) write; notebook checks
 are refused categorically, as for C++. The measured trap: a teaching-language
 module EXPORTS NOTHING, so a generated test loads the submission with
 `dynamic-require` + `module->namespace` and evaluates an application form rather
-than a bare identifier. See `docs/multi-language-audit.md` for the two runner
-defects still open against it.
+than a bare identifier. Its two runner defects — `.rkt` dispatching to `/bin/sh`,
+and `racket --version`'s letter-led `v8.10` defeating the runner's version parser
+— are fixed, each with an `allCases` guard; a Racket assignment still needs a
+runner new enough to carry both. See `docs/multi-language-audit.md`.
 
 **Assignments are Python, R, Lua, Octave, C++ *or* Racket; language is first-class (`AssignmentLanguage`).**
 `AssignmentLanguage` (`.python | .r | .lua | .octave | .cpp | .racket`, Core) is resolved from the manifest

--- a/Sources/RunnerCore/ScriptClassification.swift
+++ b/Sources/RunnerCore/ScriptClassification.swift
@@ -18,6 +18,7 @@ public enum ScriptInterpreter: String, Sendable, Equatable {
     case rscript
     case lua
     case octave
+    case racket
     /// No recognised extension, shebang, or Python-looking content. The caller
     /// decides the fallback (e.g. executable bit, else /bin/sh).
     case unknown
@@ -37,6 +38,7 @@ public func classifyScriptInterpreter(name: String, source: String) -> ScriptInt
     case "r": return .rscript
     case "lua": return .lua
     case "m": return .octave
+    case "rkt": return .racket
     default: break  // no / unrecognised extension → shebang, then content
     }
     if let viaShebang = interpreterFromShebang(source) {
@@ -59,6 +61,10 @@ private func interpreterFromShebang(_ source: String) -> ScriptInterpreter? {
     if containsSubstring(firstLine, "perl") { return .perl }
     if containsSubstring(firstLine, "lua") { return .lua }
     if containsSubstring(firstLine, "octave") { return .octave }
+    // Before the sh/bash checks like the rest: "racket" contains none of
+    // "sh", "bash" or "zsh", but keeping the language checks together is what
+    // stops the next addition from being ordered wrong.
+    if containsSubstring(firstLine, "racket") { return .racket }
     if containsSubstring(firstLine, "bash") { return .bash }
     if containsSubstring(firstLine, "zsh") { return .zsh }
     if containsSubstring(firstLine, "sh") { return .sh }

--- a/Sources/Worker/RunnerProfileDetector.swift
+++ b/Sources/Worker/RunnerProfileDetector.swift
@@ -266,9 +266,35 @@ struct RunnerProfileDetector {
     }
 
     private func firstNumericVersion(in raw: String) -> String? {
+        Self.firstNumericVersion(in: raw)
+    }
+
+    /// The first dotted version number in an interpreter's `--version` banner.
+    ///
+    /// INTERNAL AND STATIC so it can be tested directly. It had no test at all,
+    /// and the defect below is one only a test of the real banners finds.
+    ///
+    /// Each whitespace token is stripped of surrounding punctuation, then any
+    /// LEADING NON-DIGITS are dropped before the numeric prefix is taken. That
+    /// last step is the fix: Racket's banner is `Welcome to Racket v8.10 [cs].`
+    /// and its version token is `v8.10` — letter-led, which no other language's
+    /// is. The prefix rule alone yielded an empty match, `detectVersion`
+    /// returned nil, the runner advertised no `racket`, and `RunnerLanguageGate`
+    /// then refused EVERY runner for every Racket assignment. Jobs queued
+    /// forever with no error, no failed test and no log line — instructor
+    /// validation included.
+    ///
+    /// Dropping leading non-digits is deliberately narrower than "find any
+    /// dotted number in the token": a token still contributes at most its first
+    /// numeric run, so `1994-2022` (Lua's copyright line) and `2023-06-16` (R's
+    /// release date) stay unmatched for want of a dot, and `Lua.org` contributes
+    /// nothing for want of a digit. Every one of the six banners is pinned in
+    /// `RunnerProfileDetectorTests`.
+    static func firstNumericVersion(in raw: String) -> String? {
         for token in raw.split(whereSeparator: \.isWhitespace) {
-            let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: ",;:()"))
-            let numericPrefix = cleaned.prefix { $0.isNumber || $0 == "." }
+            let cleaned = token.trimmingCharacters(in: CharacterSet(charactersIn: ",;:()[]"))
+            let fromFirstDigit = cleaned.drop { !$0.isNumber }
+            let numericPrefix = fromFirstDigit.prefix { $0.isNumber || $0 == "." }
             if !numericPrefix.isEmpty, numericPrefix.contains(".") {
                 return String(numericPrefix)
             }

--- a/Sources/Worker/ScriptInvocation.swift
+++ b/Sources/Worker/ScriptInvocation.swift
@@ -85,6 +85,13 @@ func scriptInvocation(for script: URL) -> ScriptInvocation {
     // reach a display. The package that ships it is `octave` (there is no
     // CLI-only Debian package).
     case .octave: return envInvocation(interpreter: "octave-cli", script: script)
+    // Interpreted and needing no wrapper: `racket file.rkt` runs a generated
+    // test directly under the ordinary shell-script exit-code contract.
+    // Without this arm a `.rkt` classified `.unknown`, fell through to
+    // `/bin/sh`, and exited 2 on its own leading `;` — every generated Racket
+    // test reporting `error`, in the only grading path an upload-only language
+    // has.
+    case .racket: return envInvocation(interpreter: "racket", script: script)
     case .unknown:
         if FileManager.default.isExecutableFile(atPath: script.path) {
             return ScriptInvocation(executableURL: script, arguments: [])

--- a/Tests/Fixtures/script-dispatch-cases.json
+++ b/Tests/Fixtures/script-dispatch-cases.json
@@ -35,6 +35,7 @@
 
     { "name": "test_stats.lua",            "content": "print(1)\n",                                       "kind": "lua",    "note": "Lua's generated and hand-authored extension" },
     { "name": "test_stats.m",              "content": "disp(1)\n",                                        "kind": "octave", "note": ".m is Octave here; the runner spawns octave-cli, never MATLAB" },
-    { "name": "publictest_fam_01.sh",      "content": "cat > t.cpp <<'EOF'\nint main(){}\nEOF\ng++ t.cpp\n", "kind": "shell",  "note": "C++'s generated case is a POSIX shell wrapper — .sh must keep carrying no language signal" }
+    { "name": "publictest_fam_01.sh",      "content": "cat > t.cpp <<'EOF'\nint main(){}\nEOF\ng++ t.cpp\n", "kind": "shell",  "note": "C++'s generated case is a POSIX shell wrapper — .sh must keep carrying no language signal" },
+    { "name": "publictest_fam_01.rkt",     "content": "; Test: b\n#lang racket/base\n(void)\n",              "kind": "racket", "note": "leading ; comment: this exact shape fell through to /bin/sh and exited 2" }
   ]
 }

--- a/Tests/WorkerTests/GeneratedScriptDispatchTests.swift
+++ b/Tests/WorkerTests/GeneratedScriptDispatchTests.swift
@@ -1,0 +1,97 @@
+// Tests/WorkerTests/GeneratedScriptDispatchTests.swift
+//
+// A language's generated scripts must actually DISPATCH — the runbook's
+// compiler-invisible item 9, and the guard that would have caught Racket's F1
+// the moment its descriptor literal landed.
+//
+// WHY IT IS A TEST AND NOT A COMPILE ERROR. `classifyScriptInterpreter` lives in
+// `RunnerCore`, which the browser compiles to wasm and which therefore has NO
+// dependency on `Core` — so it cannot reach `AssignmentLanguage` to iterate, and
+// the dependency direction forbids the obvious fix. `Worker` depends on both,
+// which is why this lives here.
+//
+// What went wrong without it: Racket's generated `.rkt` had no
+// `ScriptInterpreter` case and no extension arm, so it classified `.unknown`,
+// fell through to the `/bin/sh` fallback, and exited 2 on its own leading `;`.
+// Every generated Racket test reported `error`, in the only grading path an
+// upload-only language has — and every other language's rows in the dispatch
+// fixture still passed.
+
+import Core
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite struct GeneratedScriptDispatchTests {
+
+    /// The interpreter each language's generated scripts must reach.
+    ///
+    /// EXHAUSTIVE, so a seventh language has to state its answer here too —
+    /// which is as close to compile-forced as this can get given that the
+    /// classifier itself cannot see `AssignmentLanguage`.
+    ///
+    /// C++ is the deliberate exception and the reason this maps to a command
+    /// rather than asserting "not the shell fallback": its generated case IS a
+    /// POSIX shell wrapper (heredoc C++ source → g++ → run the binary), so it
+    /// dispatches as shell ON PURPOSE. `.sh` must keep carrying no language
+    /// signal, or every hand-written shell suite in every course would start
+    /// sniffing as C++.
+    static func expectedInterpreter(for language: AssignmentLanguage) -> String {
+        switch language {
+        case .python: return "python3"
+        case .r: return "Rscript"
+        case .lua: return "lua"
+        case .octave: return "octave-cli"
+        case .racket: return "racket"
+        case .cpp: return "sh"
+        }
+    }
+
+    /// A file named the way this language's generated tests are named, carrying
+    /// a first line shaped the way they really begin, dispatches to that
+    /// language's interpreter.
+    ///
+    /// The leading-comment line matters and is not decoration: Racket's
+    /// generated tests open with `; Test: …`, which is what defeated the
+    /// shebang check and the Python content sniff on the way to `/bin/sh`.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func generatedScriptsDispatchToTheirOwnInterpreter(_ language: AssignmentLanguage) throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ck-dispatch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let filename = "publictest_fam_01.\(language.generatedScriptExtension)"
+        let url = dir.appendingPathComponent(filename)
+        // A comment in the language's own leader, so nothing is classified by
+        // accident of a shebang the real generated files do not carry.
+        try "\(language.lineCommentLeader) Test: generated\n".write(
+            to: url, atomically: true, encoding: .utf8)
+
+        let invocation = scriptInvocation(for: url)
+        let expected = Self.expectedInterpreter(for: language)
+        // Two invocation shapes: `envInvocation` runs /usr/bin/env with the
+        // interpreter as the first argument; `shInvocation` runs /bin/sh
+        // directly with the script as its only argument. Read whichever names
+        // the interpreter.
+        let executable = invocation.executableURL.lastPathComponent
+        let actual = executable == "env" ? (invocation.arguments.first ?? executable) : executable
+        #expect(
+            actual == expected,
+            """
+            A generated \(language) test (\(filename)) dispatches to `\(actual)`, expected \
+            `\(expected)`. If this is the `/bin/sh` fallback, the language has no \
+            ScriptInterpreter case and every generated test will report `error` at grade time.
+            """)
+    }
+
+    /// `.sh` still carries no language signal.
+    ///
+    /// The other half of the C++ exception: its generated wrapper must dispatch
+    /// as shell, and so must every hand-written `.sh` suite that predates any
+    /// of this.
+    @Test func shellScriptsStayLanguageless() {
+        #expect(AssignmentLanguage(scriptExtension: "sh") == nil)
+    }
+}

--- a/Tests/WorkerTests/RacketNativeGradingTests.swift
+++ b/Tests/WorkerTests/RacketNativeGradingTests.swift
@@ -1,0 +1,179 @@
+// Tests/WorkerTests/RacketNativeGradingTests.swift
+//
+// The end-to-end proof for Racket's dispatch fix (audit F1): a generated `.rkt`
+// test reaches a real `racket` and comes back with a STATUS, rather than being
+// handed to `/bin/sh` and dying on its own leading `;`.
+//
+// WHY IT MATTERS MORE HERE THAN FOR ITS PEERS. Racket is upload-only, so the
+// native worker is not one of two grading paths — it is the only one. Every
+// generated Racket test reported `error` before this, and the sibling suites for
+// Lua, Octave and C++ all existed while this one did not: the audit's F5 is
+// exactly the observation that the newest language had the least coverage.
+//
+// Modelled on `LuaNativeGradingTests`, deliberately — same workspace shape, same
+// did-not-skip proof — so the four read as one family rather than four
+// inventions.
+
+import Core
+import Foundation
+import RunnerCore
+import Testing
+
+@testable import chickadee_runner
+
+@Suite(.timeLimit(.minutes(3))) struct RacketNativeGradingTests {
+
+    static var racketAvailable: Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["racket", "--version"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+
+    /// The did-not-skip proof. Every test below returns silently when Racket is
+    /// absent — correct on a laptop, a silent hole in CI, and precisely how a
+    /// language ships with a suite that never runs.
+    @Test func racketIsPresentInCI() {
+        guard ProcessInfo.processInfo.environment["CI"] != nil else { return }
+        #expect(
+            Self.racketAvailable,
+            """
+            racket is absent in the CI image, so every native Racket grading test skipped \
+            silently. Add it to .github/docker/ci-image/Dockerfile and the WorkerTests apt \
+            fallback in swift-tests.yml.
+            """)
+    }
+
+    /// A workspace shaped like the one `RunnerDaemon` materializes: the injected
+    /// runtime, the student's submission, and the hint naming it.
+    static func makeWorkspace(submission: String, scripts: [String: String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-racketnative-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        // The SAME embedded source the worker injects — reached through
+        // `runtimeHelperFiles(for:)` rather than the constant, so this also
+        // proves the helper a Racket workspace gets is the one the loop
+        // installs. That indirection is the F2 fix; before it, this file was
+        // never written at all.
+        for (name, source) in runtimeHelperFiles(for: .racket) {
+            try source.write(
+                to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        try submission.write(
+            to: dir.appendingPathComponent("solution.rkt"), atomically: true, encoding: .utf8)
+        try "solution.rkt".write(
+            to: dir.appendingPathComponent(".chickadee_student_module"),
+            atomically: true, encoding: .utf8)
+        for (name, source) in scripts {
+            try source.write(
+                to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    static func runSuites(_ items: [SuiteItem], in dir: URL) async -> [TestOutcome] {
+        let executor = NativeScriptExecutor(
+            runner: UnsandboxedScriptRunner(), workDir: dir, overrides: [:])
+        return await executeSuites(
+            items, timeLimitSeconds: 30, attemptNumber: 1, executor: executor)
+    }
+
+    static func item(_ script: String) -> SuiteItem {
+        SuiteItem(script: script, tier: .pub, displayName: script, dependsOn: [], points: 1)
+    }
+
+    /// The regression test for F1. The script opens with `; Test: …` — the exact
+    /// shape that defeated the shebang check and the Python content sniff and
+    /// fell through to `/bin/sh`, where the leading `;` is a syntax error and
+    /// the run exits 2.
+    @Test func aRacketTestIsGradedByTheNativeWorker() async throws {
+        guard Self.racketAvailable else { return }
+
+        let dir = try Self.makeWorkspace(
+            submission: """
+                #lang racket/base
+                (define (double x) (* 2 x))
+                """,
+            scripts: [
+                "publictest_fam_01.rkt": """
+                ; Test: double
+                #lang racket/base
+                (exit 0)
+                """
+            ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let outcomes = await Self.runSuites([Self.item("publictest_fam_01.rkt")], in: dir)
+        let outcome = try #require(outcomes.first)
+        #expect(
+            outcome.status == .pass,
+            """
+            A generated .rkt was not graded by racket — status \(outcome.status), \
+            stderr: \(outcome.longResult ?? "none"). An `error` here with a shell syntax \
+            complaint means the script fell through to /bin/sh: the dispatch fix regressed.
+            """)
+    }
+
+    /// The exit-code contract holds through the real interpreter, not just
+    /// through the classifier.
+    @Test func exitCodesMapToOutcomeStatuses() async throws {
+        guard Self.racketAvailable else { return }
+
+        let dir = try Self.makeWorkspace(
+            submission: "#lang racket/base\n(define (f) 1)\n",
+            scripts: [
+                "publictest_pass.rkt": "; pass\n#lang racket/base\n(exit 0)",
+                "publictest_fail.rkt": "; fail\n#lang racket/base\n(exit 1)",
+                "publictest_error.rkt": "; error\n#lang racket/base\n(exit 2)",
+            ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let outcomes = await Self.runSuites(
+            [
+                Self.item("publictest_pass.rkt"),
+                Self.item("publictest_fail.rkt"),
+                Self.item("publictest_error.rkt"),
+            ], in: dir)
+        let byName = Dictionary(uniqueKeysWithValues: outcomes.map { ($0.testName, $0.status) })
+        #expect(byName["publictest_pass.rkt"] == .pass)
+        #expect(byName["publictest_fail.rkt"] == .fail)
+        #expect(byName["publictest_error.rkt"] == .error)
+    }
+
+    /// The runtime the worker installs is loadable by a generated test.
+    ///
+    /// `(require "test_runtime.rkt")` is the first line of every generated
+    /// Racket test, and before F2 the file was never written into the workspace
+    /// — so this is the assertion that the helper actually lands and parses,
+    /// rather than that a constant exists in the binary.
+    @Test func theInstalledRuntimeIsRequirableByAGeneratedTest() async throws {
+        guard Self.racketAvailable else { return }
+
+        let dir = try Self.makeWorkspace(
+            submission: "#lang racket/base\n(define (f) 1)\n",
+            scripts: [
+                "publictest_requires.rkt": """
+                ; Test: the runtime loads
+                #lang racket/base
+                (require "test_runtime.rkt")
+                (exit 0)
+                """
+            ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let outcomes = await Self.runSuites([Self.item("publictest_requires.rkt")], in: dir)
+        let outcome = try #require(outcomes.first)
+        #expect(
+            outcome.status == .pass,
+            """
+            A generated test could not `require` test_runtime.rkt — status \(outcome.status), \
+            stderr: \(outcome.longResult ?? "none"). Either the helper is not being installed \
+            (F2) or the embedded copy no longer parses.
+            """)
+    }
+}

--- a/Tests/WorkerTests/RunnerProfileDetectorTests.swift
+++ b/Tests/WorkerTests/RunnerProfileDetectorTests.swift
@@ -1,0 +1,113 @@
+// Tests/WorkerTests/RunnerProfileDetectorTests.swift
+//
+// The version parse behind runner capability advertisement.
+//
+// WHY THIS FILE EXISTS. `RunnerProfileDetector` had NO test of any kind, and
+// `firstNumericVersion` — the function that decides whether a runner advertises
+// a language at all — had zero coverage. That is where Racket was lost: the
+// banner is `Welcome to Racket v8.10 [cs].`, the version token is letter-led,
+// and the old prefix-only rule matched nothing. `detectVersion` returned nil,
+// `racket` never entered `languageVersions`, and `RunnerLanguageGate` then
+// refused EVERY runner for every Racket assignment — so the jobs queued forever
+// with no error, no failed test and no log line. Instructor validation included.
+//
+// The conformance matrix's `everyLanguageProbeActuallyReportsAVersion` runs the
+// real probe and asserts it EXITS 0, which `racket --version` does. Exit code
+// and parse are different questions, and this file asks the second one.
+
+import Core
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite struct RunnerProfileDetectorTests {
+
+    /// The real banner each interpreter prints, as observed. Pinned as data so
+    /// a parser change is checked against every language at once rather than
+    /// against whichever one someone had in mind.
+    static let banners: [(AssignmentLanguage, String, String)] = [
+        (.python, "Python 3.11.2", "3.11.2"),
+        (.r, "R version 4.3.1 (2023-06-16) -- \"Beagle Scouts\"", "4.3.1"),
+        (.lua, "Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio", "5.4.4"),
+        (.octave, "GNU Octave, version 8.4.0", "8.4.0"),
+        (.cpp, "g++ (Debian 12.2.0-14) 12.2.0", "12.2.0"),
+        // The one that broke. Letter-led, and no other language's is.
+        (.racket, "Welcome to Racket v8.10 [cs].", "8.10"),
+    ]
+
+    @Test func everyLanguagesRealBannerParses() {
+        for (language, banner, expected) in Self.banners {
+            let parsed = RunnerProfileDetector.firstNumericVersion(in: banner)
+            #expect(
+                parsed == expected,
+                """
+                \(language)'s banner "\(banner)" parsed as \(parsed ?? "nil"), expected \(expected). \
+                A nil here means no runner advertises \(language), and every job in it queues \
+                forever with nothing reporting why.
+                """)
+        }
+    }
+
+    /// The tokens that must NOT be mistaken for a version.
+    ///
+    /// Dropping leading non-digits is narrower than "any dotted number in the
+    /// token", and these are the cases that keep it narrow: a copyright range
+    /// and a release date have digits but no dot, and a domain has a dot but no
+    /// digits. If any of them started matching, a runner would advertise a
+    /// version like `1994` and an assignment's `minimumVersion` requirement
+    /// would compare against nonsense.
+    @Test(arguments: [
+        "Copyright (C) 1994-2022", "(2023-06-16)", "Lua.org,", "PUC-Rio", "[cs].", "x86_64-linux",
+    ])
+    func nonVersionTokensDoNotParse(_ fragment: String) {
+        #expect(
+            RunnerProfileDetector.firstNumericVersion(in: fragment) == nil,
+            "\"\(fragment)\" was read as a version")
+    }
+
+    /// A banner with no version at all yields nil rather than something.
+    @Test func anEmptyOrVersionlessBannerIsNil() {
+        #expect(RunnerProfileDetector.firstNumericVersion(in: "") == nil)
+        #expect(RunnerProfileDetector.firstNumericVersion(in: "no version here") == nil)
+    }
+
+    /// The did-not-skip proof, run against the REAL interpreters.
+    ///
+    /// The pinned banners above are what was observed; this is what the machine
+    /// actually prints today. Under `CI` every language must both answer its
+    /// probe and have that answer parse — the two-step the original guard only
+    /// checked the first half of. On a laptop a missing interpreter is not a
+    /// defect, so absence is skipped there.
+    @Test func everyProbeOutputParsesInCI() {
+        guard ProcessInfo.processInfo.environment["CI"] != nil else { return }
+        for language in AssignmentLanguage.allCases {
+            let probe = language.interpreterProbe
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [probe.command] + probe.versionArguments
+            let out = Pipe()
+            let err = Pipe()
+            process.standardOutput = out
+            process.standardError = err
+            guard (try? process.run()) != nil else {
+                Issue.record("\(language): could not spawn \(probe.command)")
+                continue
+            }
+            let stdout = out.fileHandleForReading.readDataToEndOfFile()
+            let stderr = err.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            let combined =
+                (String(data: stdout, encoding: .utf8) ?? "") + "\n"
+                + (String(data: stderr, encoding: .utf8) ?? "")
+            #expect(
+                RunnerProfileDetector.firstNumericVersion(in: combined) != nil,
+                """
+                \(language)'s probe (`\(probe.command) \
+                \(probe.versionArguments.joined(separator: " "))`) printed a banner \
+                `firstNumericVersion` cannot read, so no runner will advertise \(language) and \
+                every job in it will queue forever. Banner was: \(combined.prefix(200))
+                """)
+        }
+    }
+}

--- a/Tests/WorkerTests/ScriptDispatchContractTests.swift
+++ b/Tests/WorkerTests/ScriptDispatchContractTests.swift
@@ -61,26 +61,21 @@ import Testing
         if first == "Rscript" { return "r" }
         if first == "lua" { return "lua" }
         if first == "octave-cli" { return "octave" }
+        if first == "racket" { return "racket" }
         if exe == "sh" || first == "bash" || first == "zsh" { return "shell" }
         return "other"
     }
 
-    /// Languages deliberately absent from the fixture, each with its reason.
+    /// Languages deliberately absent from the fixture, each with its reason —
+    /// a NAMED EXEMPTION rather than a skip, so an absence is one somebody
+    /// chose with the reason greppable beside it.
     ///
-    /// A NAMED EXEMPTION, not a skip. The same shape as
-    /// `submissionGuaranteeExemption`: an absence somebody chose, with the
-    /// reason greppable beside it, rather than an absence nobody noticed —
-    /// which is precisely how the fixture came to cover neither Lua nor Octave
-    /// for two releases.
-    static let fixtureExemptions: [AssignmentLanguage: String] = [
-        // Racket's generated `.rkt` does not classify at all today: no
-        // ScriptInterpreter case, no extension arm, so it falls through to
-        // `/bin/sh` and exits 2 on its own leading `;`. A row here would either
-        // pin that defect as expected behaviour or fail the build ahead of the
-        // fix. It comes out when dispatch lands — see F1 in
-        // docs/multi-language-audit.md.
-        .racket: "dispatch unimplemented; see docs/multi-language-audit.md F1"
-    ]
+    /// EMPTY, and that is the point. Racket sat here while its generated
+    /// `.rkt` had no `ScriptInterpreter` case and fell through to `/bin/sh`;
+    /// the exemption was written to come out WITH the fix, and it has. A
+    /// non-empty map now means someone has a language whose generated scripts
+    /// nothing pins — which is what this file exists to prevent.
+    static let fixtureExemptions: [AssignmentLanguage: String] = [:]
 
     /// Every language's generated scripts have a fixture row.
     ///

--- a/changelog.d/racket-dispatch-and-version-parse.md
+++ b/changelog.d/racket-dispatch-and-version-parse.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **Racket assignments are gradable.** Two runner defects closed together, both
+  from the multi-language audit:
+  - A generated `.rkt` test had no `ScriptInterpreter` case and no extension arm,
+    so it classified as unknown, fell through to `/bin/sh`, and exited 2 on its
+    own leading `;` — every generated Racket test reporting `error`, in the only
+    grading path an upload-only language has.
+  - `RunnerProfileDetector.firstNumericVersion` could not read
+    `Welcome to Racket v8.10 [cs].` because the version token is letter-led, so
+    no runner ever advertised `racket` and `RunnerLanguageGate` refused every
+    runner — jobs queued forever with no error, no failed test and no log line,
+    instructor validation included.
+
+### Changed
+
+- **Three guards, each the one that would have caught its defect.**
+  `GeneratedScriptDispatchTests` asserts from `allCases` that every language's
+  generated extension reaches its own interpreter (C++'s `.sh` wrapper is the
+  stated exception). `RunnerProfileDetectorTests` — the detector's first test of
+  any kind — pins all six real banners and, under CI, asserts each probe's live
+  output *parses* rather than merely exiting 0. `RacketNativeGradingTests`
+  executes generated `.rkt` through a real interpreter, so Racket meets the
+  runbook's done test rather than being declared finished.
+
+**Operational note:** dispatch and the runtime helper both live in the runner
+binary, so a Racket assignment needs a runner at this version or newer. Refresh
+the fleet before opening one.

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -606,13 +606,11 @@ additions, because prose is the surface no guard reaches.
    every job in that language queues forever, instructor validation included,
    with no error, no failed test and no log line anywhere.
 
-   The existing guard stops one step short: `everyLanguageProbeActuallyReportsAVersion`
-   asserts the probe **exits 0**, which Racket does. Assert instead that its
-   output *parses*:
-
-   ```swift
-   #expect(firstNumericVersion(in: probeOutput) != nil)
-   ```
+   The old guard stopped one step short: `everyLanguageProbeActuallyReportsAVersion`
+   asserts the probe **exits 0**, which Racket does. `RunnerProfileDetectorTests`
+   now asserts the other half — every language's real banner parses, and under
+   `CI` every probe's live output does too. Add your language's banner to its
+   pinned table.
 
    Run the probe by hand and read the banner before trusting the loop. Command,
    arguments, output format — three separate ways to be invisible to capability
@@ -653,14 +651,11 @@ additions, because prose is the surface no guard reaches.
    obvious fix.
 
    What closes it is a test in `Worker`, which depends on both:
-
-   ```swift
-   @Test(arguments: AssignmentLanguage.allCases)
-   func generatedScriptsDispatchToTheirOwnInterpreter(_ language: AssignmentLanguage) {
-       // render a family, write it, assert scriptInvocation resolves to this
-       // language's interpreter rather than the /bin/sh fallback
-   }
-   ```
+   `GeneratedScriptDispatchTests.generatedScriptsDispatchToTheirOwnInterpreter`
+   walks `allCases` and asserts each language's generated extension reaches its
+   own interpreter rather than the `/bin/sh` fallback. Its
+   `expectedInterpreter(for:)` is exhaustive, so a seventh language states its
+   answer there.
 
    C++ is the deliberate exception and shows what the test must tolerate: its
    generated case IS a `.sh` wrapper, so it dispatches as shell on purpose.

--- a/docs/multi-language-audit.md
+++ b/docs/multi-language-audit.md
@@ -4,11 +4,14 @@ Scope: the arc from Lua's completion (#1282) through Racket (#1305) — Octave
 (#1292), the upload-only submission mode and C++ (#1293–#1296, #1303), the
 runner language gate (#1297, #1300), and Racket (#1305). Audited at v0.5.35.
 
-The headline is narrow and specific. **The server half of this arc is in good
-shape; the runner half of the sixth language is absent.** Racket renders,
-validates, refuses the right kinds and personalizes correctly — and no
-`chickadee-runner` can claim, dispatch or execute a single Racket job. Three
-independent defects stack in exactly the order that hides the two behind them.
+**Everything below is the audit AS FOUND** — read "Status at merge" first for
+what has since changed, or you will chase defects that are fixed.
+
+The headline was narrow and specific. **The server half of this arc was in good
+shape; the runner half of the sixth language was absent.** Racket rendered,
+validated, refused the right kinds and personalized correctly — and no
+`chickadee-runner` could claim, dispatch or execute a single Racket job. Three
+independent defects stacked in exactly the order that hides the two behind them.
 
 Everything else here is smaller: one coherence rule that generalised at two of
 its five sites, a set of guards that are hand-enumerated where `allCases` was
@@ -30,16 +33,39 @@ what follows is what changed, so a later reader does not chase a fixed defect.
 - **F4** — all five enforcement sites ask `EditorSupport`, the refusal message
   is a function of the language, and `TestProperties.effectiveSubmissionMode`
   makes the incoherent pair inert wherever it arrives.
-- **F5, partly** — the script-dispatch fixture gained Lua, Octave and C++ rows
-  (it had covered neither Lua nor Octave since they shipped) plus an `allCases`
-  row-existence assertion; Racket is a named exemption until F1 lands.
-- **F6, partly** — this document exists; `CLAUDE.md` and the runbook still stop
-  at the fifth language.
+- **F5** — the script-dispatch fixture gained Lua, Octave and C++ rows (it had
+  covered neither Lua nor Octave since they shipped) plus an `allCases`
+  row-existence assertion, and Racket's row landed with the F1 fix.
+  `RunnerProfileDetector` and Racket native grading both have suites now, so the
+  coverage asymmetry the audit measured is gone.
+- **F6** — this document exists, and `CLAUDE.md` and the runbook are current: the
+  runbook gained the authoring-UI section and its counts were re-measured.
 
-**Open, and deliberately so.** F1 and F3 — Racket dispatch and the version
-parse. Held while production catches up. Nothing else in the branch depends on
-them, and F3's guard (asserting the probe's output *parses*, not merely that it
-exits 0) is the one-line change that should land with them.
+**F1 and F3 are closed too, in a follow-up.** Racket's generated `.rkt` now has
+a `ScriptInterpreter` case, an extension arm and a `racket` invocation; and
+`firstNumericVersion` drops leading non-digits before taking the numeric prefix,
+so `v8.10` parses. Each landed with the guard that would have caught it:
+
+- `GeneratedScriptDispatchTests` walks `allCases` and asserts every language's
+  generated extension reaches its own interpreter — the runbook's
+  compiler-invisible item 9. C++ is the stated exception, since its generated
+  case really is a `.sh` wrapper.
+- `RunnerProfileDetectorTests` pins all six real banners and, under `CI`, runs
+  each probe and asserts its output *parses* — not merely that it exits 0, which
+  is what the previous guard checked and what `racket --version` satisfies.
+- `RacketNativeGradingTests` executes generated `.rkt` through the real
+  interpreter, so the language meets the runbook's done test (the generated code
+  is run, not parsed) rather than being declared finished.
+- The `.racket` exemption in `ScriptDispatchContractTests` was written to come
+  out with the fix, and has; that map is empty now.
+
+Both fixes were verified by reverting each in isolation and confirming the new
+guards go red.
+
+**Still required before a Racket assignment grades in production:** the runner
+fleet must be refreshed. Dispatch and the runtime helper both live in the runner
+binary, so a runner older than this change still cannot grade Racket — and the
+`runnerVersionSkew` alert stops being informational at that point.
 
 **Found while fixing, and not in the original audit:**
 


### PR DESCRIPTION
The last two open findings from `docs/multi-language-audit.md`, landed with the guards that would have caught each. After this, a Racket assignment is gradable.

## F1 — dispatch

A generated `.rkt` had no `ScriptInterpreter` case and no extension arm, so it classified `.unknown`, fell through to `/bin/sh`, and exited 2 on its own leading `;`. Every generated Racket test reported `error` — in the only grading path an upload-only language has.

Three sites: the enum case and extension arm in `RunnerCore`, a shebang check beside the other languages', and the `racket` invocation in `Worker`.

## F3 — the version parse

`firstNumericVersion` took a token's numeric *prefix*, and Racket's version token is `v8.10` — letter-led, which no other language's is. It returned nil, `racket` never entered `languageVersions`, and `RunnerLanguageGate` then refused every runner for every Racket assignment: jobs queued forever with no error, no failed test and no log line, instructor validation included.

It now drops leading non-digits before taking the numeric prefix — deliberately narrower than "any dotted number in the token", so Lua's `1994-2022` copyright range and R's `2023-06-16` release date still fail for want of a dot, and `Lua.org` for want of a digit.

## The guards

- **`GeneratedScriptDispatchTests`** — the runbook's compiler-invisible item 9. It has to be a test rather than a compile error because `RunnerCore` compiles to wasm and cannot depend on `Core`; the dependency direction forbids the obvious fix. Its `expectedInterpreter(for:)` is exhaustive, so a seventh language states its answer. C++ is the stated exception, since its generated case really is a `.sh` wrapper.
- **`RunnerProfileDetectorTests`** — the detector's first test of any kind. The existing conformance-matrix guard asserts the probe **exits 0**, which `racket --version` does; this asserts the other half, pinning all six real banners and, under CI, checking each probe's live output actually parses.
- **`RacketNativeGradingTests`** — executes generated `.rkt` through a real interpreter, giving Racket the sibling suite Lua, Octave and C++ already had. That asymmetry was F5. It also loads the runtime through `runtimeHelperFiles(for:)` rather than the constant, so it proves the F2 fix installs what a Racket workspace needs.
- The `.racket` exemption in `ScriptDispatchContractTests` was written to come out with the fix, and has. That map is empty now.

**Both fixes were verified by reverting each in isolation** and confirming the new guards go red, each naming its own defect.

## Docs

Nothing now claims these are open: the audit's status section, the runbook's items 6 and 9 (which described these tests as required and now name them), and `CLAUDE.md`. The audit's body is explicitly marked as-found with a pointer to the status section, so a later reader doesn't chase a fixed defect.

## Operational

Dispatch and the runtime helper both live in the **runner binary**, so a Racket assignment needs a runner at this version or newer. The fleet currently has one runner on 0.5.33. `runnerVersionSkew` stops being informational the moment a Racket assignment is opened — worth refreshing the fleet before opening one.

## Verification

618 worker+core tests, APITests clean, all JS suites, and every gate: swift-format, swiftlint, eslint, check-styles, generate-js-constants. The executed Racket assertions skip locally (no `racket` in this container) and run in CI, where the `worker-tests` job provisions it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4dLGw94C2mGzveMq1MYNU)_