### PR TITLE
refactor(families): lift the render and suite-entry phases out of applyPatternFamilies (#1253)

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyApplication+SuiteEntries.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+SuiteEntries.swift
@@ -1,0 +1,259 @@
+// APIServer/Utilities/PatternFamilyApplication+SuiteEntries.swift
+//
+// Phase 5 of `applyPatternFamilies`: turn the authored ordering plus the
+// already-rendered artifacts into the manifest's `testSuites` list.
+//
+// Split out of PatternFamilyApplication.swift (#1253).  This phase is a pure
+// function of its inputs — it reads no database, mutates no zip, and every
+// value it needs is decided by the time it runs — which is what made it the
+// first piece to lift out of a 575-line body.
+
+import Core
+import Foundation
+
+/// Accumulates the manifest's ordered `testSuites` list.
+///
+/// The order counter and the emitted-id sets are state shared by the authored
+/// pass and the two defensive passes, so they live on a type rather than as
+/// variables captured by nested closures.  That is also what keeps each
+/// emit step short enough to read on its own.
+private struct SuiteEntryBuilder {
+    let familyByID: [String: PatternFamily]
+    let checkByID: [String: NotebookCheck]
+    /// familyID → the generated filenames of its enabled cases, used to expand
+    /// `family:<id>` dependency tokens.
+    let familyFilenames: [String: [String]]
+    let artifacts: RenderedFamilyArtifacts
+    let renderedCheckByID: [String: GeneratedScript]
+    /// The zip phase's deletion set.  A dependency pointing at a file that is
+    /// going away is dropped rather than persisted as a dangling reference.
+    let deletedFilenames: Set<String>
+
+    var entries: [ConfiguredSuiteEntry] = []
+    private var order = 0
+    private var emittedFamilyIDs: Set<String> = []
+    private var emittedCheckIDs: Set<String> = []
+
+    init(
+        familyByID: [String: PatternFamily],
+        checkByID: [String: NotebookCheck],
+        familyFilenames: [String: [String]],
+        artifacts: RenderedFamilyArtifacts,
+        renderedCheckByID: [String: GeneratedScript],
+        deletedFilenames: Set<String>
+    ) {
+        self.familyByID = familyByID
+        self.checkByID = checkByID
+        self.familyFilenames = familyFilenames
+        self.artifacts = artifacts
+        self.renderedCheckByID = renderedCheckByID
+        self.deletedFilenames = deletedFilenames
+    }
+
+    /// Expands `family:<id>` tokens to concrete generated filenames and drops
+    /// anything the zip phase is deleting.  Deduplicates while preserving
+    /// authored order.
+    func expandDeps(_ deps: [String]) -> [String] {
+        var out: [String] = []
+        var seen = Set<String>()
+        for d in deps {
+            if let fid = parseFamilyDepToken(d) {
+                for f in familyFilenames[fid] ?? [] {
+                    guard !deletedFilenames.contains(f), seen.insert(f).inserted else { continue }
+                    out.append(f)
+                }
+            } else {
+                guard !deletedFilenames.contains(d), seen.insert(d).inserted else { continue }
+                out.append(d)
+            }
+        }
+        return out
+    }
+
+    mutating func appendRawScript(_ s: AuthoredRawScript) {
+        order += 1
+        entries.append(
+            ConfiguredSuiteEntry(
+                script: s.script,
+                tier: s.tier.rawValue,
+                order: order,
+                dependsOn: expandDeps(s.dependsOn),
+                points: s.points,
+                displayName: s.displayName,
+                generatedBy: nil,
+                sectionID: s.sectionID,
+                hint: s.hint,
+                timeLimitSeconds: s.timeLimitSeconds
+            ))
+    }
+
+    /// Emits a family's existence guard, if it has one, and returns its
+    /// filename so the cases can chain off it.
+    private mutating func appendGuard(
+        _ family: PatternFamily, inherited: [String], section: String?
+    ) -> String? {
+        guard let guardScript = artifacts.guardScripts[family.id] else { return nil }
+        order += 1
+        // The guard inherits the family's own prerequisites; the cases
+        // chain off the guard, so prereqs → guard → cases.
+        entries.append(
+            ConfiguredSuiteEntry(
+                script: guardScript.filename,
+                tier: guardScript.tier.rawValue,
+                order: order,
+                dependsOn: inherited,
+                points: guardScript.points,
+                displayName: guardScript.displayName,
+                generatedBy: guardScript.familyID,
+                sectionID: section,
+                // The guard inherits the family-level time limit.
+                timeLimitSeconds: guardScript.timeLimitSeconds
+            ))
+        return guardScript.filename
+    }
+
+    /// Emits a family's generated entries: the existence guard first (for
+    /// function-calling kinds), then one entry per enabled case wired to
+    /// `dependsOn` the guard — so a missing function fails once on the guard
+    /// and the cases auto-skip through the runner's dependency gate.  Shared
+    /// by the authored-order pass and the defensive pass so the two can't
+    /// drift on the guard wiring.  Consumes the render-once `artifacts`, so
+    /// the manifest entries describe exactly the bytes the zip phase wrote.
+    mutating func appendFamily(_ family: PatternFamily, section: String?) {
+        guard emittedFamilyIDs.insert(family.id).inserted else { return }
+        let inherited = expandDeps(family.dependsOn)
+        let guardFilename = appendGuard(family, inherited: inherited, section: section)
+
+        for generated in artifacts.caseScripts[family.id] ?? [] {
+            order += 1
+            // Generated-case deps are fully derived from the *current* spec:
+            // the guard first (so a missing function reports the guard as the
+            // unmet prerequisite), then the family's inherited prerequisites
+            // (deduped).  We deliberately do NOT carry the prior manifest
+            // entry's deps forward.  Doing so made a once-set family-level
+            // dependency permanently "sticky": every regeneration re-read the
+            // old generated row's deps, so clearing `family.dependsOn` (or
+            // dropping a hand-written prereq the family used to point at) could
+            // never remove it from the generated rows — leaving a dangling
+            // reference that no edit could delete, because a hand-written
+            // script is not a generated file and so never entered the
+            // `expandDeps` `deletedFilenames` filter.
+            var combined: [String] = []
+            var seen = Set<String>()
+            for d in (guardFilename.map { [$0] } ?? []) + inherited {
+                guard seen.insert(d).inserted else { continue }
+                combined.append(d)
+            }
+            // Per-test time limit is resolved by the renderer
+            // (`case.resolvedTimeLimit(defaults:)`, then normalised so a
+            // 0/negative becomes nil) and carried on `generated`.
+            entries.append(
+                ConfiguredSuiteEntry(
+                    script: generated.filename,
+                    tier: generated.tier.rawValue,
+                    order: order,
+                    dependsOn: combined,
+                    points: generated.points,
+                    displayName: generated.displayName,
+                    generatedBy: generated.familyID,
+                    sectionID: section,
+                    timeLimitSeconds: generated.timeLimitSeconds
+                ))
+        }
+    }
+
+    /// Emits one notebook check's generated entry.  Shared by the authored
+    /// pass and the defensive pass for the same can't-drift reason.
+    mutating func appendCheck(_ check: NotebookCheck, section: String?) {
+        guard let generated = renderedCheckByID[check.id],
+            emittedCheckIDs.insert(check.id).inserted
+        else { return }
+        order += 1
+        // Per-test time limit comes from the check spec (0/negative → nil,
+        // i.e. inherit the assignment-wide default).
+        entries.append(
+            ConfiguredSuiteEntry(
+                script: generated.filename,
+                tier: generated.tier.rawValue,
+                order: order,
+                dependsOn: expandDeps(check.dependsOn),
+                points: generated.points,
+                displayName: generated.displayName,
+                generatedBy: nil,
+                generatedByCheck: check.id,
+                sectionID: section,
+                timeLimitSeconds: normalizedGeneratedTimeLimit(check.timeLimitSeconds)
+            ))
+    }
+
+    mutating func appendAuthored(_ item: AuthoredSuiteItem) {
+        switch item {
+        case .script(let s):
+            appendRawScript(s)
+        case .family(let fid, let section):
+            guard let family = familyByID[fid] else { return }
+            appendFamily(family, section: section)
+        case .check(let cid, let section):
+            guard let check = checkByID[cid] else { return }
+            appendCheck(check, section: section)
+        }
+    }
+
+    func hasEmitted(familyID: String) -> Bool { emittedFamilyIDs.contains(familyID) }
+    func hasEmitted(checkID: String) -> Bool { emittedCheckIDs.contains(checkID) }
+}
+
+/// Builds the manifest's ordered `testSuites` list.
+///
+/// Raw scripts keep their authored position, tier, points, hint and
+/// dependencies; each family expands in place to its existence guard followed
+/// by one entry per enabled case; each notebook check expands to its single
+/// generated entry.  `family:<id>` dependency tokens are expanded to concrete
+/// generated filenames here, so the persisted manifest — the one the runner
+/// consumes — never contains a token.
+func buildConfiguredSuiteEntries(
+    itemsForOrdering: [AuthoredSuiteItem],
+    families: [PatternFamily],
+    checks: [NotebookCheck],
+    artifacts: RenderedFamilyArtifacts,
+    renderedCheckByID: [String: GeneratedScript],
+    deletedFilenames: Set<String>
+) -> [ConfiguredSuiteEntry] {
+    var familyFilenames: [String: [String]] = [:]
+    for f in families {
+        familyFilenames[f.id] = f.cases
+            .filter(\.enabled)
+            .map { c in
+                generatedScriptFilename(
+                    familyID: f.id,
+                    caseKey: c.key,
+                    tier: c.resolvedTier(defaults: f.defaults)
+                )
+            }
+    }
+
+    var builder = SuiteEntryBuilder(
+        familyByID: Dictionary(uniqueKeysWithValues: families.map { ($0.id, $0) }),
+        checkByID: Dictionary(uniqueKeysWithValues: checks.map { ($0.id, $0) }),
+        familyFilenames: familyFilenames,
+        artifacts: artifacts,
+        renderedCheckByID: renderedCheckByID,
+        deletedFilenames: deletedFilenames
+    )
+
+    for item in itemsForOrdering {
+        builder.appendAuthored(item)
+    }
+
+    // Defensive: anything in `families` / `checks` that wasn't referenced by
+    // `itemsForOrdering` still needs its generated entries emitted (e.g. if
+    // the caller forgot to include a newly added family).
+    for family in families where !builder.hasEmitted(familyID: family.id) {
+        builder.appendFamily(family, section: nil)
+    }
+    for check in checks where !builder.hasEmitted(checkID: check.id) {
+        builder.appendCheck(check, section: nil)
+    }
+
+    return builder.entries
+}

--- a/Sources/APIServer/Utilities/PatternFamilyApplication+ZipMutation.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+ZipMutation.swift
@@ -1,0 +1,167 @@
+// APIServer/Utilities/PatternFamilyApplication+ZipMutation.swift
+//
+// Phase 4 of `applyPatternFamilies`: render every generated artifact exactly
+// once, diff the result against what the previous manifest generated, and
+// apply both the writes and the deletions to the setup zip in one pass.
+//
+// Split out of PatternFamilyApplication.swift (#1253).  Unlike phase 5 this
+// one has a side effect — it mutates the zip — so it is not a pure function;
+// what makes it separable is that every decision feeding it is already made,
+// and nothing after it needs anything from it beyond the four values in
+// `AppliedZipMutations`.
+
+import Core
+import Foundation
+
+/// Everything the render-and-write phase needs.
+///
+/// This is a parameter object rather than a nine-argument function because the
+/// repo's `function_parameter_count` ceiling is six — and because bundling the
+/// arguments that travel together is the point, not a workaround for the lint
+/// rule.
+struct GeneratedArtifactPlan {
+    let families: [PatternFamily]
+    let checks: [NotebookCheck]
+    /// familyID → sectionID, built once by the caller and shared with the
+    /// validator so the two cannot disagree about where a family lives.
+    let familySectionID: [String: String]
+    let sections: [TestSuiteSection]
+    let globalVariables: [FamilyVariable]
+    let perStudentNames: Set<String>
+    let itemsForOrdering: [AuthoredSuiteItem]
+    let language: AssignmentLanguage
+    /// The language the *previous* manifest was written in, if it had one.
+    let previousLanguage: AssignmentLanguage?
+}
+
+/// What phase 4 produced, and what the phases after it consume.
+struct AppliedZipMutations {
+    /// Rendered once here; the manifest rebuild consumes these same values, so
+    /// the entries it writes describe exactly the bytes that went into the zip.
+    let artifacts: RenderedFamilyArtifacts
+    let renderedCheckByID: [String: GeneratedScript]
+    let writtenFilenames: [String]
+    let deletedFilenames: Set<String>
+}
+
+/// Renders families and notebook checks, computes the add/delete diff against
+/// the previous manifest's generated filenames, and applies both to the zip.
+func renderAndApplyZipMutations(
+    plan: GeneratedArtifactPlan,
+    previousProps: TestProperties,
+    zipPath: String
+) throws -> AppliedZipMutations {
+    // Old-side filenames for both generators are pooled into one set so
+    // the deletion diff is computed in one shot.  Notebook checks may
+    // produce sidecar files (e.g. `_expected_<id>.csv` for
+    // `.dataFrameEquality`); both the script and the sidecars are
+    // tracked here so removing a check cleans up all of its files.
+    // The generated extension is part of the filename, so the old files must be
+    // listed under the language the *previous* manifest was written in — and,
+    // when the assignment changes language, under the new one too, or the
+    // old-extension scripts would be stranded in the setup forever. Listing
+    // only these two keeps `deletedFiles` free of names that were never written.
+    // `previousLanguage` is optional (an assignment that had no language yet),
+    // so the pair is built explicitly rather than as a set literal — which also
+    // keeps the two comprehensions below inside the type-checker's budget.
+    var oldFilenameLanguages: Set<AssignmentLanguage> = [plan.language]
+    if let previousLanguage = plan.previousLanguage {
+        oldFilenameLanguages.insert(previousLanguage)
+    }
+    let oldGeneratedFilenames = Set(
+        oldFilenameLanguages.flatMap { language in
+            previousProps.patternFamilies.flatMap {
+                patternFamilyAllGeneratedFilenames($0, language: language)
+            }
+        }
+    ).union(
+        oldFilenameLanguages.flatMap { language in
+            previousProps.notebookChecks.flatMap {
+                notebookCheckAllGeneratedFilenames($0, language: language)
+            }
+        }
+    )
+
+    // A family whose id is missing from `familySectionID` (the defensive path
+    // in the entry builder) renders with no section variables — matching its
+    // "unanchored" status.
+    let sectionVarsByID: [String: [FamilyVariable]] = Dictionary(
+        uniqueKeysWithValues: plan.sections.map { ($0.id, $0.variables) }
+    )
+    // Every family renders exactly once, here.  Both the zip write below
+    // and the manifest rebuild consume these artifacts — the manifest phase
+    // used to invoke the renderer a second time per family, which wasted work
+    // and meant a renderer that ever became non-deterministic would silently
+    // desync the zip bytes from the manifest entries (#1123).
+    let artifacts = renderFamilyArtifacts(
+        families: plan.families,
+        familySectionID: plan.familySectionID,
+        sectionVarsByID: sectionVarsByID,
+        globalVariables: plan.globalVariables,
+        perStudentNames: plan.perStudentNames,
+        language: plan.language
+    )
+
+    var renderedByFilename: [String: GeneratedScript] = [:]
+    for family in plan.families {
+        for generated in artifacts.caseScripts[family.id] ?? [] {
+            renderedByFilename[generated.filename] = generated
+        }
+        if let guardScript = artifacts.guardScripts[family.id] {
+            renderedByFilename[guardScript.filename] = guardScript
+        }
+    }
+    // Render notebook checks alongside pattern families so a single zip
+    // mutation pass writes everything.  Each check produces one script
+    // file plus zero or more sidecar files (e.g. `_expected_<id>.csv`
+    // for `.dataFrameEquality`).  Sidecars don't have a `GeneratedScript`
+    // — they aren't entries in the suite — but they DO need to be in
+    // `newGeneratedFilenames` so stale ones get diffed away when a check
+    // changes kind or is removed.
+    var renderedCheckByID: [String: GeneratedScript] = [:]
+    var sidecarFilesToWrite: [String: String] = [:]
+    for check in plan.checks {
+        let bundle = renderNotebookCheck(check, language: plan.language)
+        renderedByFilename[bundle.script.filename] = bundle.script
+        renderedCheckByID[check.id] = bundle.script
+        for (name, content) in bundle.sidecars {
+            sidecarFilesToWrite[name] = content
+        }
+    }
+    let newGeneratedFilenames = Set(renderedByFilename.keys)
+        .union(sidecarFilesToWrite.keys)
+
+    let toDelete = oldGeneratedFilenames.subtracting(newGeneratedFilenames)
+    // Merge generated sources with check sidecars (e.g. expected CSVs) into
+    // the single write map.  applyScriptChangesToZip is bytes-agnostic — it
+    // doesn't care that some entries are scripts and others are CSV.
+    var toWrite = renderedByFilename.mapValues(\.source)
+    for (name, content) in sidecarFilesToWrite {
+        toWrite[name] = content
+    }
+
+    // Re-inline global + section variables into every raw (non-generated)
+    // test script (idempotent; see the helper).
+    for (filename, content) in rawScriptOverlayWrites(
+        items: plan.itemsForOrdering,
+        generatedFilenames: Set(renderedByFilename.keys),
+        zipPath: zipPath,
+        globalVariables: plan.globalVariables,
+        sectionVarsByID: sectionVarsByID
+    ) {
+        toWrite[filename] = content
+    }
+
+    try applyScriptChangesToZip(
+        zipPath: zipPath,
+        writes: toWrite,
+        deletions: Array(toDelete)
+    )
+
+    return AppliedZipMutations(
+        artifacts: artifacts,
+        renderedCheckByID: renderedCheckByID,
+        writtenFilenames: Array(toWrite.keys).sorted(),
+        deletedFilenames: toDelete
+    )
+}

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -149,7 +149,7 @@ struct PatternFamilyApplyResult: Equatable {
 /// `renderFamilyArtifacts`, `rawScriptOverlayWrites`); what remains
 /// inline genuinely threads state between phases (#1123).
 @discardableResult
-func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclomatic_complexity
+func applyPatternFamilies(  // swiftlint:disable:this function_body_length
     to setup: APITestSetup,
     nextFamilies: [PatternFamily],
     nextChecks: [NotebookCheck]? = nil,
@@ -376,301 +376,31 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     )
 
     // ── 4. Render generated scripts ONCE, then diff and mutate the zip ──
-    // Old-side filenames for both generators are pooled into one set so
-    // the deletion diff is computed in one shot.  Notebook checks may
-    // produce sidecar files (e.g. `_expected_<id>.csv` for
-    // `.dataFrameEquality`); both the script and the sidecars are
-    // tracked here so removing a check cleans up all of its files.
-    // The generated extension is part of the filename, so the old files must be
-    // listed under the language the *previous* manifest was written in — and,
-    // when the assignment changes language, under the new one too, or the
-    // old-extension scripts would be stranded in the setup forever. Listing
-    // only these two keeps `deletedFiles` free of names that were never written.
-    // `previousLanguage` is optional (an assignment that had no language yet),
-    // so the pair is built explicitly rather than as a set literal — which also
-    // keeps the two comprehensions below inside the type-checker's budget.
-    var oldFilenameLanguages: Set<AssignmentLanguage> = [assignmentLanguage]
-    if let previousLanguage { oldFilenameLanguages.insert(previousLanguage) }
-    let oldGeneratedFilenames = Set(
-        oldFilenameLanguages.flatMap { language in
-            props.patternFamilies.flatMap {
-                patternFamilyAllGeneratedFilenames($0, language: language)
-            }
-        }
-    ).union(
-        oldFilenameLanguages.flatMap { language in
-            props.notebookChecks.flatMap {
-                notebookCheckAllGeneratedFilenames($0, language: language)
-            }
-        }
-    )
-
-    // A family whose id is missing from `familySectionID` (defensive path
-    // below) renders with no section variables — matching its "unanchored"
-    // status.
-    let sectionVarsByID: [String: [FamilyVariable]] = Dictionary(
-        uniqueKeysWithValues: resolvedSections.map { ($0.id, $0.variables) }
-    )
-    // Every family renders exactly once, here.  Both the zip write below
-    // and the manifest rebuild (`appendFamilyConfigured`) consume these
-    // artifacts — the manifest phase used to invoke the renderer a second
-    // time per family, which wasted work and meant a renderer that ever
-    // became non-deterministic would silently desync the zip bytes from
-    // the manifest entries (#1123).
-    let artifacts = renderFamilyArtifacts(
-        families: nextFamilies,
-        familySectionID: familySectionID,
-        sectionVarsByID: sectionVarsByID,
-        globalVariables: resolvedGlobalVariables,
-        perStudentNames: perStudentExpressionNames,
-        language: assignmentLanguage
-    )
-
-    var renderedByFilename: [String: GeneratedScript] = [:]
-    for family in nextFamilies {
-        for generated in artifacts.caseScripts[family.id] ?? [] {
-            renderedByFilename[generated.filename] = generated
-        }
-        if let guardScript = artifacts.guardScripts[family.id] {
-            renderedByFilename[guardScript.filename] = guardScript
-        }
-    }
-    // Render notebook checks alongside pattern families so a single zip
-    // mutation pass writes everything.  Each check produces one `.py`
-    // file plus zero or more sidecar files (e.g. `_expected_<id>.csv`
-    // for `.dataFrameEquality`).  Sidecars don't have a `GeneratedScript`
-    // — they aren't entries in the suite — but they DO need to be in
-    // `newGeneratedFilenames` so stale ones get diffed away when a check
-    // changes kind or is removed.
-    var renderedCheckByID: [String: GeneratedScript] = [:]
-    var sidecarFilesToWrite: [String: String] = [:]
-    for check in resolvedChecks {
-        let bundle = renderNotebookCheck(check, language: assignmentLanguage)
-        renderedByFilename[bundle.script.filename] = bundle.script
-        renderedCheckByID[check.id] = bundle.script
-        for (name, content) in bundle.sidecars {
-            sidecarFilesToWrite[name] = content
-        }
-    }
-    let newGeneratedFilenames = Set(renderedByFilename.keys)
-        .union(sidecarFilesToWrite.keys)
-
-    let toDelete = oldGeneratedFilenames.subtracting(newGeneratedFilenames)
-    // Merge generated `.py` sources with check sidecars (e.g. expected
-    // CSVs) into the single write map.  applyScriptChangesToZip is
-    // bytes-agnostic — it doesn't care that some entries are Python and
-    // others are CSV.
-    var toWrite = renderedByFilename.mapValues(\.source)
-    for (name, content) in sidecarFilesToWrite {
-        toWrite[name] = content
-    }
-
-    // Slice 1: re-inline global + section variables into every raw
-    // (non-generated) Python test script (idempotent; see the helper).
-    for (filename, content) in rawScriptOverlayWrites(
-        items: itemsForOrdering,
-        generatedFilenames: Set(renderedByFilename.keys),
-        zipPath: setup.zipPath,
-        globalVariables: resolvedGlobalVariables,
-        sectionVarsByID: sectionVarsByID
-    ) {
-        toWrite[filename] = content
-    }
-
-    try applyScriptChangesToZip(
-        zipPath: setup.zipPath,
-        writes: toWrite,
-        deletions: Array(toDelete)
+    let mutations = try renderAndApplyZipMutations(
+        plan: GeneratedArtifactPlan(
+            families: nextFamilies,
+            checks: resolvedChecks,
+            familySectionID: familySectionID,
+            sections: resolvedSections,
+            globalVariables: resolvedGlobalVariables,
+            perStudentNames: perStudentExpressionNames,
+            itemsForOrdering: itemsForOrdering,
+            language: assignmentLanguage,
+            previousLanguage: previousLanguage
+        ),
+        previousProps: props,
+        zipPath: setup.zipPath
     )
 
     // ── 5. Build new `testSuites` in authored order, expanding family refs ─
-    let familyByID: [String: PatternFamily] = Dictionary(
-        uniqueKeysWithValues: nextFamilies.map { ($0.id, $0) }
+    let newConfigured = buildConfiguredSuiteEntries(
+        itemsForOrdering: itemsForOrdering,
+        families: nextFamilies,
+        checks: resolvedChecks,
+        artifacts: mutations.artifacts,
+        renderedCheckByID: mutations.renderedCheckByID,
+        deletedFilenames: mutations.deletedFilenames
     )
-    var familyFilenames: [String: [String]] = [:]
-    for f in nextFamilies {
-        familyFilenames[f.id] = f.cases
-            .filter(\.enabled)
-            .map { c in
-                generatedScriptFilename(
-                    familyID: f.id,
-                    caseKey: c.key,
-                    tier: c.resolvedTier(defaults: f.defaults)
-                )
-            }
-    }
-
-    func expandDeps(_ deps: [String]) -> [String] {
-        var out: [String] = []
-        var seen = Set<String>()
-        for d in deps {
-            if let fid = parseFamilyDepToken(d) {
-                for f in familyFilenames[fid] ?? [] {
-                    guard !toDelete.contains(f), seen.insert(f).inserted else { continue }
-                    out.append(f)
-                }
-            } else {
-                guard !toDelete.contains(d), seen.insert(d).inserted else { continue }
-                out.append(d)
-            }
-        }
-        return out
-    }
-
-    let checkByID: [String: NotebookCheck] = Dictionary(
-        uniqueKeysWithValues: resolvedChecks.map { ($0.id, $0) }
-    )
-
-    var newConfigured: [ConfiguredSuiteEntry] = []
-    var order = 0
-    var emittedFamilyIDs: Set<String> = []
-    var emittedCheckIDs: Set<String> = []
-
-    /// Emits a family's generated entries: the existence guard first (for
-    /// function-calling kinds), then one entry per enabled case wired to
-    /// `dependsOn` the guard — so a missing function fails once on the guard
-    /// and the cases auto-skip through the runner's dependency gate.  Shared
-    /// by the authored-order loop and the defensive pass below so the two
-    /// can't drift on the guard wiring.  Consumes the render-once
-    /// `artifacts`, so the manifest entries describe exactly the bytes the
-    /// zip phase wrote.
-    func appendFamilyConfigured(_ family: PatternFamily, familySection: String?) {
-        let inherited = expandDeps(family.dependsOn)
-        var guardFilename: String?
-        if let guardScript = artifacts.guardScripts[family.id] {
-            order += 1
-            guardFilename = guardScript.filename
-            // The guard inherits the family's own prerequisites; the cases
-            // chain off the guard, so prereqs → guard → cases.
-            newConfigured.append(
-                ConfiguredSuiteEntry(
-                    script: guardScript.filename,
-                    tier: guardScript.tier.rawValue,
-                    order: order,
-                    dependsOn: inherited,
-                    points: guardScript.points,
-                    displayName: guardScript.displayName,
-                    generatedBy: guardScript.familyID,
-                    sectionID: familySection,
-                    // The guard inherits the family-level time limit.
-                    timeLimitSeconds: guardScript.timeLimitSeconds
-                ))
-        }
-        for generated in artifacts.caseScripts[family.id] ?? [] {
-            order += 1
-            var combined: [String] = []
-            var seen = Set<String>()
-            // Generated-case deps are fully derived from the *current* spec:
-            // the guard first (so a missing function reports the guard as the
-            // unmet prerequisite), then the family's inherited prerequisites
-            // (deduped).  We deliberately do NOT carry the prior manifest
-            // entry's deps forward.  Doing so made a once-set family-level
-            // dependency permanently "sticky": every regeneration re-read the
-            // old generated row's deps, so clearing `family.dependsOn` (or
-            // dropping a hand-written prereq the family used to point at) could
-            // never remove it from the generated rows — leaving a dangling
-            // reference that no edit could delete, because a hand-written
-            // script is not a generated file and so never entered the
-            // `expandDeps` `toDelete` filter.
-            for d in (guardFilename.map { [$0] } ?? []) + inherited {
-                guard seen.insert(d).inserted else { continue }
-                combined.append(d)
-            }
-            // Per-test time limit is resolved by the renderer
-            // (`case.resolvedTimeLimit(defaults:)`, then normalised so a
-            // 0/negative becomes nil) and carried on `generated`.
-            newConfigured.append(
-                ConfiguredSuiteEntry(
-                    script: generated.filename,
-                    tier: generated.tier.rawValue,
-                    order: order,
-                    dependsOn: combined,
-                    points: generated.points,
-                    displayName: generated.displayName,
-                    generatedBy: generated.familyID,
-                    sectionID: familySection,
-                    timeLimitSeconds: generated.timeLimitSeconds
-                ))
-        }
-    }
-
-    for item in itemsForOrdering {
-        switch item {
-        case .script(let s):
-            order += 1
-            newConfigured.append(
-                ConfiguredSuiteEntry(
-                    script: s.script,
-                    tier: s.tier.rawValue,
-                    order: order,
-                    dependsOn: expandDeps(s.dependsOn),
-                    points: s.points,
-                    displayName: s.displayName,
-                    generatedBy: nil,
-                    sectionID: s.sectionID,
-                    hint: s.hint,
-                    timeLimitSeconds: s.timeLimitSeconds
-                ))
-
-        case .family(let fid, let familySection):
-            guard let family = familyByID[fid], !emittedFamilyIDs.contains(fid) else { continue }
-            emittedFamilyIDs.insert(fid)
-            appendFamilyConfigured(family, familySection: familySection)
-
-        case .check(let cid, let checkSection):
-            guard let check = checkByID[cid],
-                let generated = renderedCheckByID[cid],
-                !emittedCheckIDs.contains(cid)
-            else { continue }
-            emittedCheckIDs.insert(cid)
-            order += 1
-            let inherited = expandDeps(check.dependsOn)
-            // Per-test time limit comes from the check spec (0/negative → nil,
-            // i.e. inherit the assignment-wide default).
-            newConfigured.append(
-                ConfiguredSuiteEntry(
-                    script: generated.filename,
-                    tier: generated.tier.rawValue,
-                    order: order,
-                    dependsOn: inherited,
-                    points: generated.points,
-                    displayName: generated.displayName,
-                    generatedBy: nil,
-                    generatedByCheck: check.id,
-                    sectionID: checkSection,
-                    timeLimitSeconds: normalizedGeneratedTimeLimit(check.timeLimitSeconds)
-                ))
-        }
-    }
-
-    // Defensive: any family in `nextFamilies` that wasn't referenced by
-    // `authoredItems` still needs its generated scripts emitted (e.g. if
-    // the caller forgot to include a newly added family).
-    for family in nextFamilies where !emittedFamilyIDs.contains(family.id) {
-        emittedFamilyIDs.insert(family.id)
-        appendFamilyConfigured(family, familySection: nil)
-    }
-
-    // Same defensive pass for checks: any check not referenced by
-    // `authoredItems` still needs its generated entry emitted.
-    for check in resolvedChecks where !emittedCheckIDs.contains(check.id) {
-        guard let generated = renderedCheckByID[check.id] else { continue }
-        order += 1
-        let inherited = expandDeps(check.dependsOn)
-        newConfigured.append(
-            ConfiguredSuiteEntry(
-                script: generated.filename,
-                tier: generated.tier.rawValue,
-                order: order,
-                dependsOn: inherited,
-                points: generated.points,
-                displayName: generated.displayName,
-                generatedBy: nil,
-                generatedByCheck: check.id,
-                sectionID: nil,
-                timeLimitSeconds: normalizedGeneratedTimeLimit(check.timeLimitSeconds)
-            ))
-    }
 
     // ── 6. Rewrite and persist the manifest ─────────────────────────────
     let newManifest = try makeWorkerManifestJSON(
@@ -719,8 +449,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     try await setup.save(on: db)
 
     return PatternFamilyApplyResult(
-        writtenFiles: Array(toWrite.keys).sorted(),
-        deletedFiles: Array(toDelete).sorted(),
+        writtenFiles: mutations.writtenFilenames,
+        deletedFiles: mutations.deletedFilenames.sorted(),
         manifestBefore: oldManifest,
         manifestAfter: newManifest
     )

--- a/changelog.d/1253-apply-pattern-families-phases.md
+++ b/changelog.d/1253-apply-pattern-families-phases.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **`applyPatternFamilies` no longer suppresses a cyclomatic-complexity
+  warning.** Its render-and-write phase and its suite-entry-building phase
+  moved into `PatternFamilyApplication+ZipMutation.swift` and
+  `+SuiteEntries.swift`, taking the function from a 575-line body to 306 and
+  dropping its complexity below the threshold on its own — so the repo's only
+  double lint exemption is now a single one. No behavioural change: the
+  manifests and zip file lists produced for a fixture covering families,
+  existence guards, notebook checks with sidecars, sections, global variables,
+  `family:` dependency expansion, disabled cases and the deletion diff are
+  unchanged.


### PR DESCRIPTION
Item 3 of #1253, first of two landings. Follows #1311 and #1312.

## Scope

The issue asks for `applyPatternFamilies` to be decomposed so the repo's only double lint exemption goes away. Measured against the actual thresholds (`function_body_length` 100, `cyclomatic_complexity` 15), that needs all six of its `── N.` phases out — the two obvious ones only get the body from 575 to ~306. So this is the smaller, safe landing; the rest follows in a second PR.

**This PR retires `cyclomatic_complexity`.** SwiftLint flagged the disable as superfluous once the phases moved, and it's removed rather than left in place. `function_body_length` remains.

## What moved

- **Phase 4, render-and-write** → `PatternFamilyApplication+ZipMutation.swift`. Not a pure function — it mutates the zip — but every decision feeding it is already made and nothing downstream needs more than four values back. Its nine inputs travel as a `GeneratedArtifactPlan`: the parameter ceiling is six, and these arguments genuinely travel together.
- **Phase 5, building `testSuites`** → `+SuiteEntries.swift`. This one *is* pure: no database, no zip, every input decided before it runs.

## The part that needed a second pass

Phase 5 as a straight lift was 135 lines — over the same threshold, i.e. trading one over-long function for another. SwiftLint caught it; it would have been easy to ship as "extracted" while having moved the problem.

It's now a `SuiteEntryBuilder` whose order counter and emitted-id sets are stored properties rather than state captured by nested closures, split across four short emit steps. That also removed a duplication the original had: **emitting a notebook check was written out twice**, once in the authored pass and once in the defensive pass — the family emit path had already been factored into a shared helper for exactly that reason, and the check path hadn't. Both passes now call one `appendCheck`.

## Verification

A golden capture taken **before any of this landed**, over a fixture covering three families, existence guards, a notebook check, two sections, global variables, `family:` dependency expansion, a disabled case, the deletion diff, and the no-`authoredItems` carry-forward path.

Worth recording: **manifest bytes are not a usable criterion.** `makeWorkerManifestJSON` serializes Swift dictionaries, so JSON key order varies run to run — a byte diff reports hundreds of differences between a build and itself. The comparison parses each manifest and compares structurally, preserving list order (`testSuites` order is meaningful). All 3 manifests and all 6 written/deleted file lists match.

Plus 461 tests across the pattern-family, notebook-check, suite and personalization suites, and `scripts/swiftlint.sh --strict` at 0 violations in 969 files.

## Next

A follow-up PR takes out input resolution, authored ordering, language resolution, validation and the manifest rebuild, which is what it takes to get under 100 lines and drop `function_body_length`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sew4JYA3L2zHhQLHi3MM3S)_