### PR TITLE
fix(core): stop zip subprocesses reading the global environ (Family 6)

### DIFF
--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -318,7 +318,7 @@ func zipContainsNotebook(_ zipData: Data) -> Bool {
 
     guard (try? zipData.write(to: tmp)) != nil else { return false }
 
-    let proc = Process()
+    let proc = makeZipProcess()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
     proc.arguments = ["-l", tmp.path]
     let pipe = closeOnExecPipe()

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -34,7 +34,7 @@ func repackZipFromDirectory(zipPath: String, sourceDir: URL) throws {
         return
     }
     try withZipProcessLock {
-        let zip = Process()
+        let zip = makeZipProcess()
         zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
         zip.currentDirectoryURL = sourceDir
         zip.arguments = ["-q", "-r", zipPath, "."]
@@ -113,7 +113,7 @@ enum ZipUploadValidationError: Error, CustomStringConvertible {
 /// (Length, Method, Size, Cmpr, Date, Time, CRC-32) before the name.
 func validateZipUploadSize(zipPath: String, limits: ZipUploadLimits = .default) throws {
     let (status, data): (Int32, Data) = try withZipProcessLock {
-        let process = Process()
+        let process = makeZipProcess()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
         process.arguments = ["-v", zipPath]
         let out = closeOnExecPipe()
@@ -171,7 +171,7 @@ struct RunnerSetupPackage {
 
 func listZipEntries(zipPath: String) -> [String] {
     let result: (Int32, Data)? = try? withZipProcessLock {
-        let process = Process()
+        let process = makeZipProcess()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
         process.arguments = ["-Z1", zipPath]
         let out = closeOnExecPipe()
@@ -305,7 +305,7 @@ func removeScriptFromZip(zipPath: String, filename: String) throws {
 
 func extractZipEntry(zipPath: String, entryName: String) -> Data? {
     let result: (Int32, Data)? = try? withZipProcessLock {
-        let process = Process()
+        let process = makeZipProcess()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
         process.arguments = ["-p", zipPath, entryName]
         let out = closeOnExecPipe()

--- a/Sources/Core/PipeCloseOnExec.swift
+++ b/Sources/Core/PipeCloseOnExec.swift
@@ -27,9 +27,12 @@ import Foundation
 /// answer is narrower than the issue text implies (see
 /// `Tests/CoreTests/PipeCloseOnExecTests.swift`): on Swift 6.3 / glibc 2.39
 /// both spawners this codebase uses already close inherited descriptors
-/// themselves — Foundation's `Process` leaves a child holding only fds 0/1/2,
-/// and swift-subprocess `close_range`s everything above stderr. A bare
-/// `posix_spawn` still inherits the lot. So this is defence in depth against
+/// themselves — a pipe of ours does not reach a child spawned through
+/// Foundation's `Process`, and swift-subprocess `close_range`s everything
+/// above stderr. (Stated precisely: *our pipe's write end* does not reach the
+/// child. Other inherited descriptors do, so "the child holds only fds 0/1/2"
+/// is too strong and measures false.) A bare `posix_spawn` still inherits the
+/// lot. So this is defence in depth against
 /// a spawner that does not do it, not a live bug being patched — but it costs
 /// two `fcntl`s, and having every hand-built pipe state the same invariant is
 /// what makes an exception visible.

--- a/Sources/Core/ZipArchiver.swift
+++ b/Sources/Core/ZipArchiver.swift
@@ -111,7 +111,7 @@ public func listZipContents(zipPath: String) throws -> [String] {
     // Sync path holds the lock across read + wait too since both touch
     // the same Pipe / Process state.
     return try withZipProcessLock {
-        let proc = Process()
+        let proc = makeZipProcess()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
         proc.arguments = ["-Z1", zipPath]
         // CLOEXEC before the spawn: an unrelated process started concurrently
@@ -152,7 +152,7 @@ private func runZipProcess(
         // terminationHandler runs on Foundation's queue and resumes the
         // continuation independently.
         acquireZipProcessLock()
-        let proc = Process()
+        let proc = makeZipProcess()
         proc.executableURL = URL(fileURLWithPath: executablePath)
         proc.arguments = arguments
         if let dir = workingDirectory {

--- a/Sources/Core/ZipProcessSerialization.swift
+++ b/Sources/Core/ZipProcessSerialization.swift
@@ -64,9 +64,44 @@ public func releaseZipProcessLock() {
     zipProcessLock.unlock()
 }
 
+/// The parent environment, read **once** for the lifetime of the process.
+///
+/// `Process.run()` with a nil `environment` inherits by reading the global
+/// environ itself, which makes every zip spawn an unsynchronized *reader* of
+/// state that `setenv`/`unsetenv` can reallocate underneath it. That is the
+/// same race as the EFAULT one below, in the form the retry cannot help with:
+/// when the kernel notices, `run()` throws EFAULT and is retried; when the
+/// read walks a reallocated environ in user space instead, the process takes
+/// a bad pointer dereference and dies. Seen 2026-08-09 on `api-tests`
+/// (`Bad pointer dereference at 0x210`, Thread 5:
+/// `_ProcessInfo.environment.getter` ← `Process.run()` ← `listZipEntries`).
+///
+/// A `let` is initialized exactly once, on first use, under `swift_once` — so
+/// every zip subprocess after that gets the snapshot with no further reads.
+/// Contents are unchanged from what these spawns inherited before; only the
+/// number of racy reads changes, from one per spawn to one per process.
+private let zipInheritedEnvironment: [String: String] = ProcessInfo.processInfo.environment
+
+/// A `Process` preconfigured for a zip/unzip spawn.
+///
+/// Use this instead of a bare `Process()` for every `/usr/bin/zip` and
+/// `/usr/bin/unzip` invocation. Setting `environment` non-nil is what stops
+/// `run()` from performing the implicit environ read described above — it is
+/// not a convenience, and a site that constructs `Process()` directly silently
+/// opts back into the crash. `ZipProcessEnvironmentTests` fails on such a site.
+public func makeZipProcess() -> Process {
+    let process = Process()
+    process.environment = zipInheritedEnvironment
+    return process
+}
+
 /// Calls `proc.run()`, retrying once after a 10 ms backoff if it throws
 /// `NSPOSIXErrorDomain` / `EFAULT` (Foundation Process race; see file
 /// header).  `proc` must not have been started yet.
+///
+/// This handles only the *throwing* form of the race. The crashing form is
+/// prevented upstream by `makeZipProcess()`, because a segfault cannot be
+/// caught and retried.
 public func runProcessWithEFAULTRetry(_ proc: Process) throws {
     do {
         try proc.run()

--- a/Tests/CoreTests/ZipProcessEnvironmentTests.swift
+++ b/Tests/CoreTests/ZipProcessEnvironmentTests.swift
@@ -1,0 +1,109 @@
+// Tests/CoreTests/ZipProcessEnvironmentTests.swift
+//
+// The zip subprocess paths must never let Foundation read the global environ
+// for them.
+//
+// WHY THIS IS A CRASH AND NOT A FLAKE YOU CAN RETRY. `Process.run()` with a
+// nil `environment` inherits by reading environ itself. `setenv`/`unsetenv`
+// can reallocate that array, so a spawn concurrent with an env-mutating test
+// is an unsynchronized reader of freed memory. Sometimes the kernel notices
+// and `run()` throws EFAULT — `runProcessWithEFAULTRetry` exists for exactly
+// that, and absorbs it. Sometimes the read happens in user space instead, and
+// then there is nothing to catch: the process dies.
+//
+// Observed 2026-08-09 on `api-tests` (PR #1313's run, unrelated diff):
+//   *** Program crashed: Bad pointer dereference at 0x0000000000000210 ***
+//   Thread 5: _ProcessInfo.environment.getter ← Process.run()
+//             ← runProcessWithEFAULTRetry ← listZipEntries
+//
+// `withAsyncEnvLock` did not cover it. Its own header asks that "every test
+// that mutates env vars and every helper that reads them" take the lock — a
+// zip spawn is an *undeclared* reader, so it never did.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct ZipProcessEnvironmentTests {
+
+    /// The property the whole fix rests on: non-nil `environment` is what
+    /// stops `run()` from doing the implicit read.
+    @Test func makeZipProcessSuppliesAnEnvironment() {
+        #expect(
+            makeZipProcess().environment != nil,
+            """
+            makeZipProcess() left `environment` nil, so Process.run() will read the global \
+            environ itself — the unsynchronized read that segfaults against a concurrent \
+            setenv. This is the entire point of the factory.
+            """)
+    }
+
+    /// The control for the test above: a bare `Process` really does start with
+    /// a nil environment, so "non-nil" is a property the factory supplies
+    /// rather than one Foundation was giving us anyway.
+    @Test func aBareProcessHasNoEnvironmentUntilItIsGivenOne() {
+        #expect(Process().environment == nil)
+    }
+
+    /// The snapshot is stable across calls, so two spawns cannot disagree
+    /// about the environment and no second read happens per spawn.
+    @Test func theSnapshotIsStableAcrossCalls() {
+        #expect(makeZipProcess().environment == makeZipProcess().environment)
+    }
+
+    /// It is a real inherited environment, not an empty dictionary — the
+    /// contents these spawns saw before the fix are preserved. `PATH` is set
+    /// in every environment this runs in (CI container, dev shell); if that
+    /// ever stops being true this wants relaxing, not deleting, because an
+    /// accidental `[:]` would change what the child sees.
+    @Test func theSnapshotCarriesTheInheritedEnvironment() throws {
+        let environment = try #require(makeZipProcess().environment)
+        guard ProcessInfo.processInfo.environment["PATH"] != nil else { return }
+        #expect(environment["PATH"] != nil, "the snapshot dropped the inherited environment")
+    }
+
+    /// Drift guard. A new `/usr/bin/zip` or `/usr/bin/unzip` call site that
+    /// constructs `Process()` directly silently opts back into the crash, and
+    /// every existing test still passes — which is how this class of defect
+    /// survives. Structural, not textual: it counts constructions against
+    /// factory calls per file rather than pattern-matching prose about them.
+    @Test func everyZipProcessSiteUsesTheFactory() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+
+        // The files that spawn /usr/bin/zip or /usr/bin/unzip. Listed rather
+        // than discovered because the rule is about those two executables, not
+        // about `Process` in general — the worker spawns interpreters through
+        // swift-subprocess and is not in scope.
+        let zipSpawningFiles = [
+            "Sources/Core/ZipArchiver.swift",
+            "Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift",
+            "Sources/APIServer/Helpers/NotebookContentHelpers.swift",
+        ]
+
+        for relativePath in zipSpawningFiles {
+            let source = try String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+            // `makeZipProcess()` contains `Process()` as a substring, so count
+            // constructions that are NOT preceded by an identifier character.
+            let bareConstructions = source.ranges(of: "Process()").filter { range in
+                guard range.lowerBound > source.startIndex else { return true }
+                let preceding = source[source.index(before: range.lowerBound)]
+                return !(preceding.isLetter || preceding.isNumber || preceding == "_")
+            }
+            #expect(
+                bareConstructions.isEmpty,
+                """
+                \(relativePath) constructs Process() directly \(bareConstructions.count) time(s). \
+                A zip/unzip spawn must use makeZipProcess(), or Process.run() reads the global \
+                environ and can segfault against a concurrent setenv — uncatchably, so the \
+                EFAULT retry does not save it. See docs/ci-flakiness.md Family 6.
+                """)
+            #expect(
+                source.contains("makeZipProcess()"),
+                "\(relativePath) no longer uses makeZipProcess() — did its zip spawn move?")
+        }
+    }
+}

--- a/changelog.d/zip-process-environ-race.md
+++ b/changelog.d/zip-process-environ-race.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **`api-tests` SIGSEGV in `Process.run()` reading the global environ.** Every
+  `/usr/bin/zip` and `/usr/bin/unzip` spawn left `Process.environment` nil, so
+  Foundation inherited by reading environ itself — an unsynchronized read of a
+  structure `setenv`/`unsetenv` reallocates, racing the three `APITests` suites
+  that mutate env. This is the same race `ZipProcessSerialization` already
+  mitigated in its *throwing* form (EFAULT, retried); in its user-space form it
+  is a bad pointer dereference that no retry can catch, and it killed a CI run
+  on 2026-08-09. All seven zip/unzip sites now build their process through
+  `makeZipProcess()`, which supplies an environment snapshot taken once per
+  process, so `run()` never performs the implicit read. Contents are unchanged;
+  only the number of racy reads is, from one per spawn to one per process.
+  `ZipProcessEnvironmentTests` fails on a bare `Process()` at any of those
+  sites — verified to bite by reverting one — since a new site would otherwise
+  opt back into the crash with every existing test still green. Recorded as
+  Family 6 in `docs/ci-flakiness.md`, with the note that the crashing thread,
+  not the first familiar name in the dump, is the one to read.

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -1,9 +1,15 @@
 # CI flakiness — state of knowledge (2026-07-02, last extended 2026-08-09)
 
 Handoff document for the flakiness work. Families 1–3 are the original
-2026-07-02 body; **Family 4 (2026-08-05) and Family 5 (2026-08-09) were added
-later**, so the header date is where this started, not where it ends. Check
-the newest families first — they are the ones still open.
+2026-07-02 body; **Families 4–6 were added later** (2026-08-05 and 2026-08-09),
+so the header date is where this started, not where it ends. Check the newest
+families first.
+
+Two of them are `api-tests` failures that look alike and are not: **Family 5**
+is a `cancelled` job at the timeout ceiling (starvation — tests still
+completing), **Family 6** is a hard SIGSEGV mid-run (an environ race in
+`Process.run()`). The conclusion string tells them apart before anything
+else does.
 
 The first snapshot (earlier on
 2026-07-02) was written while landing PRs #1138–#1142; the headline then:
@@ -445,6 +451,74 @@ regression in the change under test and is not one.
    than instead of it.
 3. **Finish the CLOEXEC sweep** on the three helpers above, closing the
    mechanism that turns a transient overload into a permanent one.
+
+---
+
+## Family 6 — `api-tests` SIGSEGV in `Process.run()` reading environ — ROOT-CAUSED & FIXED (2026-08-09)
+
+**Symptom.** `api-tests` fails (not `cancelled` — a real crash) partway
+through, with a Swift backtrace and no failing assertion:
+
+```
+*** Program crashed: Bad pointer dereference at 0x0000000000000210 ***
+Thread 5 crashed:
+  1  specialized _ProcessInfo.environment.getter  in libFoundationEssentials.so
+  2  Process.run()                                in libFoundation.so
+  3  runProcessWithEFAULTRetry(_:)                Sources/Core/ZipProcessSerialization.swift
+  4  closure #1 in listZipEntries(zipPath:)       Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+```
+
+**Read the crashing thread, not the first familiar name in the dump.** The
+same backtrace shows `WedgeWatchdog.monitorLoop` on another thread, sitting in
+`Thread.sleep` — that is the watchdog idling, not firing, and mistaking it for
+the cause costs a wrong diagnosis on a PR that did not touch either.
+
+**Root cause.** `Process.run()` with a **nil `environment`** inherits by
+reading the global environ itself. None of the zip/unzip spawns set
+`environment`, so every one of them was an unsynchronized *reader* of a
+structure `setenv`/`unsetenv` can reallocate. Three `APITests` suites
+(`OIDCTests`, `AuthModeGatingTests`, `AuditTockRegressionTests`) mutate env,
+and Swift Testing runs them concurrently with everything else.
+
+**Why the existing mitigation could not help.** This is the same race
+`ZipProcessSerialization.swift` was written for — its header documents
+`NSPOSIXErrorDomain Code=14 "Bad address"` (EFAULT) from `Process.run()` — but
+in its *uncatchable* form. When the kernel notices the bad address, `run()`
+throws EFAULT and `runProcessWithEFAULTRetry` absorbs it. When the read walks
+a reallocated environ in user space instead, the process takes a SIGSEGV and
+there is nothing to catch or retry. The retry covers exactly half the race,
+and the half it misses is the fatal one.
+
+`withAsyncEnvLock` did not cover it either, though its own header asks for
+precisely this: "every test that mutates env vars **and every helper that
+reads them** must go through it." A zip spawn is an *undeclared* reader — the
+read happens inside Foundation, not in any helper anyone thought to wrap.
+
+**The fix.** `makeZipProcess()` in `ZipProcessSerialization.swift` returns a
+`Process` with `environment` preset from a snapshot taken **once** per process
+(a `let`, initialized under `swift_once`). A non-nil `environment` is what
+stops `run()` performing the implicit read. Contents are unchanged from what
+these spawns inherited before; only the number of racy reads changes, from one
+per spawn to one per process. All seven zip/unzip sites across
+`Core/ZipArchiver`, `TestSetupZipHelpers` and `NotebookContentHelpers` use it.
+
+**The guard.** `ZipProcessEnvironmentTests.everyZipProcessSiteUsesTheFactory`
+fails on a bare `Process()` in any of those files, because a new site would
+silently opt back into the crash while every existing test still passed. It
+matches constructions **not** preceded by an identifier character, since
+`makeZipProcess()` contains `Process()` as a substring. Verified to bite by
+reverting one site: it fails naming the file and the count. A control test
+pins that a bare `Process` really does start with a nil environment, so
+"non-nil" is a property the factory supplies rather than one Foundation was
+giving us anyway.
+
+**Residual.** Only the zip/unzip paths are converted, because those are the
+ones observed crashing and the ones that run concurrently with env-mutating
+tests. Any *other* `Process` with a nil `environment` has the same exposure in
+principle. The worker's script execution goes through `swift-subprocess`, not
+Foundation `Process`, and is not affected. If this recurs from a different
+call site, the general fix is the same one applied wider — not another retry,
+which cannot work against a segfault.
 
 ---
 


### PR DESCRIPTION
Fixes the crash that killed `api-tests` on #1313's run — a diff that touched neither the crashing code nor anything it depends on.

## The failure

```
*** Program crashed: Bad pointer dereference at 0x0000000000000210 ***
Thread 5 crashed:
  1  specialized _ProcessInfo.environment.getter  libFoundationEssentials.so
  2  Process.run()                                libFoundation.so
  3  runProcessWithEFAULTRetry(_:)                Sources/Core/ZipProcessSerialization.swift
  4  closure #1 in listZipEntries(zipPath:)       Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
```

Not an assertion, not a timeout — a SIGSEGV mid-run.

## Root cause

`Process.run()` with a **nil `environment`** inherits by reading the global environ itself. None of the zip/unzip spawns set `environment`, so every one was an unsynchronized *reader* of a structure `setenv`/`unsetenv` reallocates. Three `APITests` suites (`OIDCTests`, `AuthModeGatingTests`, `AuditTockRegressionTests`) mutate env, and Swift Testing runs them concurrently with everything else.

**Why the existing mitigation could not help.** This is the same race `ZipProcessSerialization.swift` exists for — its header documents `NSPOSIXErrorDomain Code=14 "Bad address"` (EFAULT) from `Process.run()` — but in its uncatchable form. When the kernel notices the bad address, `run()` throws EFAULT and the retry absorbs it. When the read walks a reallocated environ in user space instead, the process takes a SIGSEGV. The retry covers exactly half the race and misses the fatal half.

`withAsyncEnvLock` missed it for a related reason. Its own header asks that "every test that mutates env vars **and every helper that reads them**" take the lock — but a zip spawn is an *undeclared* reader, since the read happens inside Foundation rather than in any helper anyone thought to wrap.

## The fix

`makeZipProcess()` returns a `Process` with `environment` preset from a snapshot taken **once** per process (a `let`, initialized under `swift_once`). Non-nil `environment` is what stops `run()` performing the implicit read. Contents are unchanged from what these spawns inherited before; only the number of racy reads changes, from one per spawn to one per process. All seven zip/unzip sites across `Core/ZipArchiver`, `TestSetupZipHelpers` and `NotebookContentHelpers` use it.

## The guard, verified to bite

A new bare `Process()` at one of those sites would silently opt back into the crash with every existing test still green. `ZipProcessEnvironmentTests.everyZipProcessSiteUsesTheFactory` fails on one — matching constructions **not** preceded by an identifier character, since `makeZipProcess()` contains `Process()` as a substring. Confirmed by reverting a site and re-running:

```
✘ Sources/Core/ZipArchiver.swift constructs Process() directly 1 time(s).
```

A control test pins that a bare `Process` really does start with a nil environment, so "non-nil" is a property the factory supplies rather than one Foundation was giving us anyway.

## Diagnosis note worth keeping

The same crash dump shows `WedgeWatchdog.monitorLoop` on another thread — **asleep in `Thread.sleep`, not firing.** I initially misread that as the cause, since the watchdog had just been armed in this lane one PR earlier. Family 6 records the lesson: read the crashing thread, not the first familiar name in the dump, or a PR that touched neither gets blamed.

## Also in here

`Sources/Core/PipeCloseOnExec.swift`'s comment still claimed a `Process` child "holds only fds 0/1/2". That measures false — other inherited descriptors do survive; only *our pipe's write end* doesn't, which is the narrower claim the test actually asserts. Corrected in the test header before #1309 merged, missed in the source copy.

## Residual, stated rather than fixed

Only the zip/unzip paths are converted — the ones observed crashing and the ones running concurrently with env-mutating tests. Any other Foundation `Process` with a nil `environment` has the same exposure in principle. The worker's script execution goes through `swift-subprocess`, not Foundation `Process`, and is unaffected.

## Verification

`scripts/lint.sh`, `scripts/swiftlint.sh` (`--strict`, 0 violations in 967 files), `scripts/no-new-xctest.sh`, `swift build --build-tests`, `CoreTests` 304/304, `APITests` 2741/2741 at CI's parallelism width — all green.

Note what this does **not** prove: the crash is a race observed once, so a green run is consistent with the fix and also with the race simply not firing. The argument that it is fixed is structural — the implicit per-spawn read is gone from these paths — not statistical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4dLGw94C2mGzveMq1MYNU)_