### PR TITLE
MCP language capability discovery, and no more hand-typed language lists (#1290)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,6 +362,28 @@ is in force) so agents can re-read them mid-session; the initialize copy is
 frozen per connection. Advisory text only — it never alters tools, scopes, or
 the admin surface.
 
+**The MCP surface reports its own languages, and holds none of their names
+(#1290).** `get_server_info` returns a `languages` payload
+(`MCPLanguageCapability`): per language, its wire token and display name, its
+script/generated/source extensions, editor-kernel-vs-upload-only, expression
+support and interpreter, and the supported/refused pattern-family and
+notebook-check kinds **with a reason for each exclusion** — the check-kind
+answers taken from `notebookCheckKindUnsupportedReason`, the same predicate the
+save-time refusal calls, so the payload cannot promise what a save would reject.
+Before it, an agent discovered that six check kinds are refused on Lua (and all
+ten on C++ and Racket) by getting rejected. Every rendering of the language list
+in agent-facing copy derives from `allCases` via `MCPLanguageProse` (display-name
+prose, wire-token prose, `"a" | "b"` schema union); no description or schema
+holds a language name. This is the SECOND fix of that defect: #1288 derived the
+one list it was looking at, and one language later five other hand-typed lists
+still stopped at `cpp` — `set_assignment_language` refusing Racket in prose while
+its derived JSON `enum` accepted it — and four tool descriptions still called
+personalization expressions "Python source", the very sentence #1288 existed to
+fix. So the guard is scoped to the whole served catalog, not to one string:
+`MCPLanguageCoverageTests` fails on any list that stops short of `allCases`
+anywhere in the instructions, tool descriptions or schemas. A seventh language
+needs no edit to any MCP prose.
+
 **Pattern-generated test families (v0.4.75+).** Instructors can define a
 `PatternFamily` (Core/) — one function, shared defaults, a table of cases —
 and Chickadee expands each enabled case into an ordinary Python test script

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -106,8 +106,8 @@ enum MCPServerInstructions {
     /// `text(withCourseGuidance:)` (see MCPCourseGuidance.swift).
     static let text = operationalGuide + "\n\n" + authoringVoice
 
-    /// The languages an assignment can be authored in, as prose ("Python, R or
-    /// Lua"), DERIVED from `AssignmentLanguage.allCases`.
+    /// The languages an assignment can be authored in, as prose ("Python, R,
+    /// Lua, Octave, C++ or Racket"), DERIVED from `AssignmentLanguage.allCases`.
     ///
     /// Interpolated into the guide rather than typed into it. This prose is
     /// served to every connecting agent and no compiler or `allCases` test can
@@ -115,12 +115,12 @@ enum MCPServerInstructions {
     /// stale silently — and it did: the guide told every agent that
     /// personalization expressions are "Python source" for the whole of R's and
     /// Lua's existence, which is a syntax error on those assignments.
-    static var supportedLanguageNames: String {
-        let names = AssignmentLanguage.allCases.map(\.displayName)
-        guard let last = names.last else { return "" }
-        guard names.count > 1 else { return last }
-        return names.dropLast().joined(separator: ", ") + " or " + last
-    }
+    ///
+    /// Now a forwarding alias. The renderings moved to `MCPLanguageProse` when
+    /// it turned out the guide was not the only stale copy — the tool
+    /// descriptions had the same defect, and needed the same derived list in two
+    /// other spellings. See that type for what the second round taught.
+    static var supportedLanguageNames: String { MCPLanguageProse.displayNames }
 
     /// The operational half: domain vocabulary, the read-before-write
     /// workflow, and the validation/scope/safety rules.
@@ -198,8 +198,9 @@ enum MCPServerInstructions {
         student: literal `variables` (a name + JSON value) and `expressions` (a name + source in the \
         ASSIGNMENT'S OWN LANGUAGE, evaluated server-side against the student's `seed`). An expression \
         on a \(supportedLanguageNames) assignment is written in that language and evaluated by that \
-        language's interpreter — writing Python on an R or Lua assignment fails with a syntax error \
-        from that interpreter. Use get_assignment to see the language before authoring one. They \
+        language's interpreter — writing Python on an assignment in any other language fails with a \
+        syntax error from that interpreter. Use get_assignment to see the language before authoring \
+        one. They \
         inline into generated/raw tests and substitute \
         into the starter notebook's `{{name}}` placeholders. Read with get_global_inputs, replace \
         with update_global_inputs. Sections can also carry their own scoped variables/expressions \
@@ -234,14 +235,19 @@ enum MCPServerInstructions {
         Recommended workflow:
         1. Discover: list_courses, then list_assignments for a course. get_server_info reports the \
         deployed version and whether writes are honored — call it to confirm a feature/deploy is live \
-        (a tool call reflects the running process even if your tool list is cached).
+        (a tool call reflects the running process even if your tool list is cached). It ALSO reports \
+        `languages`: every language this deployment supports and, for each, its file extensions, \
+        whether it has an editor kernel or is upload-only, and exactly which pattern-family and \
+        notebook-check kinds it can render with the reason for every exclusion. Read that before \
+        authoring for a language you have not used here — the available kinds are not uniform, and \
+        it answers from the same predicate that refuses a save, so it cannot mislead you.
         2. Inspect before editing: get_assignment, get_suite, get_notebook, get_solution, \
         get_support_files, get_global_inputs, get_achievements. Use \
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \
         set_submission_mode (notebook editor vs upload-only hand-in), \
-        set_assignment_language (declare python/r/lua/octave/cpp — normally derived from the \
+        set_assignment_language (declare \(MCPLanguageProse.tokens) — normally derived from the \
         notebook kernel or a graded script's extension, but REQUIRED for cpp, which has neither an \
         in-browser kernel nor a language-bearing script extension; a cpp assignment must be \
         uploadOnly, and the language must be declared before any pattern family or notebook check \

--- a/Sources/APIServer/MCP/Protocol/MCPLanguageCapability.swift
+++ b/Sources/APIServer/MCP/Protocol/MCPLanguageCapability.swift
@@ -1,0 +1,142 @@
+// APIServer/MCP/Protocol/MCPLanguageCapability.swift
+//
+// What one assignment language can do, as a value an agent can READ — the
+// capability-discovery half of issue #1290.
+//
+// WHY THIS EXISTS. Before it, no MCP tool reported which languages the server
+// has. `get_server_info` returned version / mode / scopes; `get_assignment`
+// reported an assignment's language but nothing about what that language
+// supports. So an agent could not discover which pattern-family and
+// notebook-check kinds are available to it, or that six check kinds are refused
+// on Lua and all ten on C++ and Racket. It found out by having a save REJECTED.
+//
+// That is a poor interface on its own, but the reason it mattered enough to fix
+// is second-order: with no machine-readable answer, the guidance had to be
+// carried in PROSE — and prose is the surface that goes stale silently. It did,
+// twice (see `MCPLanguageProse`). A payload built from `allCases` cannot omit a
+// language, and a per-kind answer taken from the save-time predicate cannot
+// disagree with the refusal an agent would actually hit.
+//
+// EVERY FIELD IS DERIVED FROM WHATEVER ALREADY OWNS THE ANSWER. Nothing here is
+// tabulated per language: the extensions and kernel facts come off
+// `LanguageDescriptor`, the check-kind exclusions off
+// `notebookCheckKindUnsupportedReason` (the predicate the save-time refusal
+// itself calls), null support off `AuthoringLanguageFacts` (which took it from
+// `JSONValue.literal`), and expression support off `PersonalizationEvaluator`.
+// If a seventh language needs a NEW fact, add it to whichever type owns it and
+// project it here — do not answer it twice.
+
+import Core
+
+/// One language's authoring capabilities, as reported by `get_server_info`.
+struct MCPLanguageCapability: Encodable, Sendable, Equatable {
+
+    /// The wire token an agent passes to `set_assignment_language`, and the
+    /// value `get_assignment` reports.
+    let name: String
+
+    /// How the language is written in prose.
+    let displayName: String
+
+    /// Graded-script filename extensions that mark a hand-written script as
+    /// this language, sorted for a stable payload.
+    let scriptExtensions: [String]
+
+    /// The extension Chickadee's GENERATED tests get. Not always the
+    /// language's own: a generated C++ case is a `.sh` wrapper that compiles
+    /// and runs a translation unit, which is why this is reported separately
+    /// from `sourceFileExtension` rather than inferred from the language.
+    let generatedScriptExtension: String
+
+    /// The extension a source file in this language carries — what an
+    /// extracted notebook's code becomes, and what `solution.<ext>` is called.
+    let sourceFileExtension: String
+
+    /// How students hand work in for this language: "notebook" when a vendored
+    /// editor kernel exists, "uploadOnly" when none does.
+    ///
+    /// Load-bearing for an authoring agent, not decoration: on an uploadOnly
+    /// language there is no starter notebook to write `{{placeholder}}`s into
+    /// and no submitted notebook for a check to inspect, which is exactly why
+    /// every notebook-check kind is refused there.
+    let submissionMode: String
+
+    /// The vendored JupyterLite kernel serving this language, or nil when the
+    /// language is upload-only.
+    let editorKernel: String?
+
+    /// Whether a per-student `=` expression can be evaluated for this language,
+    /// and the interpreter that evaluates it.
+    ///
+    /// The expression LANGUAGE is always the assignment's own — that is the
+    /// fact whose prose form went stale twice — so it is not restated as a
+    /// separate field. What an agent cannot otherwise know is whether the
+    /// server can run one, and with what.
+    let personalizationExpressions: Bool
+    let personalizationInterpreter: String
+
+    /// Whether a JSON `null` has a rendering in this language. False only for
+    /// C++, whose renderer emits a poison identifier so that a leaked null is a
+    /// compile error; a C++ family carrying a null is refused at save.
+    let supportsNullValues: Bool
+
+    /// Pattern-family kinds this language can render, sorted.
+    ///
+    /// Every language currently renders all eight — `performanceThreshold` on
+    /// C++ is supportable precisely BECAUSE it is native-only — so there is no
+    /// per-language predicate to consult and this is `PatternKind.allCases`.
+    /// It is reported anyway, and as a derived list rather than a documented
+    /// constant, so that a seventh language which refuses one is a change to
+    /// this projection and not a silent lie in the payload.
+    let supportedPatternKinds: [String]
+
+    /// Notebook-check kinds this language can render, sorted, and the ones it
+    /// cannot with the reason for each.
+    ///
+    /// Both come from `notebookCheckKindUnsupportedReason`, which is the same
+    /// predicate `validateKindSupport` refuses a save with — so what an agent
+    /// is told here and what it is told when it tries cannot disagree.
+    let supportedNotebookCheckKinds: [String]
+    let unsupportedNotebookCheckKinds: [String: String]
+
+    init(_ language: AssignmentLanguage) {
+        let descriptor = language.descriptor
+        self.name = language.rawValue
+        self.displayName = descriptor.displayName
+        self.scriptExtensions = descriptor.scriptExtensions.sorted()
+        self.generatedScriptExtension = descriptor.generatedScriptExtension
+        self.sourceFileExtension = descriptor.sourceFileExtension
+        switch descriptor.editorSupport {
+        case .notebookKernel(_, let kernelName, _, _):
+            self.submissionMode = SubmissionMode.notebook.rawValue
+            self.editorKernel = kernelName
+        case .uploadOnly:
+            self.submissionMode = SubmissionMode.uploadOnly.rawValue
+            self.editorKernel = nil
+        }
+        self.personalizationExpressions = PersonalizationEvaluator.supportsEvaluation(language)
+        self.personalizationInterpreter = descriptor.interpreterProbe.command
+        self.supportsNullValues = AuthoringLanguageFacts(language).nullLiteral != nil
+        self.supportedPatternKinds = PatternKind.allCases.map(\.rawValue).sorted()
+
+        var supported: [String] = []
+        var unsupported: [String: String] = [:]
+        for kind in NotebookCheckKind.allCases {
+            if let reason = notebookCheckKindUnsupportedReason(kind, language: language) {
+                unsupported[kind.rawValue] = reason
+            } else {
+                supported.append(kind.rawValue)
+            }
+        }
+        self.supportedNotebookCheckKinds = supported.sorted()
+        self.unsupportedNotebookCheckKinds = unsupported
+    }
+
+    /// Every language the server has, in `allCases` order.
+    ///
+    /// The whole point: a seventh language appears here by existing, with no
+    /// edit to this file, to `get_server_info`, or to any prose.
+    static var all: [MCPLanguageCapability] {
+        AssignmentLanguage.allCases.map(MCPLanguageCapability.init)
+    }
+}

--- a/Sources/APIServer/MCP/Protocol/MCPLanguageProse.swift
+++ b/Sources/APIServer/MCP/Protocol/MCPLanguageProse.swift
@@ -1,0 +1,69 @@
+// APIServer/MCP/Protocol/MCPLanguageProse.swift
+//
+// How the assignment languages are SPELLED in the agent-facing copy — the
+// `initialize` instructions and every tool description — derived from
+// `AssignmentLanguage.allCases` in one place.
+//
+// WHY THIS EXISTS, AND WHY IT IS NOT A CONSTANT PER CALL SITE.
+// Agent-facing copy is prose, and prose is the one surface no compiler and no
+// `allCases` test reaches. A hand-typed language list there is the shape that
+// goes stale silently, and it has now done so twice:
+//
+//   * #1288 found the `initialize` instructions telling every agent that
+//     personalization expressions are "Python source" — wrong from the moment R
+//     shipped, and wrong for the whole of R's and Lua's existence.
+//   * The fix derived THAT sentence's list from `allCases` and stopped there.
+//     One language later (Racket, #1308), five other hand-typed lists were
+//     still enumerating up to `cpp`: `set_assignment_language` told agents
+//     Racket was not a legal value while its own JSON `enum` — derived —
+//     accepted it, and four tool descriptions still called expressions Python.
+//
+// The lesson of the second round is that fixing the string you are looking at
+// does not fix the class. So the RENDERINGS live here rather than the lists:
+// three ways the same derived set is written, chosen by where it appears, and
+// no call site holds a language name at all.
+//
+// Adding a seventh language requires no edit to this file and no edit to any
+// copy that uses it. `MCPLanguageCoverageTests` fails if a hand-typed list
+// reappears anywhere in the served catalog.
+
+import Core
+
+/// The assignment languages, rendered for the three places agent-facing copy
+/// needs them.
+enum MCPLanguageProse {
+
+    /// Prose for a sentence a human or agent reads: `"Python, R, Lua, Octave,
+    /// C++ or Racket"`. Display names, Oxford-comma-free, joined with "or".
+    ///
+    /// Use inside a sentence about what the system supports.
+    static var displayNames: String {
+        prose(AssignmentLanguage.allCases.map(\.displayName))
+    }
+
+    /// Prose for a sentence naming the WIRE TOKENS a caller passes:
+    /// `"python, r, lua, octave, cpp or racket"`.
+    ///
+    /// Distinct from `displayNames` because these are values, not names — an
+    /// agent setting `language` sends `cpp`, not `C++`.
+    static var tokens: String {
+        prose(AssignmentLanguage.allCases.map(\.rawValue))
+    }
+
+    /// The alternatives of a JSON string field, as a schema-style union:
+    /// `"\"python\" | \"r\" | \"lua\" | \"octave\" | \"cpp\" | \"racket\""`.
+    ///
+    /// For a field's `description`, where the value set reads better as a union
+    /// than as a sentence. The quoting is part of the rendering so no call site
+    /// has to escape it.
+    static var quotedTokenAlternatives: String {
+        AssignmentLanguage.allCases.map { "\"\($0.rawValue)\"" }.joined(separator: " | ")
+    }
+
+    /// `["a", "b", "c"]` → `"a, b or c"`; a one-element list is itself.
+    private static func prose(_ items: [String]) -> String {
+        guard let last = items.last else { return "" }
+        guard items.count > 1 else { return last }
+        return items.dropLast().joined(separator: ", ") + " or " + last
+    }
+}

--- a/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
@@ -14,7 +14,8 @@
 // id already exists its spec is replaced, otherwise a new check row is appended
 // (contiguously within its section).  Read-modify-write through the same
 // buildSuitePayload / applySuiteEdit path the editor uses, which renders the
-// check's generated Python script AND runs the per-kind structural validation
+// check's generated script (in the assignment's language) AND runs the
+// per-kind structural validation
 // synchronously (so a malformed spec is rejected here, not silently shipped),
 // then closes a currently-open assignment and re-kicks validation — exactly like
 // the other content-edit write tools.

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -35,7 +35,8 @@ struct CreatePatternFamilyTool: ContentTool {
         /// Parallel to `args`: `$`-less variable name for a per-student/section/
         /// family ref at that position, or null for the literal in `args`.
         let argVarRefs: [String?]?
-        /// Parallel to `args`: false omits that argument (Python default applies).
+        /// Parallel to `args`: false omits that argument, so the function's own
+        /// parameter default applies.
         let argsProvided: [Bool]?
         /// Per-student expected: name of a global/section `=` expression resolved
         /// for the student's seed at grading time (validator enforces eligible kinds).
@@ -253,7 +254,8 @@ struct CreatePatternFamilyTool: ContentTool {
                         ]),
                         "argsProvided": .object([
                             "type": .string("array"),
-                            "description": .string("Parallel to args: false omits the arg (Python default)."),
+                            "description": .string(
+                                "Parallel to args: false omits the arg, so the function's own default applies."),
                         ]),
                         "expectedVarRef": .object([
                             "type": .string("string"),

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -40,10 +40,15 @@ struct GetAssignmentTool: ContentTool {
         /// mode from this tool — which, until now, never returned it, leaving
         /// an agent no way to see the mode it had just been told to check.
         let submissionMode: String
-        /// The assignment's language ("python" | "r" | "lua" | "octave" |
-        /// "cpp"), or nil when the suite is plain shell scripts with no
-        /// language. Decides which pattern-family and notebook-check kinds are
-        /// available, so an authoring agent needs it before it starts.
+        /// The assignment's `AssignmentLanguage` raw value, or nil when the
+        /// suite is plain shell scripts with no language. Decides which
+        /// pattern-family and notebook-check kinds are available, so an
+        /// authoring agent needs it before it starts — `get_server_info`
+        /// reports what each language supports.
+        ///
+        /// The legal values are deliberately NOT listed here: this doc comment
+        /// and the serialized description below both used to enumerate them by
+        /// hand, and both stopped at "cpp" when Racket shipped.
         let language: String?
         /// Optional minimum native-runner version required to grade this
         /// assignment (semver, e.g. "0.5.0"); null when ungated. A submission is
@@ -73,8 +78,9 @@ struct GetAssignmentTool: ContentTool {
         + "secret-tier test results; set via the assignment-update tool), minimumRunnerVersion "
         + "(the optional minimum native-runner version required to grade it, null when ungated), "
         + "submissionMode (\"notebook\" = embedded editor plus upload form, \"uploadOnly\" = upload "
-        + "only), and language (\"python\" | \"r\" | \"lua\" | \"octave\" | \"cpp\", null for a plain "
-        + "shell-script suite) — which together decide what may be authored here."
+        + "only), and language (\(MCPLanguageProse.quotedTokenAlternatives), null for a plain "
+        + "shell-script suite; get_server_info reports what each language supports) — which "
+        + "together decide what may be authored here."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([

--- a/Sources/APIServer/MCP/Tools/GetGlobalInputsTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetGlobalInputsTool.swift
@@ -2,7 +2,8 @@
 //
 // Read tool: returns an assignment's global inputs (personalization) by public
 // ID — the literal `variables` (name + JSON value) and per-student
-// `expressions` (name + Python source).  content:read, course-scoped.  Mirrors
+// `expressions` (name + source in the assignment's own language).  content:read,
+// course-scoped.  Mirrors
 // `GET /instructor/:assignmentID/global-variables`.
 
 import Core
@@ -19,16 +20,17 @@ struct GetGlobalInputsTool: ContentTool {
         /// Literal values inlined into generated/raw tests and substituted into
         /// the starter notebook at student first-open.
         let variables: [FamilyVariable]
-        /// Python expressions evaluated per-student at notebook first-open
-        /// (`seed` + every static variable in scope).
+        /// Expressions in the assignment's own language, evaluated per-student
+        /// at notebook first-open (`seed` + every static variable in scope).
         let expressions: [PersonalizationExpression]
     }
 
     static let name = "get_global_inputs"
     static let description =
         "Get an assignment's global inputs (personalization) by public ID: the literal `variables` "
-        + "(each a name + JSON value) and the per-student `expressions` (each a name + Python source "
-        + "evaluated against the student's seed). Read-only — use this to inspect personalization "
+        + "(each a name + JSON value) and the per-student `expressions` (each a name + source in the "
+        + "assignment's own language, evaluated against the student's seed). Read-only — use this to "
+        + "inspect personalization "
         + "before editing it with update_global_inputs."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),

--- a/Sources/APIServer/MCP/Tools/GetServerInfoTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetServerInfoTool.swift
@@ -31,15 +31,34 @@ struct GetServerInfoTool: ContentTool {
         let advertisedScopes: [String]
         /// Convenience flag: true when `content:write` is honored (read_write).
         let writeEnabled: Bool
+        /// Every assignment language the server has, and what each supports —
+        /// see `MCPLanguageCapability`.
+        ///
+        /// Here rather than in a `get_languages` tool of its own because it is
+        /// the same question this tool already answers ("what can this
+        /// deployment do?"), it is static server metadata like everything else
+        /// here, and an agent that must call a second tool to learn what its
+        /// first tool's answer means will often skip it. Adding a field costs
+        /// an agent nothing; adding a tool costs it a round-trip it has to
+        /// think to make.
+        let languages: [MCPLanguageCapability]
     }
 
     static let name = "get_server_info"
     static let description =
         "Report the deployed server's version and MCP capability surface: the Chickadee version, "
-        + "the active MCP mode (read_only / read_write), the advertised content scopes, and whether "
-        + "writes are honored. Use it to confirm a deploy is live (a tool call hits the running "
-        + "process, unlike a cached tool list) or to check whether write tools will work before "
-        + "calling them. Read-only; touches no course, student, or database state."
+        + "the active MCP mode (read_only / read_write), the advertised content scopes, whether "
+        + "writes are honored, and `languages` — every assignment language this deployment supports "
+        + "with, for each, its wire token and display name, its script/generated/source file "
+        + "extensions, whether it has an in-browser editor kernel or is upload-only, whether "
+        + "per-student expressions can be evaluated and by which interpreter, and exactly which "
+        + "pattern-family and notebook-check kinds it can render (with the reason for every "
+        + "exclusion). Read `languages` BEFORE authoring for an unfamiliar language: the kinds are "
+        + "NOT uniform across languages, and this is the same predicate that refuses a save, so it "
+        + "will not disagree with what you are allowed to write. Also use it to confirm a deploy is "
+        + "live (a tool call hits the running process, unlike a cached tool list) or to check "
+        + "whether write tools will work before calling them. Read-only; touches no course, "
+        + "student, or database state."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([:]),
@@ -54,9 +73,42 @@ struct GetServerInfoTool: ContentTool {
                 "type": .string("array"), "items": MCPSchema.string,
             ]),
             "writeEnabled": MCPSchema.boolean,
+            "languages": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Every assignment language the server supports, and what each can render."),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "name": MCPSchema.string,
+                        "displayName": MCPSchema.string,
+                        "scriptExtensions": .object([
+                            "type": .string("array"), "items": MCPSchema.string,
+                        ]),
+                        "generatedScriptExtension": MCPSchema.string,
+                        "sourceFileExtension": MCPSchema.string,
+                        "submissionMode": MCPSchema.string,
+                        "editorKernel": MCPSchema.string,
+                        "personalizationExpressions": MCPSchema.boolean,
+                        "personalizationInterpreter": MCPSchema.string,
+                        "supportsNullValues": MCPSchema.boolean,
+                        "supportedPatternKinds": .object([
+                            "type": .string("array"), "items": MCPSchema.string,
+                        ]),
+                        "supportedNotebookCheckKinds": .object([
+                            "type": .string("array"), "items": MCPSchema.string,
+                        ]),
+                        "unsupportedNotebookCheckKinds": .object([
+                            "type": .string("object"),
+                            "description": .string("Kind → why this language cannot render it."),
+                        ]),
+                    ]),
+                ]),
+            ]),
         ]),
         "required": .array([
-            .string("version"), .string("mcpMode"), .string("advertisedScopes"), .string("writeEnabled"),
+            .string("version"), .string("mcpMode"), .string("advertisedScopes"),
+            .string("writeEnabled"), .string("languages"),
         ]),
     ])
     static let requiredScopes: Set<ContentScope> = [.read]
@@ -67,6 +119,7 @@ struct GetServerInfoTool: ContentTool {
             version: ChickadeeVersion.current,
             mcpMode: mode.rawValue,
             advertisedScopes: mode.advertisedScopes.map(\.rawValue),
-            writeEnabled: mode.scopeCeiling.contains(.write))
+            writeEnabled: mode.scopeCeiling.contains(.write),
+            languages: MCPLanguageCapability.all)
     }
 }

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -25,7 +25,8 @@ struct GetSuiteTool: ContentTool {
             let name: String
             /// Section-scoped literal personalization values (name + JSON value).
             let variables: [FamilyVariable]
-            /// Section-scoped per-student expressions (name + Python source).
+            /// Section-scoped per-student expressions (name + source in the
+            /// assignment's own language).
             let expressions: [PersonalizationExpression]
         }
         struct Item: Encodable, Sendable {
@@ -71,7 +72,8 @@ struct GetSuiteTool: ContentTool {
             /// Full pattern-family spec — function, kind, paramNames, defaults
             /// (including the family `hint`), variables, and every case's
             /// args/expected/hint — for `kind == "family"` items. This is the
-            /// source of truth the grader renders into Python, so it reveals the
+            /// source of truth the grader renders into the assignment's
+            /// language, so it reveals the
             /// exact values each case checks and the hints students see on failure.
             let family: PatternFamily?
             /// Full notebook-check spec, for `kind == "check"` items.

--- a/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+++ b/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
@@ -1,7 +1,7 @@
 // APIServer/MCP/Tools/PreviewPersonalizationTool.swift
 //
 // Read tool: previews what a student with a given seed would see for an
-// assignment's personalization — the resolved `name → Python-literal` values
+// assignment's personalization — the resolved `name → language-literal` values
 // (literals + per-seed-evaluated expressions) and a `{{placeholder}}` audit of
 // the starter notebook (which placeholders resolve, which don't).  content:read,
 // course-scoped.
@@ -9,8 +9,8 @@
 // Drives the same `PersonalizationSubstitution.resolve` the student first-open
 // path uses, so the preview matches reality. When no seed is supplied it uses
 // the acting account's own per-assignment seed (deterministic). Read-only: it
-// evaluates expressions in the sandboxed `python3` subprocess but writes
-// nothing.
+// evaluates expressions in a sandboxed subprocess running the assignment
+// language's own interpreter, but writes nothing.
 
 import Core
 import Fluent
@@ -27,7 +27,8 @@ struct PreviewPersonalizationTool: ContentTool {
     struct Output: Encodable, Sendable {
         struct ResolvedValue: Encodable, Sendable {
             let name: String
-            /// The Python literal substituted into `{{name}}`.
+            /// The literal substituted into `{{name}}`, rendered in the
+            /// assignment's own language.
             let value: String
         }
         struct Placeholders: Encodable, Sendable {

--- a/Sources/APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
@@ -3,8 +3,8 @@
 // Write tool: declare the language an assignment is authored and graded in, by
 // assignment public ID. content:write, course-scoped.
 //
-// For the four kernel languages the language is DERIVED, not declared — a
-// notebook's kernelspec or a graded script's extension answers it, and the
+// For a language with an editor kernel the language is DERIVED, not declared —
+// a notebook's kernelspec or a graded script's extension answers it, and the
 // recorded manifest field is only a memo of that. This tool exists for the case
 // derivation cannot reach: C++ has no editor kernel (so no kernelspec implies
 // it) and its generated tests are deliberately extension-free `.sh` wrappers
@@ -22,7 +22,10 @@ import Foundation
 struct SetAssignmentLanguageTool: ContentTool {
     struct Input: Decodable, Sendable {
         let assignmentPublicID: String
-        /// An `AssignmentLanguage` raw value: python, r, lua, octave, cpp.
+        /// An `AssignmentLanguage` raw value. Not enumerated here — the
+        /// hand-typed copy of this list stopped at `cpp` when Racket shipped,
+        /// while the `enum` in `inputSchema` (derived) accepted it. See
+        /// `MCPLanguageProse`.
         let language: String
     }
 
@@ -36,9 +39,10 @@ struct SetAssignmentLanguageTool: ContentTool {
 
     static let name = "set_assignment_language"
     static let description =
-        "Declare the language an assignment is authored and graded in by its public ID: python, r, lua, "
-        + "octave, or cpp. For every language except cpp this is normally unnecessary — the language is "
-        + "derived from the starter notebook's kernel or a graded script's extension — but declaring it "
+        "Declare the language an assignment is authored and graded in by its public ID: "
+        + "\(MCPLanguageProse.tokens). For every language except cpp this is normally unnecessary — the "
+        + "language is derived from the starter notebook's kernel or a graded script's extension — but "
+        + "declaring it "
         + "pins a suite made only of pattern families, which has no script on disk to derive from. For "
         + "cpp it is required: C++ has no in-browser kernel and its generated tests are extension-free "
         + "shell wrappers, so nothing implies the language. A cpp assignment must already be uploadOnly "

--- a/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
@@ -22,8 +22,9 @@ struct UpdateGlobalInputsTool: ContentTool {
         /// Replacement literal values (name + JSON value).  Required; send `[]`
         /// to clear all literals.
         let variables: [FamilyVariable]
-        /// Replacement per-student expressions (name + Python source).  Optional;
-        /// omitted leaves the request treating expressions as `[]` (cleared).
+        /// Replacement per-student expressions (name + source in the
+        /// assignment's own language).  Optional; omitted leaves the request
+        /// treating expressions as `[]` (cleared).
         let expressions: [PersonalizationExpression]?
     }
 
@@ -38,16 +39,21 @@ struct UpdateGlobalInputsTool: ContentTool {
     static let name = "update_global_inputs"
     static let description =
         "Replace an assignment's global inputs (personalization), by its public ID. Provide the full "
-        + "desired `variables` (literal name + JSON value) and `expressions` (name + Python source "
-        + "evaluated per-student against `seed`); both lists are replaced wholesale, not merged. "
-        + "Names must be valid Python identifiers, unique across both lists and any section variable, "
+        + "desired `variables` (literal name + JSON value) and `expressions` (name + source IN THE "
+        + "ASSIGNMENT'S OWN LANGUAGE, evaluated per-student against `seed` by that language's "
+        + "interpreter — read the language from get_assignment first); both lists are replaced "
+        + "wholesale, not merged. "
+        + "Names must be valid Python identifiers, whatever the assignment's language (so no hyphens, "
+        + "even on a Racket assignment), unique across both lists and any section variable, "
         + "and `seed` is reserved. Every starter-notebook `{{placeholder}}` must match a declared name. "
         + "Each expression is eval-checked against your own seed before saving, so typos are caught here. "
         + "Prefer calling the auto-imported `solution.*` / support-module functions over re-implementing "
-        + "logic inline (e.g. `solution.composite(fortune, 1 + seed % 25, 2 + seed % 5)`) — an inline copy "
+        + "logic inline (e.g. `solution.composite(fortune, 1 + seed % 25, 2 + seed % 5)` in Python; each "
+        + "language reaches it by its own loading mechanism) — an inline copy "
         + "can diverge from what the suite grades and mis-grade some seeds. The auto-imported `solution` "
         + "module is best-effort (skipped when the solution uses `{{ }}` placeholders); for those, share "
-        + "reusable logic via an uploaded `.py` support module that both the solution and the expression import."
+        + "reusable logic via an uploaded support module in the assignment's language that both the "
+        + "solution and the expression load."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -60,10 +66,13 @@ struct UpdateGlobalInputsTool: ContentTool {
                     "properties": .object([
                         "name": .object([
                             "type": .string("string"),
-                            "description": .string("Valid Python identifier; not \"seed\"."),
+                            "description": .string(
+                                "Valid Python identifier (the rule in every language); not \"seed\"."),
                         ]),
                         "value": .object([
-                            "description": .string("Any JSON-expressible Python literal (scalar, list, dict).")
+                            "description": .string(
+                                "Any JSON value (scalar, list, object); rendered as a literal in the assignment's language."
+                            )
                         ]),
                     ]),
                     "required": .array([.string("name"), .string("value")]),
@@ -78,11 +87,14 @@ struct UpdateGlobalInputsTool: ContentTool {
                     "properties": .object([
                         "name": .object([
                             "type": .string("string"),
-                            "description": .string("Valid Python identifier; not \"seed\"."),
+                            "description": .string(
+                                "Valid Python identifier (the rule in every language); not \"seed\"."),
                         ]),
                         "expression": .object([
                             "type": .string("string"),
-                            "description": .string("Python expression; `seed` and every variable are in scope."),
+                            "description": .string(
+                                "An expression in the assignment's own language; `seed` and every variable are in scope."
+                            ),
                         ]),
                     ]),
                     "required": .array([.string("name"), .string("expression")]),

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -34,7 +34,7 @@ struct UpdatePatternFamilyTool: ContentTool {
         /// null at a position to use the literal in `args`.
         let argVarRefs: [String?]?
         /// Parallel to `args`: false at a position omits that argument so
-        /// Python's own parameter default applies.
+        /// the function's own parameter default applies.
         let argsProvided: [Bool]?
         /// Per-student expected (issue #461): the name of a global/section `=`
         /// expression whose value, resolved for the student's seed at grading
@@ -207,7 +207,8 @@ struct UpdatePatternFamilyTool: ContentTool {
                         ]),
                         "argsProvided": .object([
                             "type": .string("array"),
-                            "description": .string("Parallel to args: false omits the arg (use Python default)."),
+                            "description": .string(
+                                "Parallel to args: false omits the arg, so the function's own default applies."),
                         ]),
                         "expectedVarRef": .object([
                             "type": .string("string"),
@@ -259,7 +260,8 @@ struct UpdatePatternFamilyTool: ContentTool {
                         ]),
                         "argsProvided": .object([
                             "type": .string("array"),
-                            "description": .string("Parallel to args: false omits the arg (Python default)."),
+                            "description": .string(
+                                "Parallel to args: false omits the arg, so the function's own default applies."),
                         ]),
                         "expectedVarRef": .object([
                             "type": .string("string"),

--- a/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
@@ -36,8 +36,10 @@ struct UpdateSectionVariablesTool: ContentTool {
     static let description =
         "Replace one test-suite section's personalization inputs, by assignment public ID + section "
         + "id (from get_suite). Provide the full desired `variables` (literal name + JSON value) and "
-        + "`expressions` (name + Python source evaluated per-student against `seed`); both lists are "
-        + "replaced wholesale, not merged. Names must be valid Python identifiers, unique within the "
+        + "`expressions` (name + source in the ASSIGNMENT'S OWN LANGUAGE, evaluated per-student against "
+        + "`seed` by that language's interpreter); both lists are "
+        + "replaced wholesale, not merged. Names must be valid Python identifiers whatever the "
+        + "language, unique within the "
         + "section, and must not clash with global inputs or any other section; `seed` is reserved. "
         + "Each expression is eval-checked against your own seed before saving."
     static let inputSchema: JSONValue = .object([
@@ -56,10 +58,13 @@ struct UpdateSectionVariablesTool: ContentTool {
                     "properties": .object([
                         "name": .object([
                             "type": .string("string"),
-                            "description": .string("Valid Python identifier; not \"seed\"."),
+                            "description": .string(
+                                "Valid Python identifier (the rule in every language); not \"seed\"."),
                         ]),
                         "value": .object([
-                            "description": .string("Any JSON-expressible Python literal (scalar, list, dict).")
+                            "description": .string(
+                                "Any JSON value (scalar, list, object); rendered as a literal in the assignment's language."
+                            )
                         ]),
                     ]),
                     "required": .array([.string("name"), .string("value")]),
@@ -74,11 +79,14 @@ struct UpdateSectionVariablesTool: ContentTool {
                     "properties": .object([
                         "name": .object([
                             "type": .string("string"),
-                            "description": .string("Valid Python identifier; not \"seed\"."),
+                            "description": .string(
+                                "Valid Python identifier (the rule in every language); not \"seed\"."),
                         ]),
                         "expression": .object([
                             "type": .string("string"),
-                            "description": .string("Python expression; `seed` and every variable are in scope."),
+                            "description": .string(
+                                "An expression in the assignment's own language; `seed` and every variable are in scope."
+                            ),
                         ]),
                     ]),
                     "required": .array([.string("name"), .string("expression")]),

--- a/Sources/APIServer/Utilities/NotebookCheckValidator.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckValidator.swift
@@ -94,9 +94,6 @@ func validateNotebookChecks(
     }
 }
 
-/// Reject a kind with no renderer in this assignment's language at save time.
-/// Rendering Python for an R assignment would emit a `.py` script the R suite
-/// can never run, and the failure would surface as a confusing grading error
 /// Whether `language` can render `kind` — THE predicate, shared by the save-time
 /// refusal below and by the authoring UI's menu.
 ///
@@ -132,6 +129,9 @@ func notebookCheckKindUnsupportedReason(
     }
 }
 
+/// Reject a kind with no renderer in this assignment's language at save time.
+/// Rendering Python for an R assignment would emit a `.py` script the R suite
+/// can never run, and the failure would surface as a confusing grading error
 /// rather than an authoring mistake. Exhaustive so a future language cannot
 /// silently skip kind-support validation (docs/language-handling-review.md §4).
 private func validateKindSupport(_ check: NotebookCheck, language: AssignmentLanguage) throws {

--- a/Tests/APITests/MCP/MCPLanguageCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPLanguageCoverageTests.swift
@@ -1,0 +1,244 @@
+// Drift guards for how the assignment languages appear in the AGENT-FACING
+// surface: the `initialize` instructions and every tool's description and
+// schema.
+//
+// WHY THESE EXIST, AND WHY THEY ARE NOT THE ONES IN
+// `MCPInstructionsCatalogSyncTests`. Those guards pin the INSTRUCTIONS, and
+// they worked — the instructions were correct when Racket shipped. The tool
+// descriptions were not: five of them still enumerated languages by hand and
+// stopped at `cpp`, and four still called personalization expressions "Python
+// source", which is the exact defect #1288 was opened to fix one language
+// earlier.
+//
+// So the lesson these encode is the one that round taught: a guard scoped to
+// the string someone was looking at does not protect the class. Everything
+// below is scoped to the WHOLE served catalog, and derives its expectations
+// from `AssignmentLanguage.allCases`, so a seventh language fails them without
+// anyone thinking to come here.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct MCPLanguageCoverageTests {
+
+    /// Every piece of text an agent can actually read: the server instructions,
+    /// plus each tool's name, description, and both schemas rendered as JSON.
+    ///
+    /// Schemas are included deliberately — the `cpp`-truncated list in
+    /// `get_assignment` lived in a description, but field `description`s inside
+    /// a schema are just as agent-facing and just as hand-written.
+    private static let servedText: String = {
+        var parts = [MCPServerInstructions.text]
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        for tool in MCPToolCatalog.live.all {
+            parts.append(tool.name)
+            parts.append(tool.description)
+            for schema in [tool.inputSchema, tool.outputSchema] {
+                guard let schema,
+                    let data = try? encoder.encode(schema),
+                    let json = String(data: data, encoding: .utf8)
+                else { continue }
+                parts.append(json)
+            }
+        }
+        return parts.joined(separator: "\n")
+    }()
+
+    // MARK: - No truncated language list survives anywhere
+
+    /// THE guard this whole change exists to install.
+    ///
+    /// Every historical instance of this bug has the same shape: a list written
+    /// when there were N languages, still listing N when there are N+1. So the
+    /// stale forms are exactly the PROPER PREFIXES of today's derived lists,
+    /// and they are computable — no judgement, no maintenance, and a seventh
+    /// language turns every list that stops at six into a named failure here.
+    ///
+    /// Checked in all three renderings, because the real defect appeared in all
+    /// three: `"python, r, lua, octave or cpp"` (set_assignment_language's
+    /// prose), `"\"python\" | ... | \"cpp\""` (get_assignment's description),
+    /// and the display-name form the instructions use.
+    @Test func noProperPrefixOfALanguageListSurvivesInTheServedCatalog() {
+        // Scan with the CORRECT renderings removed first. The union form
+        // (`"python" | "r" | …`) has no terminal connector, so it literally
+        // contains each of its own prefixes — without this, a correctly derived
+        // list fails the guard meant to catch a hand-typed one. Deleting the
+        // full renderings leaves exactly the remnants that are not derived.
+        var scanned = Self.servedText
+        for rendering in [
+            MCPLanguageProse.displayNames,
+            MCPLanguageProse.tokens,
+            MCPLanguageProse.quotedTokenAlternatives,
+        ] {
+            scanned = scanned.replacingOccurrences(of: rendering, with: "«derived»")
+        }
+        for stale in Self.staleLanguageLists() {
+            #expect(
+                !scanned.contains(stale),
+                """
+                The served MCP catalog contains "\(stale)" — a language list that stops short of \
+                \(AssignmentLanguage.allCases.count) languages. That is a hand-typed list going \
+                stale, which has now happened twice (#1288, then again for Racket). Interpolate \
+                the derived rendering from `MCPLanguageProse` instead of typing the names.
+                """)
+        }
+    }
+
+    /// Every proper prefix of `allCases`, rendered all three ways. With six
+    /// languages that is fifteen distinctive strings; each is long and specific
+    /// enough that a false positive is not a realistic worry.
+    private static func staleLanguageLists() -> [String] {
+        let cases = AssignmentLanguage.allCases
+        guard cases.count > 1 else { return [] }
+        var stale: [String] = []
+        for count in 1..<cases.count {
+            let prefix = Array(cases.prefix(count))
+            stale.append(prose(prefix.map(\.displayName)))
+            stale.append(prose(prefix.map(\.rawValue)))
+            stale.append(prefix.map { "\"\($0.rawValue)\"" }.joined(separator: " | "))
+        }
+        // A single-language "list" is just that language's name and appears all
+        // over legitimate prose ("a cpp assignment must be uploadOnly"). Only
+        // multi-item prefixes are evidence of a list.
+        return stale.filter { $0.contains(",") || $0.contains(" | ") || $0.contains(" or ") }
+    }
+
+    private static func prose(_ items: [String]) -> String {
+        guard let last = items.last else { return "" }
+        guard items.count > 1 else { return last }
+        return items.dropLast().joined(separator: ", ") + " or " + last
+    }
+
+    /// The complement: the derived renderings are actually REACHING the
+    /// catalog. Without this, deleting every list would pass the guard above.
+    @Test func everyDerivedLanguageRenderingIsInterpolatedSomewhere() {
+        for (label, rendering) in [
+            ("displayNames", MCPLanguageProse.displayNames),
+            ("tokens", MCPLanguageProse.tokens),
+            ("quotedTokenAlternatives", MCPLanguageProse.quotedTokenAlternatives),
+        ] {
+            #expect(
+                Self.servedText.contains(rendering),
+                """
+                No served text contains MCPLanguageProse.\(label) ("\(rendering)") verbatim, so \
+                either it is unused or a hand-typed list replaced it at its call site.
+                """)
+        }
+    }
+
+    // MARK: - Expressions are never described as Python
+
+    /// The specific regression #1288 named, generalized from the instructions
+    /// (where it was already guarded) to the tool descriptions (where it was
+    /// not, and where it had survived).
+    ///
+    /// A personalization expression is written in the ASSIGNMENT'S language and
+    /// evaluated by that language's interpreter. Telling an agent otherwise
+    /// makes it write something that fails with a syntax error on five of six
+    /// languages.
+    @Test func personalizationIsNeverDescribedAsPython() {
+        for phrase in [
+            "Python source", "Python expression", "Python literal", "Python expressions",
+            "Python-literal",
+        ] {
+            #expect(
+                !Self.servedText.contains(phrase),
+                """
+                The served MCP catalog says "\(phrase)". Personalization expressions and the \
+                literals they resolve to are in the ASSIGNMENT'S own language — describing them as \
+                Python tells an agent on an R, Lua, Octave, C++ or Racket assignment to write \
+                something that cannot run. Say "the assignment's own language".
+                """)
+        }
+    }
+
+    // MARK: - The capability payload
+
+    @Test func capabilityPayloadCoversEveryLanguage() throws {
+        let payload = MCPLanguageCapability.all
+        #expect(payload.count == AssignmentLanguage.allCases.count)
+        for language in AssignmentLanguage.allCases {
+            let entry = try #require(
+                payload.first { $0.name == language.rawValue },
+                "get_server_info reports no capabilities for \(language.displayName)")
+            #expect(entry.displayName == language.displayName)
+            #expect(entry.generatedScriptExtension == language.generatedScriptExtension)
+            #expect(!entry.scriptExtensions.isEmpty)
+            #expect(!entry.personalizationInterpreter.isEmpty)
+        }
+    }
+
+    /// The property that makes the payload worth having over prose: what an
+    /// agent is TOLD is available and what it is ALLOWED to save come from the
+    /// same predicate, so they cannot drift apart.
+    @Test func reportedCheckKindsAgreeWithTheSaveTimeRefusal() {
+        for language in AssignmentLanguage.allCases {
+            let entry = MCPLanguageCapability(language)
+            for kind in NotebookCheckKind.allCases {
+                let supported = notebookCheckKindIsSupported(kind, language: language)
+                #expect(
+                    entry.supportedNotebookCheckKinds.contains(kind.rawValue) == supported,
+                    """
+                    get_server_info reports \(kind.rawValue) as \
+                    \(supported ? "unsupported" : "supported") for \(language.displayName), but \
+                    the save-time predicate disagrees. An agent told one thing and refused the \
+                    other has no way to proceed.
+                    """)
+                #expect(
+                    (entry.unsupportedNotebookCheckKinds[kind.rawValue] != nil) == !supported,
+                    "\(language.displayName)/\(kind.rawValue): exclusion reason and support disagree"
+                )
+            }
+        }
+    }
+
+    /// Every refusal carries a reason. A kind listed as unavailable with an
+    /// empty explanation is barely better than the rejection-message-only state
+    /// this replaced.
+    @Test func everyExclusionExplainsItself() {
+        for entry in MCPLanguageCapability.all {
+            for (kind, reason) in entry.unsupportedNotebookCheckKinds {
+                #expect(
+                    reason.count > 10,
+                    "\(entry.name)/\(kind) is excluded with no usable reason: \"\(reason)\"")
+            }
+        }
+    }
+
+    /// The upload-only languages are reported as such, and are exactly the ones
+    /// with no editor kernel. Derived from `EditorSupport`, so this pins the
+    /// projection rather than the current membership.
+    @Test func uploadOnlyLanguagesReportNoEditorKernel() {
+        for language in AssignmentLanguage.allCases {
+            let entry = MCPLanguageCapability(language)
+            switch language.editorSupport {
+            case .uploadOnly:
+                #expect(entry.submissionMode == SubmissionMode.uploadOnly.rawValue)
+                #expect(entry.editorKernel == nil)
+                // No notebook exists to inspect, so no check kind can apply.
+                #expect(entry.supportedNotebookCheckKinds.isEmpty)
+            case .notebookKernel(_, let kernelName, _, _):
+                #expect(entry.submissionMode == SubmissionMode.notebook.rawValue)
+                #expect(entry.editorKernel == kernelName)
+            }
+        }
+    }
+
+    /// `get_server_info` advertises the field, so a client validating
+    /// `structuredContent` against the declared schema does not reject it.
+    @Test func serverInfoSchemaDeclaresLanguages() throws {
+        guard case .object(let schema) = try #require(GetServerInfoTool.outputSchema),
+            case .object(let properties) = try #require(schema["properties"])
+        else {
+            Issue.record("get_server_info outputSchema is not an object with properties")
+            return
+        }
+        #expect(properties["languages"] != nil, "get_server_info does not declare `languages`")
+        guard case .array(let required) = try #require(schema["required"]) else { return }
+        #expect(required.contains(.string("languages")))
+    }
+}

--- a/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
+++ b/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
@@ -95,9 +95,14 @@ import Testing
             ),
             (
                 GetServerInfoTool.name, GetServerInfoTool.outputSchema,
+                // The REAL capability payload, not a stub: it is derived from
+                // `allCases`, so validating it here means a seventh language
+                // whose entry does not match the declared schema fails at this
+                // test rather than at an agent's client.
                 GetServerInfoTool.Output(
                     version: "0.0.0", mcpMode: "read_write",
-                    advertisedScopes: ["content:read"], writeEnabled: true)
+                    advertisedScopes: ["content:read"], writeEnabled: true,
+                    languages: MCPLanguageCapability.all)
             ),
             (
                 CloneAssignmentTool.name, CloneAssignmentTool.outputSchema,

--- a/changelog.d/1290-mcp-language-discovery.md
+++ b/changelog.d/1290-mcp-language-discovery.md
@@ -1,0 +1,24 @@
+### Added
+
+- **`get_server_info` reports every assignment language and what it supports (#1290).** The MCP
+  surface had no way to discover which languages exist: an agent learned that six notebook-check
+  kinds are refused on Lua, and all ten on C++ and Racket, by having a save rejected. The tool now
+  returns a `languages` array — per language, its wire token and display name, its
+  script/generated/source extensions, whether it has an in-browser editor kernel or is upload-only,
+  whether per-student expressions can be evaluated and by which interpreter, and exactly which
+  pattern-family and notebook-check kinds it renders with the reason for every exclusion. Every
+  field is derived from whatever already owns the answer — the check-kind exclusions come from the
+  same predicate the save-time refusal calls, so what an agent is told and what it is allowed to
+  write cannot disagree, and a seventh language appears in the payload without an edit.
+
+### Fixed
+
+- **The agent-facing MCP copy no longer describes a five-language world (#1290).** Five hand-typed
+  language lists still stopped at `cpp` after Racket shipped — including `set_assignment_language`'s
+  own description, which told agents Racket was not a legal value while its (derived) JSON schema
+  accepted it. Four more tool descriptions still called personalization expressions "Python source",
+  the exact defect #1288 fixed in the `initialize` instructions one language earlier and did not
+  fix in the tool catalog. All of it is now interpolated from `AssignmentLanguage.allCases` via
+  `MCPLanguageProse`, and `MCPLanguageCoverageTests` fails on any list in the served catalog that
+  stops short of every language — scoped to the whole catalog rather than to the string someone
+  happened to be looking at, which is why the first fix did not hold.

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -625,18 +625,41 @@ additions, because prose is the surface no guard reaches.
    + Python source" for the whole of R's and Lua's existence — a syntax error on
    those assignments — and never said assignments have a language at all.
 
-   The language LIST now derives from `allCases`
-   (`MCPServerInstructions.supportedLanguageNames`, pinned by
-   `theDerivedLanguageListIsActuallyInterpolated`), so it cannot silently cover
-   fewer languages than exist. **That protects the list, not the sentences.**
-   Re-read the guide for per-language claims — grep it for `Python`, `.py`,
-   `import`, `source`, `require` — and check each is still true. One
-   hand-enumerated clause ("imported on Python, sourced on R, required on Lua")
-   was removed for exactly this reason and would have gone stale here.
+   **This item has largely been retired, and how it was retired is the point.**
+   #1288 derived the instructions' language LIST from `allCases` and stopped
+   there. One language later (Racket), *five other* hand-typed lists across the
+   tool catalog were still enumerating up to `cpp` — `set_assignment_language`
+   told agents Racket was not a legal value while its own derived JSON `enum`
+   accepted it — and four tool descriptions still called personalization
+   expressions "Python source", which is the very sentence #1288 was opened to
+   fix. A guard scoped to the string someone is looking at does not protect the
+   class.
 
-   Also make sure the language's REFUSED pattern-family and notebook-check kinds
-   are discoverable before a save is attempted, not only via the rejection
-   message. See issue #1290.
+   So there is now nothing per-language for you to write:
+
+   - **Every rendering of the language list derives from `allCases`**
+     (`MCPLanguageProse`: display-name prose, wire-token prose, and the
+     `"a" | "b"` schema union). No call site holds a language name.
+   - **`get_server_info` reports a `languages` payload**
+     (`MCPLanguageCapability`) — extensions, editor-kernel-vs-upload-only,
+     expression support and interpreter, and the supported/refused
+     pattern-family and notebook-check kinds with a reason for each exclusion.
+     That answers the "refused kinds must be discoverable before a save" ask
+     from issue #1290 for every language at once, including yours. Its check-kind
+     answers come from `notebookCheckKindUnsupportedReason`, the same predicate
+     the save-time refusal calls, so the payload cannot promise what a save
+     would reject.
+   - **`MCPLanguageCoverageTests` scans the WHOLE served catalog** — the
+     instructions plus every tool's description and both schemas — and fails on
+     any list that stops short of `allCases`, on any missing derived rendering,
+     and on any surviving "Python source"/"Python expression"/"Python literal".
+
+   What is left for you is the residue no derivation reaches: a *sentence* that
+   makes a per-language claim in words. Grep the guide for `.py`, `import`,
+   `source`, `require` and check each is still true. One hand-enumerated clause
+   ("imported on Python, sourced on R, required on Lua") was removed for exactly
+   this reason. If you find yourself wanting to add a per-language fact to the
+   copy, add it to `MCPLanguageCapability` instead and let the payload carry it.
 9. **Whether the generated scripts DISPATCH.** The newest item, and the most
    direct: a generated test is only graded if `scriptInvocation` knows how to run
    it. Racket's generated `.rkt` had no `ScriptInterpreter` case and no extension
@@ -868,7 +891,10 @@ state this document exists to warn you about:
       and both halves fail open together. Verify with a runner that does NOT
       have the interpreter, not only with one that does. See
       [runner-capability-profiles.md](runner-capability-profiles.md)
-- [ ] the MCP guide is true for this language — see item 8 above
+- [ ] the MCP guide is true for this language — see item 8 above. Mostly this is
+      now `swift test --filter MCPLanguageCoverageTests` plus reading your
+      language's entry in a real `get_server_info` response; what those cannot
+      check is a *sentence* making a per-language claim in words
 - [ ] **the instructor walkthrough below passes, by hand, on a real server**
 
 ### The last step: walk an instructor's path by hand


### PR DESCRIPTION
Closes #1290. Also closes #500 and #77 (both verified already-shipped and closed with evidence — no code in this PR).

## The problem, in the order it was found

#1290 filed a checklist to run "once Octave and C++ land". Octave, C++ **and** Racket have since landed. Running it turned up five hand-typed language lists in the MCP surface, all stopping at `cpp`:

| File | What it said |
|---|---|
| `SetAssignmentLanguageTool` description | `python, r, lua, octave, or cpp` — telling agents Racket is not a legal value, while the tool's own **derived** JSON `enum` accepted it |
| `SetAssignmentLanguageTool.Input` doc | same list |
| `GetAssignmentTool` description | `"python" \| "r" \| "lua" \| "octave" \| "cpp"` |
| `GetAssignmentTool.Output` doc | same list |
| `InitializeTypes` step 3 | `declare python/r/lua/octave/cpp` |

And then the thing the issue is really about: **four more tool descriptions still described personalization expressions as "Python source"** — the exact defect #1288 was opened to fix one language earlier. #1288 fixed the `initialize` instructions and stopped there, so `update_global_inputs`, `update_section_variables`, `get_global_inputs` and `preview_personalization` went on telling agents to write Python for five of six languages. That is a syntax error from the interpreter, on save.

The lesson encoded here: **a guard scoped to the string you are looking at does not protect the class.**

## What changed

**`MCPLanguageProse`** — one owner for the three renderings the copy needs, all derived from `allCases`: display-name prose (`Python, R, Lua, Octave, C++ or Racket`), wire-token prose (`python, r, lua, … or racket`), and the schema union (`"python" | "r" | …`). No description or schema holds a language name any more. `MCPServerInstructions.supportedLanguageNames` becomes a forwarding alias so the existing guards keep pinning it.

**`MCPLanguageCapability` + `get_server_info.languages`** — the capability-discovery decision the issue left open: **build it.** Per language: wire token, display name, script/generated/source extensions, editor-kernel-vs-upload-only (plus the kernel name), whether per-student expressions evaluate and by which interpreter, null-value support, and the supported/refused pattern-family and notebook-check kinds **with a reason for each exclusion**.

Every field is projected from whatever already owns the answer — nothing is tabulated per language. The extensions and kernel facts come off `LanguageDescriptor`; the check-kind exclusions off `notebookCheckKindUnsupportedReason`, **the same predicate `validateKindSupport` refuses a save with**, so the payload cannot promise what a save would reject; null support off `AuthoringLanguageFacts`; expression support off `PersonalizationEvaluator`.

It lives on `get_server_info` rather than a new `get_languages` tool because it is the same question that tool already answers ("what can this deployment do?"), it is static metadata like everything else there, and an agent that must call a second tool to learn what its first tool's answer *means* will often skip it.

`get_assignment` already reported `language` (the issue's "natural companion" suggestion) — that needed no change beyond de-staling its docs.

## The guard

`MCPLanguageCoverageTests` scans the **whole served catalog** — the instructions plus every tool's name, description, and both schemas rendered as JSON — not one string:

- **`noProperPrefixOfALanguageListSurvivesInTheServedCatalog`** — every historical instance of this bug is a list written for N languages still listing N when there are N+1, so the stale forms are exactly the *proper prefixes* of today's derived lists, in all three renderings. Computable, no maintenance, and a seventh language turns every list that stops at six into a named failure. (The correct union rendering literally contains its own prefixes, so the scan removes the full renderings first — otherwise the guard fails on correct code.)
- **`everyDerivedLanguageRenderingIsInterpolatedSomewhere`** — the complement; without it, deleting every list would pass.
- **`personalizationIsNeverDescribedAsPython`** — the #1288 regression, generalized from the instructions to the whole catalog.
- **`reportedCheckKindsAgreeWithTheSaveTimeRefusal`** — payload and refusal cannot drift.
- plus exclusion-reasons-are-non-empty, upload-only-implies-no-kernel-and-no-check-kinds, and schema declaration.

**Mutation-verified.** Reintroducing `python, r, lua, octave or cpp` into `set_assignment_language` fails the guard by name; restoring the derived form passes.

`MCPOutputSchemaSyncTests` now validates the **real** `MCPLanguageCapability.all` against the declared schema, so a seventh language whose entry does not match fails there rather than at an agent's client.

## Drive-by

A doc comment in `NotebookCheckValidator` had been split in half when `notebookCheckKindIsSupported` was inserted into the middle of it — three orphaned lines above the new function, two dangling above `validateKindSupport`. Restored.

## Testing

- `swift test --filter MCP` — 311 tests, 52 suites, green
- `swift test --filter "Language|NotebookCheck|Authoring|ServerInfo"` — 268 tests, green
- `scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh --strict` — 0 violations in 962 files

## Docs

`docs/adding-a-xeus-kernel.md` item 8 largely retires: a seventh language now needs **no** edit to any MCP prose, and the item says what is left (a *sentence* making a per-language claim in words, which no derivation reaches) and what to do instead (add the fact to `MCPLanguageCapability`). `CLAUDE.md` and a changelog fragment record the same.

## On #500 and #77

Neither needed code — both were already shipped and left open. Closed with the evidence:

- **#77** — worker R shipped in #1207; the browser R kernel shipped as **xeus-r**, not WebR (that package is permanently capped at `jupyterlite-core<0.7` against our 0.8.x pin); and the half the 2026-08-01 triage correctly called open — in-browser R *grading* — shipped in #1271/#1274, with `/r-grading-worker.js` on `NotebookAssetIsolationMiddleware.isolatedWorkerScripts`, which is the part that actually decides whether an isolated engine ever runs it.
- **#500** — done in #1266 + #1269. Worth reading the comment: the "LeafKit multi-extend parser bug" that blocked this for months **was a misdiagnosis** (Leaf's lexer has no notion of an HTML comment, so tag syntax in a comment lexes as markup), and once corrected, the real shared-markup opportunity measured at *one* ~70-line block. `assignment-new.leaf` 1,722 → 715. The remaining template from that issue's table, `assignments.leaf`, stays tracked in #1253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QexGRK93kBbppAsRtBUpSj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QexGRK93kBbppAsRtBUpSj)_