### PR TITLE
fix(runner): stop one prepare-phase fetch's failure cancelling the other (Family 4)

### DIFF
--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -43,6 +43,14 @@ struct JobDiskReadings {
     var workdirPeakBytes: Int?
 }
 
+/// Outcome of the two concurrent prepare-phase artifact fetches.  Both legs
+/// are `Result`s rather than `throws` on purpose — see `fetchJobArtifacts`.
+struct JobArtifactFetch {
+    let submission: Result<Void, Error>
+    let testSetup: Result<TestSetupCache.AcquireResult, Error>
+    let testSetupAcquireMilliseconds: Int
+}
+
 extension WorkerDaemon {
 
     // MARK: - Job processing
@@ -313,6 +321,71 @@ extension WorkerDaemon {
         )
     }
 
+    /// Runs the submission download and the test-setup acquire concurrently,
+    /// and returns what each one did.  The test setup is served from the LRU
+    /// cache: on a hit the cached directory is copied into a fresh scratch
+    /// location; on a miss it is downloaded, unzipped, committed to cache,
+    /// then copied.
+    ///
+    /// BOTH legs report a `Result` and BOTH are always awaited, so neither
+    /// one's failure can leave this scope while the other is still
+    /// transferring.  That is not a style choice.  Leaving an `async let`
+    /// scope early cancels the sibling child, and cancelling an in-flight
+    /// `URLSession.download` on Linux deadlocks: `swift_asyncLet_finish` →
+    /// `swift_task_cancel` takes the child task's status-record lock and then
+    /// `DispatchQueue.sync`s onto the session's work queue, while that same
+    /// work queue is completing the child's transfer and resuming its
+    /// continuation — which needs the very lock the canceller is holding.
+    /// Neither side moves and the cooperative pool fills up behind them
+    /// (Family 4 in docs/ci-flakiness.md; `worker-tests` SIGABRTing at the
+    /// wedge watchdog's five-minute mark).  Several tests point both URLs at a
+    /// 404 server, which made the racing shape hit it routinely.
+    ///
+    /// Deliberate cancellation is deliberately NOT weakened.  The download
+    /// stays a *structured child* of the job task, so cancelling the daemon
+    /// still tears an in-flight submission transfer down — exactly as
+    /// cancelling an `acquire` still cancels the shared populate task once its
+    /// last waiter detaches (#1233).  What is removed is only the incidental
+    /// cancellation one leg's failure used to inflict on the other.
+    private func fetchJobArtifacts(job: Job, paths: JobWorkspacePaths) async -> JobArtifactFetch {
+        async let submissionDownload: Result<Void, Error> = {
+            do {
+                try await self.download(url: job.submissionURL, to: paths.submissionZip)
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }()
+
+        let testSetupAcquireStartedAt = Date()
+        let cacheKey = testSetupCacheKey(for: job)
+        let testSetup: Result<TestSetupCache.AcquireResult, Error>
+        do {
+            testSetup = .success(
+                try await testSetupCache.acquire(testSetupID: cacheKey) {
+                    let stagingZip = paths.workDir.appendingPathComponent("testsetup.zip")
+                    let stagingDir = paths.workDir.appendingPathComponent(
+                        "testsetup_staging", isDirectory: true)
+                    try FileManager.default.createDirectory(
+                        at: stagingDir, withIntermediateDirectories: true)
+                    try await self.download(url: job.testSetupURL, to: stagingZip)
+                    try await extractZipArchive(zipPath: stagingZip.path, into: stagingDir)
+                    return stagingDir
+                })
+        } catch {
+            testSetup = .failure(error)
+        }
+        let acquireMilliseconds = Int(Date().timeIntervalSince(testSetupAcquireStartedAt) * 1000)
+
+        // Reached on every path, including both failures — this join is what
+        // keeps either leg from ever being cancelled by the other's throw.
+        return JobArtifactFetch(
+            submission: await submissionDownload,
+            testSetup: testSetup,
+            testSetupAcquireMilliseconds: acquireMilliseconds
+        )
+    }
+
     /// Downloads + unzips the submission and test setup, stages the
     /// submission into the test workspace, runs the optional `make` step,
     /// and installs the runtime helpers.  Returns a `JobPreparedWorkspace`
@@ -322,27 +395,19 @@ extension WorkerDaemon {
         paths: JobWorkspacePaths,
         stageTimings: inout JobStageTimings
     ) async throws -> JobPreparedWorkspace {
-        // Download submission and acquire the prepared test setup concurrently.
-        // The test setup is served from the LRU cache: on a hit the cached
-        // directory is copied into a fresh scratch location; on a miss it is
-        // downloaded, unzipped, committed to cache, then copied.
-        let submissionDownloadStartedAt = Date()
-        async let submissionDownload: Void = download(url: job.submissionURL, to: paths.submissionZip)
+        let fetchStartedAt = Date()
+        let fetched = await fetchJobArtifacts(job: job, paths: paths)
+        let submissionOutcome = fetched.submission
 
-        let testSetupAcquireStartedAt = Date()
-        let cacheKey = testSetupCacheKey(for: job)
-        let acquireResult = try await testSetupCache.acquire(testSetupID: cacheKey) {
-            let stagingZip = paths.workDir.appendingPathComponent("testsetup.zip")
-            let stagingDir = paths.workDir.appendingPathComponent("testsetup_staging", isDirectory: true)
-            try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
-            try await self.download(url: job.testSetupURL, to: stagingZip)
-            try await extractZipArchive(zipPath: stagingZip.path, into: stagingDir)
-            return stagingDir
-        }
+        // A failed acquire produced no scratch directory, so there is nothing
+        // to clean up and nothing to report from the submission leg; its error
+        // is the job's error, matching the pre-reconciliation ordering where
+        // `acquire` was awaited first.
+        let acquireResult = try fetched.testSetup.get()
         let testSetupDir = acquireResult.directory
         stageTimings.record(
             "test_setup_acquire",
-            milliseconds: Int(Date().timeIntervalSince(testSetupAcquireStartedAt) * 1000)
+            milliseconds: fetched.testSetupAcquireMilliseconds
         )
         stageTimings.testSetupCacheHit = acquireResult.didHit
 
@@ -354,10 +419,10 @@ extension WorkerDaemon {
         // leaks a fully-prepared test-setup dir in /tmp (#1106; disk-fill has
         // taken prod down once already).
         do {
-            try await submissionDownload
+            try submissionOutcome.get()
             stageTimings.record(
                 "submission_download",
-                milliseconds: Int(Date().timeIntervalSince(submissionDownloadStartedAt) * 1000)
+                milliseconds: Int(Date().timeIntervalSince(fetchStartedAt) * 1000)
             )
 
             let manifest = job.manifest

--- a/Tests/WorkerTests/Support/LocalHTTPTestServer.swift
+++ b/Tests/WorkerTests/Support/LocalHTTPTestServer.swift
@@ -209,6 +209,72 @@ final class LocalHTTPTestServer: @unchecked Sendable {
         }
     }
 
+    /// Serves a 200 whose body is written in `chunks` 1 KiB pieces with
+    /// `delayMilliseconds` between them, so a transfer stays *in flight* for a
+    /// controllable length of time.  Two breadcrumb files in `markerDirectory`
+    /// report what the client did:
+    ///
+    ///   * `started` — written as soon as the response body begins;
+    ///   * `completed` — written only if every chunk was accepted, i.e. the
+    ///     client did **not** disconnect part-way;
+    ///   * `aborted` — written when a write fails, i.e. the client tore the
+    ///     transfer down mid-body.
+    ///
+    /// Those three are what make "was this download cancelled?" observable
+    /// from the far side of `URLSession`, which reports a cancelled transfer
+    /// and an abandoned one identically.  Used by the Family 4 regression
+    /// tests (docs/ci-flakiness.md): a sibling leg's failure must leave
+    /// `completed` behind, while cancelling the daemon must leave `aborted`.
+    static func slowBody(
+        chunks: Int,
+        delayMilliseconds: Int,
+        markerDirectory: URL
+    ) async throws -> LocalHTTPTestServer {
+        try await withSubprocessSlot {
+            try LocalHTTPTestServer(
+                pythonProgram: #"""
+                    import http.server
+                    import os
+                    import socketserver
+                    import sys
+                    import time
+
+                    chunks = int(sys.argv[1])
+                    delay = float(sys.argv[2]) / 1000.0
+                    markers = sys.argv[3]
+                    payload = b"x" * 1024
+
+                    def mark(name):
+                        with open(os.path.join(markers, name), "w") as handle:
+                            handle.write("1")
+
+                    class Handler(http.server.BaseHTTPRequestHandler):
+                        def do_GET(self):
+                            self.send_response(200)
+                            self.send_header("Content-Length", str(len(payload) * chunks))
+                            self.end_headers()
+                            mark("started")
+                            try:
+                                for _ in range(chunks):
+                                    self.wfile.write(payload)
+                                    self.wfile.flush()
+                                    time.sleep(delay)
+                            except Exception:
+                                mark("aborted")
+                                return
+                            mark("completed")
+
+                        def log_message(self, format, *args):
+                            pass
+
+                    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+                        print(httpd.server_address[1], flush=True)
+                        httpd.serve_forever()
+                    """#,
+                extraArguments: [String(chunks), String(delayMilliseconds), markerDirectory.path])
+        }
+    }
+
     /// Returns 404 for every request — exercises the terminal (non-retryable)
     /// download-failure path.
     static func alwaysNotFound() async throws -> LocalHTTPTestServer {

--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -1179,4 +1179,166 @@ import Testing
         let runnerInvocations = await runner.observedInvocationCount()
         #expect(runnerInvocations == 0, "ScriptRunner should not have been invoked when the submission download failed")
     }
+
+    // MARK: - Prepare-phase fetch reconciliation (docs/ci-flakiness.md, Family 4)
+
+    /// The two prepare-phase fetches run concurrently, and one leg's failure
+    /// must NOT cancel the other while it is still transferring.
+    ///
+    /// Cancelling an in-flight `URLSession.download` on Linux deadlocks:
+    /// `swift_task_cancel` holds the task's status-record lock and then
+    /// `DispatchQueue.sync`s onto the session's work queue, while that queue is
+    /// completing the same task's transfer and resuming its continuation, which
+    /// wants that lock.  The old `async let` shape performed exactly that cancel
+    /// every time the test-setup leg failed first — which is what several of
+    /// the 404 tests above do — and `worker-tests` SIGABRTed at the wedge
+    /// watchdog roughly one run in fifteen.
+    ///
+    /// The server reports what the client actually did: `completed` means every
+    /// byte was accepted, `aborted` means the transfer was torn down part-way.
+    /// This test therefore fails on the old code rather than merely being
+    /// slower on it.
+    @Test func testSetupFailureDoesNotCancelTheInFlightSubmissionDownload() async throws {
+        let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-no-sibling-cancel-cache")
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let markers = try makeTempCacheRoot(named: "worker-daemon-no-sibling-cancel-markers")
+        defer { try? FileManager.default.removeItem(at: markers) }
+
+        // The test setup 404s immediately (terminal, no retries); the
+        // submission takes ~1.5 s, so the failure lands with the submission
+        // transfer unambiguously mid-flight.
+        let failServer = try await LocalHTTPTestServer.alwaysNotFound()
+        defer { failServer.stop() }
+        let slowServer = try await LocalHTTPTestServer.slowBody(
+            chunks: 15, delayMilliseconds: 100, markerDirectory: markers)
+        defer { slowServer.stop() }
+
+        let job = Job(
+            submissionID: "sub_no_sibling_cancel",
+            testSetupID: "setup_no_sibling_cancel",
+            attemptNumber: 1,
+            submissionURL: testURL("http://127.0.0.1:\(slowServer.port)/submission.zip"),
+            testSetupURL: testURL("http://127.0.0.1:\(failServer.port)/testsetup.zip"),
+            manifest: try makeManifest(),
+            submissionFilename: "submission.ipynb"
+        )
+        let poller = MockPoller(jobs: [job, nil])
+        let reporter = MockReporter()
+        let runner = MockRunner(
+            output: ScriptOutput(exitCode: 0, stdout: "", stderr: "", executionTimeMs: 1, timedOut: false))
+        let daemon = WorkerDaemon(
+            poller: poller,
+            reporter: reporter,
+            runner: runner,
+            apiBaseURL: testURL("http://localhost:8080"),
+            workerID: "worker-no-sibling-cancel",
+            workerSecret: "secret",
+            maxConcurrentJobs: 1,
+            runnerProfile: nil,
+            downloadRetryPolicy: fastRetryPolicy,
+            testSetupCache: TestSetupCache(cacheRoot: cacheRoot)
+        )
+
+        let task = Task { try await daemon.run() }
+        let reported = await waitUntil(timeoutSeconds: 30) { await reporter.snapshot().count == 1 }
+        #expect(reported, "expected a synthetic failure report for the 404 test setup")
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
+
+        #expect(
+            FileManager.default.fileExists(atPath: markers.appendingPathComponent("started").path),
+            "the submission download never started, so this test proved nothing")
+        // Polled, not sampled: the server writes `completed` one chunk-delay
+        // after the client has already seen the last byte, so an instantaneous
+        // read races it.
+        let completedPath = markers.appendingPathComponent("completed").path
+        let completed = await waitUntil(timeoutSeconds: 15) {
+            FileManager.default.fileExists(atPath: completedPath)
+        }
+        #expect(
+            completed,
+            "the test-setup failure cancelled the in-flight submission download (Family 4 trigger)")
+        #expect(
+            FileManager.default.fileExists(atPath: markers.appendingPathComponent("aborted").path) == false,
+            "the submission transfer was torn down mid-body by the sibling's failure")
+    }
+
+    /// The mirror-image property, and the one the reconciliation above must not
+    /// weaken: cancelling the daemon still stops an in-flight artifact
+    /// download rather than riding it out (#1233).  The submission transfer
+    /// here would take ~2 minutes; a daemon that ignored cancellation would
+    /// blow the 30 s bound in `awaitCancelledDaemon`, and the server's
+    /// `aborted` breadcrumb proves the transfer was actually torn down rather
+    /// than merely abandoned by a task that stopped awaiting it.
+    @Test func cancellingTheDaemonStopsTheInFlightSubmissionDownload() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("worker-daemon-cancel-download-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-cancel-download-cache")
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let markers = try makeTempCacheRoot(named: "worker-daemon-cancel-download-markers")
+        defer { try? FileManager.default.removeItem(at: markers) }
+
+        // The test setup resolves normally; only the submission drips.
+        let marker = "canceldl\(UUID().uuidString.prefix(8))"
+        let setupZipPath = root.appendingPathComponent("\(marker)-setup.zip").path
+        try await makeZip(at: setupZipPath, files: [("test.sh", "#!/bin/sh\necho passed\n")])
+        let setupServer = try await LocalHTTPTestServer.staticFiles(directory: root)
+        defer { setupServer.stop() }
+        let slowServer = try await LocalHTTPTestServer.slowBody(
+            chunks: 600, delayMilliseconds: 200, markerDirectory: markers)
+        defer { slowServer.stop() }
+
+        let job = Job(
+            submissionID: "sub_\(marker)",
+            testSetupID: "setup-\(marker)",
+            attemptNumber: 1,
+            submissionURL: testURL("http://127.0.0.1:\(slowServer.port)/submission.zip"),
+            testSetupURL: testURL("http://127.0.0.1:\(setupServer.port)/\(marker)-setup.zip"),
+            manifest: try makeManifest(),
+            submissionFilename: "submission.ipynb"
+        )
+        let poller = MockPoller(jobs: [job, nil])
+        let reporter = MockReporter()
+        let runner = MockRunner(
+            output: ScriptOutput(exitCode: 0, stdout: "", stderr: "", executionTimeMs: 1, timedOut: false))
+        let daemon = WorkerDaemon(
+            poller: poller,
+            reporter: reporter,
+            runner: runner,
+            apiBaseURL: testURL("http://localhost:8080"),
+            workerID: "worker-cancel-download",
+            workerSecret: "secret",
+            maxConcurrentJobs: 1,
+            runnerProfile: nil,
+            downloadRetryPolicy: fastRetryPolicy,
+            testSetupCache: TestSetupCache(cacheRoot: cacheRoot)
+        )
+
+        let task = Task { try await daemon.run() }
+        let startedPath = markers.appendingPathComponent("started").path
+        let started = await waitUntil(timeoutSeconds: 20) {
+            FileManager.default.fileExists(atPath: startedPath)
+        }
+        #expect(started, "the submission download never started, so this test proved nothing")
+
+        // ~118 s of body is still outstanding at this point.
+        let cancelledAt = Date()
+        let shutDown = await awaitCancelledDaemon(task)
+        let shutdownSeconds = Date().timeIntervalSince(cancelledAt)
+        #expect(shutDown, "daemon rode out the in-flight submission download instead of cancelling it (#1233)")
+        #expect(
+            shutdownSeconds < 30,
+            "daemon took \(Int(shutdownSeconds))s to stop, which is not 'promptly' for a cancelled download")
+
+        let abortedPath = markers.appendingPathComponent("aborted").path
+        let aborted = await waitUntil(timeoutSeconds: 15) {
+            FileManager.default.fileExists(atPath: abortedPath)
+        }
+        #expect(aborted, "the in-flight transfer was abandoned rather than torn down (#1233)")
+        #expect(
+            FileManager.default.fileExists(atPath: markers.appendingPathComponent("completed").path) == false,
+            "a cancelled daemon must not finish transferring the artifact")
+    }
 }

--- a/changelog.d/worker-prepare-fetch-reconciliation.md
+++ b/changelog.d/worker-prepare-fetch-reconciliation.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The runner no longer cancels one prepare-phase artifact download because
+  the other failed.** Cancelling an in-flight `URLSession.download` on Linux
+  can deadlock — `swift_task_cancel` takes the task's status-record lock and
+  then blocks on the session's Dispatch work queue, while that queue is
+  completing the same task's transfer and resuming its continuation, which
+  wants that lock — and the job setup's `async let` performed exactly that
+  cancel whenever the test-setup fetch failed first. The submission download
+  and the test-setup acquire now both report a `Result` and are both always
+  awaited, so neither leg's failure can cancel the other. Deliberate
+  cancellation is unchanged: cancelling the daemon still stops both transfers.
+  This was Family 4 in `docs/ci-flakiness.md` — `worker-tests` SIGABRTing at
+  the wedge watchdog roughly one CI run in fifteen.

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -209,7 +209,7 @@ chromium failure is treated as real, first time.
 
 ---
 
-## Family 4 — `worker-tests` SIGABRT via the wedge watchdog (URLSession cancel deadlock) — OPEN, upstream
+## Family 4 — `worker-tests` SIGABRT via the wedge watchdog (URLSession cancel deadlock) — MITIGATED first-party; root cause still upstream
 
 **Symptom.** `worker-tests` fails (not cancelled) after ~5 minutes with
 `exited with unexpected signal code 6`. The crashing thread is
@@ -247,18 +247,64 @@ feature branch (run 31029658951, job 92390500832) with identical stacks.
 `main` was otherwise green on 14 of its 15 preceding runs, so the rate is
 low but real.
 
-**Handling for now.** Re-run the failed job — `/rerun-failed` on the PR, or
-`rerun-failed-jobs`. Before blaming a red `worker-tests` on the diff in front
-of you, check the dump for `WedgeWatchdog.abortWedgedProcess` plus a
+**Diagnosis confirmed, and sharpened (2026-08-09, Swift 6.3, this container).**
+A standalone `swiftc` harness reproduces it on demand, and `gdb -p` on the
+wedged process shows exactly the two stacks above. Two refinements the original
+entry did not state, both load-bearing:
+
+- The two threads are contending over **the same task's** status-record lock.
+  Foundation's `URLSession` has one `workQueue` per session, so the canceller
+  (`swift_task_cancel` → `withStatusRecordLock` → `CancelState.cancel` →
+  `URLSessionTask.cancel` → `DispatchQueue.sync`) blocks on a queue that the
+  multi-handle is already occupying inside `completeTask` →
+  `urlProtocolDidFinishLoading` → `CheckedContinuation.resume` →
+  `flagAsAndEnqueueOnExecutor` → `withStatusRecordLock`, waiting for the lock
+  the canceller holds. Same task, opposite order — a plain AB-BA.
+- It is therefore **not specific to `async let`**. Any cancellation of a task
+  suspended in `URLSession.download` that is completing at that instant can hit
+  it. `async let` was simply the site that did it on a schedule.
+
+**Fix shipped (first-party mitigation only).** The prepare phase's two fetches
+now both report a `Result` and are **both always awaited**
+(`fetchJobArtifacts` in `RunnerDaemon+JobProcessing.swift`), so one leg's
+failure can no longer leave the scope with the other still transferring. The
+submission download stays a *structured child* of the job task, so cancelling
+the daemon still tears an in-flight transfer down — the #1233 property is
+untouched, and `cancellingTheDaemonStopsTheInFlightSubmissionDownload` pins it
+end to end (the server writes an `aborted` breadcrumb, which is the only way to
+tell a cancelled transfer from an abandoned one from outside `URLSession`).
+`testSetupFailureDoesNotCancelTheInFlightSubmissionDownload` pins the new
+property and fails on the old code rather than merely being slower on it.
+
+Sequencing the two fetches was the other candidate and was rejected: it removes
+the same trigger but serialises a network fetch against a network-or-copy on
+every job, and it does not remove any cancellation site the reconciliation
+leaves behind — so it costs throughput for no additional coverage.
+
+**Measured.** In-repo harness: 300 jobs against an always-404 server, 4 slots.
+Before: 4 wedges in 8 runs (a wedge starves the cooperative pool so completely
+that the harness's own progress poll stops running). After: 0 wedges in 16 runs
+/ 4,800 jobs. Standalone harness, same shape without the repo: 10 wedges in 10
+runs before, 0 in 13 runs / 88,000 iterations after.
+
+**What is NOT fixed.** The upstream bug is untouched, and four sites still
+cancel an in-flight `URLSession` transfer. Three are the deliberate ones
+cancellation is *for*: cancelling the job task (which propagates into the
+submission download), `TestSetupCache.detachWaiter` cancelling the shared
+populate task once its last waiter leaves (#1233), and
+`withThrowingDiscardingTaskGroup` in `daemon.run()` cancelling the sibling
+worker loops when one takes a terminal poll error. The fourth is incidental and
+was left alone deliberately: `process(_:)`'s `defer` cancels the per-job
+heartbeat task, which may be mid-POST. That loop sleeps 30 s between ~1 ms
+requests, so the window is ~10⁻³ of a job rather than every failed one, and
+closing it means letting the loop finish cooperatively (up to 30 s of lingering
+task per job) — worth doing only if this family reappears.
+
+**Handling if it reappears.** Re-run the failed job — `/rerun-failed` on the
+PR, or `rerun-failed-jobs`. Before blaming a red `worker-tests` on the diff in
+front of you, check the dump for `WedgeWatchdog.abortWedgedProcess` plus a
 `CancelState.cancel` / `withStatusRecordLock` pair; that combination is this
 family, not the change under test.
-
-**Attack notes.** A real fix is upstream. First-party mitigation would be to
-stop cancelling in-flight downloads: sequence the two fetches instead of
-racing them under `async let`, or give each its own detached task whose
-failure does not cancel its sibling. Neither has been attempted — this entry
-records the diagnosis so the next person does not re-derive it from a
-register dump.
 
 ---
 


### PR DESCRIPTION
First-party mitigation for CI flake **Family 4** (`docs/ci-flakiness.md`): `worker-tests` intermittently SIGABRTing at the wedge watchdog's 5-minute mark, with every frame in `libFoundationNetworking` / `libswift_Concurrency` / `libdispatch`.

## The bug

Cancelling an in-flight `URLSession` download on Linux deadlocks. `swift_asyncLet_finish` → `swift_task_cancel` takes the child task's status-record lock and then `DispatchQueue.sync`s onto the session's work queue, while that same work queue is completing the child's transfer and resuming its continuation — which needs the lock the canceller holds. Neither moves; the cooperative pool fills behind them.

The trigger was the prepare phase: `async let submissionDownload` racing the test-setup acquire. When one leg threw, leaving the `async let` scope cancelled the sibling **mid-transfer**. Several tests point both URLs at a 404 server, which made the racing shape hit it routinely.

## The fix

`fetchJobArtifacts(job:paths:)` runs both fetches concurrently but has each report a `Result`, and **always awaits both** before returning. Nothing throws between the `async let` and its join, so `swift_asyncLet_finish` can never cancel a live sibling. Reconciliation preserves the previous ordering exactly: a failed acquire is the job's error (no scratch dir to clean), a successful acquire plus a failed submission still enters the `do` and removes the scratch dir on the way out (#1106).

**Deliberate cancellation is not weakened.** The download stays a *structured child* of the job task, so cancelling the daemon still tears an in-flight transfer down — the #1233 property. Only the incidental sibling cancellation is removed.

Two alternatives were rejected: sequencing the fetches costs `max(a,b) → a+b` on every job's hot path and removes no cancellation site that reconciliation leaves behind; an unstructured `Task {}` does not inherit cancellation, so a cancelled daemon would ride out the transfer, undoing #1233.

## Verification

**The new test fails without the fix.** Confirmed independently by reverting only `RunnerDaemon+JobProcessing.swift` and rebuilding — `testSetupFailureDoesNotCancelTheInFlightSubmissionDownload` fails with `Expectation failed: completed` plus `aborted == true`, i.e. the transfer was torn down mid-flight. Restored, it passes. `URLSession` reports a cancelled and an abandoned transfer identically, so the test server writes `started`/`completed`/`aborted` breadcrumbs — that is what makes the property observable at all.

**Stress repro, before → after:**

| harness | before | after |
|---|---|---|
| In-repo (300 jobs vs always-404 server, 4 slots, real `WorkerDaemon`) | **4 wedges / 8 runs** | **0 / 16 runs, 4,800 jobs** |
| Standalone (same shape, outside the repo) | **10 / 10 runs** | **0 / 13 runs, 88,000 iterations** |

The in-repo wedge starves the pool so completely that the harness's own progress poll stops running — the #1233 "the scheduler stopped" signature.

**#1233 preserved, by test.** `cancellingTheDaemonStopsTheInFlightSubmissionDownload` cancels the daemon against a ~2-minute in-flight transfer: it shuts down in ~0.9 s and the server records `aborted`, so the transfer was torn down rather than merely un-awaited. It passes on both old and new source — that is the point of it. The two existing `TestSetupCacheTests` cancellation tests were mutation-checked: deleting `population.task.cancel()` from `detachWaiter` makes `lastWaiterCancellationCancelsThePopulation` hang to its limit, so they still test what they claim.

## Doc corrections

Family 4's entry is updated with two sharpenings of the diagnosis, verified under `gdb -p` on Swift 6.3:

1. The contention is over **the same task's** status-record lock — Foundation has one `workQueue` per session, so the canceller blocks on a queue already occupied by that task's own completion. Plain AB-BA, not a diffuse "queue vs lock" hazard.
2. It is therefore **not `async let`-specific**. Any cancellation of a task suspended in `URLSession.download` that is completing at that instant can hit it; `async let` was just the site that did it on a schedule. The previous framing implied otherwise.

## Known residual, deliberately left

Four sites can still cancel an in-flight transfer. Three are the deliberate ones cancellation exists for. The fourth is incidental: `process(_:)`'s `defer` does `heartbeatTask.cancel()`, which may land mid-POST. That loop sleeps 30 s between ~1 ms requests, so the window is ~10⁻³ per job rather than every failed one, and closing it means a cooperative shutdown flag that leaves a task lingering up to 30 s per job. It is named in the doc as the thing to do if the family reappears.

Not verified: the fix was not reproduced in CI itself, only locally on 4 cores — the 1-in-15 CI rate is an unchanged input, not something re-measured. The heartbeat residual is argued from timing, not measured.

## Gates

`scripts/lint.sh`, `scripts/swiftlint.sh` (`--strict`, 0 violations in 966 files), `scripts/no-new-xctest.sh`, `swift build --build-tests`, `swift test --filter WorkerTests` (325 tests, 34 suites) — all green on the rebased tree. `APITests` not run: the diff does not touch `Sources/APIServer`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4dLGw94C2mGzveMq1MYNU)_