### PR TITLE
fix(ui): stop the authoring UI naming Python and C++ for every language

### DIFF
--- a/Public/authoring-language.js
+++ b/Public/authoring-language.js
@@ -28,6 +28,7 @@
         trueLiteral: 'True',
         falseLiteral: 'False',
         nullLiteral: 'None',
+        scriptExtension: 'py',
         functionScanning: true,
         expressionEvaluation: true,
         unsupportedCheckKinds: {}
@@ -52,6 +53,7 @@
             // No null token at all is a legitimate answer — C++ has no null
             // value, and its renderer emits a poison identifier rather than one.
             nullLiteral: parsed.nullLiteral || null,
+            scriptExtension: parsed.scriptExtension || PYTHON_FALLBACK.scriptExtension,
             functionScanning: parsed.functionScanning !== false,
             expressionEvaluation: parsed.expressionEvaluation !== false,
             unsupportedCheckKinds: parsed.unsupportedCheckKinds || {}
@@ -135,6 +137,34 @@
         return !name || name === 'python';
     }
 
+    /// The extension a new hand-written test should get: `py`, `R`, `lua`,
+    /// `m`, `rkt`, or `sh` for C++.
+    function scriptExtension() {
+        return facts().scriptExtension || 'py';
+    }
+
+    /// Whether scanning the solution notebook for function definitions can
+    /// work here at all.
+    ///
+    /// Read this BEFORE offering the scan, not after running it. The scan does
+    /// report its own reason when asked, but a control that invites a click and
+    /// then explains itself is worse than one that explains itself first.
+    function canScanFunctions() {
+        return facts().functionScanning !== false;
+    }
+
+    /// Whether a case's expected value can be computed by running the solution.
+    ///
+    /// True for all six languages today — every one has an interpreter on the
+    /// server image, so `PersonalizationEvaluator` can answer. It is read
+    /// rather than assumed because the failure it guards is silent: a seventh
+    /// language whose driver is not yet written reports false here, and an
+    /// unread flag would leave the editor auto-filling Expected cells from a
+    /// server that refuses.
+    function canEvaluateExpressions() {
+        return facts().expressionEvaluation !== false;
+    }
+
     global.ChickadeeLanguage = {
         isPython: isPython,
         facts: facts,
@@ -142,6 +172,9 @@
         label: label,
         scalarTokens: scalarTokens,
         matchScalarToken: matchScalarToken,
-        reprToJSON: reprToJSON
+        reprToJSON: reprToJSON,
+        scriptExtension: scriptExtension,
+        canScanFunctions: canScanFunctions,
+        canEvaluateExpressions: canEvaluateExpressions
     };
 })(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/Public/generated-starter-tests.js
+++ b/Public/generated-starter-tests.js
@@ -1,0 +1,179 @@
+// Chickadee — "Generate Starter Tests" panel on the new-assignment page.
+//
+// Scans the draft's solution notebook for function definitions, lists them as
+// checkboxes, and writes one generated test script per checked function into
+// the draft suite.
+//
+// WHY IT LIVES HERE. It was ~90 lines of inline JS in `assignment-new.leaf`,
+// which is neither linted nor testable, and #1269 already established that the
+// create page's inline copies are where this codebase's stale forks accumulate.
+// `applyScanPayload` had been moved into `pattern-family-editor.js` for exactly
+// this reason; the caller stayed behind. Two of the three defects fixed in the
+// move were invisible from the template:
+//
+//   * the scan did not tell the server which language to read, so a declared-R
+//     assignment whose solution still carried a Python kernelspec scanned as
+//     Python and listed functions no generated test could be written for;
+//   * the generate step filtered its work list to empty on any non-Python
+//     assignment and then reported "N test file(s) added to suite." from the
+//     count of files it had NOT written.
+//
+// Config is passed in rather than read from globals, so the page's Leaf
+// conditionals (is there a draft? is there a solution notebook?) stay in the
+// template where they belong:
+//
+//   csrfToken          string
+//   draftID            string | null   — null before the first notebook upload
+//   solutionNotebookURL string | null  — the draft's saved solution, when it has one
+
+(function (global) {
+    'use strict';
+
+    /// Wires the panel. Safe to call on a page that does not render it.
+    function initGeneratedStarterTests(config) {
+        var cfg = config || {};
+        var csrfToken = cfg.csrfToken;
+
+        var scanBtn        = document.getElementById('scan-solution-btn');
+        var scanStatus     = document.getElementById('scan-status');
+        var scanResults    = document.getElementById('scan-results');
+        var fnChecklist    = document.getElementById('fn-checklist');
+        var genTplSelect   = document.getElementById('gen-template-select');
+        var addGenTestsBtn = document.getElementById('add-gen-tests-btn');
+        var genPanel       = document.getElementById('gen-tests-panel');
+
+        if (!scanBtn && !addGenTestsBtn) return;
+
+        var scannedFunctions = [];
+
+        if (cfg.solutionNotebookURL && genPanel) genPanel.style.display = '';
+
+        function setStatus(text) { if (scanStatus) scanStatus.textContent = text; }
+
+        /// The template the scan already rendered for this function, or a
+        /// placeholder when the scan carried none.
+        function generatedTemplate(type, fnName) {
+            var fn = scannedFunctions.find(function (f) { return f.name === fnName; });
+            if (fn && Array.isArray(fn.templates)) {
+                var key = type.indexOf(':') === -1 ? type : type.split(':')[1];
+                var tpl = fn.templates.find(function (t) { return t.id === key; });
+                if (tpl && typeof tpl.content === 'string') return tpl.content;
+            }
+            return '# Test: ' + fnName + '\n# TODO: implement test\npassed("placeholder")\n';
+        }
+
+        function runScan(notebookText) {
+            setStatus('Scanning…');
+            if (scanResults) scanResults.style.display = 'none';
+            // Tell the server which language to read, as the family editor's
+            // scan does. Without it the endpoint falls back to the notebook's
+            // own kernelspec — a better default than assuming Python, but not
+            // the assignment's declared answer.
+            var scanLanguage = global.ChickadeeLanguage.facts().name;
+            var scanURL = '/instructor/scan-notebook'
+                + (scanLanguage ? '?language=' + encodeURIComponent(scanLanguage) : '');
+            return fetch(scanURL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken },
+                body: notebookText
+            })
+            .then(function (r) { return r.ok ? r.json() : Promise.reject(r.statusText); })
+            .then(function (payload) {
+                // Shared with the family editor, so the "we cannot read this
+                // language" message is written once. It clears the checklist on
+                // an unsupported language, which is what stops the generate
+                // step below from ever being reachable there.
+                scannedFunctions = global.chickadeeApplyScanPayload(payload,
+                    { status: scanStatus, checklist: fnChecklist, results: scanResults });
+                return scannedFunctions;
+            })
+            .catch(function (err) { setStatus('Scan failed: ' + err); return []; });
+        }
+
+        if (scanBtn) {
+            scanBtn.addEventListener('click', function () {
+                var solInput = document.getElementById('solution-notebook-file-input');
+                var hasUpload = solInput && solInput.files.length > 0;
+                if (!hasUpload && cfg.solutionNotebookURL) {
+                    fetch(cfg.solutionNotebookURL, { headers: { 'x-csrf-token': csrfToken } })
+                        .then(function (r) { return r.ok ? r.text() : Promise.reject(r.statusText); })
+                        .then(function (text) { runScan(text); })
+                        .catch(function (err) { setStatus('Scan failed: ' + err); });
+                    return;
+                }
+                if (!hasUpload) {
+                    setStatus('Upload a solution notebook first.');
+                    return;
+                }
+                var reader = new FileReader();
+                reader.onload = function (e) { runScan(e.target.result); };
+                reader.readAsText(solInput.files[0]);
+            });
+        }
+
+        if (addGenTestsBtn) {
+            addGenTestsBtn.addEventListener('click', function () {
+                if (!cfg.draftID) {
+                    setStatus('Upload a notebook first to start a draft.');
+                    return;
+                }
+                var tplType = genTplSelect ? genTplSelect.value : 'py:correctness';
+                var checked = fnChecklist
+                    ? Array.prototype.slice.call(
+                        fnChecklist.querySelectorAll('input[type=checkbox]:checked'))
+                    : [];
+                if (checked.length === 0) {
+                    setStatus('Select at least one function.');
+                    return;
+                }
+                // REFUSE OUT LOUD. This used to filter the work list to empty
+                // on any non-Python assignment and then report success with
+                // `checked.length` — a count of files nobody wrote. The guard
+                // is right: these templates ARE Python and land under a `.py`
+                // name, which is a thing to keep out of another language's
+                // suite. Only its silence was wrong.
+                if (!global.ChickadeeLanguage.isPython()) {
+                    var langLabel = global.ChickadeeLanguage.label();
+                    setStatus('Generated starter tests are Python-only'
+                        + (langLabel ? ', and this is a ' + langLabel + ' assignment' : '')
+                        + '. Use "+ Add Test" in a section to add one by hand.');
+                    return;
+                }
+                setStatus('Saving ' + checked.length + ' test(s)…');
+                var ops = checked.map(function (chk) {
+                    var fnName = chk.value;
+                    return fetch('/instructor/new/draft/scripts?draftID='
+                        + encodeURIComponent(cfg.draftID), {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken },
+                        body: JSON.stringify({
+                            filename: 'test_' + fnName + '.py',
+                            content: generatedTemplate(tplType, fnName),
+                            tier: 'public',
+                            points: 1,
+                            isTest: true
+                        })
+                    }).then(function (r) {
+                        return r.ok
+                            ? r.json()
+                            : r.text().then(function (t) {
+                                return Promise.reject(t || ('HTTP ' + r.status));
+                            });
+                    }).then(function (data) {
+                        if (global.chickadeeAddExistingSuiteScript) {
+                            global.chickadeeAddExistingSuiteScript(data);
+                        }
+                    });
+                });
+                Promise.all(ops).then(function () {
+                    setStatus(checked.length + ' test file(s) added to suite.');
+                    if (scanResults) scanResults.style.display = 'none';
+                }).catch(function (err) {
+                    setStatus('Could not add generated tests: ' + err);
+                });
+            });
+        }
+    }
+
+    global.initGeneratedStarterTests = initGeneratedStarterTests;
+})(window);

