### PR TITLE
fix(inputs): inline hand-written test inputs in the script's own language

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyRendering.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRendering.swift
@@ -71,15 +71,24 @@ func rawScriptOverlayWrites(
         // raw script to clash with a family-generated name), the family
         // version wins — skip the raw-script overlay.
         guard !generatedFilenames.contains(filename) else { continue }
-        // A raw script's extension names its language: `.py` gets Python
-        // literals, `.R`/`.r` gets R ones. Anything else (a shell script, a
-        // data file) has no literal syntax to inline into and is left alone.
-        let scriptLanguage: AssignmentLanguage?
-        switch (filename as NSString).pathExtension.lowercased() {
-        case "py": scriptLanguage = .python
-        case "r": scriptLanguage = .r
-        default: scriptLanguage = nil
-        }
+        // A raw script's extension names its language. Resolved through
+        // `AssignmentLanguage(scriptExtension:)` — the same call the MCP
+        // `author_script` and single-script save paths already used.
+        //
+        // This was a hand-written switch on `py` and `r` with `default: nil`,
+        // written when those were the only two languages. Lua, Octave, Racket
+        // and C++ fell to the default, so a hand-written test in any of them
+        // silently received NO global or section variables through this path
+        // while the other two paths delivered them — the same feature present
+        // or absent depending on which button the instructor pressed.
+        let scriptLanguage: AssignmentLanguage? = {
+            guard
+                let language = AssignmentLanguage(
+                    scriptExtension: (filename as NSString).pathExtension),
+                TestScriptVariablePrepender.supportsRawScriptInlining(language)
+            else { return nil }
+            return language
+        }()
         let sectionVars = s.sectionID.flatMap { sectionVarsByID[$0] } ?? []
         if let provided = s.content {
             // Declarative content from the payload (the PUT /suite channel

--- a/Sources/APIServer/Utilities/TestScriptVariablePrepender.swift
+++ b/Sources/APIServer/Utilities/TestScriptVariablePrepender.swift
@@ -58,24 +58,17 @@ enum TestScriptVariablePrepender {
                 .map { "\(octaveIdentifier($0.name)) = \($0.value.octaveLiteral);" }
                 .joined(separator: "\n")
         case .cpp:
-            // A C++ assignment's hand-authored graded scripts are SHELL
-            // scripts (the makefile path), so globals inline as POSIX shell
-            // assignments — scalars only. Containers have no faithful shell
-            // form; they stay reachable through `_ck_inputs.hpp` and family
-            // variables, and the comment says so rather than guessing one.
-            return
-                variables
-                .map { variable -> String in
-                    switch variable.value {
-                    case .int(let i): return "\(variable.name)=\(i)"
-                    case .double(let d): return "\(variable.name)=\(d)"
-                    case .bool(let b): return "\(variable.name)=\(b ? 1 : 0)"
-                    case .string(let s): return "\(variable.name)=\(shellSingleQuoted(s))"
-                    case .null, .array, .object:
-                        return "# \(variable.name): no shell form; read it from C++ instead"
-                    }
-                }
-                .joined(separator: "\n")
+            // Nothing, and the empty answer is the correct one — see
+            // `supportsRawScriptInlining`, which stops this being reached.
+            //
+            // This arm used to emit POSIX SHELL assignments, on the reasoning
+            // that a C++ assignment's graded scripts are `.sh` wrappers. True,
+            // but it made the arm unreachable-or-wrong: a `.sh` file resolves
+            // to no language at all (no language claims that extension), so the
+            // only way in was a hand-added `.cpp`/`.h`/`.hpp` suite entry —
+            // which would have received shell assignments inside a C++ file.
+            // No caller ever passed `.cpp` here.
+            return ""
         case .racket:
             // `(define name value)` — top-level definitions in the generated
             // test's own module. Unlike C++'s shell arm there is no scalar
@@ -96,12 +89,61 @@ enum TestScriptVariablePrepender {
         return decls.isEmpty ? "" : decls + "\n\n"
     }
 
-    /// Marker line written above the prepended assignments in raw
-    /// instructor-uploaded `.py` test scripts.  Used both as a "do not
-    /// edit" cue for the reader and as a sentinel for `stripExistingBlock`
-    /// so re-prepending stays idempotent across saves.
-    static let rawScriptBannerComment =
-        "# === Chickadee inputs: name = value, prepended at save time. Do not edit. ==="
+    /// Whether a hand-written test script in `language` can host an inlined
+    /// variable block at all.
+    ///
+    /// False for C++ alone, and not as a limitation — as a fact about what a
+    /// graded C++ "script" is. C++ test cases are `.sh` wrappers that compile a
+    /// translation unit; a bare `.cpp` in the suite is not something the runner
+    /// executes, so there is no point at which an inlined declaration would be
+    /// read. Inputs reach C++ through `_ck_inputs.hpp` instead.
+    ///
+    /// Exhaustive, so a seventh language answers it rather than inheriting an
+    /// assumption.
+    static func supportsRawScriptInlining(_ language: AssignmentLanguage) -> Bool {
+        switch language {
+        case .python, .r, .lua, .octave, .racket: return true
+        case .cpp: return false
+        }
+    }
+
+    /// The banner text, without its comment marker.  Shared by every
+    /// language's banner so `stripExistingBlock` can recognise all of them.
+    private static let rawScriptBannerBody =
+        " === Chickadee inputs: name = value, prepended at save time. Do not edit. ==="
+
+    /// Marker line written above the prepended assignments in a raw
+    /// instructor-uploaded test script.  Used both as a "do not edit" cue for
+    /// the reader and as a sentinel for `stripExistingBlock` so re-prepending
+    /// stays idempotent across saves.
+    ///
+    /// COMMENTED IN THE SCRIPT'S OWN LANGUAGE.  This was a single `#`-prefixed
+    /// constant for every language, which is a comment in Python, R, Octave and
+    /// shell and a syntax error in the other three: `#` is Lua's length
+    /// operator, starts a Racket reader form, and is a C++ preprocessor
+    /// directive.  A Lua or Racket assignment with global inputs plus a
+    /// hand-written test produced a file the interpreter refused to load — and
+    /// the marker is also the sentinel, so the block could not be stripped and
+    /// re-saving compounded it.
+    ///
+    /// Python, R and Octave keep byte-identical output, so no existing script
+    /// changes.
+    static func rawScriptBannerComment(language: AssignmentLanguage = .python) -> String {
+        language.lineCommentPrefix + rawScriptBannerBody
+    }
+
+    /// Every spelling of the banner, for recognition rather than emission.
+    ///
+    /// Includes the legacy `#` form unconditionally, so a Lua or Racket script
+    /// that already carries a broken block gets it stripped on the next save
+    /// instead of accumulating a second one. That is the only recovery path
+    /// those files have — the block cannot be removed by hand without also
+    /// removing the instructor's own first line if they have already tried.
+    private static var allBannerComments: [String] {
+        var banners = AssignmentLanguage.allCases.map { $0.lineCommentPrefix + rawScriptBannerBody }
+        banners.append("#" + rawScriptBannerBody)
+        return banners
+    }
 
     /// Prepends `variables` to the body of a raw Python test script.
     /// Preserves a leading shebang line on line 1.  Idempotent: any
@@ -123,25 +165,33 @@ enum TestScriptVariablePrepender {
         guard !variables.isEmpty else { return stripped }
 
         let decls = emit(variables, language: language)
+        let banner = rawScriptBannerComment(language: language)
 
-        // Detect a leading shebang so we can keep it on line 1.
-        if stripped.hasPrefix("#!") {
+        // A line that must stay first keeps line 1, and the block goes under it.
+        //
+        // Two of these exist. A shebang is the familiar one. Racket's `#lang`
+        // is the other, and it is a STRONGER constraint than the shebang: a
+        // `#lang` line does not merely prefer to be first, it opens the module
+        // whose body the declarations belong to. `(define …)` written above it
+        // is a read error no comment placement can rescue — so for Racket this
+        // branch is not a nicety, it is the only correct placement.
+        if stripped.hasPrefix("#!") || stripped.hasPrefix("#lang") {
             let lines = stripped.split(
                 separator: "\n",
                 maxSplits: 1,
                 omittingEmptySubsequences: false)
-            let shebang = String(lines.first ?? "")
+            let prologue = String(lines.first ?? "")
             let rest = lines.count > 1 ? String(lines[1]) : ""
             return [
-                shebang,
-                rawScriptBannerComment,
+                prologue,
+                banner,
                 decls,
                 "",
                 rest,
             ].joined(separator: "\n")
         }
         return [
-            rawScriptBannerComment,
+            banner,
             decls,
             "",
             stripped,
@@ -153,12 +203,13 @@ enum TestScriptVariablePrepender {
     /// first blank line that follows.  Returns `body` unchanged when
     /// no banner is present.
     static func stripExistingBlock(_ body: String) -> String {
-        guard body.contains(rawScriptBannerComment) else { return body }
+        let banners = Set(allBannerComments)
+        guard banners.contains(where: body.contains) else { return body }
         var lines =
             body
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map(String.init)
-        guard let startIdx = lines.firstIndex(of: rawScriptBannerComment) else {
+        guard let startIdx = lines.firstIndex(where: { banners.contains($0) }) else {
             return body
         }
         // Walk forward to find the blank line that closes the block.
@@ -189,7 +240,8 @@ enum TestScriptVariablePrepender {
     ) -> String {
         guard
             let language = AssignmentLanguage(
-                scriptExtension: (filename as NSString).pathExtension)
+                scriptExtension: (filename as NSString).pathExtension),
+            supportsRawScriptInlining(language)
         else { return content }
         let sectionID: String?
         if let explicitSectionID {

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -347,6 +347,9 @@ extension AssignmentLanguage {
     /// See `LanguageDescriptor.sourceFileExtension`.
     public var sourceFileExtension: String { descriptor.sourceFileExtension }
 
+    /// See `LanguageDescriptor.lineCommentPrefix`.
+    public var lineCommentPrefix: String { descriptor.lineCommentPrefix }
+
     /// Body of the per-student grading-inputs file. `values` maps each input
     /// name to its already-rendered literal *in this language* (Python literal
     /// for `.python`, R literal for `.r`). Keys are emitted in sorted order for

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -219,6 +219,20 @@ public struct LanguageDescriptor: Equatable, Sendable {
     /// one fact is the shape this file exists to stop.
     public let sourceFileExtension: String
 
+    /// How this language opens a single-line comment: `#`, `--`, `;` or `//`.
+    ///
+    /// A FACT, and one that used to be assumed. `TestScriptVariablePrepender`
+    /// wrote a `#`-prefixed banner above the inputs it inlines into a
+    /// hand-written test, in every language — correct for Python, R, Octave and
+    /// shell, and a syntax error in the other three. `#` is Lua's length
+    /// operator, starts a Racket reader form, and is a C++ preprocessor
+    /// directive, so a Lua or Racket assignment with global inputs plus a
+    /// hand-written test produced a file its interpreter refused to load.
+    ///
+    /// Exhaustive like the rest of this type, so a seventh language answers it
+    /// rather than inheriting Python's.
+    public let lineCommentPrefix: String
+
     /// Filename of the per-student grading-inputs file the worker materializes.
     /// Must match byte-for-byte what the language's `test_runtime` reads AND
     /// what the browser's `personalizationInputsSource<X>` writes.
@@ -310,6 +324,7 @@ public struct LanguageDescriptor: Equatable, Sendable {
         scriptExtensions: Set<String>,
         generatedScriptExtension: String,
         sourceFileExtension: String,
+        lineCommentPrefix: String,
         inputsFileName: String,
         notebookKernelNames: Set<String>,
         editorSupport: EditorSupport,
@@ -322,6 +337,7 @@ public struct LanguageDescriptor: Equatable, Sendable {
         self.scriptExtensions = scriptExtensions
         self.generatedScriptExtension = generatedScriptExtension
         self.sourceFileExtension = sourceFileExtension
+        self.lineCommentPrefix = lineCommentPrefix
         self.inputsFileName = inputsFileName
         self.notebookKernelNames = notebookKernelNames
         self.editorSupport = editorSupport
@@ -347,6 +363,7 @@ extension AssignmentLanguage {
                 scriptExtensions: ["py"],
                 generatedScriptExtension: "py",
                 sourceFileExtension: "py",
+                lineCommentPrefix: "#",
                 inputsFileName: "_ck_inputs.py",
                 notebookKernelNames: AssignmentLanguage.pythonKernelNames,
                 editorSupport: .notebookKernel(
@@ -372,6 +389,7 @@ extension AssignmentLanguage {
                 scriptExtensions: ["r"],
                 generatedScriptExtension: "R",
                 sourceFileExtension: "R",
+                lineCommentPrefix: "#",
                 inputsFileName: "_ck_inputs.R",
                 notebookKernelNames: AssignmentLanguage.rKernelNames,
                 editorSupport: .notebookKernel(
@@ -395,6 +413,7 @@ extension AssignmentLanguage {
                 scriptExtensions: ["lua"],
                 generatedScriptExtension: "lua",
                 sourceFileExtension: "lua",
+                lineCommentPrefix: "--",
                 inputsFileName: "_ck_inputs.lua",
                 notebookKernelNames: AssignmentLanguage.luaKernelNames,
                 editorSupport: .notebookKernel(
@@ -421,6 +440,7 @@ extension AssignmentLanguage {
                 scriptExtensions: ["m"],
                 generatedScriptExtension: "m",
                 sourceFileExtension: "m",
+                lineCommentPrefix: "#",
                 inputsFileName: "_ck_inputs.m",
                 notebookKernelNames: AssignmentLanguage.octaveKernelNames,
                 editorSupport: .notebookKernel(
@@ -461,6 +481,7 @@ extension AssignmentLanguage {
                 // here — no other language generates `.sh`.
                 generatedScriptExtension: "sh",
                 sourceFileExtension: "cpp",
+                lineCommentPrefix: "//",
                 inputsFileName: "_ck_inputs.hpp",
                 // No notebook workflow, so no kernel aliases to claim — like
                 // Python's empty set, but for the opposite reason (nothing to
@@ -507,6 +528,7 @@ extension AssignmentLanguage {
                 // ordinary shell-script contract. No wrapper, no build step.
                 generatedScriptExtension: "rkt",
                 sourceFileExtension: "rkt",
+                lineCommentPrefix: ";",
                 inputsFileName: "_ck_inputs.rkt",
                 // No kernel exists to claim aliases for. Empty for the same
                 // reason as C++ — nothing to detect — not Python's

--- a/Tests/APITests/GlobalInputsTests.swift
+++ b/Tests/APITests/GlobalInputsTests.swift
@@ -56,11 +56,11 @@ import Testing
             body,
             variables: [FamilyVariable(name: "x", value: .int(7))]
         )
-        #expect(result.contains(TestScriptVariablePrepender.rawScriptBannerComment))
+        #expect(result.contains(TestScriptVariablePrepender.rawScriptBannerComment()))
         #expect(result.contains("x = 7"))
         #expect(result.contains("import os"))
         // Banner appears before the original body.
-        if let bannerRange = result.range(of: TestScriptVariablePrepender.rawScriptBannerComment),
+        if let bannerRange = result.range(of: TestScriptVariablePrepender.rawScriptBannerComment()),
             let importRange = result.range(of: "import os")
         {
             #expect(bannerRange.upperBound < importRange.lowerBound)
@@ -98,7 +98,7 @@ import Testing
         #expect(secondPass.contains("x = 2"))
         let bannerOccurrences =
             secondPass.components(
-                separatedBy: TestScriptVariablePrepender.rawScriptBannerComment
+                separatedBy: TestScriptVariablePrepender.rawScriptBannerComment()
             ).count - 1
         #expect(bannerOccurrences == 1, "banner should appear exactly once after re-prepending")
     }
@@ -114,7 +114,7 @@ import Testing
             prepended,
             variables: []
         )
-        #expect(stripped.contains(TestScriptVariablePrepender.rawScriptBannerComment) == false)
+        #expect(stripped.contains(TestScriptVariablePrepender.rawScriptBannerComment()) == false)
         #expect(stripped.contains("x = 1") == false)
         #expect(stripped.contains("import os"))
     }

--- a/Tests/APITests/RawScriptVariableInliningTests.swift
+++ b/Tests/APITests/RawScriptVariableInliningTests.swift
@@ -1,0 +1,244 @@
+// Tests/APITests/RawScriptVariableInliningTests.swift
+//
+// Global + section inputs inlined into a HAND-WRITTEN test script, in every
+// language.
+//
+// Two defects motivated these, and both were invisible to the coverage that
+// existed — `PatternFamilyRendererRTests` exercised `.R`, `.py` and `.sh`, which
+// is precisely the set where the bugs did not appear:
+//
+//   1. The banner above the inlined block was a hardcoded `#` line for every
+//      language. `#` is a comment in Python, R, Octave and shell, and is Lua's
+//      length operator, a Racket reader prefix and a C++ preprocessor
+//      directive. A Lua or Racket assignment with global inputs plus a
+//      hand-written test produced a file the interpreter refused to load. The
+//      banner is also the strip sentinel, so re-saving compounded it.
+//   2. `rawScriptOverlayWrites` picked the language with a hand-written switch
+//      on `py`/`r` and `default: nil`, so the PUT /suite path silently skipped
+//      four languages that the MCP and single-script paths served.
+//
+// The execution suite at the bottom is the part that would actually have caught
+// (1): it writes the emitted file and runs it.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct RawScriptVariableInliningTests {
+
+    private static let manifest = TestProperties(
+        requiredFiles: [], testSuites: [], timeLimitSeconds: 10,
+        globalVariables: [FamilyVariable(name: "threshold", value: .double(18.5))])
+
+    /// A hand-written test filename in `language`, using the extension the
+    /// runner dispatches on.
+    private static func filename(for language: AssignmentLanguage) -> String {
+        "publictest_x.\(language.sourceFileExtension)"
+    }
+
+    // MARK: - The banner is a comment in the script's own language
+
+    /// The banner must be a COMMENT in the language it is written into. Asked
+    /// of every language, so a seventh cannot inherit Python's `#`.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theBannerIsCommentedInTheScriptsOwnLanguage(_ language: AssignmentLanguage) {
+        let banner = TestScriptVariablePrepender.rawScriptBannerComment(language: language)
+        #expect(
+            banner.hasPrefix(language.lineCommentPrefix),
+            "\(language.displayName)'s banner does not open with its comment marker")
+    }
+
+    /// Python, R and Octave keep byte-identical output — `#` was right for
+    /// them, and every script already saved carries that exact line. If this
+    /// fails, existing scripts stop being strippable.
+    @Test(arguments: [AssignmentLanguage.python, .r, .octave])
+    func thePreviouslyCorrectLanguagesAreByteIdentical(_ language: AssignmentLanguage) {
+        #expect(
+            TestScriptVariablePrepender.rawScriptBannerComment(language: language)
+                == "# === Chickadee inputs: name = value, prepended at save time. Do not edit. ===")
+    }
+
+    // MARK: - Every language that can be inlined into, is
+
+    /// The defect in `rawScriptOverlayWrites`: four languages fell to
+    /// `default: nil` and received nothing.
+    @Test(arguments: [AssignmentLanguage.python, .r, .lua, .octave, .racket])
+    func aHandWrittenTestReceivesTheAssignmentsInputs(_ language: AssignmentLanguage) {
+        let script = TestScriptVariablePrepender.applyForRawScript(
+            filename: Self.filename(for: language), content: "body\n", manifest: Self.manifest)
+        #expect(script.contains("18.5"), "\(language.displayName) got no inlined value")
+        #expect(script.contains("threshold"))
+        #expect(script.contains("body"), "the instructor's own content must survive")
+    }
+
+    /// C++ is the one language that declines, and not as a limitation: its
+    /// graded scripts are `.sh` wrappers, so a bare `.cpp` in the suite is not
+    /// a thing the runner executes and an inlined declaration would never be
+    /// read. Inputs reach C++ through `_ck_inputs.hpp`.
+    @Test(arguments: ["publictest_x.cpp", "publictest_x.h", "publictest_x.hpp"])
+    func cppSourceIsLeftAlone(_ name: String) {
+        #expect(
+            TestScriptVariablePrepender.applyForRawScript(
+                filename: name, content: "int main(){}\n", manifest: Self.manifest)
+                == "int main(){}\n")
+    }
+
+    /// A shell script belongs to no language and is left alone — the universal
+    /// test contract carries no language signal, deliberately.
+    @Test func shellScriptsAreLeftAlone() {
+        #expect(
+            TestScriptVariablePrepender.applyForRawScript(
+                filename: "publictest_x.sh", content: "echo hi\n", manifest: Self.manifest)
+                == "echo hi\n")
+    }
+
+    // MARK: - Placement
+
+    /// Racket declarations must land INSIDE the module, so the `#lang` line
+    /// keeps line 1. This is stronger than the shebang rule it reuses: a
+    /// `(define …)` above `#lang` is a read error, not a style problem.
+    @Test func racketKeepsItsLangLineFirst() {
+        let script = TestScriptVariablePrepender.applyForRawScript(
+            filename: "publictest_x.rkt",
+            content: "#lang racket\n(displayln threshold)\n", manifest: Self.manifest)
+        let lines = script.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines.first == "#lang racket", "#lang must stay on line 1")
+        let defineIndex = lines.firstIndex { $0.contains("(define threshold") }
+        #expect(defineIndex != nil, "the inlined define is missing")
+        #expect((defineIndex ?? 0) > 0, "the define must follow #lang, not precede it")
+    }
+
+    @Test func aShebangKeepsLineOne() {
+        let script = TestScriptVariablePrepender.applyForRawScript(
+            filename: "publictest_x.py",
+            content: "#!/usr/bin/env python3\nprint(threshold)\n", manifest: Self.manifest)
+        #expect(script.hasPrefix("#!/usr/bin/env python3\n"))
+    }
+
+    // MARK: - Idempotency and recovery
+
+    /// Re-saving must not stack blocks — the banner is the strip sentinel, and
+    /// a banner in the wrong comment syntax is one the stripper cannot find.
+    @Test(arguments: [AssignmentLanguage.python, .r, .lua, .octave, .racket])
+    func resavingReplacesTheBlockRatherThanStackingIt(_ language: AssignmentLanguage) {
+        let name = Self.filename(for: language)
+        let once = TestScriptVariablePrepender.applyForRawScript(
+            filename: name, content: "body\n", manifest: Self.manifest)
+        let twice = TestScriptVariablePrepender.applyForRawScript(
+            filename: name, content: once, manifest: Self.manifest)
+        #expect(once == twice, "\(language.displayName) stacked a second block on re-save")
+    }
+
+    /// A Lua or Racket script already carrying the broken `#` banner gets it
+    /// removed on the next save. That is the only recovery path those files
+    /// have, since the instructor cannot delete the block by hand without
+    /// guessing where it ends.
+    @Test(arguments: [AssignmentLanguage.lua, .racket])
+    func theLegacyBrokenBannerIsStrippedOnResave(_ language: AssignmentLanguage) {
+        let legacy = """
+            # === Chickadee inputs: name = value, prepended at save time. Do not edit. ===
+            threshold = 1.0
+
+            body
+            """
+        let fixed = TestScriptVariablePrepender.applyForRawScript(
+            filename: Self.filename(for: language), content: legacy, manifest: Self.manifest)
+        #expect(
+            !fixed.contains("# ==="),
+            "\(language.displayName) kept a `#` banner its interpreter cannot read")
+        #expect(fixed.contains("body"))
+    }
+}
+
+/// Runs the emitted script for real, in every language whose interpreter is on
+/// this machine.
+///
+/// The point of the suite: a `#`-prefixed banner in a Lua file is a *syntax
+/// error*, and no amount of string assertion says so as plainly as a non-zero
+/// exit. Interpreters absent from the host are skipped silently — the CI image
+/// carries more of them than a dev box does.
+@Suite(.serialized, .timeLimit(.minutes(3))) struct RawScriptVariableInliningExecutionTests {
+
+    /// A script that exits 0 only if the inlined `threshold` is readable and
+    /// carries the value that was inlined.
+    private static func probeBody(for language: AssignmentLanguage) -> String {
+        switch language {
+        case .python: return "import sys\nsys.exit(0 if threshold == 18.5 else 1)\n"
+        case .r: return "if (threshold != 18.5) quit(status = 1)\n"
+        case .lua: return "os.exit(threshold == 18.5 and 0 or 1)\n"
+        case .octave: return "if (threshold != 18.5)\n  exit(1);\nend\n"
+        case .racket:
+            return "#lang racket\n(exit (if (= threshold 18.5) 0 1))\n"
+        case .cpp:
+            // Declines inlining by design, so there is nothing to execute.
+            return ""
+        }
+    }
+
+    private static func interpreter(for language: AssignmentLanguage) -> [String]? {
+        switch language {
+        case .python: return ["python3"]
+        case .r: return ["Rscript"]
+        case .lua: return ["lua"]
+        case .octave: return ["octave-cli", "--no-gui", "--quiet"]
+        case .racket: return ["racket"]
+        case .cpp: return nil
+        }
+    }
+
+    private static func isAvailable(_ command: String) -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["which", command]
+        proc.standardOutput = Pipe()
+        proc.standardError = Pipe()
+        do { try proc.run() } catch { return false }
+        proc.waitUntilExit()
+        return proc.terminationStatus == 0
+    }
+
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theInlinedScriptRunsInItsOwnInterpreter(_ language: AssignmentLanguage) throws {
+        guard let argv = Self.interpreter(for: language), let command = argv.first else { return }
+        // Not "expected on this platform" as a failure: a dev box has neither
+        // octave-cli nor racket, and a silent skip is the house rule for that.
+        guard Self.isAvailable(command) else { return }
+
+        let manifest = TestProperties(
+            requiredFiles: [], testSuites: [], timeLimitSeconds: 10,
+            globalVariables: [FamilyVariable(name: "threshold", value: .double(18.5))])
+        let name = "publictest_probe.\(language.sourceFileExtension)"
+        let source = TestScriptVariablePrepender.applyForRawScript(
+            filename: name, content: Self.probeBody(for: language), manifest: manifest)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck_inline_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let path = dir.appendingPathComponent(name)
+        try source.write(to: path, atomically: true, encoding: .utf8)
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = argv + [path.path]
+        proc.currentDirectoryURL = dir
+        let errPipe = Pipe()
+        proc.standardOutput = Pipe()
+        proc.standardError = errPipe
+        try proc.run()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+
+        #expect(
+            proc.terminationStatus == 0,
+            """
+            The inlined \(language.displayName) script did not run cleanly \
+            (exit \(proc.terminationStatus)). stderr:
+            \(String(data: errData, encoding: .utf8) ?? "")
+            Source:
+            \(source)
+            """)
+    }
+}

--- a/changelog.d/raw-script-inlining-language.md
+++ b/changelog.d/raw-script-inlining-language.md
@@ -1,0 +1,32 @@
+### Fixed
+
+- **A hand-written test in Lua or Racket no longer gets a banner its interpreter
+  cannot read.** The comment written above inlined global/section inputs was a
+  hardcoded `#` line in every language — a comment in Python, R, Octave and
+  shell, and a syntax error in the other three, where `#` is Lua's length
+  operator, a Racket reader prefix and a C++ preprocessor directive. Because the
+  banner is also the sentinel used to strip the previous block, re-saving
+  compounded the damage instead of repairing it. `LanguageDescriptor` gained
+  `lineCommentPrefix`, and a script already carrying the broken banner is
+  repaired on its next save. Python, R and Octave output is byte-identical.
+
+- **The main web authoring path no longer skips four languages when inlining
+  inputs.** `PUT /suite` picked a raw script's language with a hand-written
+  switch on `py`/`r` and `default: nil`, so a hand-written Lua, Octave, Racket or
+  C++ test received no global or section variables — while MCP `author_script`
+  and the single-script save, which resolve through
+  `AssignmentLanguage(scriptExtension:)`, delivered them. All three paths now
+  resolve the same way, behind one `supportsRawScriptInlining` predicate that
+  declines C++ (whose graded scripts are `.sh` wrappers, so an inlined
+  declaration would never be read).
+
+- **Racket inputs land inside the module.** A `#lang` line now keeps line 1 the
+  way a shebang does. This is stronger than the shebang rule it reuses: a
+  `(define …)` written above `#lang` is a read error, not a formatting problem.
+
+### Added
+
+- **`docs/authoring-parity.md`** — what an instructor authoring in each of the
+  six languages can and cannot do, which differences are defects and which are
+  correct refusals (with the substrate reason for each, so they stop being
+  re-litigated), and the remaining work in order.

--- a/docs/authoring-parity.md
+++ b/docs/authoring-parity.md
@@ -1,0 +1,222 @@
+# Authoring parity across the six languages
+
+What an instructor authoring in R, Lua, Octave, C++ or Racket can and cannot do
+that a Python author can — which of those differences are defects, which are
+correct refusals, and what it costs to close the ones worth closing.
+
+Written 2026-08 after the language-support UI audit (#1319). That audit fixed
+the *presentation* layer — copy that named Python or C++ where the system had
+six languages and two upload-only ones. This document is about the capability
+layer underneath it, and about four defects the audit missed.
+
+**Read the "deliberately open" section before proposing work here.** Several of
+these gaps are correct as they stand, and have been re-litigated more than once.
+
+---
+
+## The measured state
+
+| capability | Python | R | Lua | Octave | C++ | Racket |
+|---|---|---|---|---|---|---|
+| Pattern-family kinds | 8/8 | 8/8 | 8/8 | 8/8 | 8/8 | 8/8 |
+| Notebook checks | 10/10 | 9/10 | 4/10 | 5/10 | 0 (n/a) | 0 (n/a) |
+| Custom-script templates | 9 | 0 | 0 | 0 | 0 | 0 |
+| Auto-compute expected | in-page kernel | server | server | server | server | server |
+| Solution function scan | yes | no | no | no | n/a | n/a |
+
+Two rows mislead as stated:
+
+- **Templates.** Three *shell* templates are offered on every language, but
+  their bodies name Python — `FILE="solution.py"` and
+  `python3 -c "import solution; …"` (`TestScriptTemplates.swift`). A non-Python
+  author gets three templates, all wrong for them, which is worse than zero.
+- **Function scan.** The gap is three languages, not five. C++ and Racket are
+  upload-only, so there is no solution notebook to scan;
+  `notebookFunctionScanSupport` already separates the missing-parser reason from
+  the structural one.
+
+---
+
+## Defects (things that are simply wrong)
+
+### 1. Raw-script variable inlining — FIXED
+
+Three code paths answered "which language is this script?" three ways, and the
+banner written above the inlined block was a hardcoded `#` line in every
+language. `#` is a comment in Python, R, Octave and shell; it is Lua's length
+operator, a Racket reader prefix, and a C++ preprocessor directive. A Lua or
+Racket assignment with global inputs plus a hand-written test produced a file
+the interpreter refused to load — and because the banner is also the strip
+sentinel, re-saving compounded it rather than repairing it.
+
+Separately, `rawScriptOverlayWrites` (the `PUT /suite` path, which is the
+*primary web authoring path*) chose the language with a hand-written switch on
+`py`/`r` and `default: nil`, so four languages silently received no variables at
+all while MCP `author_script` and the single-script save delivered them.
+
+`LanguageDescriptor.lineCommentPrefix` is now the one place that answers the
+comment question, `supportsRawScriptInlining` is the one place that answers
+"can this language host an inlined block" (false only for C++, whose graded
+scripts are `.sh` wrappers), and all three paths resolve through
+`AssignmentLanguage(scriptExtension:)`.
+
+A fourth defect surfaced while fixing it: Racket's `#lang` line must stay first,
+and declarations must land *inside* the module it opens. A `(define …)` above
+`#lang` is a read error no comment placement rescues, so `#lang` now keeps line 1
+the way a shebang does.
+
+`RawScriptVariableInliningTests` covers all six languages, and its execution
+suite writes the emitted file and runs it in each interpreter present on the
+host — which is the only kind of assertion that would have caught the original
+bug.
+
+### 2. "Create notebook" always writes a Python kernelspec
+
+`defaultNotebookData(title:)` in `NotebookScaffoldHelpers.swift` hardcodes
+`xpython` / `Python (xeus-python)` / `"language": "python"`, and is called from
+four sites with no language argument. Select R in the language selector, click
+"Create assignment notebook", and you get a Python notebook: the assignment
+still resolves R (a recorded manifest language outranks the kernelspec), so
+generated tests are `.R` while the editor boots `xpython` and the student writes
+R into a Python kernel. On a draft with no recorded language yet, the Python
+kernelspec becomes a *sticky* signal.
+
+Every fact needed is already on `EditorSupport.notebookKernel`.
+
+Related, same area: the Files table offers a "Solution Notebook" row and a
+"create solution from assignment notebook" button on C++ and Racket assignments,
+which have no notebook workflow. MCP's `update_solution` handles this correctly
+with a `solutionFile` parameter; the web UI has no equivalent, so a web-only C++
+author has no supported way to supply the reference solution that
+`compute-expected` and every `= solution.foo(...)` expression depend on.
+
+### 3. Markdown-section scaffolding is refused as collateral
+
+`autoScaffoldFromSolutionNotebook` bails on `scan.functions.isEmpty` before
+writing sections, and the scan returns nothing at all for a language it cannot
+read. But section names come from `## ` markdown headers and have nothing to do
+with the code language. So five languages get no auto-scaffolded suite sections
+for a reason that only applies to function extraction.
+
+`NotebookScanResult` conflates two answers; `unsupportedReason` should scope to
+`functions`, not to `sectionNames`.
+
+### 4. A residual of the upload-only copy defect, and the guard's blind spot
+
+`UpdateSolutionTool` still says "For a language with no notebook workflow (C++),
+pass solutionFile instead". Racket has been the second such language since it
+shipped. `MCPLanguageCoverageTests`' subset guard misses it because the guard
+triggers on the literal token `uploadOnly` and this sentence says "no notebook
+workflow" — the guard needs its *trigger phrases* widened, not its match rule
+loosened (loosening it would flag the legitimately-C++-only prose about `.sh`
+generated extensions).
+
+---
+
+## Gaps that are correct as they stand
+
+Do not open work items for these. Each has been checked against the substrate
+rather than assumed.
+
+**Lua's four data-frame kinds and `figureCount`.** Lua has no data-frame type,
+and `emscripten-forge-4x` ships no Lua library packages at all — which is why
+`KernelImportGuard` declines `.lua` outright. Not a packaging decision anyone
+can reverse by paying a boot cost. Permanent.
+
+**Octave's four data-frame kinds.** No `table` in core Octave; Octave Forge's
+`dataframe` is not on the channel. The stronger reason, and the one to cite:
+**check support is per-language, not per-grading-mode.** An Octave assignment
+may be browser- or worker-graded, and the same saved check must mean the same
+thing in both. A kind only the native substrate could run would let a
+grading-mode toggle silently invalidate saved checks. Permanent unless both
+substrates can serve it.
+
+**`astStructure` outside Python.** Its predicate vocabulary (`for_loop`,
+`list_comprehension`, `lambda`, `recursion`, `import:<module>`) is Python
+semantics, not generic structure: `lambda` in R would match every function,
+`list_comprehension` has no analogue, `import:` would have to silently mean
+`library()`. The renderer also walks the preserved `_submission.ipynb` with
+Python's `ast` at grade time. A check whose name means something different per
+language is worse than no check. `cellContains` remains the escape hatch.
+Permanent.
+
+**`cellContains` with `regex: true` on Lua.** Lua patterns are not PCRE — no
+alternation, no `{n,m}`, `%d` for `\d`. A pattern authored against the Python or
+R renderer would not error; it would match the wrong thing and award marks on
+that basis. Refused at save, and surfaced in the authoring form since #1319.
+Permanent. Octave answers the opposite (its `regexp` is PCRE, verified against
+`octave-cli`), which is what shows these are per-language judgements rather than
+copied ones.
+
+**All ten notebook checks and the function scan on C++ and Racket.** Both are
+`EditorSupport.uploadOnly`: no submitted notebook for a check to inspect, no
+solution notebook to scan. C++'s upload-only status is a *decision* (grading a
+different compiler than the course teaches is a pedagogy defect); Racket's is
+*contingent* (no Scheme-family kernel exists on the channel). Only Racket's is
+reviewable, and only if a kernel appears.
+
+**Moving Python auto-compute to the server.** The in-page evaluator is
+xeus-python — the same kernel that grades browser-graded Python — so the split
+gives Python *more* fidelity than uniformity would: the expected value is
+computed on the exact interpreter and package set the generated test will be
+asserted against. The old reason to move it (retiring `Public/pyodide`) no
+longer applies; that worker already migrated. **CLAUDE.md's roadmap note listing
+`pyodide-worker.js` as a Pyodide blocker is stale.**
+
+**In-page kernels for R/Lua/Octave auto-compute.** Five more kernel boots on the
+edit page, paid by every author on every visit, to close a fidelity gap those
+languages do not have — their kernels ship bare, so there is no package-version
+surface to diverge on.
+
+**Per-language custom-script template sets.** Seven of the nine Python templates
+are already available in every language as pattern-family kinds, in a better
+form: server-rendered, spec-hashed, re-renderable, and pinned by execution
+tests. `structural_check` is Python-only by nature. Only `differential` has no
+equivalent, and it is reachable with a family plus auto-compute. Writing 45
+templates would be a second implementation of renderers that already exist, and
+would turn a one-line vocabulary change into a 54-file edit.
+
+| template | pattern-family equivalent | available in |
+|---|---|---|
+| `exists` | the automatic existence guard | all 6 |
+| `correctness` | `boundaryEquality` | all 6 |
+| `corner_cases` | `boundaryEquality`, several cases | all 6 |
+| `exception` | `exceptionExpected` | all 6 |
+| `type_check` | `returnTypeCheck` | all 6 |
+| `performance` | `performanceThreshold` | all 6 |
+| `variable_equality` | `variableEquality` | all 6 |
+| `structural_check` | the `astStructure` notebook check | Python only, by nature |
+| `differential` | none | — |
+
+**CodeMirror modes for Lua, Octave and Racket.** Requires re-vendoring
+`Public/vendor/codemirror.js`; the payoff is syntax colour.
+
+---
+
+## Work, in order
+
+1. **Raw-script inlining.** *(done — see Defect 1.)*
+2. **Language-aware notebook scaffolding.** `defaultNotebookData(title:language:)`
+   from `EditorSupport.notebookKernel`; refuse for upload-only languages and
+   replace the notebook rows in the Files table with a reference-solution *file*
+   control backed by the same write `update_solution`'s `solutionFile` path uses.
+3. **Split the scan's two answers** so section scaffolding runs for every
+   language. Prerequisite for 5.
+4. **Copy and guard.** `update_solution`'s sentence via `LanguageProse`; widen
+   the coverage guard's trigger phrases; give `shellTestScript` the assignment's
+   language so its three templates stop naming `solution.py`; correct the stale
+   doc comment on `AuthoringLanguageFacts.expressionEvaluation`, which still
+   describes a browser-only evaluator that hides the control on non-Python.
+5. **R, Lua and Octave function parsers.** Factor `extractTopLevelFunctions`
+   into a per-language `parseDefinition` selected behind the existing exhaustive
+   `notebookFunctionScanSupport`, and move those three arms as each parser
+   lands. Name and parameter names for all three; defaults for R; return-variable
+   names for Octave; no type hints anywhere, which is the same state an
+   un-annotated Python function already produces. Do **not** write a grammar
+   table: Octave puts return variables before the name, Lua has three definition
+   forms, and R's is an assignment whose RHS is a `function` literal. A table
+   expressive enough for all of them is a parser generator; one that is not will
+   silently miss definitions, which is the failure mode this whole apparatus
+   exists to end.
+6. **Close the template row in writing.** Put the cross-reference table above in
+   the Add Test picker on non-Python assignments, derived from the kind list.


### PR DESCRIPTION
A hand-written test in a Lua or Racket assignment that uses global or section inputs is currently **written to disk broken**. This fixes that, plus two other defects in the same feature found on the way.

Split out from the language-support audit (#1319) because it is a bugfix that should not wait behind UI work. Independent of that branch — this one is cut from `main`.

## The bug

The banner comment written above inlined inputs was one hardcoded `#` line for every language:

```
# === Chickadee inputs: name = value, prepended at save time. Do not edit. ===
```

`#` is a comment in Python, R, Octave and shell. It is **Lua's length operator**, **starts a Racket reader form**, and is a **C++ preprocessor directive**. So a Lua or Racket assignment with global inputs plus a hand-written test produced a file its interpreter refuses to load.

It compounds, because the banner is also the sentinel `stripExistingBlock` searches for: a banner the stripper cannot recognise is one it cannot remove, so each re-save stacked another broken block on top.

`LanguageDescriptor.lineCommentPrefix` now answers this in one place, exhaustively. The stripper recognises every language's banner *plus* the legacy `#` form, so a file already carrying a broken block is repaired on its next save — the only recovery path those files have, since the block's extent is not obvious to someone editing by hand. **Python, R and Octave output is byte-identical**, so no existing script changes.

## Second defect, same feature

`rawScriptOverlayWrites` — the `PUT /suite` path, which is the *primary web authoring path* — chose a raw script's language with a hand-written switch on `py`/`r` and `default: nil`. Lua, Octave, Racket and C++ fell to the default and received no variables at all, while MCP `author_script` and the single-script save resolved all six through `AssignmentLanguage(scriptExtension:)` and delivered them. The same feature, present or absent depending on which button the instructor pressed.

All three paths now resolve identically, behind one `supportsRawScriptInlining` predicate.

That predicate declines C++, and says why rather than falling through: a C++ test case is a `.sh` wrapper, so a bare `.cpp` in the suite is not something the runner executes and an inlined declaration would never be read — inputs reach C++ through `_ck_inputs.hpp`. The `emit` arm that answered `.cpp` with POSIX shell assignments turned out to be unreachable (no caller ever passed `.cpp`) and would have written shell into a C++ file if one had.

## Third defect, found while writing the tests

Racket's `#lang` line must stay first, and declarations must land *inside* the module it opens. A `(define …)` above `#lang` is a read error that no comment placement rescues — so even a correctly-commented banner would not have been enough. `#lang` now holds line 1 the way a shebang does.

I could not verify this against a real `racket` in this container (see Verification), so it is argued from the language's module semantics rather than measured. Worth a reviewer's eye.

## Tests

`RawScriptVariableInliningTests` covers all six languages: banner-is-a-comment, every-language-gets-its-inputs, C++ and `.sh` declining, `#lang`/shebang placement, idempotency on re-save, and repair of the legacy broken banner.

The execution suite writes the emitted file and runs it in each interpreter present on the host. **That is the assertion that would have caught the original bug** — the existing coverage exercised `.R`, `.py` and `.sh`, which is precisely the set where it does not appear. I sabotaged the Python probe to confirm the suite actually fails rather than silently skipping.

## Also included

`docs/authoring-parity.md` — the per-language capability map: which differences are defects, which are **correct refusals** (with the substrate reason for each, so they stop being re-litigated), and the remaining work in order. Two things in it are worth a maintainer's attention beyond this PR: the notebook scaffold always writes a Python kernelspec regardless of the selected language, and CLAUDE.md's roadmap note listing `pyodide-worker.js` as a Pyodide blocker is stale — that worker already moved to xeus-python.

## Verification

`swift build` clean; 302 tests across the touched suites pass; `format.sh`, `lint.sh`, `swiftlint.sh --strict` (0 violations) green.

**Only `python3` and `g++` are installed in this container**, so the execution suite exercised Python for real and skipped R, Lua, Octave and Racket silently (the house idiom for "expected on this platform"). CI has more of them; the Racket case in particular has not run anywhere yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcV8dFXd1H9476AxSwpeam)_