### PR TITLE
refactor(instructor): one redirect builder for the new-assignment form (#1253)

### DIFF
--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -193,12 +193,13 @@ extension DraftAssignmentRoutes {
         }()
         return redirectToNewAssignmentDraft(
             req: req,
-            draftID: setupID,
-            assignmentName: payload.assignmentName,
-            dueAt: payload.dueAt,
-            startsAt: payload.startsAt,
-            sectionID: payload.sectionIDRaw,
-            notice: nil,
+            form: NewAssignmentFormContext(
+                title: payload.assignmentName,
+                dueAt: payload.dueAt,
+                startsAt: payload.startsAt,
+                sectionID: payload.sectionIDRaw,
+                draftID: setupID
+            ),
             error: errorMessage
         )
     }
@@ -361,12 +362,13 @@ extension DraftAssignmentRoutes {
             guard hasEligibleRunner else {
                 return redirectToNewAssignmentDraft(
                     req: req,
-                    draftID: validated.draftID,
-                    assignmentName: validated.title,
-                    dueAt: validated.dueAtRaw,
-                    startsAt: validated.startsAtRaw,
-                    sectionID: validated.sectionIDRaw,
-                    notice: nil,
+                    form: NewAssignmentFormContext(
+                        title: validated.title,
+                        dueAt: validated.dueAtRaw,
+                        startsAt: validated.startsAtRaw,
+                        sectionID: validated.sectionIDRaw,
+                        draftID: validated.draftID
+                    ),
                     error: "No compatible active runner is available to validate this assignment."
                 )
             }
@@ -657,35 +659,13 @@ extension DraftAssignmentRoutes {
     // MARK: - POST /instructor
     // Creates a draft (isOpen: false) assignment and redirects to the validate page.
 
-    // The argument list mirrors the URL query string the redirect builds —
-    // each parameter is an independent named field on the new-assignment
-    // form, so bundling them into a struct would only push the same names
-    // one layer down without removing any.
-    // swiftlint:disable:next function_parameter_count
     private func redirectToNewAssignmentDraft(
         req: Request,
-        draftID: String,
-        assignmentName: String,
-        dueAt: String,
-        startsAt: String,
-        sectionID: String,
-        notice: String?,
-        error: String?
+        form: NewAssignmentFormContext,
+        notice: String? = nil,
+        error: String? = nil
     ) -> Response {
-        var parts: [String] = [
-            "draftID=\(urlEncode(draftID))",
-            "assignmentName=\(urlEncode(assignmentName))",
-            "dueAt=\(urlEncode(dueAt))",
-            "startsAt=\(urlEncode(startsAt))",
-            "sectionID=\(urlEncode(sectionID))",
-        ]
-        if let notice, !notice.isEmpty {
-            parts.append("notice=\(urlEncode(notice))")
-        }
-        if let error, !error.isEmpty {
-            parts.append("error=\(urlEncode(error))")
-        }
-        return req.redirect(to: "/instructor/new?\(parts.joined(separator: "&"))")
+        req.redirect(to: form.redirectURL(notice: notice, error: error))
     }
 
     private func resolveOrCreateNewAssignmentDraft(

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SaveValidation.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SaveValidation.swift
@@ -160,16 +160,19 @@ extension DraftAssignmentRoutes {
         let startsAtRaw = form.startsAtRaw ?? ""
         let sectionIDRaw = form.sectionIDRaw ?? ""
 
+        // The bounce-back context for every redirect below.  The title is
+        // filled in from `title` rather than the raw field so a name that was
+        // only whitespace comes back empty, as it did before.
+        let formContext = NewAssignmentFormContext(
+            title: title,
+            dueAt: dueAtRaw,
+            startsAt: startsAtRaw,
+            sectionID: sectionIDRaw,
+            draftID: draftID
+        )
+
         guard !title.isEmpty else {
-            return .redirect(
-                toURL: newAssignmentErrorRedirect(
-                    title: "",
-                    dueAt: dueAtRaw,
-                    startsAt: startsAtRaw,
-                    sectionID: sectionIDRaw,
-                    draftID: draftID,
-                    error: "Assignment name is required"
-                ))
+            return .redirect(toURL: formContext.redirectURL(error: "Assignment name is required"))
         }
 
         let suiteFiles = form.suiteFilesRaw.filter { $0.data.readableBytes > 0 }
@@ -182,7 +185,7 @@ extension DraftAssignmentRoutes {
         if let earlyRedirect = redirectIfNotebookDataInvalid(
             data: assignmentNotebookRaw,
             isPresent: !assignmentNotebookRaw.isEmpty,
-            title: title, dueAtRaw: dueAtRaw, startsAtRaw: startsAtRaw, sectionIDRaw: sectionIDRaw, draftID: draftID,
+            form: formContext,
             missingError: "Assignment notebook (.ipynb) is required",
             invalidJSONError: "Assignment notebook is not valid JSON (.ipynb)"
         ) {
@@ -194,7 +197,7 @@ extension DraftAssignmentRoutes {
         if let earlyRedirect = redirectIfNotebookDataInvalid(
             data: solutionNotebookRaw,
             isPresent: !solutionNotebookRaw.isEmpty,
-            title: title, dueAtRaw: dueAtRaw, startsAtRaw: startsAtRaw, sectionIDRaw: sectionIDRaw, draftID: draftID,
+            form: formContext,
             missingError: "Solution notebook (.ipynb) is required",
             invalidJSONError: "Solution notebook is not valid JSON (.ipynb)"
         ) {
@@ -278,59 +281,20 @@ extension DraftAssignmentRoutes {
     }
 
     // Returns a `.redirect` validation result if the bytes are missing
-    // or not valid JSON; otherwise nil.  Parameter count tracks the
-    // caller's distinct redirect-context strings; bundling them into a
-    // struct would just push the same names one layer down.
-    // swiftlint:disable:next function_parameter_count
+    // or not valid JSON; otherwise nil.
     private func redirectIfNotebookDataInvalid(
         data: Data,
         isPresent: Bool,
-        title: String,
-        dueAtRaw: String,
-        startsAtRaw: String,
-        sectionIDRaw: String,
-        draftID: String,
+        form: NewAssignmentFormContext,
         missingError: String,
         invalidJSONError: String
     ) -> SaveNewAssignmentValidation? {
         guard isPresent else {
-            return .redirect(
-                toURL: newAssignmentErrorRedirect(
-                    title: title, dueAt: dueAtRaw, startsAt: startsAtRaw, sectionID: sectionIDRaw, draftID: draftID,
-                    error: missingError
-                ))
+            return .redirect(toURL: form.redirectURL(error: missingError))
         }
         guard (try? JSONSerialization.jsonObject(with: data)) != nil else {
-            return .redirect(
-                toURL: newAssignmentErrorRedirect(
-                    title: title, dueAt: dueAtRaw, startsAt: startsAtRaw, sectionID: sectionIDRaw, draftID: draftID,
-                    error: invalidJSONError
-                ))
+            return .redirect(toURL: form.redirectURL(error: invalidJSONError))
         }
         return nil
-    }
-
-    // MARK: - Error redirect builder
-
-    /// Builds the `/instructor/new?…` URL used to bounce the instructor
-    /// back to the new-assignment page with a user-visible error.  All
-    /// guarded fields (title, dueAt, sectionID, draftID) are preserved so
-    /// the form re-renders with the values they typed.
-    func newAssignmentErrorRedirect(
-        title: String,
-        dueAt: String,
-        startsAt: String,
-        sectionID: String,
-        draftID: String,
-        error: String
-    ) -> String {
-        let q =
-            "assignmentName=\(urlEncode(title))"
-            + "&dueAt=\(urlEncode(dueAt))"
-            + "&startsAt=\(urlEncode(startsAt))"
-            + "&sectionID=\(urlEncode(sectionID))"
-            + "&draftID=\(urlEncode(draftID))"
-            + "&error=\(urlEncode(error))"
-        return "/instructor/new?\(q)"
     }
 }

--- a/Sources/APIServer/Routes/Web/NewAssignmentFormContext.swift
+++ b/Sources/APIServer/Routes/Web/NewAssignmentFormContext.swift
@@ -1,0 +1,49 @@
+// APIServer/Routes/Web/NewAssignmentFormContext.swift
+//
+// The five form fields the new-assignment page round-trips through every
+// redirect back to itself, plus the one builder that turns them into that URL.
+
+import Foundation
+
+/// The subset of the new-assignment form that has to survive a bounce back to
+/// `/instructor/new` so the page re-renders with what the instructor typed
+/// rather than an empty form.
+///
+/// These five travelled as five separate parameters through three functions,
+/// two of which tripped `function_parameter_count`.  More to the point, two of
+/// those functions each built the same query string with the same five fields
+/// in a different order — a second spelling of one thing, which is how the
+/// instructor dashboard's two item tables came to disagree (#1253).  There is
+/// one builder here and no second spelling.
+struct NewAssignmentFormContext {
+    let title: String
+    let dueAt: String
+    let startsAt: String
+    let sectionID: String
+    let draftID: String
+
+    /// Builds the `/instructor/new?…` URL that bounces the instructor back to
+    /// the page, optionally carrying a notice or a user-visible error.
+    ///
+    /// Field order is `draftID` first because `AssignmentRoutesPublishTests`
+    /// matched on that prefix before this type existed; nothing else depends
+    /// on the order, and a correct consumer reads these by name.  An empty
+    /// notice or error is omitted rather than emitted as a bare `error=` —
+    /// previously true of one caller and not the other.
+    func redirectURL(notice: String? = nil, error: String? = nil) -> String {
+        var parts: [String] = [
+            "draftID=\(urlEncode(draftID))",
+            "assignmentName=\(urlEncode(title))",
+            "dueAt=\(urlEncode(dueAt))",
+            "startsAt=\(urlEncode(startsAt))",
+            "sectionID=\(urlEncode(sectionID))",
+        ]
+        if let notice, !notice.isEmpty {
+            parts.append("notice=\(urlEncode(notice))")
+        }
+        if let error, !error.isEmpty {
+            parts.append("error=\(urlEncode(error))")
+        }
+        return "/instructor/new?\(parts.joined(separator: "&"))"
+    }
+}

--- a/Tests/APITests/AssignmentRoutesPublishTests.swift
+++ b/Tests/APITests/AssignmentRoutesPublishTests.swift
@@ -421,7 +421,22 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .seeOther)
                     redirectLocation = res.headers.first(name: .location)
-                    #expect((redirectLocation ?? "").contains("/instructor/new?draftID="))
+                    // Assert the field is present with a value, not that it
+                    // happens to come first: query-parameter order carries no
+                    // meaning, and pinning it here made unifying the two
+                    // redirect builders look like a breaking change (#1253).
+                    let location = redirectLocation ?? ""
+                    #expect(location.hasPrefix("/instructor/new?"))
+                    let query = location.drop(while: { $0 != "?" }).dropFirst()
+                    let draftIDValue =
+                        query
+                        .split(separator: "&")
+                        .first { $0.hasPrefix("draftID=") }
+                        .map { $0.dropFirst("draftID=".count) }
+                    #expect(
+                        !(draftIDValue ?? "").isEmpty,
+                        "Redirect must carry a non-empty draftID; got \(location)"
+                    )
                 })
 
             let setup = try await APITestSetup.query(on: app.db).first()

--- a/changelog.d/1253-new-assignment-form-context.md
+++ b/changelog.d/1253-new-assignment-form-context.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **The new-assignment page's bounce-back redirect has one builder instead of
+  two.** The five form fields that survive a redirect to `/instructor/new`
+  (title, due date, start date, section, draft id) are now a
+  `NewAssignmentFormContext`, and the two functions that each assembled the
+  same query string from them — in a different field order — collapsed into one
+  method on it. Two `function_parameter_count` lint exemptions went with them.
+  No behavioural change: a correct consumer reads query parameters by name, and
+  the emitted fields and values are unchanged.


### PR DESCRIPTION
Item 1 of #1253 — second of four slices. Follows #1311.

## What the issue said, and what's actually there

The issue describes four `function_parameter_count` sites that "thread the same wide parameter list through the new-assignment save path" and says "a save-context struct retires all four in one refactor." Reading them, they aren't one list:

| Site | Parameters | |
|---|---|---|
| `+NewAssignment.swift` `redirectToNewAssignmentDraft` | draftID, assignmentName, dueAt, startsAt, sectionID, notice, error | **form-redirect context** |
| `+SaveValidation.swift` `redirectIfNotebookDataInvalid` | title, dueAtRaw, startsAtRaw, sectionIDRaw, draftID + data, isPresent, 2 error strings | **form-redirect context** |
| `+NewAssignment.swift` `persistNewAssignmentSetup` | setupID, manifest, zipPath, notebookPath, courseID | mirrors `APITestSetup.init` |
| `AssignmentSlugHelpers.swift` `createAssignmentWithUniquePublicID` | the `APIAssignment` column set | mirrors `APIAssignment.init` |

Only the first two share anything — and they share it with a third function, `newAssignmentErrorRedirect`, which has no exemption only because it sits at six parameters.

So this retires **2 of 4**, not 4 of 4. The bottom two stay, keeping their existing comments: each is called from one place and mirrors a model's own initializer, so a struct would mint a parallel type to keep in sync with the model and remove no names. Those comments were already making that argument and they're right.

## The part worth more than the parameter count

`redirectToNewAssignmentDraft` and `newAssignmentErrorRedirect` each assembled the **same** `/instructor/new` query string from the **same** five fields — in a different field order, and with different empty-value handling (one omitted an empty `error`, the other emitted a bare `error=`). Two spellings of one thing.

That is the shape that produced the drifted dashboard tables in #1311, one commit ago. So rather than bundle the parameters and leave two builders standing, there is now one `redirectURL(notice:error:)` on `NewAssignmentFormContext` and `newAssignmentErrorRedirect` is deleted.

## Order, and the test that pinned it

Unified on **draftID-first**, matching the more widely used of the two.

Exactly one test pinned an order: `AssignmentRoutesPublishTests` matched `/instructor/new?draftID=` as a prefix. Query-parameter order carries no meaning and every consumer here reads by name, so that assertion was pinning an accident — and it briefly argued me out of unifying at all. It now parses the query and checks `draftID` is present with a non-empty value.

(`DraftSuiteSectionRoutesTests:102`, which asserts an exact `/instructor/new?draftID=…`, is a *different* redirect — a hardcoded one-field one in `DraftAssignmentRoutes+Sections.swift:135`. Untouched.)

## Behaviour

Unchanged. Same fields, same values, same encoding; only order differs, plus an empty `error`/`notice` is now consistently omitted rather than emitted bare by one of the two callers. In the empty-title guard the old code passed `title: ""` explicitly and the new context passes `title`, which is `""` in exactly that branch.

## Verification

302 tests across the assignment / web-routes / draft / instructor suites, plus `scripts/format.sh` and `scripts/swiftlint.sh --strict` (0 violations in 963 files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sew4JYA3L2zHhQLHi3MM3S)_