### PR TITLE
docs: record the drift theme #1253 surfaced

### DIFF
--- a/changelog.d/1253-drift-review-note.md
+++ b/changelog.d/1253-drift-review-note.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **`docs/leaf-decomposition-review.md` gained a section scoring #1253's four
+  landings against its own finding.** Each of the four was filed as a tidiness
+  task; three of the four stated rationales pointed somewhere other than the
+  defect, and in every case what a diff actually showed was two copies of one
+  thing that had drifted. The section records the corrected premises, the
+  rules worth carrying forward, and why the review's earlier "not planned"
+  call on `assignments.leaf` changed.

--- a/docs/leaf-decomposition-review.md
+++ b/docs/leaf-decomposition-review.md
@@ -303,6 +303,11 @@ tolerates the extra include.
 Sharing the files table, the page skeleton, or the seed tags; decomposing
 `assignments.leaf` or `admin.leaf` under this heading.
 
+> Superseded in part: `assignments.leaf` **was** decomposed, by #1311 under
+> #1253. Section 7 records why that call changed — the reason was not the Leaf
+> rule but a ~250-line duplication inside the file that had already drifted
+> into a user-visible defect.
+
 ---
 
 ## 6. Note for `CLAUDE.md`
@@ -312,3 +317,69 @@ UNBLOCKED", which reads as though a large decomposition is waiting. It is
 worth amending to say that the decomposition itself is roughly one partial,
 and that the substantive create-versus-edit drift is JavaScript. Otherwise
 the next person inherits the same overestimate this review was asked to check.