--- a/Public/generated-starter-tests.js
+++ b/Public/generated-starter-tests.js
@@ -50,6 +50,20 @@
 
         function setStatus(text) { if (scanStatus) scanStatus.textContent = text; }
 
+        // Say up front that the scan cannot read this language, rather than
+        // running it and reporting "No functions found." — the same answer an
+        // empty solution gives, which is how an R author was left unable to
+        // tell a limitation from a mistake.  The server says as much when
+        // asked; asking requires clicking a button that looks like it works.
+        if (!global.ChickadeeLanguage.canScanFunctions()) {
+            var scanLabel = global.ChickadeeLanguage.label();
+            if (scanBtn) scanBtn.disabled = true;
+            setStatus('Scanning a solution for functions is Python-only'
+                + (scanLabel ? ', and this is a ' + scanLabel + ' assignment' : '')
+                + '. Use "+ Add Test" in a section to add a test by hand.');
+            return;
+        }
+
         /// The template the scan already rendered for this function, or a
         /// placeholder when the scan carried none.
         function generatedTemplate(type, fnName) {

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -1931,6 +1931,14 @@
 
         function autoComputeRow(row) {
             if (!row || !row.parentElement) return;
+            // A language with no expression driver cannot answer this at all,
+            // and the failure would be silent in the worst direction: the row
+            // sits empty, or the server refuses and the instructor reads it as
+            // a bug in their solution.  True for all six languages today —
+            // every one has an interpreter on the server image — so this reads
+            // the fact rather than assuming it, which is the whole point of the
+            // fact existing.
+            if (!ChickadeeLanguage.canEvaluateExpressions()) return;
             // Variable-equality families don't call a function — skip.
             if (kindInput && kindInput.value === 'variable_equality') return;
             // Return-type-check expected is a type name (e.g. "DataFrame"),

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -220,6 +220,18 @@
             return noopAPI();
         }
 
+        // Name the assignment's language in the variables table header.  The
+        // static markup reads "Value (JSON or literal)" so the page is honest
+        // before this runs; it said "Python literal" to R, Lua, Octave, C++ and
+        // Racket authors, the same defect the "Python default" placeholder
+        // below had — missed because this instance lives in Leaf, not here.
+        (function () {
+            var valueHeader = document.getElementById('family-variable-value-header');
+            if (valueHeader && languageLabel()) {
+                valueHeader.textContent = 'Value (JSON / ' + languageLabel() + ' literal)';
+            }
+        })();
+
         var editingIndex = -1;   // index in familiesState; -1 when creating.
         // The modal no longer asks for tier/points — the suite table row owns
         // those.  On edit we keep the family's existing values; on create we

--- a/Public/test-renderer-check.js
+++ b/Public/test-renderer-check.js
@@ -52,6 +52,9 @@
         if (field.control === 'checkbox') {
             var cb = el('input', { type: 'checkbox', 'data-field': field.name });
             if (field.defaultChecked) cb.checked = true;
+            // Unusable in this language: uncheckable, and never checked by
+            // default, so the value the form reads back is the one that saves.
+            if (field.unsupportedReason) { cb.disabled = true; cb.checked = false; }
             return cb;
         }
         var input = el('input', {
@@ -67,9 +70,16 @@
     }
 
     function renderField(field) {
-        var help = field.help ? (function () {
+        // A field this assignment's language cannot use is DISABLED and
+        // explained, not hidden. The reason comes from the same predicate the
+        // save-time refusal reads, so an instructor cannot be told one thing
+        // here and another on save -- which is exactly what happened to a Lua
+        // author ticking `cell_contains` regex, whose save was guaranteed to
+        // fail with a message they only saw afterwards.
+        var reasonText = field.unsupportedReason || null;
+        var help = (field.help || reasonText) ? (function () {
             var p = el('p', { 'class': 'card-meta' }, 'font-size:.72rem;margin:0');
-            p.textContent = field.help;
+            p.textContent = reasonText || field.help;
             return p;
         })() : null;
         if (field.control === 'checkbox') {
@@ -118,6 +128,13 @@
 
     function writeField(control, field, value) {
         var vt = field.valueType;
+        // A stored value for a field this language cannot use does not get
+        // restored into a disabled control -- that would produce a check the
+        // instructor can neither save (the server refuses it) nor fix (the
+        // control is disabled). Clearing it makes re-saving the recovery path,
+        // and the reason is displayed directly beneath. Reachable for a check
+        // authored before its language was declared, or carried in by a clone.
+        if (field.unsupportedReason) { defaultField(control, field); return; }
         if (vt === 'bool') { control.checked = (value != null) ? !!value : !!field.defaultChecked; return; }
         if (vt === 'enum') { control.value = (value != null) ? value : (field.defaultValue || ''); return; }
         if (vt === 'stringList' || vt === 'numberList') { control.value = Array.isArray(value) ? value.join('\n') : ''; return; }
@@ -126,8 +143,11 @@
     }
 
     function defaultField(control, field) {
-        if (field.control === 'checkbox') { control.checked = !!field.defaultChecked; return; }
-        control.value = field.defaultValue || '';
+        if (field.control === 'checkbox') {
+            control.checked = field.unsupportedReason ? false : !!field.defaultChecked;
+            return;
+        }
+        control.value = field.unsupportedReason ? '' : (field.defaultValue || '');
     }
 
     function generateID(kind, name) {

--- a/Public/test-renderer-script.js
+++ b/Public/test-renderer-script.js
@@ -30,8 +30,24 @@ import {
 (function (global) {
     'use strict';
 
-    var TEMPLATE_OPTIONS = [
-        { group: 'Python', items: [
+    // Which template groups an assignment may pick from.
+    //
+    // The Python group is Python-only, and used not to be gated at all: an
+    // Octave author opened "Write a custom script" — advertised in the Add Test
+    // catalog as "your assignment's language, or .sh" — and was offered nine
+    // Python templates and a `test_correctness.py` filename. Applying one wrote
+    // Python into an Octave suite.
+    //
+    // The Shell group is offered everywhere because it IS everywhere: `.sh` is
+    // the universal test-script contract, and a shell test is a legitimate
+    // thing to hand-write in any assignment.
+    //
+    // The other five languages have no template set. That is an authoring gap,
+    // not a structural one — writing pedagogically sound R/Lua/Octave/C++/
+    // Racket equivalents of these nine is content work. Until they exist the
+    // picker offers Shell and Blank, and Blank opens an empty file with the
+    // assignment's own extension, which is the honest answer.
+    var PYTHON_TEMPLATE_GROUP = { group: 'Python', items: [
             { value: 'py:exists', label: 'Function Exists' },
             { value: 'py:correctness', label: 'Correctness (input/output pairs)' },
             { value: 'py:corner_cases', label: 'Corner Cases' },
@@ -41,17 +57,42 @@ import {
             { value: 'py:differential', label: 'Differential (reference solution)' },
             { value: 'py:variable_equality', label: 'Variable Equality' },
             { value: 'py:structural_check', label: 'Structural Check (AST properties)' }
-        ] },
-        { group: 'Shell', items: [
-            { value: 'sh:always_pass', label: 'Always Pass (placeholder)' },
-            { value: 'sh:file_exists', label: 'File Exists Check' },
-            { value: 'sh:command_output', label: 'Command Output Check' }
-        ] }
-    ];
+    ] };
+
+    var SHELL_TEMPLATE_GROUP = { group: 'Shell', items: [
+        { value: 'sh:always_pass', label: 'Always Pass (placeholder)' },
+        { value: 'sh:file_exists', label: 'File Exists Check' },
+        { value: 'sh:command_output', label: 'Command Output Check' }
+    ] };
+
+    /// The groups this assignment may pick from, in menu order.
+    function templateGroups() {
+        var language = global.ChickadeeLanguage;
+        if (!language || language.isPython()) {
+            return [PYTHON_TEMPLATE_GROUP, SHELL_TEMPLATE_GROUP];
+        }
+        return [SHELL_TEMPLATE_GROUP];
+    }
+
+    /// The extension a new test file gets when the instructor has not named
+    /// one, and the extension a chosen template forces.
+    ///
+    /// `sh:` templates are shell whatever the assignment is. Everything else
+    /// takes the assignment's own extension, which for C++ is `sh` too — its
+    /// test cases are shell wrappers, so there is no contradiction to resolve.
+    function extensionFor(templateKey) {
+        if ((templateKey || '').split(':')[0] === 'sh') return 'sh';
+        var language = global.ChickadeeLanguage;
+        return language ? language.scriptExtension() : 'py';
+    }
 
     function cfg() { return global.ChickadeeScriptRendererConfig || {}; }
 
     var langComp = new Compartment();
+    /// Syntax highlighting for the open file. Python, R and shell are the three
+    /// modes the vendored CodeMirror bundle carries; `.lua`, `.m` and `.rkt`
+    /// fall back to shell highlighting, which is wrong but harmless — adding
+    /// their modes means re-vendoring `Public/vendor/codemirror.js`.
     function langExtensionFor(filename) {
         var ext = (filename || '').split('.').pop().toLowerCase();
         if (ext === 'py') return python();
@@ -121,7 +162,10 @@ import {
             newControls = el('div', null, 'display:flex;flex-direction:column;gap:.5rem');
             var nameLabel = el('label', null, 'font-size:.85rem;display:flex;flex-direction:column;gap:.2rem');
             nameLabel.appendChild(document.createTextNode('Filename'));
-            nameInput = el('input', { type: 'text', 'class': 'form-input', placeholder: 'e.g. test_correctness.py' }, 'padding:.3rem .5rem;font-size:.85rem');
+            nameInput = el('input', {
+                type: 'text', 'class': 'form-input',
+                placeholder: 'e.g. test_correctness.' + extensionFor(null)
+            }, 'padding:.3rem .5rem;font-size:.85rem');
             nameLabel.appendChild(nameInput);
             newControls.appendChild(nameLabel);
 
@@ -130,7 +174,7 @@ import {
             tplCaption.textContent = 'Template:';
             tplRow.appendChild(tplCaption);
             templateSel = el('select', { 'class': 'form-input' }, 'padding:.25rem .5rem;font-size:.8rem;max-width:28rem');
-            TEMPLATE_OPTIONS.forEach(function (g) {
+            templateGroups().forEach(function (g) {
                 var og = el('optgroup', { label: g.group });
                 g.items.forEach(function (it) { var o = el('option', { value: it.value }); o.textContent = it.label; og.appendChild(o); });
                 templateSel.appendChild(og);
@@ -166,21 +210,20 @@ import {
             metaRow.appendChild(limitLabel);
             bodyEl.appendChild(metaRow);
 
-            // Keep the filename extension in sync with the chosen template lang.
+            // Keep the filename extension in sync with the chosen template.
+            // "Blank" leaves a name the instructor has already typed alone —
+            // it carries no language of its own.
             templateSel.addEventListener('change', function () {
-                var lang = (templateSel.value || '').split(':')[0];
+                var key = templateSel.value || '';
                 var name = (nameInput.value || '').trim();
-                if (!name) return;
-                var stem = name.replace(/\.[^.]*$/, '');
-                if (lang === 'py') nameInput.value = stem + '.py';
-                if (lang === 'sh') nameInput.value = stem + '.sh';
+                if (!name || key === 'blank') return;
+                nameInput.value = name.replace(/\.[^.]*$/, '') + '.' + extensionFor(key);
             });
             applyBtn.addEventListener('click', function () {
                 var tplKey = templateSel ? templateSel.value : 'blank';
                 var apply = function (content) {
                     if (!nameInput.value.trim()) {
-                        var lang = (tplKey || '').split(':')[0];
-                        nameInput.value = 'test_new.' + (lang === 'sh' ? 'sh' : 'py');
+                        nameInput.value = 'test_new.' + extensionFor(tplKey);
                     }
                     if (view) {
                         view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: content } });

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -72,7 +72,7 @@
                         #endfor
                     </select>
                 </label>
-                <p class="card-meta fine-print">Chickadee normally works the language out from the starter notebook's kernel or a test script's extension. Declare it when there is nothing to work it out from — a suite made only of pattern families — or for C++, which has no notebook kernel and whose generated tests are shell wrappers. Declare it before adding pattern families or notebook checks: their filenames carry the language's extension, so it cannot be changed once they exist.</p>
+                <p class="card-meta fine-print">Chickadee normally works the language out from the starter notebook's kernel or a test script's extension. Declare it when there is nothing to work it out from — a suite made only of pattern families — or for C++, whose generated tests are shell wrappers carrying no language extension. #(uploadOnlyLanguagesProse) assignments are upload-only and have no notebook editor. Declare the language before adding pattern families or notebook checks: their filenames carry the language's extension, so it cannot be changed once they exist.</p>
                 <label class="form-label field-gap">
                     Submission Method
                     <select class="form-input" name="submissionMode" id="submissionModeSelect">

--- a/Resources/Views/_family-editor-body.leaf
+++ b/Resources/Views/_family-editor-body.leaf
@@ -68,14 +68,14 @@
                         <tr>
                             <th class="fv-valid-col" aria-label="Valid"></th>
                             <th class="fv-name-col">Name</th>
-                            <th>Value (JSON / Python literal)</th>
+                            <th id="family-variable-value-header">Value (JSON or literal)</th>
                             <th class="fv-action-col"></th>
                         </tr>
                     </thead>
                     <tbody id="family-variables-body"></tbody>
                 </table>
                 <p class="card-meta family-empty-note" id="family-variables-empty">
-                    Define a name and a value (e.g. a dict or list) once; reference it from any arg cell by typing <code>$name</code>.  Locked rows come from the section's shared inputs (edit in the section's Inputs table).
+                    Define a name and a value (e.g. a list or a mapping) once; reference it from any arg cell by typing <code>$name</code>.  Locked rows come from the section's shared inputs (edit in the section's Inputs table).
                 </p>
             </div>
 

--- a/Resources/Views/_notebook-body.leaf
+++ b/Resources/Views/_notebook-body.leaf
@@ -131,7 +131,7 @@
 <div id="nb-device-warning" class="nb-device-warning" role="note" hidden>
     <span class="nb-device-warning-text">
         This device may be low on memory for the in-browser editor. If the
-        notebook gets slow or the Python kernel stops, try a laptop or desktop
+        notebook gets slow or the kernel stops, try a laptop or desktop
         in Chrome or Firefox.
     </span>
     <button type="button" id="nb-device-warning-dismiss" class="nb-device-warning-dismiss" aria-label="Dismiss this notice">&times;</button>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -61,7 +61,7 @@ Create Assignment
                     </select>
                 </label>
             </div>
-            <p class="card-meta fine-print">Every generated test renders in this language, so it is stated here rather than worked out later. Pick "None" for a suite of plain shell scripts. Choosing C++ makes the assignment upload-only, since C++ has no notebook editor.</p>
+            <p class="card-meta fine-print">Every generated test renders in this language, so it is stated here rather than worked out later. Pick "None" for a suite of plain shell scripts. Choosing #(uploadOnlyLanguagesProse) makes the assignment upload-only, since those languages have no notebook editor.</p>
             <div id="uw-date-warning" class="card-meta date-warning" style="display:none"></div>
             <p id="grading-mode-hint" class="card-meta grading-mode-hint" style="display:none"></p>
         </div>
@@ -195,7 +195,7 @@ Create Assignment
         <label class="req-field">
             Languages
             <input class="form-input input-sm" type="text" name="requiredLanguagesCSV" value="#(requiredLanguagesCSV)"
-                   placeholder="e.g. python, r, lua, octave, cpp, racket">
+                   placeholder="e.g. #(languageTokensCSV)">
         </label>
         <label class="req-field">
             Capabilities
@@ -416,16 +416,17 @@ Create Assignment
      mode a ReferenceError, so its POST never went out at all. -->
 #endif
 
+<!-- The Generate Starter Tests panel.  Loaded unconditionally, because the
+     panel's own init is in the form-level block below and runs whether or not
+     a draft exists yet — with no draft it reports that one is needed. -->
+<script src="/generated-starter-tests.js?v=#appVersion()"></script>
+
 <!-- ── Form-level helpers (notebook upload, gen-tests, UW dates) ────────── -->
 <script>
 (function () {
     'use strict';
 
     var csrfToken = ChickadeeUI.getCsrfToken();
-
-    // Shared implementations (Public/chickadee-ui.js, loaded from base.leaf).
-    var escHtml = ChickadeeUI.escapeHtml;
-    var escAttr = ChickadeeUI.escapeAttr;
 
     // ── Notebook upload buttons ────────────────────────────────────────
     // Open hidden file pickers, then submit the main form to the draft
@@ -539,107 +540,22 @@ Create Assignment
         });
     })();
 
-    // ── Generate Tests from Solution ──────────────────────────────────
-    // Each generated script is POSTed to the draft scripts endpoint and
-    // then handed to suite-table.js via `chickadeeAddExistingSuiteScript`
-    // so it appears in the appropriate section's tbody without a reload.
-    var scanBtn         = document.getElementById('scan-solution-btn');
-    var scanStatus      = document.getElementById('scan-status');
-    var scanResults     = document.getElementById('scan-results');
-    var fnChecklist     = document.getElementById('fn-checklist');
-    var genTplSelect    = document.getElementById('gen-template-select');
-    var addGenTestsBtn  = document.getElementById('add-gen-tests-btn');
-    var genPanel        = document.getElementById('gen-tests-panel');
-    var scannedFunctions = [];
-
-    #if(solutionNotebook):
-    if (genPanel) genPanel.style.display = '';
-    #endif
-
-    function genPyTemplate(type, fnName) {
-        var fn = scannedFunctions.find(function (f) { return f.name === fnName; });
-        if (fn && Array.isArray(fn.templates)) {
-            var key = type.indexOf(':') === -1 ? type : type.split(':')[1];
-            var tpl = fn.templates.find(function (t) { return t.id === key; });
-            if (tpl && typeof tpl.content === 'string') return tpl.content;
-        }
-        return '# Test: ' + fnName + '\n# TODO: implement test\npassed("placeholder")\n';
-    }
-
-    if (scanBtn) {
-        scanBtn.addEventListener('click', function () {
-            var solInput = document.getElementById('solution-notebook-file-input');
-            #if(solutionNotebook):
-            if (!solInput || solInput.files.length === 0) {
-                fetch('/instructor/new/draft/solution-notebook?draftID=#(draftID)', { headers: { 'x-csrf-token': csrfToken } })
-                    .then(function (r) { return r.ok ? r.text() : Promise.reject(r.statusText); })
-                    .then(function (text) { runScan(text); })
-                    .catch(function (err) { if (scanStatus) scanStatus.textContent = 'Scan failed: ' + err; });
-                return;
-            }
-            #endif
-            if (!solInput || solInput.files.length === 0) {
-                if (scanStatus) scanStatus.textContent = 'Upload a solution notebook first.';
-                return;
-            }
-            var reader = new FileReader();
-            reader.onload = function (e) { runScan(e.target.result); };
-            reader.readAsText(solInput.files[0]);
-        });
-    }
-
-    function runScan(notebookText) {
-        if (scanStatus) scanStatus.textContent = 'Scanning…';
-        if (scanResults) scanResults.style.display = 'none';
-        fetch('/instructor/scan-notebook', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken },
-            body: notebookText
-        })
-        .then(function (r) { return r.ok ? r.json() : Promise.reject(r.statusText); })
-        .then(function (payload) {
-            scannedFunctions = window.chickadeeApplyScanPayload(payload,
-                { status: scanStatus, checklist: fnChecklist, results: scanResults });
-        })
-        .catch(function (err) { if (scanStatus) scanStatus.textContent = 'Scan failed: ' + err; });
-    }
-
-    if (addGenTestsBtn) {
-        addGenTestsBtn.addEventListener('click', function () {
-            #if(draftID):
-            var draftID = #rawJSON(draftIDJSON);
-            if (!draftID) { if (scanStatus) scanStatus.textContent = 'No draft to save into.'; return; }
-            var tplType = genTplSelect ? genTplSelect.value : 'py:correctness';
-            var checked = Array.from(fnChecklist.querySelectorAll('input[type=checkbox]:checked'));
-            if (checked.length === 0) { if (scanStatus) scanStatus.textContent = 'Select at least one function.'; return; }
-            if (scanStatus) scanStatus.textContent = 'Saving ' + checked.length + ' test(s)…';
-            // POST each generated script in series to the draft scripts
-            // endpoint, then hand it to suite-table.js for in-place add.
-            var ops = (window.ChickadeeLanguage.isPython() ? checked : []).map(function (chk) {
-                var fnName   = chk.value;
-                var content  = genPyTemplate(tplType, fnName);
-                var filename = 'test_' + fnName + '.py';
-                return fetch('/instructor/new/draft/scripts?draftID=' + encodeURIComponent(draftID), {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken },
-                    body: JSON.stringify({ filename: filename, content: content, tier: 'public', points: 1, isTest: true })
-                }).then(function (r) {
-                    return r.ok ? r.json() : r.text().then(function (t) { return Promise.reject(t || ('HTTP ' + r.status)); });
-                }).then(function (data) {
-                    if (window.chickadeeAddExistingSuiteScript) window.chickadeeAddExistingSuiteScript(data);
-                });
-            });
-            Promise.all(ops).then(function () {
-                if (scanStatus) scanStatus.textContent = checked.length + ' test file(s) added to suite.';
-                if (scanResults) scanResults.style.display = 'none';
-            }).catch(function (err) {
-                if (scanStatus) scanStatus.textContent = 'Could not add generated tests: ' + err;
-            });
-            #else:
-            if (scanStatus) scanStatus.textContent = 'Upload a notebook first to start a draft.';
-            #endif
-        });
-    }
+    // ── Generate Starter Tests ────────────────────────────────────────
+    // The flow itself lives in /generated-starter-tests.js so it is linted
+    // and testable; only the page's own facts are passed in from here.
+    initGeneratedStarterTests({
+        csrfToken: csrfToken,
+        #if(draftID):
+        draftID: #rawJSON(draftIDJSON),
+        #else:
+        draftID: null,
+        #endif
+        #if(solutionNotebook):
+        solutionNotebookURL: '/instructor/new/draft/solution-notebook?draftID=#(draftID)'
+        #else:
+        solutionNotebookURL: null
+        #endif
+    });
 
     // ── UWaterloo important-date proximity warning ────────────────────
     (function () {

--- a/Resources/Views/editor-reset.leaf
+++ b/Resources/Views/editor-reset.leaf
@@ -17,8 +17,8 @@ Reset notebook editor
         <h1>Editor reset</h1>
         <p class="reset-lead">
             Your browser&rsquo;s cached notebook-editor data has been cleared.
-            Reopen your assignment and the Python kernel will start from a clean
-            slate. Your submitted work is safe &mdash; only unsaved local edits
+            Reopen your assignment and the notebook kernel will start from a
+            clean slate. Your submitted work is safe &mdash; only unsaved local edits
             sitting in this browser were cleared, and you are still logged in.
         </p>
     </div>
@@ -29,7 +29,7 @@ Reset notebook editor
 #else:
     <h1>Reset the notebook editor</h1>
     <p class="reset-lead">
-        If the in-browser notebook editor keeps spinning and the Python kernel
+        If the in-browser notebook editor keeps spinning and the kernel
         never finishes loading, resetting clears the editor&rsquo;s cached data
         in <strong>this browser</strong> so it can boot from a clean slate. It is
         the same as &ldquo;Clear site data&rdquo; in your browser settings, scoped

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -248,8 +248,9 @@ enum MCPServerInstructions {
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \
         set_submission_mode (notebook editor vs upload-only hand-in), \
         set_assignment_language (declare \(MCPLanguageProse.tokens) — normally derived from the \
-        notebook kernel or a graded script's extension, but REQUIRED for cpp, which has neither an \
-        in-browser kernel nor a language-bearing script extension; a cpp assignment must be \
+        notebook kernel or a graded script's extension, but REQUIRED for \
+        \(LanguageProse.mustDeclareTokens), whose generated tests are shell wrappers carrying no \
+        language-bearing extension; a \(LanguageProse.uploadOnlyTokens) assignment must be \
         uploadOnly, and the language must be declared before any pattern family or notebook check \
         is authored), \
         set_time_limit (the assignment's default per-test timeout in seconds; a per-test \

--- a/Sources/APIServer/MCP/Protocol/MCPLanguageProse.swift
+++ b/Sources/APIServer/MCP/Protocol/MCPLanguageProse.swift
@@ -61,9 +61,11 @@ enum MCPLanguageProse {
     }
 
     /// `["a", "b", "c"]` → `"a, b or c"`; a one-element list is itself.
+    ///
+    /// Shared with `LanguageProse`, which renders the PREDICATE-defined subsets
+    /// (the upload-only languages, so far) this type's whole-catalog renderings
+    /// do not cover.
     private static func prose(_ items: [String]) -> String {
-        guard let last = items.last else { return "" }
-        guard items.count > 1 else { return last }
-        return items.dropLast().joined(separator: ", ") + " or " + last
+        LanguageProse.list(items)
     }
 }

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -70,8 +70,9 @@ struct CreateAssignmentTool: ContentTool {
                 "description": .string(
                     "The language this assignment is authored and graded in, or \"none\" for a suite "
                         + "of plain shell scripts. Required: the language is what every generated test "
-                        + "renders in, so it is stated rather than guessed. Declaring \"cpp\" also sets "
-                        + "submissionMode to uploadOnly, since C++ has no notebook workflow."),
+                        + "renders in, so it is stated rather than guessed. Declaring "
+                        + "\(LanguageProse.uploadOnlyTokens) also sets submissionMode to uploadOnly, "
+                        + "since those languages have no notebook workflow."),
             ]),
         ]),
         "required": .array([

--- a/Sources/APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetAssignmentLanguageTool.swift
@@ -40,12 +40,14 @@ struct SetAssignmentLanguageTool: ContentTool {
     static let name = "set_assignment_language"
     static let description =
         "Declare the language an assignment is authored and graded in by its public ID: "
-        + "\(MCPLanguageProse.tokens). For every language except cpp this is normally unnecessary — the "
+        + "\(MCPLanguageProse.tokens). For every language except "
+        + "\(LanguageProse.mustDeclareTokens) this is normally unnecessary — the "
         + "language is derived from the starter notebook's kernel or a graded script's extension — but "
         + "declaring it "
         + "pins a suite made only of pattern families, which has no script on disk to derive from. For "
-        + "cpp it is required: C++ has no in-browser kernel and its generated tests are extension-free "
-        + "shell wrappers, so nothing implies the language. A cpp assignment must already be uploadOnly "
+        + "\(LanguageProse.mustDeclareTokens) it is required: its generated tests are shell wrappers "
+        + "carrying no language extension, so nothing in the suite implies the language. A "
+        + "\(LanguageProse.uploadOnlyTokens) assignment must already be uploadOnly "
         + "(set_submission_mode) — this tool refuses otherwise. Because a language change rewrites every "
         + "generated filename, declare the language BEFORE authoring pattern families or notebook checks; "
         + "the tool refuses a change once generated tests exist. Read the current language from "
@@ -59,7 +61,8 @@ struct SetAssignmentLanguageTool: ContentTool {
                 "enum": .array(
                     AssignmentLanguage.allCases.map { .string($0.rawValue) }),
                 "description": .string(
-                    "The assignment's language. cpp additionally requires submissionMode uploadOnly."),
+                    "The assignment's language. \(LanguageProse.uploadOnlyTokens) additionally "
+                        + "require submissionMode uploadOnly."),
             ]),
         ]),
         "required": .array([.string("assignmentPublicID"), .string("language")]),

--- a/Sources/APIServer/MCP/Tools/SetSubmissionModeTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetSubmissionModeTool.swift
@@ -33,8 +33,9 @@ struct SetSubmissionModeTool: ContentTool {
     static let description =
         "Set how students hand work in for an assignment by its public ID: \"notebook\" (the embedded "
         + "editor, with the upload form beside it) or \"uploadOnly\" (file upload only, no editor). Use "
-        + "uploadOnly for a language with no in-browser kernel — C++ assignments must be uploadOnly, and "
-        + "set_assignment_language refuses C++ until they are. An uploadOnly assignment is always graded "
+        + "uploadOnly for a language with no in-browser kernel — \(LanguageProse.uploadOnlyTokens) "
+        + "assignments must be uploadOnly, and set_assignment_language refuses them until they are. "
+        + "An uploadOnly assignment is always graded "
         + "by the native worker, so switch the grading mode to \"worker\" first (set_grading_mode); this "
         + "tool refuses the browser combination rather than storing a value that could never execute. "
         + "Read the current mode from get_assignment."

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -91,6 +91,13 @@ struct NewAssignmentContext: Encodable {
     /// The required Language select's options, same builder the edit page
     /// uses. Declared at creation so nothing downstream has to derive it.
     let assignmentLanguageOptions: [AssignmentLanguageOption]
+    /// "C++ or Racket" — the languages whose assignments are upload-only,
+    /// derived so the fine print cannot name fewer of them than the rule
+    /// enforces. It named only C++ for the whole of Racket's existence.
+    let uploadOnlyLanguagesProse: String = LanguageProse.uploadOnlyDisplayNames
+    /// "python, r, lua, octave, cpp, racket" — the required-Languages input's
+    /// placeholder, derived for the same reason the select above it is.
+    let languageTokensCSV: String = LanguageProse.allTokensCSV
     let detectedLanguagesCSV: String
     let detectedCapabilitiesCSV: String
     let notice: String?
@@ -255,6 +262,10 @@ struct EditAssignmentContext: Encodable {
     /// the same discovered-not-enumerated rule the kernel-alias generator and
     /// the runner's capability probe follow.
     let assignmentLanguageOptions: [AssignmentLanguageOption]
+    /// "C++ or Racket" — see the identically-named field on
+    /// `NewAssignmentContext`. Both pages carry the same fine print and both
+    /// had gone stale the same way.
+    let uploadOnlyLanguagesProse: String = LanguageProse.uploadOnlyDisplayNames
     /// The per-assignment secret-reveal toggle: whether students may spend
     /// their one reveal token here.  Renders the "Student Options" checkbox.
     let secretRevealEnabled: Bool

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -50,6 +50,10 @@ extension DraftAssignmentRoutes {
         )
 
         let suiteRows = setup.map(editableSuiteRowsForSetup) ?? []
+        // Resolved once and handed to both language-bearing seeds below.
+        let resolvedLanguage = setup.flatMap { s in
+            s.decodedManifest().flatMap { AssignmentLanguage.resolve(for: s, manifest: $0) }
+        }
         let supportFileRows = newAssignmentSupportFileRows(setup: setup, suiteRows: suiteRows)
         let detected = newAssignmentRequirementSuggestions(req: req, userID: userID, setup: setup)
 
@@ -75,17 +79,12 @@ extension DraftAssignmentRoutes {
             supportFileRows: supportFileRows,
             patternFamiliesJSON: newAssignmentPatternFamiliesJSON(setup: setup),
             notebookChecksJSON: newAssignmentNotebookChecksJSON(setup: setup),
-            checkSchemaJSON: notebookCheckFormSchemaJSON(),
+            checkSchemaJSON: notebookCheckFormSchemaJSON(language: resolvedLanguage),
             // Same seed as the edit page, so the two authoring surfaces
             // cannot disagree about the language. A draft with no setup yet
             // has no language, which is the honest answer — its facts say so
             // and the editor omits the language-specific hints.
-            assignmentLanguageJSON: authoringLanguageFactsJSON(
-                setup.flatMap { s in
-                    s.decodedManifest().flatMap {
-                        AssignmentLanguage.resolve(for: s, manifest: $0)
-                    }
-                }),
+            assignmentLanguageJSON: authoringLanguageFactsJSON(resolvedLanguage),
             suiteStateJSON: newAssignmentSuiteStateSeedJSON(setup: setup),
             suiteSectionRows: newAssignmentSuiteSectionShellRows(setup: setup),
             sectionActionBase: "/instructor/new/draft/suite-sections",

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -617,20 +617,12 @@ struct InstructorDashboardRoutes: RouteCollection {
         let currentDueAt = dueAtLocalInputString(assignment.dueAt)
         let currentStartsAt = dueAtLocalInputString(assignment.startsAt)
         let manifest = setup.decodedManifest()
-        let patternFamiliesJSON: String = {
-            guard let props = manifest else { return "[]" }
-            let enc = JSONEncoder()
-            enc.outputFormatting = [.sortedKeys]
-            let familyData = (try? enc.encode(props.patternFamilies)) ?? Data("[]".utf8)
-            return String(data: familyData, encoding: .utf8) ?? "[]"
-        }()
-        let notebookChecksJSON: String = {
-            guard let props = manifest else { return "[]" }
-            let enc = JSONEncoder()
-            enc.outputFormatting = [.sortedKeys]
-            let checkData = (try? enc.encode(props.notebookChecks)) ?? Data("[]".utf8)
-            return String(data: checkData, encoding: .utf8) ?? "[]"
-        }()
+        // Resolved once and handed to both language-bearing seeds below.
+        let resolvedLanguage = manifest.flatMap {
+            AssignmentLanguage.resolve(for: setup, manifest: $0)
+        }
+        let patternFamiliesJSON = manifestArraySeedJSON(manifest?.patternFamilies)
+        let notebookChecksJSON = manifestArraySeedJSON(manifest?.notebookChecks)
         return EditAssignmentContext(
             currentUser: req.currentUserContext,
             assignmentID: idStr,
@@ -652,13 +644,15 @@ struct InstructorDashboardRoutes: RouteCollection {
             familyRows: familySuiteRowsForSetup(setup),
             patternFamiliesJSON: patternFamiliesJSON,
             notebookChecksJSON: notebookChecksJSON,
-            checkSchemaJSON: notebookCheckFormSchemaJSON(),
+            // Both seeds take the SAME resolved language, from one call — the
+            // check form annotates fields this language cannot use, and the
+            // facts island answers everything else.
+            checkSchemaJSON: notebookCheckFormSchemaJSON(language: resolvedLanguage),
             // The resolved language, so the authoring editors stop assuming
             // Python. Resolved through the server wrapper (never
             // `resolve(manifest:)` alone) so a brand-new notebook assignment
             // whose only signal is its kernelspec is answered correctly.
-            assignmentLanguageJSON: authoringLanguageFactsJSON(
-                manifest.flatMap { AssignmentLanguage.resolve(for: setup, manifest: $0) }),
+            assignmentLanguageJSON: authoringLanguageFactsJSON(resolvedLanguage),
             suiteStateJSON: suiteStateJSON(fromManifest: setup.manifest, zipPath: setup.zipPath),
             suiteSectionRows: suiteSectionShellRows(fromManifest: setup.manifest),
             sectionActionBase: "/instructor/\(idStr)/suite-sections",
@@ -690,4 +684,18 @@ struct InstructorDashboardRoutes: RouteCollection {
             // pane is already showing it.
         )
     }
+}
+
+/// One manifest array, encoded for a `<script>` JSON seed; `"[]"` for a
+/// missing manifest or an encode failure so the page still renders.
+///
+/// The pattern-family and notebook-check seeds were byte-identical closures
+/// differing only in which array they reached for.
+private func manifestArraySeedJSON<T: Encodable>(_ values: [T]?) -> String {
+    guard let values else { return "[]" }
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(values), let json = String(data: data, encoding: .utf8)
+    else { return "[]" }
+    return json
 }

--- a/Sources/APIServer/Utilities/AuthoringLanguageFacts.swift
+++ b/Sources/APIServer/Utilities/AuthoringLanguageFacts.swift
@@ -75,6 +75,18 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
     /// for Python, which supports all of them.
     let unsupportedCheckKinds: [String: String]
 
+    /// The extension a NEW hand-written test in this assignment should get.
+    ///
+    /// `generatedScriptExtension` is exactly the right answer, and not by
+    /// coincidence: it is each language's own extension except for C++, where
+    /// it is `sh` because the runner has no C++ build strategy and a C++ test
+    /// case is a shell wrapper. A hand-written test faces that same dispatch.
+    ///
+    /// The custom-script editor defaulted every filename to `.py` — offering an
+    /// Octave author `test_correctness.py` under a heading promising "your
+    /// assignment's language".
+    let scriptExtension: String?
+
     /// Whether the editor can compute a case's expected value by running the
     /// solution in the browser.
     ///
@@ -93,6 +105,7 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
             self.trueLiteral = nil
             self.falseLiteral = nil
             self.nullLiteral = nil
+            self.scriptExtension = nil
             self.functionScanning = false
             self.expressionEvaluation = false
             self.unsupportedCheckKinds = [:]
@@ -100,6 +113,7 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
         }
         self.name = language.rawValue
         self.displayName = language.displayName
+        self.scriptExtension = language.generatedScriptExtension
         self.trueLiteral = language.literal(.bool(true))
         self.falseLiteral = language.literal(.bool(false))
         // A language that has no null value gets NO null token. C++ is the one:

--- a/Sources/APIServer/Utilities/LanguageProse.swift
+++ b/Sources/APIServer/Utilities/LanguageProse.swift
@@ -1,0 +1,96 @@
+// APIServer/Utilities/LanguageProse.swift
+//
+// How a SET of assignment languages is spelled in copy a human or an agent
+// reads, derived from `AssignmentLanguage` rather than typed out.
+//
+// WHY THIS IS SEPARATE FROM `MCPLanguageProse`. That type renders one set — all
+// of them — three ways, and its guard (`MCPLanguageCoverageTests`) catches a
+// hand-typed list by comparing against the proper prefixes of `allCases`. That
+// guard deliberately ignores single-language mentions, because "a cpp
+// assignment must be uploadOnly" is legitimate prose and not a list.
+//
+// Which is exactly how the upload-only sentence went stale. C++ was the only
+// upload-only language when that copy was written; Racket made it two, the
+// enforcement predicate (`requiresUploadOnlySubmission`) picked the second one
+// up because it asks `editorSupport`, and four MCP tool descriptions plus both
+// authoring pages went on naming only C++. A Racket author was told nothing and
+// found out by being refused at save.
+//
+// So the general lesson is not "derive the full list" but "derive any list a
+// PREDICATE defines". This renders those, and the upload-only set is the first
+// caller. A seventh upload-only language changes every sentence below with no
+// edit to any of them.
+
+import Core
+
+/// Renders a predicate-defined set of languages as prose.
+enum LanguageProse {
+
+    /// The display names of every language satisfying `predicate`, as a
+    /// sentence fragment: `"C++ or Racket"`.
+    ///
+    /// Empty when nothing satisfies it — callers building a sentence around
+    /// this should check, since "" makes most sentences ungrammatical.
+    static func displayNames(where predicate: (AssignmentLanguage) -> Bool) -> String {
+        list(AssignmentLanguage.allCases.filter(predicate).map(\.displayName))
+    }
+
+    /// The wire tokens of every language satisfying `predicate`:
+    /// `"cpp or racket"`.
+    ///
+    /// Distinct from `displayNames(where:)` for the reason `MCPLanguageProse`
+    /// keeps the same split — an agent sends `cpp`, not `C++`.
+    static func tokens(where predicate: (AssignmentLanguage) -> Bool) -> String {
+        list(AssignmentLanguage.allCases.filter(predicate).map(\.rawValue))
+    }
+
+    /// The languages with no editor kernel, whose assignments must be
+    /// upload-only: `"C++ or Racket"` today.
+    ///
+    /// Reads the same `editorSupport` answer the save-time refusal reads, so
+    /// the explanation an instructor is given and the rule they are held to
+    /// cannot name different languages.
+    static var uploadOnlyDisplayNames: String {
+        displayNames(where: requiresUploadOnlySubmission)
+    }
+
+    /// `uploadOnlyDisplayNames` as wire tokens, for agent-facing copy.
+    static var uploadOnlyTokens: String {
+        tokens(where: requiresUploadOnlySubmission)
+    }
+
+    /// The languages whose language cannot be derived from their own suite, so
+    /// an author must declare it: `"cpp"` today.
+    ///
+    /// NOT the same set as the upload-only one, though C++ is in both and that
+    /// coincidence is what makes the two easy to conflate. This one is about
+    /// the generated FILENAME: a C++ test case is a shell wrapper, so the suite
+    /// carries no C++ extension to resolve from. Racket generates `.rkt` and is
+    /// perfectly derivable despite also being upload-only.
+    static var mustDeclareTokens: String {
+        tokens(where: { !$0.scriptExtensions.contains($0.generatedScriptExtension) })
+    }
+
+    /// `mustDeclareTokens` as display names.
+    static var mustDeclareDisplayNames: String {
+        displayNames(where: { !$0.scriptExtensions.contains($0.generatedScriptExtension) })
+    }
+
+    /// Every wire token, comma-separated with no connector:
+    /// `"python, r, lua, octave, cpp, racket"`.
+    ///
+    /// For an input PLACEHOLDER, where "or" would read as part of the example
+    /// rather than as prose. The runner-requirements input on the create page
+    /// spelled this list out by hand, directly below a select derived from
+    /// `allCases`.
+    static var allTokensCSV: String {
+        AssignmentLanguage.allCases.map(\.rawValue).joined(separator: ", ")
+    }
+
+    /// `["a", "b", "c"]` → `"a, b or c"`; a one-element list is itself.
+    static func list(_ items: [String]) -> String {
+        guard let last = items.last else { return "" }
+        guard items.count > 1 else { return last }
+        return items.dropLast().joined(separator: ", ") + " or " + last
+    }
+}

--- a/Sources/APIServer/Utilities/NotebookCheckFormSchema.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckFormSchema.swift
@@ -72,7 +72,7 @@ struct CheckFormField: Encodable {
     let name: String
     let control: CheckFormControl
     let valueType: CheckFormValueType
-    let label: String
+    var label: String
     var required: Bool = false
     var placeholder: String?
     var help: String?
@@ -83,6 +83,16 @@ struct CheckFormField: Encodable {
     /// Reset/default value for text/number/select controls (the literal the
     /// input is seeded with when authoring a brand-new check).
     var defaultValue: String?
+    /// Why this assignment's language cannot use this field, or nil when it
+    /// can. Set by `notebookCheckFormSchema(language:)` from
+    /// `notebookCheckFieldUnsupportedReason`, the same predicate the save-time
+    /// refusal reads, so the form and the rejection cannot disagree.
+    ///
+    /// The field is still RENDERED when this is set — disabled, with the reason
+    /// beside it. Hiding it would answer "why can I not do this here?" with
+    /// silence, which is the failure mode the kind-level version of this
+    /// already fixed.
+    var unsupportedReason: String?
 }
 
 /// The full schema: common fields rendered once for every kind, plus the
@@ -228,7 +238,7 @@ private let cellContainsFormFields: [CheckFormField] = [
         required: true, placeholder: ".groupby("),
     CheckFormField(
         name: "regex", control: .checkbox, valueType: .bool,
-        label: "Interpret as Python regex", defaultChecked: false),
+        label: "Interpret as a regular expression", defaultChecked: false),
     CheckFormField(
         name: "mustDifferFrom", control: .textarea, valueType: .optionalRawString,
         label:
@@ -279,21 +289,49 @@ private let astStructureFormFields: [CheckFormField] = [
 
 /// The complete schema, built by mapping every `NotebookCheckKind` to its
 /// declared fields plus the common fields.
-func notebookCheckFormSchema() -> NotebookCheckFormSchema {
+///
+/// `language` annotates fields their language cannot use, and names the
+/// language in labels that used to name Python. Pass nil for an assignment that
+/// declares no language: nothing is annotated, which is the pre-language
+/// behaviour and the right answer for a plain `.sh` suite.
+func notebookCheckFormSchema(language: AssignmentLanguage? = nil) -> NotebookCheckFormSchema {
     var kinds: [String: [CheckFormField]] = [:]
     for kind in NotebookCheckKind.allCases {
-        kinds[kind.rawValue] = formFields(for: kind)
+        kinds[kind.rawValue] = formFields(for: kind).map { field in
+            var annotated = field
+            annotated.label = localizedLabel(field, kind: kind, language: language)
+            if let language {
+                annotated.unsupportedReason = notebookCheckFieldUnsupportedReason(
+                    field.name, kind: kind, language: language)
+            }
+            return annotated
+        }
     }
     return NotebookCheckFormSchema(common: commonCheckFormFields, kinds: kinds)
+}
+
+/// A field label with the assignment's language in it where the label names a
+/// language at all.
+///
+/// One field does: the `cell_contains` regex checkbox read "Interpret as Python
+/// regex" on R and Octave assignments, whose engines are their own. The rest are
+/// returned unchanged, so this is a rewrite point rather than a second label
+/// table.
+private func localizedLabel(
+    _ field: CheckFormField, kind: NotebookCheckKind, language: AssignmentLanguage?
+) -> String {
+    guard kind == .cellContains, field.name == "regex" else { return field.label }
+    guard let language else { return "Interpret as a regular expression" }
+    return "Interpret as a \(language.displayName) regular expression"
 }
 
 /// The schema serialised to a JSON object literal for the
 /// `<script id="check-schema">` seed.  `"{}"` on the (unreachable) encode
 /// failure so the page still renders.
-func notebookCheckFormSchemaJSON() -> String {
+func notebookCheckFormSchemaJSON(language: AssignmentLanguage? = nil) -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.sortedKeys]
-    guard let data = try? encoder.encode(notebookCheckFormSchema()),
+    guard let data = try? encoder.encode(notebookCheckFormSchema(language: language)),
         let json = String(data: data, encoding: .utf8)
     else { return "{}" }
     return json

--- a/Sources/APIServer/Utilities/NotebookCheckValidator.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckValidator.swift
@@ -129,6 +129,38 @@ func notebookCheckKindUnsupportedReason(
     }
 }
 
+/// Why `language` cannot use the form field `field` on `kind`, or nil when it
+/// can.
+///
+/// The FIELD-level sibling of `notebookCheckKindUnsupportedReason`, and it
+/// exists because a kind being available does not make all of its options
+/// available. `cellContains` is supported on Lua; `cellContains` with
+/// `regex: true` is not, and that refusal lived only at save time — the kind
+/// map the Add Test menu reads is keyed by kind, so nothing could express it.
+/// A Lua author ticked a box whose save was guaranteed to fail. That is the
+/// same discoverability defect #1290 fixed one level up, one level down.
+///
+/// Returns nil for every other field, and is asked generically by the form
+/// schema builder so a second field-level refusal has somewhere to go.
+func notebookCheckFieldUnsupportedReason(
+    _ field: String, kind: NotebookCheckKind, language: AssignmentLanguage
+) -> String? {
+    guard kind == .cellContains, field == "regex" else { return nil }
+    switch language {
+    case .python, .r, .octave, .cpp, .racket:
+        // R and Octave both take a pattern authored against the Python
+        // renderer: Octave's regexp is PCRE (verified against octave-cli
+        // before claiming it) and R's engine accepts the same constructs.
+        // C++ and Racket never reach here — the kind itself is refused.
+        return nil
+    case .lua:
+        return "Lua patterns are not compatible with the regular expressions the Python and R "
+            + "renderers use — no alternation, no {n,m}, %d for \\d — so a pattern authored "
+            + "against them would not error under Lua, it would quietly match the wrong thing. "
+            + "Turn regex off to match the text literally."
+    }
+}
+
 /// Reject a kind with no renderer in this assignment's language at save time.
 /// Rendering Python for an R assignment would emit a `.py` script the R suite
 /// can never run, and the failure would surface as a confusing grading error
@@ -150,21 +182,25 @@ private func validateKindSupport(_ check: NotebookCheck, language: AssignmentLan
                 check, language: "Lua", supports: notebookCheckKindSupportsLua,
                 handWrittenExtension: ".lua")
         }
-        // Regex cell-matching is rejected here rather than approximated in
-        // the renderer. Lua patterns are a different language from PCRE —
-        // no alternation, no `{n,m}`, `%d` for `\d` — so a pattern authored
-        // against the Python or R renderer would not error under Lua, it
-        // would quietly match the wrong thing and award marks on that
-        // basis. Telling the instructor at save time is the only point at
-        // which this is fixable.
-        if check.kind == .cellContains, check.regex == true {
+        // Regex cell-matching is rejected rather than approximated in the
+        // renderer: a pattern authored against the Python or R renderer would
+        // not error under Lua, it would quietly match the wrong thing and
+        // award marks on that basis.
+        //
+        // The REASON now comes from `notebookCheckFieldUnsupportedReason`, so
+        // the authoring form can disable the checkbox with the same words this
+        // refusal uses. Save time used to be the only point at which an
+        // instructor learned this, which made it the only point at which it was
+        // fixable — after they had written the pattern.
+        if check.regex == true,
+            let reason = notebookCheckFieldUnsupportedReason(
+                "regex", kind: check.kind, language: .lua)
+        {
             throw Abort(
                 .unprocessableEntity,
                 reason:
-                    "Notebook check '\(check.id)' (cell_contains) uses regex matching, which is not "
-                    + "available for Lua assignments: Lua patterns are not compatible with the "
-                    + "regular expressions the Python and R renderers use. Turn regex off to match "
-                    + "the text literally."
+                    "Notebook check '\(check.id)' (\(check.kind.rawValue)) uses regex matching, "
+                    + "which is not available for Lua assignments: \(reason)"
             )
         }
     case .octave:

--- a/Tests/APITests/AuthoringLanguageFactsTests.swift
+++ b/Tests/APITests/AuthoringLanguageFactsTests.swift
@@ -133,6 +133,26 @@ import Testing
         }
     }
 
+    /// The extension a new hand-written test gets is the language's own, and
+    /// is derived rather than tabulated.
+    ///
+    /// `generatedScriptExtension` is the right owner, and C++ is why: its test
+    /// cases are shell wrappers, so the answer there is `sh` and not `cpp`, and
+    /// a hand-written C++ test faces exactly the same runner dispatch. Reading
+    /// any other source — `scriptExtensions.first`, a table here — would offer
+    /// an extension the runner does not execute.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theNewScriptExtensionIsTheGeneratedOne(_ language: AssignmentLanguage) {
+        #expect(AuthoringLanguageFacts(language).scriptExtension == language.generatedScriptExtension)
+    }
+
+    /// A language-less assignment gets no extension to offer. The editor falls
+    /// back to `py`, which is what a plain `.sh` suite's authors saw before any
+    /// of this and is not worth changing.
+    @Test func aLanguagelessAssignmentOffersNoScriptExtension() {
+        #expect(AuthoringLanguageFacts(nil).scriptExtension == nil)
+    }
+
     /// Expression evaluation is available in every language, because the
     /// server's evaluator has a driver for every language.
     ///

--- a/Tests/APITests/MCP/MCPLanguageCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPLanguageCoverageTests.swift
@@ -130,6 +130,57 @@ import Testing
         }
     }
 
+    // MARK: - A predicate-defined SUBSET is never named short either
+
+    /// The blind spot the guard above documents and accepts.
+    ///
+    /// `staleLanguageLists()` filters single-language "lists" out on purpose,
+    /// because "a cpp assignment must be uploadOnly" is legitimate prose and
+    /// not a stale enumeration. It was legitimate right up until Racket became
+    /// the second upload-only language, at which point that exact sentence —
+    /// in four tool descriptions and the instructions — was a one-item list
+    /// that should have had two, and nothing here could see it. The enforcement
+    /// predicate (`requiresUploadOnlySubmission`) had picked Racket up
+    /// immediately, because it asks `editorSupport` rather than naming C++.
+    ///
+    /// So this guard is scoped to a SENTENCE rather than to the catalog: any
+    /// sentence about upload-only that names one upload-only language must name
+    /// all of them. Sentence-scoped because the catalog as a whole legitimately
+    /// mentions each language alone in a dozen unrelated places.
+    @Test func noSentenceNamesSomeUploadOnlyLanguagesButNotOthers() {
+        let uploadOnly = AssignmentLanguage.allCases.filter(requiresUploadOnlySubmission)
+        // A one-language answer makes the guard vacuous rather than wrong —
+        // there is no subset to get wrong. It starts biting at two, which is
+        // where the defect appeared.
+        guard uploadOnly.count > 1 else { return }
+        for sentence in Self.sentences(of: Self.servedText) {
+            let lowered = sentence.lowercased()
+            guard lowered.contains("uploadonly") || lowered.contains("upload-only") else { continue }
+            let named = uploadOnly.filter {
+                lowered.contains($0.rawValue.lowercased())
+                    || lowered.contains($0.displayName.lowercased())
+            }
+            guard !named.isEmpty, named.count < uploadOnly.count else { continue }
+            let missing = uploadOnly.filter { !named.contains($0) }
+            Issue.record(
+                """
+                A served MCP sentence about upload-only names \
+                \(named.map(\.displayName).joined(separator: ", ")) but not \
+                \(missing.map(\.displayName).joined(separator: ", ")), which \
+                `requiresUploadOnlySubmission` treats identically. Interpolate \
+                `LanguageProse.uploadOnlyTokens` / `.uploadOnlyDisplayNames` instead of naming a \
+                language. Sentence: "\(sentence.trimmingCharacters(in: .whitespacesAndNewlines))"
+                """)
+        }
+    }
+
+    /// Split on sentence-ending punctuation. Crude on purpose: a false split
+    /// can only make the guard check a shorter span, never invent a failure,
+    /// and JSON-encoded schema text has no reliable sentence structure anyway.
+    private static func sentences(of text: String) -> [String] {
+        text.split(whereSeparator: { $0 == "." || $0 == "\n" }).map(String.init)
+    }
+
     // MARK: - Expressions are never described as Python
 
     /// The specific regression #1288 named, generalized from the instructions

--- a/Tests/APITests/NotebookCheckFormSchemaTests.swift
+++ b/Tests/APITests/NotebookCheckFormSchemaTests.swift
@@ -107,6 +107,75 @@ import Testing
         }
     }
 
+    // MARK: - Field-level language refusals
+
+    /// The form's field annotations come from the SAME predicate the save-time
+    /// refusal reads.
+    ///
+    /// The gap this closes: `cellContains` is a supported kind on Lua, so the
+    /// kind-level map the Add Test menu reads said "available" — and then
+    /// ticking its regex box produced a check the server refused. Kind-level
+    /// availability is not field-level availability, and until now only the
+    /// former could be expressed.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func everyAnnotatedFieldMatchesTheRefusalPredicate(_ language: AssignmentLanguage) {
+        let schema = notebookCheckFormSchema(language: language)
+        for kind in NotebookCheckKind.allCases {
+            for field in schema.kinds[kind.rawValue] ?? [] {
+                #expect(
+                    field.unsupportedReason
+                        == notebookCheckFieldUnsupportedReason(
+                            field.name, kind: kind, language: language),
+                    """
+                    The form schema and the save-time refusal disagree about \
+                    \(kind.rawValue).\(field.name) on \(language.displayName).
+                    """)
+            }
+        }
+    }
+
+    /// Lua is the one language with a field-level refusal today, and the
+    /// annotation lands on exactly the field that is refused.
+    @Test func luaRefusesRegexCellMatchingInTheFormAndOnSave() throws {
+        let luaFields = try #require(
+            notebookCheckFormSchema(language: .lua).kinds[NotebookCheckKind.cellContains.rawValue])
+        let regexField = try #require(luaFields.first { $0.name == "regex" })
+        let reason = try #require(
+            regexField.unsupportedReason, "Lua should refuse regex cell matching")
+        #expect(reason.contains("Lua patterns"))
+        // Its neighbour in the same kind is untouched: this is a FIELD-level
+        // refusal, and a kind-level one would have taken the whole card.
+        let textField = try #require(luaFields.first { $0.name == "containsText" })
+        #expect(textField.unsupportedReason == nil)
+    }
+
+    /// Octave's regexp is PCRE and R's engine takes the same constructs, so a
+    /// pattern authored against the Python renderer transfers. Neither is
+    /// refused — asserted so a later reader does not "fix" them by symmetry
+    /// with Lua.
+    @Test(arguments: [AssignmentLanguage.python, .r, .octave])
+    func languagesWithCompatibleRegexEnginesAreNotRefused(_ language: AssignmentLanguage) {
+        #expect(
+            notebookCheckFieldUnsupportedReason("regex", kind: .cellContains, language: language)
+                == nil)
+    }
+
+    /// The label named Python on every assignment. It now names the language,
+    /// and says nothing about one when the assignment declares none.
+    @Test func theRegexLabelNamesTheAssignmentLanguage() throws {
+        func regexLabel(_ language: AssignmentLanguage?) throws -> String {
+            let fields = try #require(
+                notebookCheckFormSchema(language: language)
+                    .kinds[NotebookCheckKind.cellContains.rawValue])
+            return try #require(fields.first { $0.name == "regex" }).label
+        }
+        #expect(try regexLabel(.r).contains("R regular expression"))
+        #expect(try regexLabel(.octave).contains("Octave"))
+        #expect(try !regexLabel(.r).contains("Python"))
+        // No language declared: no language named.
+        #expect(try regexLabel(nil) == "Interpret as a regular expression")
+    }
+
     /// Returns a copy of `s` with the named field cleared to nil.  Covers
     /// every field name any kind marks `required` in the schema.
     private func clearing(_ field: String, from s: NotebookCheck) -> NotebookCheck {

--- a/Tests/BrowserRunnerJSTests/authoring-language.test.mjs
+++ b/Tests/BrowserRunnerJSTests/authoring-language.test.mjs
@@ -1,0 +1,101 @@
+// Unit tests for `Public/authoring-language.js` — the ONE reader of the
+// `#assignment-language-seed` island, and therefore the single place every
+// authoring editor learns what language it is editing.
+//
+// It had no test file of its own, which is how two of the facts it parses
+// (`functionScanning`, `expressionEvaluation`) came to be seeded by the server,
+// parsed here, and read by nobody: an unread flag looks identical to a read one
+// from every angle except a test that asks for its accessor.
+//
+// Each case re-requires the module so the per-page `_cached` facts object is
+// rebuilt against that case's seed.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const MODULE = require.resolve('../../Public/authoring-language.js');
+
+/// Load the module with `seed` as the page's language island. Pass null for a
+/// page that has no island at all.
+function loadWith(seed) {
+  globalThis.document = {
+    getElementById(id) {
+      if (id !== 'assignment-language-seed' || seed === null) return null;
+      return { textContent: JSON.stringify(seed) };
+    }
+  };
+  delete require.cache[MODULE];
+  require(MODULE);
+  return globalThis.ChickadeeLanguage;
+}
+
+const R_SEED = {
+  name: 'r',
+  displayName: 'R',
+  trueLiteral: 'TRUE',
+  falseLiteral: 'FALSE',
+  nullLiteral: 'NULL',
+  scriptExtension: 'R',
+  functionScanning: false,
+  expressionEvaluation: true,
+  unsupportedCheckKinds: { astStructure: 'Not available for R assignments.' }
+};
+
+test('a page with no seed falls back to Python, which is the pre-seed behaviour', () => {
+  const lang = loadWith(null);
+  assert.equal(lang.isPython(), true);
+  assert.equal(lang.label(), '');
+  assert.equal(lang.scriptExtension(), 'py');
+  assert.equal(lang.canScanFunctions(), true);
+  assert.equal(lang.canEvaluateExpressions(), true);
+});
+
+test('an R seed reports R literals, not Python ones', () => {
+  const lang = loadWith(R_SEED);
+  assert.equal(lang.isPython(), false);
+  assert.equal(lang.label(), 'R');
+  // The defect this whole seed exists for: an R author typing the boolean true
+  // used to store the STRING "TRUE".
+  assert.deepEqual(lang.matchScalarToken('TRUE'), { value: true, kind: 'bool' });
+  assert.equal(lang.matchScalarToken('True'), null);
+  assert.deepEqual(lang.matchScalarToken('NULL'), { value: null, kind: 'null' });
+});
+
+test('scriptExtension is the assignment language extension a new test gets', () => {
+  assert.equal(loadWith(R_SEED).scriptExtension(), 'R');
+  // C++ generates shell wrappers, so a hand-written C++ test is a `.sh` too.
+  // Offering `.cpp` would name a file the runner does not execute.
+  assert.equal(
+    loadWith({ name: 'cpp', displayName: 'C++', scriptExtension: 'sh' }).scriptExtension(),
+    'sh');
+  // A seed that omits the field (a page cached from before it existed) must
+  // not yield "undefined" as an extension.
+  assert.equal(loadWith({ name: 'lua', displayName: 'Lua' }).scriptExtension(), 'py');
+});
+
+test('canScanFunctions reports the language, so the UI need not run a scan to find out', () => {
+  assert.equal(loadWith(R_SEED).canScanFunctions(), false);
+  assert.equal(
+    loadWith({ name: 'python', displayName: 'Python', functionScanning: true })
+      .canScanFunctions(),
+    true);
+});
+
+test('canEvaluateExpressions is read, not assumed, so a driver-less language can say no', () => {
+  assert.equal(loadWith(R_SEED).canEvaluateExpressions(), true);
+  // No language ships false today. The accessor exists for the one that will:
+  // an unread flag would leave auto-compute filling Expected cells from a
+  // server that refuses.
+  assert.equal(
+    loadWith({ name: 'zig', displayName: 'Zig', expressionEvaluation: false })
+      .canEvaluateExpressions(),
+    false);
+});
+
+test('checkKindUnsupportedReason carries the save-time refusal into the menu', () => {
+  const lang = loadWith(R_SEED);
+  assert.match(lang.checkKindUnsupportedReason('astStructure'), /Not available for R/);
+  assert.equal(lang.checkKindUnsupportedReason('variableExists'), null);
+});

--- a/changelog.d/language-support-ui-audit.md
+++ b/changelog.d/language-support-ui-audit.md
@@ -33,3 +33,25 @@
   student-facing "the Python kernel" prose on the editor-reset and notebook
   pages were stale the same way; the placeholder is now derived from
   `AssignmentLanguage.allCases`, and the kernel prose no longer names a language.
+
+- **The custom-script editor no longer offers Python to every language.** "Write
+  a custom script" is advertised in the Add Test catalog as "your assignment's
+  language, or .sh" and then offered nine Python templates, a
+  `test_correctness.py` placeholder, and a `test_new.py` default on all six
+  languages. The Python group is now shown only on Python assignments; Shell is
+  shown everywhere because `.sh` is the universal test contract; and a new
+  file's extension comes from the assignment's own language — `sh` for C++,
+  whose test cases are shell wrappers. Template sets for R, Lua, Octave, C++ and
+  Racket do not exist yet, so those assignments get Shell and Blank; writing
+  them is content work, not a structural gap.
+
+- **The two authoring facts nothing read are now read.** `functionScanning` and
+  `expressionEvaluation` were computed server-side, parsed in the browser, and
+  consumed by no one — the create page invited a solution scan on every language
+  and reported "No functions found." where the honest answer was "this language
+  cannot be scanned", and auto-compute routed on a hand-written
+  `name !== 'python'` beside an unread capability flag. The scan panel now
+  refuses up front and names the language, and auto-compute reads the flag, so a
+  seventh language without an expression driver disables the control instead of
+  filling Expected cells from a server that refuses. `authoring-language.js`
+  gained the accessors and its first test file.

--- a/changelog.d/language-support-ui-audit.md
+++ b/changelog.d/language-support-ui-audit.md
@@ -1,0 +1,35 @@
+### Fixed
+
+- **The create page no longer reports adding starter tests it did not write.**
+  "Generate Starter Tests" filtered its work list to empty on any non-Python
+  assignment and then reported `N test file(s) added to suite.` from the count
+  of files nobody wrote. It now says the templates are Python-only and names the
+  assignment's language. Its solution scan also passes the declared language to
+  `/instructor/scan-notebook`, as the family editor's scan already did — without
+  it, a declared-R assignment whose solution still carried a Python kernelspec
+  scanned as Python and listed functions no generated test could be written for.
+  The whole panel moved out of `assignment-new.leaf` into
+  `Public/generated-starter-tests.js`, where it is linted and testable; both
+  defects were invisible from the template.
+
+- **Copy that named C++ as the only upload-only language now names every
+  upload-only language.** Racket has been the second since it shipped, and the
+  enforcement predicate (`requiresUploadOnlySubmission`) picked it up
+  immediately because it asks `editorSupport` — so the rule covered Racket while
+  the explanation did not, in both authoring pages and four MCP tool
+  descriptions. All six sites now interpolate `LanguageProse`, which derives
+  predicate-defined language lists the way `MCPLanguageProse` derives the full
+  one. `MCPLanguageCoverageTests` gained the matching guard: any served sentence
+  about upload-only that names one upload-only language must name all of them.
+  Its existing guard could not see this class, because it ignores
+  single-language mentions on purpose.
+
+- **The pattern-family variables table no longer calls every value a Python
+  literal.** The `Value (JSON / Python literal)` column header was shown to R,
+  Lua, Octave, C++ and Racket authors — the same defect as the adjacent "Python
+  default" placeholder fixed earlier, missed because this instance lived in Leaf
+  rather than in the editor's JavaScript. It now names the assignment's own
+  language. The required-Languages placeholder on the create page and the
+  student-facing "the Python kernel" prose on the editor-reset and notebook
+  pages were stale the same way; the placeholder is now derived from
+  `AssignmentLanguage.allCases`, and the kernel prose no longer names a language.

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -106,7 +106,7 @@ fi
 # attributes or a JSON island).  Baseline = total non-blank lines inside
 # <script> bodies across all templates; it may only go DOWN.  <script src=…>
 # includes and single-line <script>…</script> elements don't count.
-INLINE_SCRIPT_BASELINE=2051
+INLINE_SCRIPT_BASELINE=1968
 inline_script_count="$(
   awk '
     /<script[^>]*src=/ { next }


### PR DESCRIPTION
Findings from a UI audit of the six-language surface, fixed. Every one is the same shape the multi-language docs already name: **a place that names one language where the system now has several, failing open.** The enforcement layer was fine throughout — each of these was presentation drifting away from a predicate that had already been generalised.

## What was wrong

**The create page reported adding starter tests it did not write.** "Generate Starter Tests" filtered its work list to empty on any non-Python assignment and then reported `N test file(s) added to suite.` from `checked.length` — a count of files nobody wrote. Its scan also omitted the `?language=` parameter the family editor's scan passes, so a declared-R assignment whose solution still carried a Python kernelspec scanned as Python and listed functions no generated test could be written for. Both defects lived in `assignment-new.leaf`'s inline JS, which is neither linted nor tested; `applyScanPayload` had already been moved out for exactly that reason and the caller stayed behind.

**Copy named C++ as the only upload-only language.** Racket has been the second since it shipped, and `requiresUploadOnlySubmission` picked it up immediately because it asks `editorSupport` rather than naming C++ — so the *rule* covered Racket while the *explanation* did not, on both authoring pages and in four MCP tool descriptions. `MCPLanguageCoverageTests` could not see this: it catches lists that stop short of `allCases`, and it filters single-language mentions out on purpose, because "a cpp assignment must be uploadOnly" was legitimate prose right up until it wasn't.

**"Write a custom script" offered Python to every language.** Advertised in the Add Test catalog as "your assignment's language, or .sh", then offering nine Python templates, a `test_correctness.py` placeholder and a `test_new.py` default on all six.

**Two authoring facts were computed, parsed, and read by nobody.** `functionScanning` and `expressionEvaluation` reach the browser in `#assignment-language-seed` and had no consumers at all. The create page invited a solution scan on every language and answered "No functions found." where the truth was "this language cannot be scanned"; auto-compute routed on a hand-written `name !== 'python'` sitting beside the unread flag.

**Assorted stale prose:** `Value (JSON / Python literal)` as a column header on the pattern-family variables table (the adjacent "Python default" placeholder had already been fixed in JS — this instance was missed because it lives in Leaf), a hand-typed `python, r, lua, octave, cpp, racket` placeholder directly below a select derived from `allCases`, and student-facing "the Python kernel" on the editor-reset and notebook pages.

## What changed

- `Public/generated-starter-tests.js` — the gen-tests panel, moved out of the template, refusing out loud and passing the declared language to the scan.
- `LanguageProse` — renders **predicate-defined** language lists the way `MCPLanguageProse` renders the full one. `uploadOnlyDisplayNames` / `uploadOnlyTokens` read the same `editorSupport` answer the refusal reads; `mustDeclareTokens` is deliberately a *different* set (C++ only — Racket generates `.rkt` and is perfectly derivable despite also being upload-only), which is the distinction the old copy had conflated.
- `MCPLanguageCoverageTests` — new sentence-scoped guard: any served sentence about upload-only naming one upload-only language must name all of them.
- `test-renderer-script.js` — Python group only on Python; Shell everywhere, because `.sh` is the universal test contract; new-file extension from the assignment's language.
- `AuthoringLanguageFacts.scriptExtension` — from `generatedScriptExtension`, which is right *because* C++'s answer is `sh`: its cases are shell wrappers and a hand-written C++ test faces the same dispatch.
- `authoring-language.js` — accessors for the three facts, and its first test file.

## Deliberately not done

- **Template sets for R, Lua, Octave, C++ and Racket.** Those assignments get Shell and Blank. Writing nine pedagogically sound equivalents per language is content work, not a structural gap, and is a call for the course owner.
- **The Lua `cell_contains` + `regex: true` refusal** is still save-time only. `unsupportedCheckKinds` is keyed by kind, and `cellContains` *is* supported on Lua — just not with regex on — so this is a parameter-level gate the #1290 menu fix does not reach. Flagged in the audit, left open by agreement.

## Verification

`swift build` clean; 596 Swift tests across the touched suites pass; 261 frontend `.mjs` tests pass (6 new); `format.sh`, `lint.sh`, `swiftlint.sh --strict` (0 violations) and `check-styles.sh` all green. The inline-script baseline ratcheted 2051 → 1968.

Render tests prove templates resolve but do not exercise page JS, so the gen-tests panel, the template picker and the auto-compute gate each want a manual click before this leaves draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcV8dFXd1H9476AxSwpeam)_