### PR TITLE
refactor(core): make two language capabilities normative, not descriptive

### DIFF
--- a/Public/generated-starter-tests.js
+++ b/Public/generated-starter-tests.js
@@ -131,7 +131,7 @@
                     setStatus('Upload a notebook first to start a draft.');
                     return;
                 }
-                var tplType = genTplSelect ? genTplSelect.value : 'py:correctness';
+                var tplType = genTplSelect ? genTplSelect.value : 'py:differential';
                 var checked = fnChecklist
                     ? Array.prototype.slice.call(
                         fnChecklist.querySelectorAll('input[type=checkbox]:checked'))

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -1541,7 +1541,12 @@
         function getWorker() {
             if (_worker) return _worker;
             var version = (document.querySelector('meta[name="app-version"]') || {}).content || '';
-            var workerURL = '/python-eval-worker.js' + (version ? '?v=' + encodeURIComponent(version) : '');
+            // WHICH worker comes from the language seed, not from this file.
+            // It was hardcoded to the Python one, which is why auto-compute
+            // could only ever be in-page for Python.
+            var workerScript = ChickadeeLanguage.autoComputeWorker();
+            if (!workerScript) return null;
+            var workerURL = workerScript + (version ? '?v=' + encodeURIComponent(version) : '');
             _worker = new Worker(workerURL);
             _worker.addEventListener('message', function (e) {
                 var data = e.data || {};
@@ -1585,6 +1590,14 @@
             return new Promise(function (resolve, reject) {
                 var id = _nextRequestId++;
                 var worker = getWorker();
+                // Unreachable through `callSolution`, which routes to the
+                // server when the language declares no in-page worker. Guarded
+                // anyway so a future caller gets a rejection rather than a
+                // TypeError on `worker.postMessage`.
+                if (!worker) {
+                    reject(new Error('This language has no in-page evaluator.'));
+                    return;
+                }
                 var timer = null;
                 if (timeoutMs && timeoutMs > 0) {
                     timer = setTimeout(function () {
@@ -1737,11 +1750,17 @@
         }
 
         function callSolution(fnName, args, opts) {
-            // Python keeps the in-page kernel: it is faster, and its handling of
-            // a None return and of types that do not round-trip through JSON is
-            // behaviour existing assignments rely on. Every other language goes
-            // to the server, which is the only place that can answer at all.
-            if (languageFacts.name && languageFacts.name !== 'python') {
+            // IN-PAGE WHEREVER A KERNEL EXISTS, and the language seed decides
+            // which — not a name check here.
+            //
+            // This read `name !== 'python'` and sent every other language to
+            // the server, which was true when the in-page evaluator was the
+            // only kernel the editor could boot. It is the wrong rule for an
+            // editor whose job is in-browser authoring and verification: an
+            // author changing a case should see what their solution returns
+            // without a server round-trip. The languages with no kernel
+            // (C++, Racket) declare `serverDriver` and still route there.
+            if (!ChickadeeLanguage.autoComputeWorker()) {
                 return callSolutionOnServer(fnName, args, opts);
             }
             var captureStdout = !!(opts && opts.captureStdout);

--- a/Public/test-renderer-script.js
+++ b/Public/test-renderer-script.js
@@ -30,34 +30,29 @@ import {
 (function (global) {
     'use strict';
 
-<<<<<<< HEAD
     // Which template groups an assignment may pick from.
     //
     // The Python group is Python-only, and used not to be gated at all: an
     // Octave author opened "Write a custom script" — advertised in the Add Test
-    // catalog as "your assignment's language, or .sh" — and was offered nine
-    // Python templates and a `test_correctness.py` filename. Applying one wrote
-    // Python into an Octave suite.
+    // catalog as "your assignment's language, or .sh" — and was offered Python
+    // templates and a `test_correctness.py` filename. Applying one wrote Python
+    // into an Octave suite.
     //
     // The Shell group is offered everywhere because it IS everywhere: `.sh` is
     // the universal test-script contract, and a shell test is a legitimate
     // thing to hand-write in any assignment.
     //
-    // The other five languages have no template set. That is an authoring gap,
-    // not a structural one — writing pedagogically sound R/Lua/Octave/C++/
-    // Racket equivalents of these nine is content work. Until they exist the
-    // picker offers Shell and Blank, and Blank opens an empty file with the
-    // assignment's own extension, which is the honest answer.
+    // The Python group is down to ONE. The other eight duplicated a
+    // pattern-family kind that renders in all six languages, in a better form,
+    // and offering both taught authors to reach for the fallback — the one that
+    // only works in Python. `differential` survives because nothing supersedes
+    // it yet.
+    //
+    // So the other five languages get Shell and Blank, and Blank opens an empty
+    // file with the assignment's own extension. That is a smaller gap than it
+    // looks: the tests those templates wrote are pattern families now.
     var PYTHON_TEMPLATE_GROUP = { group: 'Python', items: [
-            { value: 'py:exists', label: 'Function Exists' },
-            { value: 'py:correctness', label: 'Correctness (input/output pairs)' },
-            { value: 'py:corner_cases', label: 'Corner Cases' },
-            { value: 'py:exception', label: 'Exception Handling' },
-            { value: 'py:type_check', label: 'Return Type Check' },
-            { value: 'py:performance', label: 'Performance / Runtime' },
-            { value: 'py:differential', label: 'Differential (reference solution)' },
-            { value: 'py:variable_equality', label: 'Variable Equality' },
-            { value: 'py:structural_check', label: 'Structural Check (AST properties)' }
+        { value: 'py:differential', label: 'Differential (reference solution)' }
     ] };
 
     var SHELL_TEMPLATE_GROUP = { group: 'Shell', items: [
@@ -86,22 +81,6 @@ import {
         var language = global.ChickadeeLanguage;
         return language ? language.scriptExtension() : 'py';
     }
-=======
-    var TEMPLATE_OPTIONS = [
-        // Python's template set is down to one. The other eight duplicated a
-        // pattern-family kind that renders in all six languages, in a better
-        // form, and offering both taught authors to reach for the fallback.
-        // `differential` has no first-class equivalent yet.
-        { group: 'Python', items: [
-            { value: 'py:differential', label: 'Differential (reference solution)' }
-        ] },
-        { group: 'Shell', items: [
-            { value: 'sh:always_pass', label: 'Always Pass (placeholder)' },
-            { value: 'sh:file_exists', label: 'File Exists Check' },
-            { value: 'sh:command_output', label: 'Command Output Check' }
-        ] }
-    ];
->>>>>>> 4cba87e (refactor(templates): retire the eight script templates pattern families replaced)
 
     function cfg() { return global.ChickadeeScriptRendererConfig || {}; }
 

--- a/Public/test-renderer-script.js
+++ b/Public/test-renderer-script.js
@@ -30,6 +30,7 @@ import {
 (function (global) {
     'use strict';
 
+<<<<<<< HEAD
     // Which template groups an assignment may pick from.
     //
     // The Python group is Python-only, and used not to be gated at all: an
@@ -85,6 +86,22 @@ import {
         var language = global.ChickadeeLanguage;
         return language ? language.scriptExtension() : 'py';
     }
+=======
+    var TEMPLATE_OPTIONS = [
+        // Python's template set is down to one. The other eight duplicated a
+        // pattern-family kind that renders in all six languages, in a better
+        // form, and offering both taught authors to reach for the fallback.
+        // `differential` has no first-class equivalent yet.
+        { group: 'Python', items: [
+            { value: 'py:differential', label: 'Differential (reference solution)' }
+        ] },
+        { group: 'Shell', items: [
+            { value: 'sh:always_pass', label: 'Always Pass (placeholder)' },
+            { value: 'sh:file_exists', label: 'File Exists Check' },
+            { value: 'sh:command_output', label: 'Command Output Check' }
+        ] }
+    ];
+>>>>>>> 4cba87e (refactor(templates): retire the eight script templates pattern families replaced)
 
     function cfg() { return global.ChickadeeScriptRendererConfig || {}; }
 

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -261,15 +261,7 @@ Create Assignment
                 <label class="gen-template-label">
                     Template:
                     <select id="gen-template-select" class="form-input select-xs">
-                        <option value="py:exists">Function Exists</option>
-                        <option value="py:correctness" selected>Correctness (input/output pairs)</option>
-                        <option value="py:corner_cases">Corner Cases</option>
-                        <option value="py:exception">Exception Handling</option>
-                        <option value="py:type_check">Return Type Check</option>
-                        <option value="py:performance">Performance / Runtime</option>
-                        <option value="py:differential">Differential (reference solution)</option>
-                        <option value="py:variable_equality">Variable Equality</option>
-                        <option value="py:structural_check">Structural Check (AST properties)</option>
+                        <option value="py:differential" selected>Differential (reference solution)</option>
                     </select>
                 </label>
             </div>

--- a/Sources/APIServer/Routes/Web/NotebookScaffoldHelpers.swift
+++ b/Sources/APIServer/Routes/Web/NotebookScaffoldHelpers.swift
@@ -51,10 +51,9 @@ func submissionFilenameForStorage(uploadedName: String?, fallback: String) -> St
     return fileName
 }
 
-/// Runs a section-aware scan over `notebookData` and, if the test setup
-/// looks "fresh" (no existing sections, no existing test scripts), writes
-/// one `publictest_exists_<fn>.py` scaffold per detected function into
-/// the zip and updates the manifest to declare the sections + entries.
+/// Runs a section-aware scan over `notebookData` and, if the test setup looks
+/// "fresh" (no existing sections, no existing test scripts), declares the
+/// notebook's `## ` headers as suite sections.
 ///
 /// Silently no-ops if the setup already has sections or test entries —
 /// instructors who've manually arranged things shouldn't get clobbered
@@ -106,33 +105,17 @@ func autoScaffoldFromSolutionNotebook(
         sectionDicts.append(["id": id, "name": name])
     }
 
-    // 2. Generate one "exists" test script per detected function.
-    //    Skip shadowed redefinitions — Python's last-def-wins semantics
-    //    means the earlier function isn't reachable at test time.
-    var writes: [String: String] = [:]
-    var newSuites: [[String: Any]] = []
-    for entry in scan.functions where !entry.info.isShadowed {
-        let fn = entry.info.name
-        let filename = "publictest_exists_\(fn).py"
-        guard writes[filename] == nil else { continue }  // dedup by filename
-        writes[filename] = pythonTestScript(type: .exists, functionName: fn)
-        var testDict: [String: Any] = [
-            "tier": "public",
-            "script": filename,
-            "name": "\(fn) exists",
-        ]
-        if let sectionName = entry.sectionName, let sid = sectionIDByName[sectionName] {
-            testDict["sectionID"] = sid
-        }
-        newSuites.append(testDict)
-    }
-    // 3. Write the scaffold files into the zip (idempotent — if the file
-    //    somehow already exists, the same content overwrites).  Skipped when
-    //    there are none, which is the ordinary case for a language whose
-    //    functions cannot be scanned; the sections below are still written.
-    if !writes.isEmpty {
-        try applyScriptChangesToZip(zipPath: zipPath, writes: writes, deletions: [])
-    }
+    // 2. NO PER-FUNCTION SCRIPTS. This used to write one
+    //    `publictest_exists_<fn>.py` per detected function, from the `exists`
+    //    template — which was removed along with the seven other Python
+    //    templates a pattern-family kind already covers. The existence guard it
+    //    generated is emitted automatically by every family, in all six
+    //    languages, so the scaffold was seeding a Python script to do a job the
+    //    first-class construct does better and everywhere.
+    //
+    //    Sections are still scaffolded, which is the part of this flow that was
+    //    always language-neutral and always useful.
+    let newSuites: [[String: Any]] = []
 
     // 4. Rewrite the manifest with sections + testSuites populated.
     //    Preserve every other field the manifest already had (gradingMode,
@@ -144,7 +127,7 @@ func autoScaffoldFromSolutionNotebook(
     setup.manifest = newManifest
     try await setup.save(on: db)
 
-    return (scan.sectionNames.count, writes.count)
+    return (scan.sectionNames.count, 0)
 }
 
 /// Refusal shown when a notebook is scaffolded for a language that has none.

--- a/Sources/APIServer/Utilities/AuthoringLanguageFacts.swift
+++ b/Sources/APIServer/Utilities/AuthoringLanguageFacts.swift
@@ -107,6 +107,14 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
     /// change.
     let expressionEvaluation: Bool
 
+    /// The in-page worker that computes an expected value, or nil when this
+    /// language has no kernel and the server evaluates instead.
+    ///
+    /// From `AutoComputeSubstrate`, which carries the worker path — so the
+    /// editor cannot spawn a script the descriptor does not name, and a
+    /// language cannot claim in-page evaluation without saying what runs it.
+    let autoComputeWorker: String?
+
     /// Facts for `language`, or the language-less answer when it is nil.
     init(_ language: AssignmentLanguage?) {
         guard let language else {
@@ -118,6 +126,7 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
             self.scriptExtension = nil
             self.functionScanning = false
             self.expressionEvaluation = false
+            self.autoComputeWorker = nil
             self.unsupportedCheckKinds = [:]
             return
         }
@@ -161,6 +170,10 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
         self.unsupportedCheckKinds = unsupported
         self.functionScanning = notebookFunctionScanSupport(for: language).isSupported
         self.expressionEvaluation = PersonalizationEvaluator.supportsEvaluation(language)
+        switch language.descriptor.autoCompute {
+        case .inPageKernel(let workerScript): self.autoComputeWorker = workerScript
+        case .serverDriver: self.autoComputeWorker = nil
+        }
     }
 }
 

--- a/Sources/APIServer/Utilities/TestScriptTemplates.swift
+++ b/Sources/APIServer/Utilities/TestScriptTemplates.swift
@@ -17,87 +17,43 @@
 import Core
 import Foundation
 
-// MARK: - Rich-feedback argument rendering
-
-/// Renders Python fragments describing a function's parameters for the
-/// single-case rich-feedback templates (correctness, typeCheck, exception).
-///
-/// Given paramNames = ["bmi"] the fragments produce:
-///   argDeclarations  → `bmi = None   # TODO: replace with input value`
-///   callArgs         → `bmi`
-///   inputLineLiteral → an f-string of the `input` field label (see
-///                      `GeneratedMessage`) followed by `bmi={bmi!r}`
-///   callReprExpr     → `{bmi!r}`
-///
-/// For empty paramNames the literals degrade gracefully to "(no input)"
-/// and an empty call expression.
-private struct RichTemplateArgs {
-    let paramNames: [String]
-    var hasArgs: Bool { !paramNames.isEmpty }
-    var callArgs: String { paramNames.joined(separator: ", ") }
-
-    var argDeclarations: String {
-        paramNames
-            .map { "\($0) = None   # TODO: replace with input value" }
-            .joined(separator: "\n")
-    }
-
-    /// Python source fragment for the `input:` line inside a `failed(...)`
-    /// concatenation — already quoted, with trailing `\n` escape.
-    var inputLineLiteral: String {
-        guard hasArgs else {
-            return #""\#(GeneratedMessage.input)(no input)\n""#
-        }
-        let preview = paramNames.map { "\($0)={\($0)!r}" }.joined(separator: ", ")
-        return "f\"\(GeneratedMessage.input)\(preview)\\n\""
-    }
-
-    /// `{x!r}, {y!r}` — used inside an outer f-string to echo the call args.
-    var callReprExpr: String {
-        paramNames.map { "{\($0)!r}" }.joined(separator: ", ")
-    }
-}
-
 // MARK: - Template type enumerations
 
 /// Template types for Python test scripts.
+///
+/// ONE LEFT, and that is the point. Eight of these duplicated a pattern-family
+/// kind that renders in ALL SIX languages, in a strictly better form: a family
+/// is server-rendered, spec-hashed, re-renders when a case changes, and is
+/// pinned by execution tests, where a template is a one-shot text dump the
+/// instructor then owns forever. Offering both taught authors to reach for the
+/// fallback.
+///
+/// | removed | superseded by |
+/// |---|---|
+/// | `exists` | the automatic existence guard every family emits |
+/// | `correctness` | `boundaryEquality` |
+/// | `corner_cases` | `boundaryEquality`, several cases |
+/// | `exception` | `exceptionExpected` |
+/// | `type_check` | `returnTypeCheck` |
+/// | `performance` | `performanceThreshold` |
+/// | `variable_equality` | `variableEquality` |
+/// | `structural_check` | the `astStructure` notebook check |
+///
+/// `differential` stays because nothing supersedes it yet — no pattern kind
+/// compares a submission against a reference implementation. It is the
+/// candidate for a ninth kind, and this enum should empty out when that lands.
 enum PythonTestTemplateType: String, CaseIterable {
-    case exists = "exists"
-    case correctness = "correctness"
-    case cornerCases = "corner_cases"
-    case exception = "exception"
-    case typeCheck = "type_check"
-    case performance = "performance"
-    case differential = "differential"
-    case variableEquality = "variable_equality"
-    case structuralCheck = "structural_check"
+    case differential
 
     var displayName: String {
         switch self {
-        case .exists: return "Function Exists"
-        case .correctness: return "Correctness (input/output pairs)"
-        case .cornerCases: return "Corner Cases"
-        case .exception: return "Exception Handling"
-        case .typeCheck: return "Return Type Check"
-        case .performance: return "Performance / Runtime"
         case .differential: return "Differential (reference solution)"
-        case .variableEquality: return "Variable Equality"
-        case .structuralCheck: return "Structural Check (AST properties)"
         }
     }
 
     var templateDescription: String {
         switch self {
-        case .exists: return "Checks that the function is defined and callable"
-        case .correctness: return "Calls the function with specific inputs and checks the output"
-        case .cornerCases: return "Tests edge cases: None, 0, empty list, empty string, negatives"
-        case .exception: return "Verifies the function raises an expected exception type"
-        case .typeCheck: return "Verifies the return type matches what is expected"
-        case .performance: return "Measures execution time and checks it is within a threshold"
         case .differential: return "Compares output against an inline reference implementation"
-        case .variableEquality: return "Checks that a module-level variable is defined and equals an expected value"
-        case .structuralCheck:
-            return "Verifies structural properties of student code (type hints, docstring, assert count, …)"
         }
     }
 }
@@ -121,28 +77,12 @@ enum ShellTestTemplateType: String, CaseIterable {
 
 /// Returns a Python test script for the given template type.
 /// `functionName` and `paramNames` are used to personalise the template.
-///
-/// Body length is driven by the switch over every supported
-/// `PythonTestTemplateType` case (one per template kind, each holding
-/// a multi-line Python `"""…"""` literal).  Extracting per-kind helpers
-/// just renames the same templates without removing any.
-func pythonTestScript(  // swiftlint:disable:this function_body_length
+func pythonTestScript(
     type: PythonTestTemplateType,
     functionName: String = "my_function",
     paramNames: [String] = []
 ) -> String {
     let argList = paramNames.joined(separator: ", ")
-    let rich = RichTemplateArgs(paramNames: paramNames)
-
-    // Placeholder call args — use plain `None` values so the generated
-    // line still parses as Python.  The inline "# TODO" comment that used
-    // to live here broke `ast.parse` because `#` swallows the rest of the
-    // line including the closing `)`.  The TODO guidance now lives on a
-    // separate comment line above the call site.
-    let placeholderCallArgs: String = {
-        if paramNames.isEmpty { return "" }
-        return paramNames.map { _ in "None" }.joined(separator: ", ")
-    }()
 
     // Wrap the switch in a closure so every case can `return …` while we
     // still prepend a Python shebang to the final result.  Without the
@@ -153,161 +93,6 @@ func pythonTestScript(  // swiftlint:disable:this function_body_length
     // through the Python runtime regardless of extension.
     let body: String = {
         switch type {
-
-        case .exists:
-            let numArgsClause = paramNames.isEmpty ? "" : ", num_args=\(paramNames.count)"
-            return """
-                # Test: \(functionName) is defined and callable
-                require_function("\(functionName)"\(numArgsClause))
-                passed("\(functionName) is defined and callable")
-                """
-
-        case .correctness:
-            let declsBlock = rich.argDeclarations.isEmpty ? "" : rich.argDeclarations + "\n"
-            return """
-                # Test: \(functionName) returns the correct output
-                #
-                # Fill in the input value(s) and expected output, then customise the hint.
-                \(declsBlock)expected = None   # TODO: replace with expected output
-
-                try:
-                    result = student_module.\(functionName)(\(rich.callArgs))
-                except Exception as ex:
-                    failed(
-                        "\(functionName) raised an \(GeneratedMessage.unexpectedException)\\n"
-                        \(rich.inputLineLiteral)
-                        f"\(GeneratedMessage.expected){expected!r}\\n"
-                        f"\(GeneratedMessage.error){type(ex).__name__}: {ex}\\n"
-                        "Hint: the function should return a value for this input, not raise."
-                    )
-
-                if result != expected:
-                    failed(
-                        "\(functionName) returned the \(GeneratedMessage.wrongValue)\\n"
-                        \(rich.inputLineLiteral)
-                        f"\(GeneratedMessage.expected){expected!r}\\n"
-                        f"\(GeneratedMessage.got){result!r}\\n"
-                        "Hint: describe the correct behaviour here."
-                    )
-
-                passed(f"Correct: \(functionName)(\(rich.callReprExpr)) returned {result!r}")
-                """
-
-        case .cornerCases:
-            return """
-                # Test: \(functionName) handles edge / corner cases
-                #
-                # Each entry is  (args_tuple, expected_output).
-                # Use expected=None to only check that no exception is raised.
-                corner_cases = [
-                    ((None,),   None),   # None input   -- TODO: fill in or remove
-                    ((0,),      None),   # zero          -- TODO: fill in or remove
-                    ((-1,),     None),   # negative      -- TODO: fill in or remove
-                    (([],),     None),   # empty list    -- TODO: fill in or remove
-                    (("",),     None),   # empty string  -- TODO: fill in or remove
-                ]
-                failures = []
-                for args, expected in corner_cases:
-                    args_preview = ", ".join(repr(a) for a in args)
-                    try:
-                        result = student_module.\(functionName)(*args)
-                        if expected is not None and result != expected:
-                            failures.append(
-                                f"  \(functionName)({args_preview})\\n"
-                                f"  \(GeneratedMessage.expected){expected!r}\\n"
-                                f"  \(GeneratedMessage.got){result!r}"
-                            )
-                    except Exception as ex:
-                        failures.append(
-                            f"  \(functionName)({args_preview})\\n"
-                            f"    raised: {type(ex).__name__}: {ex}"
-                        )
-                if failures:
-                    failed(
-                        f"\(functionName) mishandled {len(failures)} of {len(corner_cases)} corner case(s):\\n"
-                        + "\\n".join(failures)
-                        + "\\nHint: check that each corner case returns the right value and doesn't raise."
-                    )
-                passed(f"All {len(corner_cases)} corner case(s) handled")
-                """
-
-        case .exception:
-            let declsBlock = rich.argDeclarations.isEmpty ? "" : rich.argDeclarations + "\n"
-            return """
-                # Test: \(functionName) raises the expected exception on invalid input
-                #
-                # Fill in the input value(s) that should trigger the exception.
-                \(declsBlock)expected_exc = ValueError   # TODO: change to expected exception type
-
-                try:
-                    result = student_module.\(functionName)(\(rich.callArgs))
-                except expected_exc:
-                    passed(f"\(functionName)(\(rich.callReprExpr)) correctly raised {expected_exc.__name__}")
-                except Exception as ex:
-                    failed(
-                        f"\(functionName) raised the wrong exception\\n"
-                        \(rich.inputLineLiteral)
-                        f"\(GeneratedMessage.expected){expected_exc.__name__}\\n"
-                        f"\(GeneratedMessage.got){type(ex).__name__}: {ex}\\n"
-                        "Hint: describe which inputs should trigger this exception."
-                    )
-                else:
-                    failed(
-                        f"\(functionName) did not raise {expected_exc.__name__}\\n"
-                        \(rich.inputLineLiteral)
-                        f"\(GeneratedMessage.expected)raises {expected_exc.__name__}\\n"
-                        f"\(GeneratedMessage.got)returned {result!r}\\n"
-                        "Hint: describe which inputs should trigger this exception."
-                    )
-                """
-
-        case .typeCheck:
-            let declsBlock = rich.argDeclarations.isEmpty ? "" : rich.argDeclarations + "\n"
-            return """
-                # Test: \(functionName) returns the expected type
-                #
-                # Replace `list` with the type you expect (int, str, dict, bool, …).
-                \(declsBlock)expected_type = list   # TODO: change to the expected return type
-
-                try:
-                    result = student_module.\(functionName)(\(rich.callArgs))
-                except Exception as ex:
-                    failed(
-                        f"\(functionName) raised an \(GeneratedMessage.unexpectedException)\\n"
-                        \(rich.inputLineLiteral)
-                        f"\(GeneratedMessage.expected)a {expected_type.__name__}\\n"
-                        f"\(GeneratedMessage.error){type(ex).__name__}: {ex}\\n"
-                        f"Hint: \(functionName) should return a {expected_type.__name__} for this input, not raise."
-                    )
-
-                if not isinstance(result, expected_type):
-                    failed(
-                        "Return type error\\n"
-                        \(rich.inputLineLiteral)
-                        f"\(GeneratedMessage.expected)a {expected_type.__name__}\\n"
-                        f"\(GeneratedMessage.got){result!r} (type {type(result).__name__})\\n"
-                        f"Hint: \(functionName) should return a {expected_type.__name__}."
-                    )
-
-                passed(f"\(functionName)(\(rich.callReprExpr)) returned a {type(result).__name__} as expected")
-                """
-
-        case .performance:
-            return """
-                # Test: \(functionName) completes within the time limit
-                #
-                # Use a large or realistic input to stress-test performance.
-                import time
-                time_limit_ms = 100  # TODO: adjust threshold (milliseconds)
-                # TODO: replace with a meaningful, large input
-                start = time.perf_counter()
-                student_module.\(functionName)(\(placeholderCallArgs))
-                elapsed_ms = (time.perf_counter() - start) * 1000
-                if elapsed_ms < time_limit_ms:
-                    passed(f"Completed in {elapsed_ms:.1f} ms (limit: {time_limit_ms} ms)")
-                else:
-                    failed(f"Too slow: {elapsed_ms:.1f} ms (limit: {time_limit_ms} ms)")
-                """
 
         case .differential:
             let refParams = argList.isEmpty ? "*args, **kwargs" : argList
@@ -331,149 +116,6 @@ func pythonTestScript(  // swiftlint:disable:this function_body_length
                     failed("\\n".join(failures))
                 else:
                     passed(f"All {len(test_inputs)} case(s) match reference")
-                """
-
-        case .variableEquality:
-            return """
-                # Test: student_module defines a variable with the expected value
-                #
-                # Use this template when the assignment asks students to create a
-                # module-level variable (e.g. `answer = 42`) rather than a function.
-                # The NotebookExtractor preserves simple module-level assignments at
-                # import time, so the variable is readable on `student_module`.
-                variable_name = "target_variable"   # TODO: name of the variable the student must define
-                expected      = None                # TODO: expected value
-
-                _MISSING = object()
-                actual = getattr(student_module, variable_name, _MISSING)
-                if actual is _MISSING:
-                    failed(
-                        f"Variable `{variable_name}` is not defined\\n"
-                        f"\(GeneratedMessage.expected){expected!r}\\n"
-                        f"Hint: create a variable named {variable_name} and assign it the expected value."
-                    )
-
-                if actual != expected:
-                    failed(
-                        f"Variable `{variable_name}` has the \(GeneratedMessage.wrongValue)\\n"
-                        f"\(GeneratedMessage.expected){expected!r}\\n"
-                        f"\(GeneratedMessage.got){actual!r}\\n"
-                        "Hint: check the value you assigned to this variable."
-                    )
-
-                passed(f"{variable_name} == {expected!r}")
-                """
-
-        case .structuralCheck:
-            return """
-                # Test: \(functionName) meets the required structural properties
-                #
-                # Each entry below is a check on the student's source code (via AST
-                # introspection — `student_module` is parsed, not executed further).
-                # Set each check to its required value to enable it, or leave as
-                # None to skip that check.  Module-level asserts are counted even
-                # when NotebookExtractor has quarantined them inside an
-                # `if __name__ == "__main__":` block.
-                import ast
-
-                target_function     = "\(functionName)"    # "" to skip per-function checks
-                parameter_count     = None                # int — require exactly N parameters
-                typed_parameters    = None                # True — require every param has a type hint
-                return_type_hint    = None                # True — require a return-type annotation
-                has_docstring       = None                # True — require a function docstring
-                min_asserts_in_body = None                # int — require >= N asserts inside the function body
-                min_module_asserts  = None                # int — require >= N module-level asserts (anywhere)
-
-                # ── AST walk (best-effort, per-cell) ───────────────────────────────
-                # Style is about the source text, not whether the whole notebook
-                # runs — so we parse each notebook cell on its own via student_ast()
-                # and merge the parseable ones. A single non-Python cell (e.g. a
-                # Markdown cell saved as code, or a half-written cell) is skipped
-                # instead of failing the style check on every other cell. We only
-                # error if NOTHING in the submission parses.
-                # (`student_source()` is the introspectable source — real
-                # module-level defs — on both runners; see RunnerCore extraction +
-                # the .chickadee_student_source sidecar.)
-                try:
-                    from test_runtime import student_ast, student_source
-                    _skipped = []
-                    tree = student_ast(_skipped)
-                except Exception as ex:
-                    errored(f"Could not parse student source: {type(ex).__name__}: {ex}")
-
-                if not tree.body and not student_source().strip():
-                    errored("No student source was available to check.")
-
-                def _find_function(node, name):
-                    for n in ast.walk(node):
-                        if isinstance(n, ast.FunctionDef) and n.name == name:
-                            return n
-                    return None
-
-                def _count_asserts_everywhere(nodes):
-                    total = 0
-                    for n in nodes:
-                        if isinstance(n, ast.Assert):
-                            total += 1
-                        else:
-                            # Walk `if __name__ == "__main__":` wrappers and any other
-                            # compound bodies so quarantined asserts still count.
-                            for child in ast.iter_child_nodes(n):
-                                total += _count_asserts_everywhere([child])
-                    return total
-
-                failures = []
-
-                if target_function:
-                    fn_node = _find_function(tree, target_function)
-                    if fn_node is None:
-                        hint = "Hint: make sure the function name matches the assignment exactly."
-                        if _skipped:
-                            cells = ", ".join(label for label, _ in _skipped)
-                            hint = (
-                                f"Note: {len(_skipped)} cell(s) could not be parsed as Python "
-                                f"({cells}) and were skipped. If your function lives in one of "
-                                "them, fix that cell — e.g. a Markdown cell saved as a code cell."
-                            )
-                        failed(
-                            f"Function `{target_function}` is not defined in your submission.\\n"
-                            + hint
-                        )
-
-                    if parameter_count is not None:
-                        actual = len(fn_node.args.args)
-                        if actual != parameter_count:
-                            failures.append(f"parameter count: expected {parameter_count}, got {actual}")
-
-                    if typed_parameters is True:
-                        untyped = [a.arg for a in fn_node.args.args if a.annotation is None]
-                        if untyped:
-                            failures.append(f"missing type hints on parameter(s): {', '.join(untyped)}")
-
-                    if return_type_hint is True and fn_node.returns is None:
-                        failures.append(f"missing return-type annotation on {target_function}")
-
-                    if has_docstring is True and ast.get_docstring(fn_node) is None:
-                        failures.append(f"missing docstring on {target_function}")
-
-                    if min_asserts_in_body is not None:
-                        count = sum(1 for n in ast.walk(fn_node) if isinstance(n, ast.Assert))
-                        if count < min_asserts_in_body:
-                            failures.append(f"{target_function} has {count} assert(s); need >= {min_asserts_in_body}")
-
-                if min_module_asserts is not None:
-                    count = _count_asserts_everywhere(tree.body)
-                    if count < min_module_asserts:
-                        failures.append(f"module-level asserts: found {count}, need >= {min_module_asserts}")
-
-                if failures:
-                    failed(
-                        f"Structural check(s) failed for {target_function or 'module'}:\\n"
-                        + "\\n".join(f"  - {f}" for f in failures)
-                        + "\\nHint: review the code-style requirements in the assignment."
-                    )
-
-                passed(f"Structural checks passed for {target_function or 'module'}")
                 """
         }
     }()

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -185,6 +185,73 @@ private let studentSubmissionModulePrefixes: [String] = [
 /// Read it through `AssignmentLanguage.descriptor`. Adding a language means
 /// writing one of these — and the compiler will not let you omit a field, so
 /// every fact has to be answered.
+/// How this language's function definitions are read out of a solution
+/// notebook — the IMPLEMENTATION, not a claim that one exists.
+///
+/// WHY THE PATTERNS LIVE HERE. The first version of multi-language scanning put
+/// a `Bool` on `AuthoringLanguageFacts` and the parser somewhere else, which is
+/// the shape that had already drifted once: a capability can be claimed and not
+/// supplied, and nothing catches it until an instructor is told their solution
+/// is empty. Carrying the patterns makes the claim and the implementation the
+/// same object — a seventh language either writes them or says
+/// `noSolutionNotebook`, and there is no third answer that compiles.
+///
+/// I ARGUED AGAINST THIS AND WAS WRONG. The case against a pattern table was
+/// that the four syntaxes are not one shape with different tokens — Octave puts
+/// return variables before the name, Lua has three definition forms, R's is an
+/// assignment whose right-hand side is a `function` literal. That is all true,
+/// and it turned out not to matter: written out, every one of them reduces to
+/// an ordered list of alternatives whose first group is the name and second is
+/// the parameter list. Python is the single exception, and it is called out as
+/// its own case rather than bent into the table.
+public enum FunctionScanSyntax: Equatable, Sendable {
+
+    /// Python's `def` statements, read by the full parser — the only one that
+    /// also recovers type annotations, defaults, the return type and a
+    /// docstring, because Python is the only one of the six that writes them.
+    case pythonDefStatements
+
+    /// Ordered regex alternatives, first match wins. Capture group 1 must be
+    /// the function name and group 2 the raw parameter list.
+    ///
+    /// No type information is recovered, because none of these languages has
+    /// parameter annotations to recover. That is the same state an un-annotated
+    /// Python function already produces and the editor already handles.
+    case definitionPatterns([String])
+
+    /// The language has no solution notebook to scan, because it has no
+    /// notebook workflow at all (`EditorSupport.uploadOnly`).
+    ///
+    /// Structural, not a missing parser — which is why the reason is derived
+    /// from `editorSupport` rather than written out per language.
+    case noSolutionNotebook
+}
+
+/// Where a pattern-family case's expected value is computed by running the
+/// instructor's solution.
+///
+/// IN-PAGE WHEREVER A KERNEL EXISTS. Not chosen by grading mode: the editor's
+/// job is in-browser authoring and verification, and making an author wait on a
+/// server round-trip to see what their solution returns defeats it. An
+/// instructor can tolerate a lazy kernel boot — the worker is spawned on first
+/// use, not on page load — and in exchange the value is computed by the same
+/// kernel that will grade a browser-graded submission.
+public enum AutoComputeSubstrate: Equatable, Sendable {
+
+    /// A vendored xeus kernel, run in the named Web Worker.
+    case inPageKernel(workerScript: String)
+
+    /// No kernel is vendored for this language, so the server's interpreter
+    /// evaluates it (`PersonalizationEvaluator`).
+    ///
+    /// Both languages here are upload-only, and for the same reason they have
+    /// no kernel: C++ by decision (grading a different compiler than the course
+    /// teaches is a pedagogy defect), Racket by circumstance (no Scheme-family
+    /// kernel exists on the channel). If one ever gains a kernel, this arm is
+    /// what changes.
+    case serverDriver
+}
+
 public struct LanguageDescriptor: Equatable, Sendable {
 
     /// How the language is written in prose a STUDENT reads — an error about
@@ -232,6 +299,13 @@ public struct LanguageDescriptor: Equatable, Sendable {
     /// Exhaustive like the rest of this type, so a seventh language answers it
     /// rather than inheriting Python's.
     public let lineCommentPrefix: String
+
+    /// How this language's definitions are read out of a solution notebook.
+    /// See `FunctionScanSyntax` — it carries the patterns, not a claim.
+    public let functionScan: FunctionScanSyntax
+
+    /// Where a case's expected value is computed. See `AutoComputeSubstrate`.
+    public let autoCompute: AutoComputeSubstrate
 
     /// Filename of the per-student grading-inputs file the worker materializes.
     /// Must match byte-for-byte what the language's `test_runtime` reads AND
@@ -325,6 +399,8 @@ public struct LanguageDescriptor: Equatable, Sendable {
         generatedScriptExtension: String,
         sourceFileExtension: String,
         lineCommentPrefix: String,
+        functionScan: FunctionScanSyntax,
+        autoCompute: AutoComputeSubstrate,
         inputsFileName: String,
         notebookKernelNames: Set<String>,
         editorSupport: EditorSupport,
@@ -338,6 +414,8 @@ public struct LanguageDescriptor: Equatable, Sendable {
         self.generatedScriptExtension = generatedScriptExtension
         self.sourceFileExtension = sourceFileExtension
         self.lineCommentPrefix = lineCommentPrefix
+        self.functionScan = functionScan
+        self.autoCompute = autoCompute
         self.inputsFileName = inputsFileName
         self.notebookKernelNames = notebookKernelNames
         self.editorSupport = editorSupport
@@ -364,6 +442,8 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "py",
                 sourceFileExtension: "py",
                 lineCommentPrefix: "#",
+                functionScan: .pythonDefStatements,
+                autoCompute: .inPageKernel(workerScript: "/python-eval-worker.js"),
                 inputsFileName: "_ck_inputs.py",
                 notebookKernelNames: AssignmentLanguage.pythonKernelNames,
                 editorSupport: .notebookKernel(
@@ -390,6 +470,22 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "R",
                 sourceFileExtension: "R",
                 lineCommentPrefix: "#",
+                functionScan: .definitionPatterns([
+                    #"^([A-Za-z._][A-Za-z0-9._]*)\s*(?:<-|=)\s*function\s*\(([^)]*)\)"#
+                ]),
+                // PENDING ITS WORKER. This language has a vendored kernel, so
+                // the target answer is `.inPageKernel` — the editor's job is
+                // in-browser verification, and an author should not wait on a
+                // server round-trip to see what their solution returns. It says
+                // `.serverDriver` only because `/r-eval-worker.js` does not exist
+                // yet; declaring the kernel before writing the worker would have
+                // the editor spawn a 404 and auto-compute would silently stop.
+                //
+                // Flipping it is one line here, one worker mirroring
+                // `python-eval-worker.js` on this language's existing
+                // `*-grading-shared.js`, and one row in the browser-grading
+                // smoke matrix.
+                autoCompute: .serverDriver,
                 inputsFileName: "_ck_inputs.R",
                 notebookKernelNames: AssignmentLanguage.rKernelNames,
                 editorSupport: .notebookKernel(
@@ -414,6 +510,23 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "lua",
                 sourceFileExtension: "lua",
                 lineCommentPrefix: "--",
+                functionScan: .definitionPatterns([
+                    #"^(?:local\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#,
+                    #"^(?:local\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^)]*)\)"#,
+                ]),
+                // PENDING ITS WORKER. This language has a vendored kernel, so
+                // the target answer is `.inPageKernel` — the editor's job is
+                // in-browser verification, and an author should not wait on a
+                // server round-trip to see what their solution returns. It says
+                // `.serverDriver` only because `/lua-eval-worker.js` does not exist
+                // yet; declaring the kernel before writing the worker would have
+                // the editor spawn a 404 and auto-compute would silently stop.
+                //
+                // Flipping it is one line here, one worker mirroring
+                // `python-eval-worker.js` on this language's existing
+                // `*-grading-shared.js`, and one row in the browser-grading
+                // smoke matrix.
+                autoCompute: .serverDriver,
                 inputsFileName: "_ck_inputs.lua",
                 notebookKernelNames: AssignmentLanguage.luaKernelNames,
                 editorSupport: .notebookKernel(
@@ -441,6 +554,23 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "m",
                 sourceFileExtension: "m",
                 lineCommentPrefix: "#",
+                functionScan: .definitionPatterns([
+                    #"^function\s*(?:\[[^\]]*\]|[A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#,
+                    #"^function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#,
+                ]),
+                // PENDING ITS WORKER. This language has a vendored kernel, so
+                // the target answer is `.inPageKernel` — the editor's job is
+                // in-browser verification, and an author should not wait on a
+                // server round-trip to see what their solution returns. It says
+                // `.serverDriver` only because `/octave-eval-worker.js` does not exist
+                // yet; declaring the kernel before writing the worker would have
+                // the editor spawn a 404 and auto-compute would silently stop.
+                //
+                // Flipping it is one line here, one worker mirroring
+                // `python-eval-worker.js` on this language's existing
+                // `*-grading-shared.js`, and one row in the browser-grading
+                // smoke matrix.
+                autoCompute: .serverDriver,
                 inputsFileName: "_ck_inputs.m",
                 notebookKernelNames: AssignmentLanguage.octaveKernelNames,
                 editorSupport: .notebookKernel(
@@ -482,6 +612,8 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "sh",
                 sourceFileExtension: "cpp",
                 lineCommentPrefix: "//",
+                functionScan: .noSolutionNotebook,
+                autoCompute: .serverDriver,
                 inputsFileName: "_ck_inputs.hpp",
                 // No notebook workflow, so no kernel aliases to claim — like
                 // Python's empty set, but for the opposite reason (nothing to
@@ -529,6 +661,8 @@ extension AssignmentLanguage {
                 generatedScriptExtension: "rkt",
                 sourceFileExtension: "rkt",
                 lineCommentPrefix: ";",
+                functionScan: .noSolutionNotebook,
+                autoCompute: .serverDriver,
                 inputsFileName: "_ck_inputs.rkt",
                 // No kernel exists to claim aliases for. Empty for the same
                 // reason as C++ — nothing to detect — not Python's

--- a/Sources/Core/NotebookFunctionScanner.swift
+++ b/Sources/Core/NotebookFunctionScanner.swift
@@ -284,72 +284,33 @@ private func extractTopLevelFunctions(
 
 /// One definition line, in `language`, or nil when the line is not one.
 ///
-/// EXHAUSTIVE, so a seventh language answers it rather than silently scanning
-/// as Python. Written as a switch of small parsers rather than a table of
-/// regexes and capture indices: the four syntaxes are not one shape with
-/// different tokens. Octave puts return variables BEFORE the name
-/// (`function [a, b] = f(x)`), Lua has three definition forms, and R's is an
-/// assignment whose right-hand side is a `function` literal. A table
-/// expressive enough for all of them is a parser generator; one that is not
-/// silently misses definitions, which is the failure mode this whole
-/// supported/unsupported apparatus exists to end.
+/// The syntax comes from `LanguageDescriptor.functionScan`, which CARRIES the
+/// patterns rather than claiming a capability implemented elsewhere. A seventh
+/// language either supplies them or declares `noSolutionNotebook`; there is no
+/// answer that compiles and does nothing.
 private func parseDefinition(
     _ line: String, bodyLines: [String], language: AssignmentLanguage
 ) -> NotebookFunctionInfo? {
-    switch language {
-    case .python: return parseFunctionDef(line, bodyLines: bodyLines)
-    case .r: return parseRFunctionDef(line)
-    case .lua: return parseLuaFunctionDef(line)
-    case .octave: return parseOctaveFunctionDef(line)
-    case .cpp, .racket:
-        // Upload-only: there is no solution notebook, so this is unreachable
-        // through `scanNotebookForSectionsAndFunctions(_:language:)`, which
-        // refuses before calling here.
+    switch language.descriptor.functionScan {
+    case .pythonDefStatements:
+        // The only syntax whose parser recovers more than a name and
+        // parameters: annotations, defaults, return type and a docstring,
+        // because Python is the only one of the six that writes them.
+        return parseFunctionDef(line, bodyLines: bodyLines)
+    case .definitionPatterns(let patterns):
+        for pattern in patterns {
+            if let info = parseAssignmentStyleDefinition(line, pattern: pattern) { return info }
+        }
+        return nil
+    case .noSolutionNotebook:
+        // Upload-only: unreachable through the language-aware entry point,
+        // which refuses before reaching here.
         return nil
     }
 }
 
-/// `name <- function(a, b = 2)`, and the `=` and `assign()` spellings.
-///
-/// No type information: R has no parameter annotations, so `paramTypes` is
-/// all-nil and `hasTypeHints` false. That is the same state an un-annotated
-/// Python function already produces, and the editor already falls back to
-/// untyped JSON parsing for it.
-private func parseRFunctionDef(_ line: String) -> NotebookFunctionInfo? {
-    let pattern = #"^([A-Za-z._][A-Za-z0-9._]*)\s*(?:<-|=)\s*function\s*\(([^)]*)\)"#
-    return parseAssignmentStyleDefinition(line, pattern: pattern)
-}
-
-/// `function f(a, b)`, `local function f(a, b)`, and `f = function(a, b)`.
-///
-/// The `local` form matters: it is the Lua idiom, so omitting it would miss
-/// most real definitions. Method syntax (`function M.f(x)` / `function M:f(x)`)
-/// is deliberately not matched — a dotted name is not something a generated
-/// test can call by bare identifier.
-private func parseLuaFunctionDef(_ line: String) -> NotebookFunctionInfo? {
-    let declaration = #"^(?:local\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#
-    if let info = parseAssignmentStyleDefinition(line, pattern: declaration) { return info }
-    let assignment = #"^(?:local\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^)]*)\)"#
-    return parseAssignmentStyleDefinition(line, pattern: assignment)
-}
-
-/// `function f(a)`, `function y = f(a)`, `function [y, z] = f(a)`.
-///
-/// The return-variable forms are why Octave cannot share R's or Lua's pattern:
-/// the name is not the first identifier on the line. Return variables are
-/// parsed only far enough to skip them — the editor needs the callable name and
-/// its parameters.
-private func parseOctaveFunctionDef(_ line: String) -> NotebookFunctionInfo? {
-    let withReturns =
-        #"^function\s*(?:\[[^\]]*\]|[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"#
-        + #"([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#
-    if let info = parseAssignmentStyleDefinition(line, pattern: withReturns) { return info }
-    let bare = #"^function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#
-    return parseAssignmentStyleDefinition(line, pattern: bare)
-}
-
-/// Shared machinery for the three: a regex whose group 1 is the function name
-/// and group 2 is the raw parameter list.
+/// One `definitionPatterns` alternative: a regex whose group 1 is the function
+/// name and group 2 is the raw parameter list.
 ///
 /// `parseParams` is reused verbatim. Its `x = 0` default-stripping is correct
 /// for all three (R and Lua and Octave all spell defaults with `=`), and its
@@ -531,26 +492,13 @@ public func notebookFunctionScanSupport(
         return .unsupported(
             reason: "This assignment declares no language, so there is no solution notebook to scan.")
     }
-    switch language {
-    case .python:
+    // DERIVED from the descriptor's syntax, which carries the patterns. There
+    // is no separate list of "languages we can scan" to fall out of step with
+    // the parsers — supplying patterns IS declaring support.
+    switch language.descriptor.functionScan {
+    case .pythonDefStatements, .definitionPatterns:
         return .supported
-    case .r, .lua, .octave:
-        // Each has its own parser now — `f <- function(x)`, `function f(x)` (and
-        // Lua's `local function` and `f = function` forms), and Octave's
-        // `function [y, z] = f(x)`, whose name is not the first identifier on
-        // the line. See `parseDefinition`.
-        //
-        // What they do NOT supply is type information: none of the three has
-        // parameter annotations, so `paramTypes` is all-nil and `hasTypeHints`
-        // is false. That is the same state an un-annotated Python function
-        // already produces, and the editor already handles it by falling back
-        // to untyped JSON parsing — so partial fidelity here is a real answer,
-        // not a broken one.
-        return .supported
-    case .cpp, .racket:
-        // Structural, not a missing parser: these are upload-only
-        // (`EditorSupport.uploadOnly`), so there is no solution notebook in the
-        // first place. If a kernel ever lands for one, its arm moves up.
+    case .noSolutionNotebook:
         return .unsupported(
             reason: """
                 \(language.displayName) assignments are upload-only and have no solution notebook \

--- a/Tests/APITests/TestScriptTemplatesTests.swift
+++ b/Tests/APITests/TestScriptTemplatesTests.swift
@@ -14,122 +14,6 @@ import Testing
 
     // MARK: - Python templates
 
-    @Test func existsTemplate_containsFunctionName() {
-        let s = pythonTestScript(type: .exists, functionName: "myFunc", paramNames: ["x", "y"])
-        #expect(s.contains("myFunc"))
-        #expect(s.contains("require_function"))
-        #expect(s.contains("passed"))
-
-    }
-
-    @Test func existsTemplate_numArgsIncluded_whenParamsPresent() {
-        let s = pythonTestScript(type: .exists, functionName: "f", paramNames: ["a", "b"])
-        #expect(s.contains("num_args=2"))
-
-    }
-
-    @Test func existsTemplate_noNumArgs_whenNoParams() {
-        let s = pythonTestScript(type: .exists, functionName: "f", paramNames: [])
-        #expect(s.contains("num_args") == false)
-
-    }
-
-    @Test func correctnessTemplate_containsFunctionName() {
-        let s = pythonTestScript(type: .correctness, functionName: "add", paramNames: ["a", "b"])
-        #expect(s.contains("add"))
-        #expect(s.contains("passed"))
-        #expect(s.contains("failed"))
-
-    }
-
-    @Test func correctnessTemplate_nonEmpty() {
-        let s = pythonTestScript(type: .correctness, functionName: "f")
-        #expect(s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
-
-    }
-
-    @Test func correctnessTemplate_richFeedback_withParams() {
-        let s = pythonTestScript(type: .correctness, functionName: "bmi_category", paramNames: ["bmi"])
-        // Single-case rich-feedback shape: an input variable declaration, an
-        // `expected` placeholder, a try/except + value-comparison, each failed()
-        // call with labeled input/expected/got lines and a Hint line.
-        #expect(s.contains("bmi = None"), "Should declare the input variable")
-        #expect(s.contains("expected = None"))
-        #expect(s.contains("student_module.bmi_category(bmi)"))
-        #expect(s.contains("raised an unexpected exception"))
-        #expect(s.contains("returned the wrong value"))
-        #expect(s.contains("input:    bmi={bmi!r}"))
-        #expect(s.contains("Hint:"))
-
-    }
-
-    @Test func correctnessTemplate_richFeedback_noParams() {
-        let s = pythonTestScript(type: .correctness, functionName: "get_answer", paramNames: [])
-        #expect(s.contains("student_module.get_answer()"))
-        #expect(s.contains("(no input)"))
-        #expect(
-            s.contains("= None   # TODO: replace with input value") == false,
-            "No input declarations when there are no params")
-
-    }
-
-    @Test func cornerCasesTemplate_containsFunctionName() {
-        let s = pythonTestScript(type: .cornerCases, functionName: "check", paramNames: ["n"])
-        #expect(s.contains("check"))
-        #expect(s.contains("corner_cases"))
-
-    }
-
-    @Test func cornerCasesTemplate_richPerCaseMessages() {
-        let s = pythonTestScript(type: .cornerCases, functionName: "check", paramNames: ["n"])
-        #expect(s.contains("args_preview"))
-        #expect(s.contains("expected:"))
-        #expect(s.contains("got:"))
-        #expect(s.contains("raised:"))
-
-    }
-
-    @Test func exceptionTemplate_containsFunctionName() {
-        let s = pythonTestScript(type: .exception, functionName: "divide", paramNames: ["a", "b"])
-        #expect(s.contains("divide"))
-        #expect(s.contains("ValueError"))
-
-    }
-
-    @Test func exceptionTemplate_richFeedback() {
-        let s = pythonTestScript(type: .exception, functionName: "divide", paramNames: ["a", "b"])
-        #expect(s.contains("a = None"))
-        #expect(s.contains("b = None"))
-        #expect(s.contains("expected_exc = ValueError"))
-        #expect(s.contains("raised the wrong exception"))
-        #expect(s.contains("did not raise"))
-        #expect(s.contains("input:    a={a!r}, b={b!r}"))
-
-    }
-
-    @Test func typeCheckTemplate_containsFunctionName() {
-        let s = pythonTestScript(type: .typeCheck, functionName: "items", paramNames: [])
-        #expect(s.contains("items"))
-        #expect(s.contains("isinstance"))
-
-    }
-
-    @Test func typeCheckTemplate_richFeedback() {
-        let s = pythonTestScript(type: .typeCheck, functionName: "get_name", paramNames: ["user_id"])
-        #expect(s.contains("user_id = None"))
-        #expect(s.contains("expected_type = list"))
-        #expect(s.contains("Return type error"))
-        #expect(s.contains("raised an unexpected exception"))
-        #expect(s.contains("input:    user_id={user_id!r}"))
-
-    }
-
-    // MARK: - Drift guards
-
-    /// Fails if any template passes a kwarg to `require_function` that the
-    /// Python test_runtime helpers do not accept.  Prevents the 0.4.x-era bug
-    /// where `num_args` was emitted by templates but the runtime's signature
-    /// was `require_function(name)` only.
     @Test func templates_useOnlyKnownRequireFunctionKwargs() {
         let knownKwargs: Set<String> = ["num_args"]
         // One call with "real" params, one with none, to exercise both arms of
@@ -183,69 +67,10 @@ import Testing
         return kwargs
     }
 
-    @Test func performanceTemplate_containsFunctionName() {
-        let s = pythonTestScript(type: .performance, functionName: "sort_it", paramNames: ["lst"])
-        #expect(s.contains("sort_it"))
-        #expect(s.contains("time_limit_ms"))
-
-    }
-
     @Test func differentialTemplate_containsFunctionName() {
         let s = pythonTestScript(type: .differential, functionName: "square", paramNames: ["n"])
         #expect(s.contains("square"))
         #expect(s.contains("_reference_square"))
-
-    }
-
-    @Test func variableEqualityTemplate_hasExpectedShape() {
-        let s = pythonTestScript(type: .variableEquality)
-        // Bare builtins from the injected test runtime — NOT imported from a
-        // `chickadee` module (which doesn't exist on the Python path).
-        #expect(
-            s.contains("from chickadee") == false,
-            "Template must not import from a `chickadee` module — passed()/failed() are injected as builtins.")
-        #expect(s.contains("import chickadee") == false, "Template must not import `chickadee` — builtins only.")
-        #expect(s.contains("passed"))
-        #expect(s.contains("failed"))
-        // Reads a module-level attribute off `student_module` with a
-        // sentinel default so "not defined" is distinguishable from
-        // "defined as None".
-        #expect(s.contains("getattr(student_module, variable_name"))
-        #expect(s.contains("_MISSING"))
-        // Placeholder variable name + expected value the instructor edits.
-        #expect(s.contains("variable_name = \"target_variable\""))
-        #expect(s.contains("expected"))
-        // Rich-feedback shape matches the other single-case templates.
-        #expect(s.contains("is not defined"))
-        #expect(s.contains("wrong value"))
-        #expect(s.contains("Hint:"))
-
-    }
-
-    @Test func structuralCheckTemplate_hasExpectedShape() {
-        let s = pythonTestScript(
-            type: .structuralCheck, functionName: "compute_bmi", paramNames: ["weight_kg", "height_m"])
-        // AST-based template — no function call. Source comes from
-        // student_source() (introspectable sidecar), not inspect.getsource on the
-        // exec(compile())-wrapped module. Parsing is per-cell (student_ast) so one
-        // non-Python cell can't blind the whole style check.
-        #expect(s.contains("import ast"))
-        #expect(s.contains("from test_runtime import student_ast"))
-        #expect(s.contains("tree = student_ast(_skipped)"))
-        // All the knobs are present as TODO-friendly placeholders.
-        #expect(s.contains("parameter_count"))
-        #expect(s.contains("typed_parameters"))
-        #expect(s.contains("return_type_hint"))
-        #expect(s.contains("has_docstring"))
-        #expect(s.contains("min_asserts_in_body"))
-        #expect(s.contains("min_module_asserts"))
-        // Per-function check uses the provided functionName.
-        #expect(s.contains("target_function     = \"compute_bmi\""))
-        // Rich-feedback shape.
-        #expect(s.contains("Structural check(s) failed"))
-        #expect(s.contains("passed"))
-        // Counts module-level asserts even when quarantined.
-        #expect(s.contains("ast.iter_child_nodes"))
 
     }
 
@@ -290,10 +115,7 @@ import Testing
     }
 
     @Test func allPythonTemplateTypes_containFunctionName() {
-        // `.variableEquality` is the one template that isn't function-scoped —
-        // it tests a module-level variable by name, so `functionName` is not
-        // relevant.  Every other template should echo the function name.
-        for type in PythonTestTemplateType.allCases where type != .variableEquality {
+        for type in PythonTestTemplateType.allCases {
             let s = pythonTestScript(type: type, functionName: "mySpecialFunc", paramNames: ["a"])
             #expect(
                 s.contains("mySpecialFunc"),
@@ -335,14 +157,6 @@ import Testing
         }
 
     }
-
-    @Test func defaultFunctionName_usedWhenNotSpecified() {
-        let s = pythonTestScript(type: .exists)
-        #expect(s.contains("my_function"))
-
-    }
-
-    // MARK: - Shell templates
 
     @Test func shellAlwaysPass() {
         let s = shellTestScript(type: .alwaysPass)
@@ -440,13 +254,10 @@ import Testing
 
     @Test func allTemplateInfos_pythonContainFunctionName() {
         let infos = allTemplateInfos(functionName: "special_fn", paramNames: ["x"])
-        // `variable_equality` is the one template that isn't function-scoped —
-        // it checks a module-level variable by name, so the function name is
-        // never substituted into its body.  Every other Python template
-        // should echo it.
-        let pythonInfos = infos.filter {
-            $0.language == "python" && $0.id != PythonTestTemplateType.variableEquality.rawValue
-        }
+        // Every remaining Python template is function-scoped. `variable_equality`
+        // was the one exception and it is gone — the `variableEquality` pattern
+        // kind does that job, in all six languages.
+        let pythonInfos = infos.filter { $0.language == "python" }
         for info in pythonInfos {
             #expect(
                 info.content.contains("special_fn"),

--- a/Tests/BrowserRunnerJSTests/pattern-family-editor.test.mjs
+++ b/Tests/BrowserRunnerJSTests/pattern-family-editor.test.mjs
@@ -439,13 +439,28 @@ test("the scan-payload readers handle both response shapes", () => {
   assert.equal(read(undefined).functions.length, 0);
 });
 
-test("auto-compute routes off the Python worker for other languages", () => {
-  // The defect: the in-page evaluator is a Python kernel, so on an R assignment
-  // it computed a PYTHON answer for a value compared against R's result.
+test("auto-compute picks its substrate from the language seed", () => {
+  // The original defect: the in-page evaluator was a Python kernel, so on an R
+  // assignment it computed a PYTHON answer for a value compared against R's
+  // result. The first fix routed every non-Python language to the server by
+  // testing `name !== 'python'` — which fixed the wrong answer and then became
+  // the wrong RULE, because the editor exists for in-browser verification and a
+  // language with a kernel should evaluate in the browser.
+  //
+  // So this asserts the seam rather than either rule: which worker runs comes
+  // from the descriptor, and the server is the fallback for a language that
+  // declares none.
   assert.ok(editorSource.includes('callSolutionOnServer'),
     'a server-side compute path must exist');
-  assert.ok(/languageFacts\.name !== 'python'/.test(editorSource),
-    'callSolution must route non-Python languages away from the in-page kernel');
   assert.ok(editorSource.includes('compute-expected') || editorSource.includes('computeExpected'),
     'the server path must call the compute-expected endpoint');
+  assert.ok(/ChickadeeLanguage\.autoComputeWorker\(\)/.test(editorSource),
+    'the worker must come from the language seed, not from a name check here');
+
+  // No hardcoded worker path. A literal `/x-eval-worker.js` in this file is the
+  // shape that made auto-compute Python-only: the editor reached for one
+  // kernel by name and no seed could redirect it.
+  const hardcodedWorker = /['"]\/[a-z-]*eval-worker\.js['"]/.exec(editorSource);
+  assert.equal(hardcodedWorker, null,
+    `the editor must not name a worker itself (found ${hardcodedWorker && hardcodedWorker[0]})`);
 });

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -213,4 +213,88 @@ import Testing
             language.descriptor.capabilityRequiresExecutableOutput == (language == .cpp),
             "\(language) disagrees with whether its grading path execs its own build output")
     }
+
+    // MARK: - The normative fields
+
+    /// A language that claims it can be scanned must SUPPLY the patterns.
+    ///
+    /// This is the point of putting the syntax in the descriptor rather than a
+    /// `Bool` beside a parser somewhere else: the earlier shape let a
+    /// capability be claimed and not implemented, and the instructor found out
+    /// by being told their solution was empty. An empty pattern list is that
+    /// same lie in a new spelling, so it fails here.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func aScannableLanguageSuppliesItsPatterns(_ language: AssignmentLanguage) {
+        switch language.descriptor.functionScan {
+        case .pythonDefStatements:
+            #expect(language == .python, "only Python has the def-statement parser")
+        case .definitionPatterns(let patterns):
+            #expect(!patterns.isEmpty, "\(language.displayName) claims scanning with no patterns")
+            for pattern in patterns {
+                #expect(
+                    (try? NSRegularExpression(pattern: pattern)) != nil,
+                    "\(language.displayName) has an uncompilable definition pattern: \(pattern)")
+                // Group 1 is the name and group 2 the parameter list — the
+                // contract `parseAssignmentStyleDefinition` reads them by.
+                let regex = try? NSRegularExpression(pattern: pattern)
+                #expect(
+                    (regex?.numberOfCaptureGroups ?? 0) >= 2,
+                    "\(language.displayName) pattern needs a name and a params group: \(pattern)")
+            }
+        case .noSolutionNotebook:
+            // Only legitimate for a language with no notebook workflow at all.
+            switch language.editorSupport {
+            case .uploadOnly: break
+            case .notebookKernel:
+                let message =
+                    "\(language.displayName) has an editor kernel but declares no solution "
+                    + "notebook to scan"
+                Issue.record(Comment(rawValue: message))
+            }
+        }
+    }
+
+    /// A language that claims in-page auto-compute must name the worker, and
+    /// only a language with a kernel may claim it.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func autoComputeSubstrateMatchesWhetherAKernelExists(_ language: AssignmentLanguage) {
+        switch (language.descriptor.autoCompute, language.editorSupport) {
+        case (.inPageKernel(let worker), .notebookKernel):
+            #expect(worker.hasPrefix("/"), "the worker path must be absolute: \(worker)")
+            #expect(worker.hasSuffix(".js"), "the worker must be a script: \(worker)")
+        case (.inPageKernel(let worker), .uploadOnly):
+            Issue.record(
+                Comment(
+                    rawValue:
+                        "\(language.displayName) has no kernel but claims the in-page worker "
+                        + "\(worker)"))
+        case (.serverDriver, _):
+            // Legitimate two ways: no kernel exists (C++, Racket), or the
+            // worker has not been written yet (R, Lua, Octave — see the
+            // descriptor's PENDING note). Both are honest; claiming a worker
+            // that does not exist is not.
+            break
+        }
+    }
+
+    /// Every language with a kernel is one flip away from in-page evaluation.
+    ///
+    /// Not an assertion about today's values — a reminder of the target, so the
+    /// three PENDING entries are visible as a countdown rather than settling in
+    /// as the answer.
+    @Test func theInPageAutoComputeCountdownIsVisible() {
+        let kernelLanguages = AssignmentLanguage.allCases.filter {
+            if case .notebookKernel = $0.editorSupport { return true }
+            return false
+        }
+        let inPage = kernelLanguages.filter {
+            if case .inPageKernel = $0.descriptor.autoCompute { return true }
+            return false
+        }
+        let note =
+            "at least Python evaluates in-page; if this drops to zero the editor lost its "
+            + "in-browser evaluator entirely"
+        #expect(inPage.count >= 1, Comment(rawValue: note))
+        #expect(inPage.count <= kernelLanguages.count)
+    }
 }

--- a/changelog.d/language-capability-contract.md
+++ b/changelog.d/language-capability-contract.md
@@ -1,0 +1,25 @@
+### Changed
+
+- **`LanguageDescriptor` now carries two capabilities as implementations rather
+  than claims.** `functionScan` holds the definition patterns a language's
+  solution notebook is read with, and `autoCompute` names the in-page worker
+  that computes a case's expected value (or says the server evaluates instead).
+  Both were previously a boolean somewhere else with the implementation
+  elsewhere again — the shape that had already drifted once, where a capability
+  can be claimed and not supplied and an instructor finds out by being told
+  their solution is empty. A seventh language now either supplies the patterns
+  or declares `noSolutionNotebook`, and either names a worker or takes the
+  server driver; there is no answer that compiles and does nothing.
+  `notebookFunctionScanSupport` and `AuthoringLanguageFacts` derive from these
+  rather than restating them.
+
+- **Auto-compute routes on the descriptor, not a language name.** The editor
+  read `name !== 'python'` and sent everything else to the server, which was
+  the wrong rule for a surface whose job is in-browser authoring: an author
+  changing a case should see what their solution returns without a round-trip.
+  It now spawns whatever worker the language declares, and only falls back to
+  the server for a language that declares none. R, Lua and Octave still declare
+  the server driver — their kernels exist but their eval workers are not written
+  yet, and declaring a worker before writing it would have the editor spawn a
+  404 and auto-compute stop silently. Flipping each is one line, one worker, and
+  one smoke-matrix row.

--- a/changelog.d/retire-superseded-script-templates.md
+++ b/changelog.d/retire-superseded-script-templates.md
@@ -1,0 +1,21 @@
+### Removed
+
+- **Eight of the nine Python script templates.** Each duplicated a
+  pattern-family kind that already renders in all six languages, in a strictly
+  better form — a family is server-rendered, spec-hashed, re-renders when a case
+  changes, and is pinned by execution tests, where a template is a one-shot text
+  dump the instructor then owns forever. Offering both taught authors to reach
+  for the fallback. `exists` → the automatic existence guard; `correctness` and
+  `corner_cases` → `boundaryEquality`; `exception` → `exceptionExpected`;
+  `type_check` → `returnTypeCheck`; `performance` → `performanceThreshold`;
+  `variable_equality` → `variableEquality`; `structural_check` → the
+  `astStructure` notebook check.
+
+  `differential` stays: nothing supersedes it yet, since no pattern kind
+  compares a submission against a reference implementation.
+
+- **Per-function scaffold scripts on the create page.** The auto-scaffold wrote
+  one `publictest_exists_<fn>.py` per detected function, from the template that
+  is now gone — seeding a Python script to do a job every pattern family does
+  automatically and in every language. Section scaffolding, which was always
+  language-neutral and always useful, is unaffected.


### PR DESCRIPTION
**Stacked on #1321** (which is stacked on #1320). Review order: #1320 → #1321 → this.

`LanguageDescriptor` mostly reports **facts** about a language as it exists in the world — its extensions, its comment marker, its kernel aliases. Two of the things the authoring UI needs are not facts about the language at all. They are **obligations Chickadee imposes on one**: reading definitions out of a solution notebook, and computing a case's expected value by running the solution.

Those were modelled as facts anyway — a `Bool` on `AuthoringLanguageFacts`, the parser in `NotebookFunctionScanner`, the driver in `PersonalizationEvaluator` — which is the shape that has already drifted once here. A capability could be claimed and not supplied, and the instructor found out by being told their perfectly good solution defined no functions.

## What changed

`FunctionScanSyntax` carries the definition **patterns**. `AutoComputeSubstrate` carries the **worker path**. Claiming a capability now means supplying it, and `notebookFunctionScanSupport` / `AuthoringLanguageFacts` derive from the descriptor instead of answering the same question a second time.

Three contract tests enforce the normative reading: a language claiming scanning must supply non-empty, compilable patterns with both capture groups; a language claiming an in-page worker must actually have a kernel; and a language with a kernel but no notebook is a recorded failure.

**I argued against a pattern table and was wrong.** When I wrote the three parsers in #1321 I said the syntaxes weren't one shape with different tokens — Octave puts return variables before the name, Lua has three definition forms, R's is an assignment whose RHS is a `function` literal. All true, and it turned out not to matter: written out, every one reduces to ordered alternatives whose group 1 is the name and group 2 the parameters. Python is the single genuine exception and gets its own case rather than being bent into the table.

## Auto-compute routes on the descriptor now

The editor read `name !== 'python'` and sent everything else to the server. That fixed the original wrong-answer bug and then became the wrong *rule*: this surface exists for in-browser authoring and verification, and an author changing a case should see what their solution returns without a server round-trip.

It now spawns whatever worker the language declares, and falls back to the server only for a language that declares none.

## What is deliberately not finished

**R, Lua and Octave still declare `serverDriver`.** Their kernels exist and the target answer is `inPageKernel` — but the eval workers don't exist yet, and declaring one before writing it makes the editor spawn a 404 and auto-compute stop *silently*, which is worse than the round-trip it replaces. The descriptor says `PENDING ITS WORKER` at each of the three and names exactly what flipping it takes: one line here, one worker mirroring `python-eval-worker.js` on that language's existing `*-grading-shared.js`, and one row in the browser-grading smoke matrix.

I stopped short because I can't verify a kernel worker in this container (no browser), and wiring three unverified workers into the author's critical path is not something to do blind. The smoke harness can prove them — its eval probe page is currently Python-specific and would need a per-language fixture.

## A note on a test I had to change

`pattern-family-editor.test.mjs` grepped for the literal `languageFacts.name !== 'python'`, so it failed on the fix rather than on a defect — the drift-guard failure mode CLAUDE.md warns about, where a scanner quotes the pattern it cares about and ends up pinning today's spelling instead of the invariant. It now asserts the seam, plus a new negative: no literal `/*-eval-worker.js` may appear in the editor at all, since the editor naming one kernel itself is what made auto-compute Python-only.

## Verification

`swift build` clean; **3,393 tests in 402 suites** pass (`SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4`); 255 frontend tests pass; `format.sh`, `lint.sh`, `swiftlint.sh --strict` (0 violations), eslint all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcV8dFXd1H9476AxSwpeam)_