+
+---
+
+## 7. Scored against #1253 — the shape generalises
+
+Section 5's "Not planned" list says decomposing `assignments.leaf` is out of
+scope here. #1311 did it anyway, and *why* that call changed is the useful
+part.
+
+#1253 collected four code-shape follow-ups deferred from the 0.5 cleanup, and
+they were worked in sequence (#1311, #1312, #1314, #1315, #1317). Each was
+filed as a tidiness task with a stated rationale. In three of the four the
+stated rationale was wrong — and in all four, what a diff of the code actually
+showed was the same thing this review found in the create-versus-edit
+templates: **two copies of one thing, already drifted.**
+
+| #1253 item | Filed as | What diffing the copies showed |
+|---|---|---|
+| 2 — `assignments.leaf` | "the largest template with an unspent inline-`extend` budget (the LeafKit one-partial-per-template limit)" — the limit #1266 had already retired | The sections table and the ungrouped table were ~250 whitespace-identical lines. The ungrouped copy had lost the retest action from **all three** of its status branches and the copy-student-link button from the preview branch. Because the ungrouped table is also the flat-table mode used when a course has no sections, a course that never created one showed neither action on **any** assignment. |
+| 1 — draft-assignment parameter struct | "four sites thread the same wide parameter list; a save-context struct retires all four in one refactor" | Two unrelated clusters, not one list — two functions mirror a model's own initialiser and were left alone with their existing comments. But the two that *did* share fields each built the same `/instructor/new` query string in a **different field order**, and disagreed on whether an empty `error` was emitted or omitted. Retired 2 of 4, honestly. |
+| 3 — `applyPatternFamilies` | accurate as filed | Lifting phase 5 verbatim reproduced the same over-length violation one file over — a decomposition that moved the problem. Rebuilt as a builder type, which exposed that notebook-check emission was written out **twice** (authored pass and defensive pass) where the family emit path had already been factored into a shared helper for exactly that reason. The later phases held a second instance: the raw-entry list and the ordering list were built from two copies of the same nine-field `AuthoredRawScript` rewrite. |
+| 4 — claim evaluator | "nested in the routes struct… worth doing next time the claim logic changes anyway" | Not nested — file-private top-level types, which is the same problem stated differently. The value was not the relocation but the seam: injecting the claim step made reachable a branch `atomicallyClaimSubmission`'s own doc comment describes as impossible to trigger through the HTTP endpoint. |
+
+### What to carry forward
+
+- **Diff the copies before believing the ticket.** Three of four rationales
+  pointed somewhere other than the defect. The diff found it every time, and
+  it cost minutes.
+- **A verbatim extraction is not a decomposition.** Moving 135 lines into a
+  new file leaves 135 lines. If the lift does not also change the shape — state
+  onto a type, a loop into named steps — expect the linter to say so, and
+  prefer being told by the linter over shipping it.
+- **When two call sites do the same thing, delete one rather than parameterise
+  both.** The instinct to preserve each caller's existing output byte-for-byte
+  is what produced two query builders in the first place; field order in a
+  query string is not behaviour, and a test that pins it is pinning an
+  accident.
+- **Pick an acceptance criterion that is actually well-defined.** "Zero
+  manifest-byte change" is not: `makeWorkerManifestJSON` serializes
+  dictionaries, so JSON key order varies between runs and a byte diff reports
+  hundreds of differences between a build and itself. Parse and compare
+  structurally, preserving list order where order is meaningful.
+- **Search the structure, not the document.** The ungrouped drift survived
+  because any page-wide search for the retest action passes as soon as *one*
+  row has it. The guard added in #1311 slices each row out by its
+  `data-assignment-id` and asserts within it. This is the same lesson
+  `InstructorWorkbenchRoutesTests` records for form open tags.
+
+### Why this is a 0.5 theme
+
+0.5 is a consolidation era: one copy where there were two, an abstraction
+where one is available, and otherwise tightening the surface of features that
+have been accumulating since 0.1. The drift catalogued above is not
+carelessness — it is what a feature added twice looks like a year later, once
+each copy has been touched by a different change. The 0.5 boundary work
+already carries several instances of the same correction (`grading-shared.js`
+deduplicating the browser grading semantics, the second migration
+consolidation, the pre-0.5 shim removals), and #1253 is that pass applied to
+code shape rather than to subsystems.
+
+The practical consequence for anyone picking up a "cleanup" or "code shape"
+ticket: the ticket's stated reason is a starting hypothesis, not a finding.
+Diff the copies first. If they are identical, the consolidation is safe and
+cheap. If they are not, the difference is either a deliberate variation worth
+a parameter, or a bug — and it has been in production for as long as the
+copies have existed.


### PR DESCRIPTION
Docs only. Closes out #1253 after #1311, #1312, #1314, #1315 and #1317.

## Why here

`docs/leaf-decomposition-review.md` already documents this exact shape from #1269 — two copies of the same JavaScript where the create page was the stale fork. #1253's four items turned out to be four more instances, so the observation belongs beside the one it generalises rather than in a new file nobody will find.

## What the section says

Each of the four items was filed as a tidiness task with a stated rationale. **Three of the four rationales pointed somewhere other than the defect**, and in all four cases what a diff actually showed was two copies of one thing that had already drifted:

- **Item 2** was filed against an inline-`extend` budget under a LeafKit limit that #1266 had already retired. The real finding: ~250 duplicated lines in which the ungrouped table had lost the retest action from all three status branches and copy-link from one — and since that table is also the no-sections flat mode, a course that never created a section showed neither action on any assignment.
- **Item 1** was filed as one wide parameter list across four sites. It was two unrelated clusters — but the two that did overlap each built the same query string in a different field order and disagreed on empty-value handling.
- **Item 3** was accurate as filed, and still yielded two more instances: notebook-check emission written out twice where the family path had already been factored to avoid exactly that, and the raw-entry and ordering lists built from two copies of the same nine-field rewrite.
- **Item 4** was filed as "nested in the routes struct" (they were file-private top-level types) and rated as churn. Its value was the seam: injecting the claim step made testable a branch the code's own comment called untestable.

It then extracts five carry-forward rules. Two are worth calling out because they cost time this round and aren't obvious:

- **A verbatim extraction is not a decomposition.** Lifting one 135-line phase into a new file reproduced the same over-length violation one file over. The linter caught it; shipping it would have looked like progress.
- **"Zero byte change" is not a well-defined acceptance criterion** when the encoder serializes dictionaries — `makeWorkerManifestJSON` produces different key order between runs, so a byte diff reports hundreds of differences between a build and itself. Compare structurally, preserving list order where order is meaningful.

## Also corrected

Section 5's *Not planned* list said decomposing `assignments.leaf` was out of scope for the review. #1311 did it. Rather than delete the line, it now carries a note pointing at section 7 for why the call changed — the reason was not the Leaf rule.

## Framing

Written as the 0.5 consolidation theme: one copy where there were two, an abstraction where one is available, and otherwise tightening the surface of features accumulating since 0.1. It connects to the boundary work that already did this at subsystem level (`grading-shared.js`, the second migration consolidation, the pre-0.5 shim removals) and positions #1253 as the same pass applied to code shape.

The closing point is the operational one: a cleanup ticket's stated reason is a hypothesis, not a finding. Diff the copies first. If they differ, the difference is either a deliberate variation worth a parameter or a bug that has been shipping for as long as both copies existed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sew4JYA3L2zHhQLHi3MM3S)_