### PR TITLE
refactor(families): finish the applyPatternFamilies decomposition (#1253)

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyApplication+Inputs.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+Inputs.swift
@@ -1,0 +1,277 @@
+// APIServer/Utilities/PatternFamilyApplication+Inputs.swift
+//
+// Phases 1-3 of `applyPatternFamilies`: resolve what the caller supplied
+// against what the stored manifest already held, reconstruct the authored
+// ordering, decide the assignment's language, and run every save-time
+// validation.
+//
+// Split out of PatternFamilyApplication.swift (#1253).  These phases share
+// state, which is why they were the ones left inline when the render and
+// entry-building phases moved out — `ResolvedApplyInputs` is that shared state
+// made explicit rather than threaded through a long argument list.
+
+import Core
+import Foundation
+import Vapor
+
+/// The caller's arguments resolved against the stored manifest.
+///
+/// Every field follows the same rule: the caller wins when it supplies a value,
+/// otherwise the manifest's existing value carries forward. That rule is why
+/// this is one save path for families, checks, sections, variables and
+/// expressions alike — a partial save must not silently drop the concepts it
+/// didn't mention.
+struct ResolvedApplyInputs {
+    let checks: [NotebookCheck]
+    let sections: [TestSuiteSection]
+    let globalVariables: [FamilyVariable]
+    let globalExpressions: [PersonalizationExpression]
+
+    /// Per-student personalization input names (global + section `=`
+    /// expressions).  The renderer uses this set to tell a `$name` arg / an
+    /// `expectedVarRef` that resolves to a per-student value — loaded from
+    /// `_ck_inputs.py` at grading time — apart from one naming a literal
+    /// variable (prepended at save time).
+    let perStudentExpressionNames: Set<String>
+
+    private let knownSectionIDs: Set<String>
+
+    init(
+        props: TestProperties,
+        nextChecks: [NotebookCheck]?,
+        sections: [TestSuiteSection]?,
+        globalVariables: [FamilyVariable]?,
+        globalExpressions: [PersonalizationExpression]?
+    ) throws {
+        self.checks = nextChecks ?? props.notebookChecks
+        self.sections = sections ?? props.sections
+        self.globalVariables = globalVariables ?? props.globalVariables
+        // Expressions don't reach the runner or get inlined into raw scripts —
+        // they only participate in notebook substitution at student first-open
+        // — so they bypass the renderer and flow straight into the manifest.
+        self.globalExpressions = globalExpressions ?? props.globalExpressions
+
+        self.perStudentExpressionNames = Set(
+            self.globalExpressions.map(\.name)
+                + self.sections.flatMap { $0.expressions.map(\.name) }
+        )
+
+        var seen: Set<String> = []
+        for s in self.sections {
+            guard seen.insert(s.id).inserted else {
+                throw Abort(.unprocessableEntity, reason: "Duplicate section id '\(s.id)'.")
+            }
+        }
+        self.knownSectionIDs = seen
+    }
+
+    /// Silently rewrites stale `sectionID` references (pointing at a section
+    /// that's not in `sections`) to `nil`.  Defends against the client-race
+    /// where the editor deletes a section locally but an in-flight PUT still
+    /// references it.
+    func normaliseSectionID(_ sid: String?) -> String? {
+        guard let sid else { return nil }
+        return knownSectionIDs.contains(sid) ? sid : nil
+    }
+}
+
+/// The authored suite as this save sees it: the raw (non-generated) scripts,
+/// and the full ordered item list that positions families and checks among
+/// them.
+struct AuthoredOrdering {
+    let rawEntries: [AuthoredRawScript]
+    let items: [AuthoredSuiteItem]
+
+    /// familyID → sectionID.  Built once and shared by the validator (which
+    /// uses it for section-variable ref checking) and the renderer (which uses
+    /// it to decide whose section variables to prepend), so the two cannot
+    /// disagree about where a family lives (#1123).
+    var familySectionID: [String: String] {
+        var out: [String: String] = [:]
+        for item in items {
+            if case .family(let fid, let sid) = item, let sid {
+                out[fid] = sid
+            }
+        }
+        return out
+    }
+
+    /// The raw entries in the shape the validators expect.
+    var rawAsTestSuites: [TestSuiteEntry] {
+        rawEntries.map {
+            TestSuiteEntry(
+                tier: $0.tier, script: $0.script, name: $0.displayName,
+                dependsOn: $0.dependsOn, points: $0.points, generatedBy: nil
+            )
+        }
+    }
+}
+
+/// Builds the authored ordering.
+///
+/// When `authoredItems` is supplied the caller is the source of truth for
+/// position, tier, points, displayName and dependencies of every raw row.
+/// When it is nil the raw entries are preserved verbatim from the existing
+/// manifest and generated entries are appended after them — the original
+/// v0.4.76 behaviour, used by callers that aren't driving the unified suite
+/// editor.
+func buildAuthoredOrdering(
+    authoredItems: [AuthoredSuiteItem]?,
+    props: TestProperties,
+    families: [PatternFamily],
+    inputs: ResolvedApplyInputs
+) -> AuthoredOrdering {
+    guard let authoredItems else {
+        let rawEntries = props.testSuites
+            .filter { !$0.isGenerated }
+            .map { e in
+                AuthoredRawScript(
+                    script: e.script,
+                    tier: e.tier,
+                    points: e.points,
+                    displayName: e.name,
+                    dependsOn: e.dependsOn,
+                    sectionID: inputs.normaliseSectionID(e.sectionID),
+                    hint: e.hint,
+                    timeLimitSeconds: e.timeLimitSeconds
+                )
+            }
+        return AuthoredOrdering(
+            rawEntries: rawEntries,
+            items: reconstructAuthoredOrdering(
+                props: props,
+                nextFamilies: families,
+                resolvedChecks: inputs.checks,
+                normaliseSectionID: inputs.normaliseSectionID
+            )
+        )
+    }
+
+    /// One rewrite of a raw script, shared by both lists below so the raw
+    /// entries and the ordering can't disagree about a normalised sectionID.
+    func normalised(_ s: AuthoredRawScript) -> AuthoredRawScript {
+        AuthoredRawScript(
+            script: s.script,
+            tier: s.tier,
+            points: s.points,
+            displayName: s.displayName,
+            dependsOn: s.dependsOn,
+            sectionID: inputs.normaliseSectionID(s.sectionID),
+            content: s.content,
+            hint: s.hint,
+            timeLimitSeconds: s.timeLimitSeconds
+        )
+    }
+
+    let items: [AuthoredSuiteItem] = authoredItems.map { item in
+        switch item {
+        case .script(let s):
+            return .script(normalised(s))
+        case .family(let id, let sid):
+            return .family(id: id, sectionID: inputs.normaliseSectionID(sid))
+        case .check(let id, let sid):
+            return .check(id: id, sectionID: inputs.normaliseSectionID(sid))
+        }
+    }
+    let rawEntries: [AuthoredRawScript] = items.compactMap {
+        if case .script(let s) = $0 { return s }
+        return nil
+    }
+    return AuthoredOrdering(rawEntries: rawEntries, items: items)
+}
+
+/// The language this save renders in, and the one the previous manifest was
+/// written in (which the deletion diff needs so old-extension scripts aren't
+/// stranded when an assignment changes language).
+struct AuthoringLanguageResolution {
+    let language: AssignmentLanguage
+    let previous: AssignmentLanguage?
+}
+
+/// Decides which language the generated scripts render in.
+///
+/// The authored items carry the edit being applied, which may be the very
+/// first non-Python graded script — the `.R` or `.lua` that establishes the
+/// language before the manifest has recorded anything. Any non-Python language
+/// wins, in `allCases` order for a deterministic answer on a mixed edit.
+/// Checking only `.r` here is what made the first `.lua` script save as Python.
+/// Python is excluded by name so adding a `.py` helper to an R assignment
+/// cannot flip the render language; the stored manifest stays authoritative.
+func resolveAuthoringLanguage(
+    setup: APITestSetup,
+    props: TestProperties,
+    authoredItems: [AuthoredSuiteItem]?
+) -> AuthoringLanguageResolution {
+    let previous = AssignmentLanguage.resolve(for: setup, manifest: props)
+
+    var authoredLanguages: Set<AssignmentLanguage> = []
+    for item in authoredItems ?? [] {
+        guard case .script(let raw) = item,
+            let language = AssignmentLanguage(
+                scriptExtension: URL(fileURLWithPath: raw.script).pathExtension),
+            language != .python
+        else { continue }
+        authoredLanguages.insert(language)
+    }
+    let resolved = AssignmentLanguage.allCases.first { authoredLanguages.contains($0) } ?? previous
+
+    // Authoring falls back to Python, deliberately and locally — this is NOT
+    // the old resolution default leaking back in.
+    //
+    // Refusing here would be circular: a pattern family is frequently the FIRST
+    // thing authored on an assignment, and generating its scripts is how the
+    // suite acquires a graded script in the first place. "Add a graded script
+    // before you can add a family" asks the instructor for the output as a
+    // precondition of the input. So when nothing names a language yet, author
+    // in Python — and the save RECORDS the choice into the manifest, so the
+    // ambiguity exists for exactly one save and never silently again.
+    //
+    // What the Optional buys is upstream of this line: an `.R`/`.lua`/`.m`
+    // assignment can no longer arrive here as Python by fallthrough, because
+    // those signals now resolve positively and nil means only "nothing said".
+    return AuthoringLanguageResolution(language: resolved ?? .python, previous: previous)
+}
+
+/// Every save-time validation, in the order the pre-split function ran them.
+///
+/// Ordering is load-bearing: the family spec is checked before the notebook
+/// checks that may reference it, and cycle detection runs last on the fully
+/// resolved authored graph.
+func validatePatternFamilySave(
+    families: [PatternFamily],
+    ordering: AuthoredOrdering,
+    inputs: ResolvedApplyInputs,
+    language: AssignmentLanguage
+) throws {
+    let rawAsTestSuites = ordering.rawAsTestSuites
+
+    try validatePatternFamilies(
+        families,
+        testSuites: rawAsTestSuites,
+        sections: inputs.sections,
+        familySectionID: ordering.familySectionID,
+        globalVariableNames: Set(inputs.globalVariables.map(\.name)),
+        perStudentExpressionNames: inputs.perStudentExpressionNames
+    )
+
+    try validateNotebookChecks(
+        inputs.checks,
+        patternFamilies: families,
+        testSuites: rawAsTestSuites,
+        language: language
+    )
+
+    try validateFamilyRefDependencies(
+        authoredRawEntries: ordering.rawEntries,
+        families: families,
+        checks: inputs.checks
+    )
+
+    // Cycle detection on the authored graph (family ids + script filenames
+    // as a single node set; family:<id> edges expand to the family node,
+    // NOT to its generated scripts, so family→family cycles are caught).
+    try detectAuthoredCycles(
+        authoredRaw: ordering.rawEntries,
+        families: families
+    )
+}

--- a/Sources/APIServer/Utilities/PatternFamilyApplication+Manifest.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+Manifest.swift
@@ -1,0 +1,65 @@
+// APIServer/Utilities/PatternFamilyApplication+Manifest.swift
+//
+// Phase 6 of `applyPatternFamilies`: rebuild the manifest JSON from the newly
+// ordered suite entries and re-validate the result.
+//
+// Split out of PatternFamilyApplication.swift (#1253).
+
+import Core
+import Foundation
+
+/// Rebuilds the manifest and re-checks the post-expansion result.
+///
+/// `makeWorkerManifestJSON` builds a fresh dictionary, so **anything not
+/// threaded through here is lost.** That is the failure mode this phase is
+/// most prone to: `submissionMode`, `requiredFiles`, `minimumRunnerVersion`,
+/// achievements and datasets are all carried forward explicitly for that
+/// reason, and a new manifest field needs adding here as well as to the
+/// encoder.
+func rebuildPatternFamilyManifest(
+    entries: [ConfiguredSuiteEntry],
+    previousProps props: TestProperties,
+    families: [PatternFamily],
+    inputs: ResolvedApplyInputs,
+    language: AssignmentLanguage
+) throws -> String {
+    let newManifest = try makeWorkerManifestJSON(
+        testSuites: entries,
+        includeMakefile: props.makefile != nil,
+        gradingMode: props.gradingMode.rawValue,
+        submissionMode: props.submissionMode.rawValue,
+        requiredFiles: props.requiredFiles,
+        timeLimitSeconds: props.timeLimitSeconds,
+        starterNotebook: props.starterNotebook,
+        patternFamilies: families,
+        notebookChecks: inputs.checks,
+        sections: inputs.sections,
+        globalVariables: inputs.globalVariables,
+        globalExpressions: inputs.globalExpressions,
+        achievements: props.achievements,
+        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
+        builtInAchievementsSeeded: props.builtInAchievementsSeeded,
+        datasets: props.datasets,
+        // Always record the language, Python included. An explicit answer is
+        // the point: a suite that later holds only pattern families has no
+        // `.R` script left to sniff, and "we inferred Python" and "this is a
+        // Python assignment" should not be the same state. The first save of
+        // a pre-existing assignment therefore changes its manifest hash once,
+        // which re-keys the runner's TestSetupCache and triggers one
+        // revision-retest fan-out for that assignment — a bounded, one-time
+        // cost accepted in exchange for the language never being re-inferred.
+        language: language,
+        minimumRunnerVersion: props.minimumRunnerVersion
+    )
+
+    // Belt-and-suspenders: the post-expansion manifest is the one the runner
+    // will actually consume.  It must not contain any `family:<id>` tokens,
+    // must reference only existing scripts, and must still be acyclic.
+    if let postData = newManifest.data(using: .utf8),
+        let postProps = decodeManifest(from: postData)
+    {
+        try validateManifestDependencies(postProps)
+    }
+
+    return newManifest
+}

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -149,7 +149,7 @@ struct PatternFamilyApplyResult: Equatable {
 /// `renderFamilyArtifacts`, `rawScriptOverlayWrites`); what remains
 /// inline genuinely threads state between phases (#1123).
 @discardableResult
-func applyPatternFamilies(  // swiftlint:disable:this function_body_length
+func applyPatternFamilies(
     to setup: APITestSetup,
     nextFamilies: [PatternFamily],
     nextChecks: [NotebookCheck]? = nil,
@@ -161,232 +161,50 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length
 ) async throws -> PatternFamilyApplyResult {
 
     let oldManifest = setup.manifest
-    guard let props = decodeManifest(fromJSON: oldManifest)
-
-    else {
+    guard let props = decodeManifest(fromJSON: oldManifest) else {
         throw Abort(.internalServerError, reason: "Test setup manifest is not valid JSON")
     }
 
-    // Resolve the final checks list: caller wins; otherwise carry forward
-    // whatever's on the manifest already.  Mirrors the section resolution
-    // below so this function is the single save path for both concepts.
-    let resolvedChecks: [NotebookCheck] = nextChecks ?? props.notebookChecks
-
-    // ── 1. Resolve section list (caller wins; otherwise carry old manifest).
-    let resolvedSections: [TestSuiteSection] = sections ?? props.sections
-
-    // Resolve assignment-scope variables (Slice 1): caller wins; otherwise
-    // carry forward whatever was on the manifest already.
-    let resolvedGlobalVariables: [FamilyVariable] = globalVariables ?? props.globalVariables
-
-    // Resolve assignment-scope expressions (Slice 2): same carry-forward
-    // semantics.  Expressions don't reach the runner or get inlined into
-    // raw scripts — they only participate in notebook substitution
-    // at student first-open — so they bypass the renderer below and
-    // flow straight into the manifest write.
-    let resolvedGlobalExpressions: [PersonalizationExpression] =
-        globalExpressions ?? props.globalExpressions
-
-    // Per-student personalization input names (global + section `=`
-    // expressions).  The renderer uses this set to tell a `$name` arg / an
-    // `expectedVarRef` that resolves to a per-student value — loaded from
-    // `_ck_inputs.py` at grading time — apart from one naming a literal
-    // variable (prepended at save time).
-    let perStudentExpressionNames: Set<String> = Set(
-        resolvedGlobalExpressions.map(\.name)
-            + resolvedSections.flatMap { $0.expressions.map(\.name) }
+    // ── 1. Resolve caller arguments against the stored manifest ─────────
+    let inputs = try ResolvedApplyInputs(
+        props: props,
+        nextChecks: nextChecks,
+        sections: sections,
+        globalVariables: globalVariables,
+        globalExpressions: globalExpressions
     )
-    var seenSectionIDs: Set<String> = []
-    for s in resolvedSections {
-        guard seenSectionIDs.insert(s.id).inserted else {
-            throw Abort(
-                .unprocessableEntity,
-                reason: "Duplicate section id '\(s.id)'.")
-        }
-    }
-    let knownSectionIDs = seenSectionIDs
-
-    /// Silently rewrites stale `sectionID` references (pointing at a
-    /// section that's not in `resolvedSections`) to `nil`.  Defends
-    /// against the client-race where the editor deletes a section
-    /// locally but an in-flight PUT still references it.
-    func normaliseSectionID(_ sid: String?) -> String? {
-        guard let sid else { return nil }
-        return knownSectionIDs.contains(sid) ? sid : nil
-    }
 
     // ── 2. Figure out the authored raw-entry list + ordering ────────────
-    // (Section-contiguity is enforced right after — see
-    // `validateAuthoredSectionContiguity` below.)
-    let authoredRawEntries: [AuthoredRawScript]
-    let itemsForOrdering: [AuthoredSuiteItem]
-    if let authoredItems {
-        authoredRawEntries = authoredItems.compactMap { item in
-            if case .script(let s) = item {
-                return AuthoredRawScript(
-                    script: s.script,
-                    tier: s.tier,
-                    points: s.points,
-                    displayName: s.displayName,
-                    dependsOn: s.dependsOn,
-                    sectionID: normaliseSectionID(s.sectionID),
-                    content: s.content,
-                    hint: s.hint,
-                    timeLimitSeconds: s.timeLimitSeconds
-                )
-            }
-            return nil
-        }
-        itemsForOrdering = authoredItems.map { item in
-            switch item {
-            case .script(let s):
-                return .script(
-                    AuthoredRawScript(
-                        script: s.script,
-                        tier: s.tier,
-                        points: s.points,
-                        displayName: s.displayName,
-                        dependsOn: s.dependsOn,
-                        sectionID: normaliseSectionID(s.sectionID),
-                        content: s.content,
-                        hint: s.hint,
-                        timeLimitSeconds: s.timeLimitSeconds
-                    ))
-            case .family(let id, let sid):
-                return .family(id: id, sectionID: normaliseSectionID(sid))
-            case .check(let id, let sid):
-                return .check(id: id, sectionID: normaliseSectionID(sid))
-            }
-        }
-    } else {
-        authoredRawEntries = props.testSuites
-            .filter { !$0.isGenerated }
-            .map { e in
-                AuthoredRawScript(
-                    script: e.script,
-                    tier: e.tier,
-                    points: e.points,
-                    displayName: e.name,
-                    dependsOn: e.dependsOn,
-                    sectionID: normaliseSectionID(e.sectionID),
-                    hint: e.hint,
-                    timeLimitSeconds: e.timeLimitSeconds
-                )
-            }
-        itemsForOrdering = reconstructAuthoredOrdering(
-            props: props,
-            nextFamilies: nextFamilies,
-            resolvedChecks: resolvedChecks,
-            normaliseSectionID: normaliseSectionID
-        )
-    }
-
-    try validateAuthoredSectionContiguity(itemsForOrdering)
-
-    // ── 3. Validate: family spec + family-ref dependency tokens ─────────
-    let authoredAsTestSuites = authoredRawEntries.map {
-        TestSuiteEntry(
-            tier: $0.tier, script: $0.script, name: $0.displayName,
-            dependsOn: $0.dependsOn, points: $0.points, generatedBy: nil
-        )
-    }
-    // v0.4.100: the familyID → sectionID map tells the validator which
-    // family lives in which section (section-variable ref checking) and
-    // later tells the renderer whose section variables to prepend.  Built
-    // ONCE here — the render phase used to rebuild it with an identical
-    // loop (#1123).
-    var familySectionID: [String: String] = [:]
-    for item in itemsForOrdering {
-        if case .family(let fid, let sid) = item, let sid {
-            familySectionID[fid] = sid
-        }
-    }
-    try validatePatternFamilies(
-        nextFamilies,
-        testSuites: authoredAsTestSuites,
-        sections: resolvedSections,
-        familySectionID: familySectionID,
-        globalVariableNames: Set(resolvedGlobalVariables.map(\.name)),
-        perStudentExpressionNames: perStudentExpressionNames
-    )
-    // The assignment's language decides how each case renders and which
-    // extension it gets. Prefer the authored items when supplied — they carry
-    // the edit being applied, which may be the very first `.R` test — and fall
-    // back to the stored manifest (which records the language once known).
-    let previousLanguage = AssignmentLanguage.resolve(for: setup, manifest: props)
-    let resolvedLanguage: AssignmentLanguage? = {
-        // The authored items carry the edit being applied, which may be the very
-        // first non-Python graded script — the `.R` or `.lua` that establishes
-        // the language before the manifest has recorded anything. Resolve it
-        // from the extension so the families/checks render in the right language
-        // at that moment. Any non-Python language wins, in `allCases` order
-        // (R before Lua) for a deterministic answer on a mixed edit. Checking
-        // only `.r` here is what made the first `.lua` script save as Python.
-        //
-        // Python is excluded by name so that adding a `.py` helper to an R
-        // assignment cannot flip the render language; the stored manifest stays
-        // authoritative in that case.
-        var authoredLanguages: Set<AssignmentLanguage> = []
-        for item in authoredItems ?? [] {
-            guard case .script(let raw) = item,
-                let language = AssignmentLanguage(
-                    scriptExtension: URL(fileURLWithPath: raw.script).pathExtension),
-                language != .python
-            else { continue }
-            authoredLanguages.insert(language)
-        }
-        return AssignmentLanguage.allCases.first { authoredLanguages.contains($0) }
-            ?? previousLanguage
-    }()
-    // Authoring falls back to Python, deliberately and locally — this is NOT the
-    // old resolution default leaking back in.
-    //
-    // Refusing here would be circular: a pattern family is frequently the FIRST
-    // thing authored on an assignment, and generating its scripts is how the
-    // suite acquires a graded script in the first place. "Add a graded script
-    // before you can add a family" asks the instructor for the output as a
-    // precondition of the input. So when nothing names a language yet, author in
-    // Python — and note that the save RECORDS the choice into the manifest, so
-    // the ambiguity exists for exactly one save and never silently again.
-    //
-    // What the Optional buys is upstream of this line: an `.R`/`.lua`/`.m`
-    // assignment can no longer arrive here as Python by fallthrough, because
-    // those signals now resolve positively and nil means only "nothing said".
-    let assignmentLanguage = resolvedLanguage ?? .python
-
-    try validateNotebookChecks(
-        resolvedChecks,
-        patternFamilies: nextFamilies,
-        testSuites: authoredAsTestSuites,
-        language: assignmentLanguage
-    )
-
-    try validateFamilyRefDependencies(
-        authoredRawEntries: authoredRawEntries,
+    let ordering = buildAuthoredOrdering(
+        authoredItems: authoredItems,
+        props: props,
         families: nextFamilies,
-        checks: resolvedChecks
+        inputs: inputs
     )
+    try validateAuthoredSectionContiguity(ordering.items)
 
-    // Cycle detection on the authored graph (family ids + script filenames
-    // as a single node set; family:<id> edges expand to the family node,
-    // NOT to its generated scripts, so family→family cycles are caught).
-    try detectAuthoredCycles(
-        authoredRaw: authoredRawEntries,
-        families: nextFamilies
+    // ── 3. Resolve the language, then validate the whole save ───────────
+    let language = resolveAuthoringLanguage(
+        setup: setup, props: props, authoredItems: authoredItems)
+    try validatePatternFamilySave(
+        families: nextFamilies,
+        ordering: ordering,
+        inputs: inputs,
+        language: language.language
     )
 
     // ── 4. Render generated scripts ONCE, then diff and mutate the zip ──
     let mutations = try renderAndApplyZipMutations(
         plan: GeneratedArtifactPlan(
             families: nextFamilies,
-            checks: resolvedChecks,
-            familySectionID: familySectionID,
-            sections: resolvedSections,
-            globalVariables: resolvedGlobalVariables,
-            perStudentNames: perStudentExpressionNames,
-            itemsForOrdering: itemsForOrdering,
-            language: assignmentLanguage,
-            previousLanguage: previousLanguage
+            checks: inputs.checks,
+            familySectionID: ordering.familySectionID,
+            sections: inputs.sections,
+            globalVariables: inputs.globalVariables,
+            perStudentNames: inputs.perStudentExpressionNames,
+            itemsForOrdering: ordering.items,
+            language: language.language,
+            previousLanguage: language.previous
         ),
         previousProps: props,
         zipPath: setup.zipPath
@@ -394,56 +212,22 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length
 
     // ── 5. Build new `testSuites` in authored order, expanding family refs ─
     let newConfigured = buildConfiguredSuiteEntries(
-        itemsForOrdering: itemsForOrdering,
+        itemsForOrdering: ordering.items,
         families: nextFamilies,
-        checks: resolvedChecks,
+        checks: inputs.checks,
         artifacts: mutations.artifacts,
         renderedCheckByID: mutations.renderedCheckByID,
         deletedFilenames: mutations.deletedFilenames
     )
 
     // ── 6. Rewrite and persist the manifest ─────────────────────────────
-    let newManifest = try makeWorkerManifestJSON(
-        testSuites: newConfigured,
-        includeMakefile: props.makefile != nil,
-        gradingMode: props.gradingMode.rawValue,
-        // Preserve the submission mode and required-files list across the
-        // family/suite rebuild, like `language` below — a fresh-dict rebuild
-        // loses anything not threaded through.
-        submissionMode: props.submissionMode.rawValue,
-        requiredFiles: props.requiredFiles,
-        timeLimitSeconds: props.timeLimitSeconds,
-        starterNotebook: props.starterNotebook,
-        patternFamilies: nextFamilies,
-        notebookChecks: resolvedChecks,
-        sections: resolvedSections,
-        globalVariables: resolvedGlobalVariables,
-        globalExpressions: resolvedGlobalExpressions,
-        achievements: props.achievements,
-        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
-        builtInAchievementsSeeded: props.builtInAchievementsSeeded,
-        datasets: props.datasets,
-        // Always record the language, Python included. An explicit answer is
-        // the point: a suite that later holds only pattern families has no
-        // `.R` script left to sniff, and "we inferred Python" and "this is a
-        // Python assignment" should not be the same state. The first save of
-        // a pre-existing assignment therefore changes its manifest hash once,
-        // which re-keys the runner's TestSetupCache and triggers one
-        // revision-retest fan-out for that assignment — a bounded, one-time
-        // cost accepted in exchange for the language never being re-inferred.
-        language: assignmentLanguage,
-        // Preserve the minimum-runner-version gate across the family rebuild.
-        minimumRunnerVersion: props.minimumRunnerVersion
+    let newManifest = try rebuildPatternFamilyManifest(
+        entries: newConfigured,
+        previousProps: props,
+        families: nextFamilies,
+        inputs: inputs,
+        language: language.language
     )
-
-    // Belt-and-suspenders: the post-expansion manifest is the one the runner
-    // will actually consume.  It must not contain any `family:<id>` tokens,
-    // must reference only existing scripts, and must still be acyclic.
-    if let postData = newManifest.data(using: .utf8),
-        let postProps = decodeManifest(from: postData)
-    {
-        try validateManifestDependencies(postProps)
-    }
 
     setup.manifest = newManifest
     try await setup.save(on: db)

--- a/changelog.d/1253-apply-pattern-families-orchestrator.md
+++ b/changelog.d/1253-apply-pattern-families-orchestrator.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **`applyPatternFamilies` carries no lint exemptions at all.** Its remaining
+  four phases — resolving caller arguments against the stored manifest,
+  rebuilding the authored ordering, resolving the assignment language, and
+  rewriting the manifest — moved into
+  `PatternFamilyApplication+Inputs.swift` and `+Manifest.swift`. The function
+  is now a 90-line orchestrator over six named phases, down from 575 lines
+  when the work started, and the `function_body_length` exemption is gone.
+  No behavioural change: the manifests and file lists produced for a fixture
+  covering families, existence guards, notebook checks with sidecars,
+  sections, global variables, `family:` dependency expansion, disabled cases,
+  the deletion diff and the carry-forward path are unchanged.


### PR DESCRIPTION
Item 3 of #1253, second of two landings. Follows #1314.

**`applyPatternFamilies` now carries no lint exemptions at all.** 575 lines when this work started → 306 after #1314 → **90** here, as an orchestrator over its six named phases.

## What moved

| Phase | Now |
|---|---|
| 1 — resolve caller args against the stored manifest | `ResolvedApplyInputs` |
| 2 — authored raw entries + ordering | `buildAuthoredOrdering` → `AuthoredOrdering` |
| language decision | `resolveAuthoringLanguage` |
| 3 — four save-time validations | `validatePatternFamilySave` |
| 6 — manifest rebuild + re-validation | `rebuildPatternFamilyManifest` |

A few of these earn their keep beyond line count:

- **`ResolvedApplyInputs`** makes one rule visible instead of restating it five times: *caller wins, else the manifest's value carries forward*. That rule is why this is a single save path for families, checks, sections, variables and expressions — a partial save must not silently drop the concepts it didn't mention. It also owns `normaliseSectionID` and the duplicate-section-id check.
- **`AuthoredOrdering`** turns `familySectionID` and the validator's view of the raw entries into computed properties rather than loose locals that had to be built in the right order.
- **`validatePatternFamilySave`** keeps the four validations in their original order, which is load-bearing: the family spec is checked before the notebook checks that may reference it, and cycle detection runs last on the fully resolved graph. Said so in a comment, since nothing else enforces it.
- **`rebuildPatternFamilyManifest`** carries the warning that `makeWorkerManifestJSON` builds a *fresh dictionary*, so any field not threaded through is silently lost — the failure mode that phase is most prone to, and the reason `submissionMode`, `requiredFiles` and `minimumRunnerVersion` are all carried explicitly.

## De-duplication that fell out

The authored-items branch built the raw entry list and the ordering list from **two separate copies of the same nine-field `AuthoredRawScript` rewrite**. They're one `normalised` helper now, and the raw list is derived from the ordering — so the two can't disagree about a normalised `sectionID`. That's the fourth instance of the same copy-drift shape in this issue's four landings.

## Verification

Same golden capture taken **before #1314 or this landed**: three manifests and six written/deleted file lists over a fixture covering three families, existence guards, a notebook check, two sections, global variables, `family:` dependency expansion, a disabled case, the deletion diff and the no-`authoredItems` carry-forward path. All match.

Compared structurally, not as bytes — `makeWorkerManifestJSON` serializes dictionaries so JSON key order varies run to run, and a byte diff reports hundreds of differences between a build and itself.

Plus **1,208 tests** across the pattern-family, notebook-check, suite, personalization, assignment, draft and MCP suites, and `scripts/swiftlint.sh --strict` at 0 violations in 971 files.

`grep` confirms no `swiftlint:disable` remains anywhere in `PatternFamilyApplication*`, and `Sources/` has no double exemption left.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sew4JYA3L2zHhQLHi3MM3S)_