### PR TITLE
feat(editor): compute R expected values in the browser

### DIFF
--- a/.github/workflows/browser-grading-smoke.yml
+++ b/.github/workflows/browser-grading-smoke.yml
@@ -65,7 +65,7 @@ jobs:
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if echo "$changed" | grep -Eq '^(Public/r-grading-|Public/python-grading-|Public/lua-grading-|Public/python-eval-|Public/pattern-family-editor\.js|Public/xeus-kernel-shared\.js|Public/browser-runner\.js|Public/grading-shared\.js|Public/vendor/xeus-|Public/jupyterlite/xeus/|Tools/browser-grading-smoke/|Tools/vendor/|Tools/runner-support/|scripts/setup-vendor\.sh|\.github/workflows/browser-grading-smoke\.yml)'; then
+          if echo "$changed" | grep -Eq '^(Public/r-grading-|Public/python-grading-|Public/lua-grading-|Public/python-eval-|Public/r-eval-|Public/eval-protocol-shared\\.js|Public/pattern-family-editor\.js|Public/xeus-kernel-shared\.js|Public/browser-runner\.js|Public/grading-shared\.js|Public/vendor/xeus-|Public/jupyterlite/xeus/|Tools/browser-grading-smoke/|Tools/vendor/|Tools/runner-support/|scripts/setup-vendor\.sh|\.github/workflows/browser-grading-smoke\.yml)'; then
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_smoke=false" >> "$GITHUB_OUTPUT"
@@ -91,6 +91,12 @@ jobs:
           # value, and auto-compute quietly stops filling anything in. Only a
           # real kernel shows that.
           - { language: python, mode: eval }
+          # The R half of in-page auto-compute. Its snippets are one top-level
+          # expression each (a xeus-lite performance constraint), they report
+          # behind a nonce, and the escaper has to be seeded before any of them
+          # runs — each of which fails SILENTLY when wrong. Only a real kernel
+          # shows that.
+          - { language: r, mode: eval }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/browser-grading-smoke.yml
+++ b/.github/workflows/browser-grading-smoke.yml
@@ -65,7 +65,7 @@ jobs:
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if echo "$changed" | grep -Eq '^(Public/r-grading-|Public/python-grading-|Public/lua-grading-|Public/python-eval-|Public/r-eval-|Public/eval-protocol-shared\\.js|Public/pattern-family-editor\.js|Public/xeus-kernel-shared\.js|Public/browser-runner\.js|Public/grading-shared\.js|Public/vendor/xeus-|Public/jupyterlite/xeus/|Tools/browser-grading-smoke/|Tools/vendor/|Tools/runner-support/|scripts/setup-vendor\.sh|\.github/workflows/browser-grading-smoke\.yml)'; then
+          if echo "$changed" | grep -Eq '^(Public/r-grading-|Public/python-grading-|Public/lua-grading-|Public/python-eval-|Public/r-eval-|Public/eval-protocol-shared\.js|Public/pattern-family-editor\.js|Public/xeus-kernel-shared\.js|Public/browser-runner\.js|Public/grading-shared\.js|Public/vendor/xeus-|Public/jupyterlite/xeus/|Tools/browser-grading-smoke/|Tools/vendor/|Tools/runner-support/|scripts/setup-vendor\.sh|\.github/workflows/browser-grading-smoke\.yml)'; then
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_smoke=false" >> "$GITHUB_OUTPUT"

--- a/Public/eval-protocol-shared.js
+++ b/Public/eval-protocol-shared.js
@@ -1,0 +1,63 @@
+// Public/eval-protocol-shared.js
+//
+// How an auto-compute snippet reports its result back out of a xeus kernel,
+// independent of which language the snippet is written in.
+//
+// WHY THIS IS ITS OWN MODULE. A Jupyter `execute_request` returns nothing — it
+// publishes messages — so a snippet's value cannot be read off a return value
+// the way `runPythonAsync` allowed. It is printed behind a per-run nonce and
+// parsed back out of stdout. The nonce is what stops an instructor's own
+// solution output from forging the boundary by printing something payload-
+// shaped.
+//
+// The FRAMING is language-neutral, so it lives here rather than in any one
+// language's module. It started inside `python-eval-shared.js`, which was right
+// while Python was the only in-page evaluator and became an odd dependency the
+// moment an R worker needed the same parser.
+//
+// Reading `execute_result` off the iopub stream would look simpler and is
+// worse: it couples the contract to display formatting (`repr` truncation,
+// `ast_node_interactivity`), which is a worse thing to depend on than a
+// delimiter we control.
+//
+// Loading: classic script (importScripts).
+// Exposes exactly one global: ChickadeeEvalProtocol.
+
+(function (root) {
+    'use strict';
+
+    /// The payload a snippet printed behind `nonce`, or null when it never
+    /// reported — a kernel that died mid-run, or output the nonce never
+    /// reached. Callers treat null as a substrate failure rather than a result.
+    ///
+    /// `lastIndexOf` because the instructor's own solution may legitimately
+    /// print before the payload; the last marker is ours.
+    function parseEvalOutput(stdoutText, nonce) {
+        var text = String(stdoutText == null ? '' : stdoutText);
+        var marker = '\n' + nonce + ':';
+        var at = text.lastIndexOf(marker);
+        if (at < 0) return null;
+        var from = at + marker.length;
+        var end = text.indexOf('\n', from);
+        var line = end < 0 ? text.slice(from) : text.slice(from, end);
+        var payload;
+        try { payload = JSON.parse(line); } catch (_) { return null; }
+        if (!payload || typeof payload !== 'object') return null;
+        return {
+            value: typeof payload.value === 'string' ? payload.value : null,
+            error: typeof payload.error === 'string' ? payload.error : null,
+        };
+    }
+
+    /// The marker a snippet must print immediately before its JSON payload.
+    /// Exposed so a language's snippet builder cannot spell it differently from
+    /// the parser that reads it.
+    function payloadMarker(nonce) {
+        return '\n' + nonce + ':';
+    }
+
+    root.ChickadeeEvalProtocol = {
+        parseEvalOutput: parseEvalOutput,
+        payloadMarker: payloadMarker,
+    };
+})(typeof self !== 'undefined' ? self : globalThis);

--- a/Public/lua-grading-shared.js
+++ b/Public/lua-grading-shared.js
@@ -104,13 +104,70 @@
     // literal.  Only used for names Chickadee itself controls (script names,
     // the seed, the nonce), but escaping keeps a surprising filename from
     // breaking the wrapper's parse.
+    /// A Lua string literal for `value`.
+    ///
+    /// Byte-identical to `encodeLuaString` in Sources/Core/JSONValue.swift,
+    /// including the decimal `\\ddd` escape for control characters and DEL that
+    /// an earlier version omitted — a literal newline inside a quoted Lua string
+    /// is a syntax error, so nothing below 0x20 may pass through. Pinned by
+    /// Tests/Fixtures/lua-literal-contract.json, which both implementations read.
     function luaStringLiteral(value) {
-        return '"' + String(value)
-            .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\t/g, '\\t') + '"';
+        var out = '"';
+        var text = String(value);
+        for (var i = 0; i < text.length; i++) {
+            var ch = text[i];
+            var code = text.charCodeAt(i);
+            if (ch === '\\') out += '\\\\';
+            else if (ch === '"') out += '\\"';
+            else if (ch === '\n') out += '\\n';
+            else if (ch === '\r') out += '\\r';
+            else if (ch === '\t') out += '\\t';
+            else if (code < 0x20 || code === 0x7f) {
+                // Decimal, not hex: `\\xNN` is Lua 5.2+, this works in 5.1 too.
+                out += '\\' + String(code).padStart(3, '0');
+            } else out += ch;
+        }
+        return out + '"';
+    }
+
+    /// Renders a JSON value as Lua source.
+    ///
+    /// A SECOND IMPLEMENTATION of `JSONValue.luaLiteral`, for the reason
+    /// `rLiteral` in r-grading-shared.js is: in-page auto-compute calls a
+    /// solution with arguments the instructor typed but has not saved, so there
+    /// is no server round-trip in which the server could render them. Neither
+    /// side owns the expectations — Tests/Fixtures/lua-literal-contract.json
+    /// does, and both read it.
+    ///
+    /// THE `inTable` DISTINCTION IS THE WHOLE TRAP. Lua spells null `nil`, and a
+    /// `nil` inside a table constructor is not stored at all: `{60, nil, 20}`
+    /// loses its middle slot, `ipairs` stops at the hole, and `#t` is
+    /// unspecified. So null is `nil` only at top level — where a function call
+    /// does accept it positionally — and the `chickadee.NULL` sentinel anywhere
+    /// inside a table.
+    function luaLiteral(value, inTable) {
+        if (value === null || value === undefined) return inTable ? 'chickadee.NULL' : 'nil';
+        if (typeof value === 'boolean') return value ? 'true' : 'false';
+        if (typeof value === 'number') {
+            if (Number.isNaN(value)) return '(0/0)';
+            if (!Number.isFinite(value)) return value < 0 ? '(-1/0)' : '(1/0)';
+            // Lua 5.4 distinguishes integers from floats. JS has one number
+            // type, so integrality decides -- the same split the server's JSON
+            // decode makes between `.int` and `.double`.
+            return String(value);
+        }
+        if (typeof value === 'string') return luaStringLiteral(value);
+        if (Array.isArray(value)) {
+            return '{' + value.map(function (v) { return luaLiteral(v, true); }).join(', ') + '}';
+        }
+        var keys = Object.keys(value).sort();
+        var pairs = keys.map(function (k) {
+            // Every key is bracketed and quoted: a JSON key may be a Lua
+            // reserved word (`end`, `then`, `nil`) or contain characters no
+            // identifier can.
+            return '[' + luaStringLiteral(k) + '] = ' + luaLiteral(value[k], true);
+        });
+        return '{' + pairs.join(', ') + '}';
     }
 
     // The one-time cell that installs the harness into the kernel's Lua state.
@@ -286,6 +343,7 @@ end)()`;
         LUA_KERNEL: LUA_KERNEL,
         SETUP_LUA: SETUP_LUA,
         luaStringLiteral: luaStringLiteral,
+        luaLiteral: luaLiteral,
         assignmentSeedLua: assignmentSeedLua,
         makeNonce: makeNonce,
         runScriptLua: runScriptLua,

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -1670,7 +1670,10 @@
                 // 30s is generous (legitimate heavy imports, large
                 // pandas reads) while still bounded.  On timeout we
                 // terminate the worker; the next attempt re-loads.
-                return workerSend({ type: 'loadCells', cells: cells }, LOAD_TIMEOUT_MS);
+                return workerSend({
+                    type: 'loadCells', cells: cells,
+                    runtimeSource: ChickadeeLanguage.facts().autoComputeRuntimeSource || null
+                }, LOAD_TIMEOUT_MS);
             })
             .then(function (data) {
                 return { cellErrors: data.cellErrors || [] };
@@ -1857,7 +1860,10 @@
                     ].join('\n');
                     // PYODIDE_SNIPPET_END: value
                 }
-                return workerSend({ type: 'run', code: pyCode }, TIMEOUT_MS).then(function (data) {
+                return workerSend({
+                    type: 'run', code: pyCode,
+                    runtimeSource: ChickadeeLanguage.facts().autoComputeRuntimeSource || null
+                }, TIMEOUT_MS).then(function (data) {
                     var parsed = JSON.parse(data.result);
                     if (parsed && parsed.__chickadee_kind__ === 'none') {
                         return { ok: true, value: null, returnedNone: true };

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -1752,6 +1752,33 @@
             .catch(function (e) { return { ok: false, error: String(e) }; });
         }
 
+        /// Turns a failed auto-compute into the shape the UI reads.
+        ///
+        /// Shared by the Python `run` path and the structured `call` path every
+        /// other in-page kernel uses, so an R author gets the same explanation
+        /// a Python author does — including the part that matters most: when a
+        /// function is missing, WHY it is missing.
+        function describeCallFailure(err, cellErrors) {
+            if (err && err.message === '__chickadee_timeout__') {
+                return { ok: false, timedOut: true,
+                         error: 'timed out after ' + (TIMEOUT_MS / 1000) + 's' };
+            }
+            var msg = (err && err.message)
+                ? String(err.message).split('\n').filter(function (l) { return l.trim(); }).pop()
+                : String(err);
+            // When the function isn't found, fold the first solution-load error
+            // into the message so the instructor sees *why* it never landed —
+            // typical case: an earlier cell raised. R says "object '<name>' not
+            // found" where Python says "not defined", so both are matched.
+            var missing = msg
+                && (msg.indexOf('not defined') >= 0 || msg.indexOf('not found') >= 0);
+            if (missing && (cellErrors || []).length > 0) {
+                var first = cellErrors[0];
+                msg += ' (cell ' + (first.index + 1) + ' failed: ' + first.message + ')';
+            }
+            return { ok: false, error: msg || 'error' };
+        }
+
         function callSolution(fnName, args, opts) {
             // IN-PAGE WHEREVER A KERNEL EXISTS, and the language seed decides
             // which — not a name check here.
@@ -1767,6 +1794,30 @@
                 return callSolutionOnServer(fnName, args, opts);
             }
             var captureStdout = !!(opts && opts.captureStdout);
+            // A NON-PYTHON in-page kernel takes the structured request and
+            // builds its own snippet, because rendering arguments into that
+            // language belongs in that language's module — not here, where
+            // the Python snippet below is assembled.
+            //
+            // Python keeps the `run` path: its snippet handles a None return
+            // and types that do not round-trip through JSON in ways existing
+            // assignments rely on.
+            if (!ChickadeeLanguage.isPython()) {
+                return ensureSolutionLoaded().then(function (loaded) {
+                    var cellErrors = loaded.cellErrors || [];
+                    return workerSend({
+                        type: 'call',
+                        functionName: fnName,
+                        args: args,
+                        captureStdout: captureStdout,
+                        runtimeSource: ChickadeeLanguage.facts().autoComputeRuntimeSource || null
+                    }, TIMEOUT_MS)
+                    .then(function (data) { return { ok: true, value: data.result }; })
+                    .catch(function (err) {
+                        return { ok: false, error: describeCallFailure(err, cellErrors) };
+                    });
+                });
+            }
             return ensureSolutionLoaded().then(function (loaded) {
                 var cellErrors = loaded.cellErrors || [];
                 var argsJSON = JSON.stringify(args);
@@ -1872,24 +1923,7 @@
                         return { ok: false, unsupported: parsed.reason || 'unknown' };
                     }
                     return { ok: true, value: parsed.value, returnedNone: false };
-                }).catch(function (err) {
-                    if (err && err.message === '__chickadee_timeout__') {
-                        return { ok: false, timedOut: true,
-                                 error: 'timed out after ' + (TIMEOUT_MS / 1000) + 's' };
-                    }
-                    var msg = (err && err.message)
-                        ? String(err.message).split('\n').filter(function (l) { return l.trim(); }).pop()
-                        : String(err);
-                    // When the function isn't found, fold the first
-                    // solution-load error into the message so the
-                    // instructor sees *why* the function never landed
-                    // in globals — typical case: an earlier cell raised.
-                    if (msg && msg.indexOf('not defined') >= 0 && cellErrors.length > 0) {
-                        var first = cellErrors[0];
-                        msg += ' (cell ' + (first.index + 1) + ' failed: ' + first.message + ')';
-                    }
-                    return { ok: false, error: msg || 'error' };
-                });
+                }).catch(function (err) { return describeCallFailure(err, cellErrors); });
             }).catch(function (err) {
                 // Solution-load failures (no-solution, empty-solution,
                 // network, load-timeout).  These come *before* any

--- a/Public/python-eval-shared.js
+++ b/Public/python-eval-shared.js
@@ -22,13 +22,18 @@
 //
 // Loading: classic script (importScripts). Requires /python-grading-shared.js
 // first, whose `makeNonce` and kernel spec are reused rather than duplicated —
-// one definition of which kernel "the Python kernel" means.
+// one definition of which kernel "the Python kernel" means; and
+// /eval-protocol-shared.js, which owns the nonce framing now that more than one
+// language reports through it.
 // Exposes exactly one global: ChickadeePythonEvalShared.
 
 (function (root) {
     'use strict';
 
     var grading = root.ChickadeePythonGradingShared;
+    // The nonce framing is language-neutral and shared with the other
+    // in-page evaluators; only the SNIPPETS below are Python.
+    var protocol = root.ChickadeeEvalProtocol;
 
     // Run one solution-notebook cell, reporting whether it raised.
     //
@@ -102,31 +107,11 @@
             .join('\n');
     }
 
-    /// The payload a cell printed behind `nonce`, or null when it never
-    /// reported — a kernel that died mid-cell, or output the nonce never
-    /// reached. Callers treat null as a substrate failure rather than a result.
-    function parseEvalOutput(stdoutText, nonce) {
-        var text = String(stdoutText == null ? '' : stdoutText);
-        var marker = '\n' + nonce + ':';
-        var at = text.lastIndexOf(marker);
-        if (at < 0) return null;
-        var from = at + marker.length;
-        var end = text.indexOf('\n', from);
-        var line = end < 0 ? text.slice(from) : text.slice(from, end);
-        var payload;
-        try { payload = JSON.parse(line); } catch (_) { return null; }
-        if (!payload || typeof payload !== 'object') return null;
-        return {
-            value: typeof payload.value === 'string' ? payload.value : null,
-            error: typeof payload.error === 'string' ? payload.error : null,
-        };
-    }
-
     root.ChickadeePythonEvalShared = {
         PYTHON_KERNEL: grading.PYTHON_KERNEL,
         makeNonce: grading.makeNonce,
         loadCellPython: loadCellPython,
         runExpressionPython: runExpressionPython,
-        parseEvalOutput: parseEvalOutput,
+        parseEvalOutput: protocol.parseEvalOutput,
     };
 })(typeof self !== 'undefined' ? self : globalThis);

--- a/Public/python-eval-worker.js
+++ b/Public/python-eval-worker.js
@@ -44,6 +44,7 @@ var _search = self.location.search || '';
 importScripts('/vendor/xeus-bootstrap.js' + _search);
 importScripts('/xeus-kernel-shared.js' + _search);
 importScripts('/grading-shared.js' + _search);
+importScripts('/eval-protocol-shared.js' + _search);
 importScripts('/python-grading-shared.js' + _search);
 importScripts('/python-eval-shared.js' + _search);
 

--- a/Public/r-eval-shared.js
+++ b/Public/r-eval-shared.js
@@ -1,0 +1,129 @@
+// Public/r-eval-shared.js
+//
+// The snippets the pattern-family editor's auto-compute runs on the xeus-r
+// kernel. The R counterpart to python-eval-shared.js; the nonce framing they
+// share lives in eval-protocol-shared.js.
+//
+// Loading: classic script (importScripts). Requires /r-grading-shared.js first
+// (kernel spec, `makeNonce`, `rStringLiteral`) and /eval-protocol-shared.js.
+// Exposes exactly one global: ChickadeeREvalShared.
+//
+// TWO R CONSTRAINTS THAT SHAPE EVERY SNIPPET BELOW.
+//
+// 1. ONE TOP-LEVEL EXPRESSION. xeus-lite yields to the JS event loop between
+//    top-level expressions and does not regain control for ~180ms, so a
+//    statement list costs multiples of what a single wrapped expression costs
+//    (measured in docs/r-support.md: ~3.5s vs ~0.8s for a test script). Every
+//    snippet here is therefore ONE `local({...})` call. At auto-compute's
+//    debounced, per-keystroke cadence that is the difference between a control
+//    that feels live and one that does not.
+//
+//    It is also why the ESCAPER is not inlined into each snippet: it is defined
+//    once at boot, in the global environment, from the source the server seeds
+//    (`AssignmentLanguage.autoComputeRuntimeSource`).
+//
+// 2. VALUES COME BACK AS R's OWN REPR (`deparse`), not as JSON. Deliberate, and
+//    it matches what the SERVER driver already returns for R: the client parses
+//    it with the same language-aware reader hand-typed values go through, and
+//    reports a composite that will not round-trip rather than silently storing
+//    the text. Returning JSON here would make the in-page and server paths
+//    disagree about what a value looks like.
+
+(function (root) {
+    'use strict';
+
+    var grading = root.ChickadeeRGradingShared;
+    var protocol = root.ChickadeeEvalProtocol;
+
+    /// `if (is.null(x)) "null" else .ck_json_str(x)` — a JSON value that is
+    /// either the escaped R string or a bare null.
+    ///
+    /// `.ck_json_str` is the SEEDED escaper (defined once at boot), not one
+    /// written here. There are three R JSON encoders in this codebase and the
+    /// seeded one is the robust char-by-char encoder; a copy in this file would
+    /// have been a fourth, and almost certainly the fragile shape.
+    function jsonOrNull(rVariable) {
+        return 'if (is.null(' + rVariable + ')) "null" else .ck_json_str(' + rVariable + ')';
+    }
+
+    /// One `cat(...)` printing the marker, then alternating literal and
+    /// computed chunks, then a newline.
+    ///
+    /// `sep = ""` throughout: `cat`'s default inserts a space between
+    /// arguments, which would land inside the JSON and after the marker. The
+    /// parser tolerates neither.
+    function payloadCat(nonce, chunks) {
+        var args = [grading.rStringLiteral(protocol.payloadMarker(nonce))]
+            .concat(chunks)
+            .concat([grading.rStringLiteral('\n')]);
+        return '  cat(' + args.join(', ') + ', sep = "")';
+    }
+
+    /// Run one solution-notebook cell, reporting whether it raised.
+    ///
+    /// Evaluated in `globalenv()` so its definitions are visible to later cells
+    /// and to the expression run afterwards — the entire point of loading it.
+    ///
+    /// Errors are caught rather than propagated for the same reason the Python
+    /// path catches them: cells load in order, and an early failure must not
+    /// stop later cells from defining their functions. The editor explains a
+    /// downstream "function not found" in terms of the earlier cell that
+    /// crashed, which it can only do if it got that far.
+    function loadCellR(source, nonce) {
+        return [
+            'local({',
+            '  .ck_err <- NULL',
+            '  tryCatch(',
+            '    eval(parse(text = ' + grading.rStringLiteral(source) + '), envir = globalenv()),',
+            '    error = function(e) .ck_err <<- conditionMessage(e)',
+            '  )',
+            payloadCat(nonce, [
+                grading.rStringLiteral('{"error":'),
+                jsonOrNull('.ck_err'),
+                grading.rStringLiteral('}')
+            ]),
+            '})'
+        ].join('\n');
+    }
+
+    /// Evaluate `source` and report its value as R's own repr.
+    ///
+    /// R needs no equivalent of Python's AST split: `eval(parse(text = …))`
+    /// already yields the value of the last expression, which is exactly the
+    /// semantics auto-compute wants.
+    ///
+    /// A NULL result comes back as JSON null rather than the string "NULL", so
+    /// the caller can tell "evaluated to nothing" from "evaluated to the value
+    /// NULL" — the same distinction the Python path draws for None.
+    ///
+    /// `deparse` returns a character VECTOR for a long value, so it is
+    /// collapsed: the payload is one line by construction.
+    function runExpressionR(source, nonce) {
+        return [
+            'local({',
+            '  .ck_err <- NULL',
+            '  .ck_val <- NULL',
+            '  tryCatch({',
+            '    .ck_res <- eval(parse(text = ' + grading.rStringLiteral(source)
+                + '), envir = globalenv())',
+            '    if (!is.null(.ck_res)) .ck_val <- paste(deparse(.ck_res), collapse = "")',
+            '  }, error = function(e) .ck_err <<- conditionMessage(e))',
+            payloadCat(nonce, [
+                grading.rStringLiteral('{"value":'),
+                jsonOrNull('.ck_val'),
+                grading.rStringLiteral(',"error":'),
+                jsonOrNull('.ck_err'),
+                grading.rStringLiteral('}')
+            ]),
+            '})'
+        ].join('\n');
+    }
+
+    root.ChickadeeREvalShared = {
+        R_KERNEL: grading.R_KERNEL,
+        makeNonce: grading.makeNonce,
+        loadCell: loadCellR,
+        runExpression: runExpressionR,
+        parseEvalOutput: protocol.parseEvalOutput,
+    };
+})(typeof self !== 'undefined' ? self : globalThis);

--- a/Public/r-eval-shared.js
+++ b/Public/r-eval-shared.js
@@ -119,11 +119,63 @@
         ].join('\n');
     }
 
+    /// Call `functionName` in the loaded solution with `args`, reporting the
+    /// result as R's repr.
+    ///
+    /// THE ARGUMENTS ARE RENDERED HERE, in the browser, by the JS twin of
+    /// `JSONValue.rLiteral` — because an instructor changing a case has not
+    /// saved it, so there is no server round-trip in which the server could
+    /// render them. Both renderers are pinned to
+    /// Tests/Fixtures/r-literal-contract.json.
+    ///
+    /// `do.call` rather than a spliced call expression: the arguments are
+    /// already R values in a list, and splicing their source into a call would
+    /// re-parse text this function just finished rendering.
+    ///
+    /// `captureStdout` reports what the solution PRINTED instead of what it
+    /// returned — the shape a stdout-equality case needs. It is deparsed like
+    /// any other value so the client reads it as the string it is.
+    function callFunctionR(functionName, args, options, nonce) {
+        var captureStdout = !!(options && options.captureStdout);
+        var argList = (args || []).map(grading.rLiteral).join(', ');
+        var invoke = captureStdout
+            // The emitted R must contain the two-character escape, not a real
+            // newline: a line break inside the string would still parse (R
+            // allows multi-line strings) but would make this snippet's source
+            // depend on invisible whitespace.
+            ? [
+                '    .ck_out <- paste(capture.output(.ck_res <- do.call(.ck_fn, .ck_args)),',
+                '                     collapse = ' + grading.rStringLiteral('\n') + ')',
+                '    .ck_res <- .ck_out'
+            ].join('\n')
+            : '    .ck_res <- do.call(.ck_fn, .ck_args)';
+        return [
+            'local({',
+            '  .ck_err <- NULL',
+            '  .ck_val <- NULL',
+            '  tryCatch({',
+            '    .ck_fn <- get(' + grading.rStringLiteral(functionName) + ', envir = globalenv())',
+            '    .ck_args <- list(' + argList + ')',
+            invoke,
+            '    if (!is.null(.ck_res)) .ck_val <- paste(deparse(.ck_res), collapse = "")',
+            '  }, error = function(e) .ck_err <<- conditionMessage(e))',
+            payloadCat(nonce, [
+                grading.rStringLiteral('{"value":'),
+                jsonOrNull('.ck_val'),
+                grading.rStringLiteral(',"error":'),
+                jsonOrNull('.ck_err'),
+                grading.rStringLiteral('}')
+            ]),
+            '})'
+        ].join('\n');
+    }
+
     root.ChickadeeREvalShared = {
         R_KERNEL: grading.R_KERNEL,
         makeNonce: grading.makeNonce,
         loadCell: loadCellR,
         runExpression: runExpressionR,
+        callFunction: callFunctionR,
         parseEvalOutput: protocol.parseEvalOutput,
     };
 })(typeof self !== 'undefined' ? self : globalThis);

--- a/Public/r-eval-worker.js
+++ b/Public/r-eval-worker.js
@@ -101,6 +101,27 @@ self.onmessage = async function (e) {
             _reply({ id: id, ok: true, cellErrors: cellErrors });
             return;
         }
+        if (msg.type === 'call') {
+            // The language-neutral request: call this function with these
+            // JSON args. The SNIPPET is built here rather than on the main
+            // thread, so rendering R values stays in the R module.
+            await ensureBooted(msg.runtimeSource);
+            var callNonce = _eval.makeNonce();
+            var callReply = await _kernel.execute(
+                _eval.callFunction(
+                    msg.functionName, msg.args || [],
+                    { captureStdout: !!msg.captureStdout }, callNonce),
+                { maxWaitMs: MAX_WAIT_MS });
+            var parsedCall = _eval.parseEvalOutput(callReply.stdout, callNonce);
+            if (!parsedCall) {
+                throw new Error(
+                    callReply.failure || (callReply.stderr || '').trim()
+                    || 'the R kernel produced no result');
+            }
+            if (parsedCall.error) throw new Error(parsedCall.error);
+            _reply({ id: id, ok: true, result: parsedCall.value });
+            return;
+        }
         if (msg.type === 'run') {
             await ensureBooted(msg.runtimeSource);
             var nonce = _eval.makeNonce();

--- a/Public/r-eval-worker.js
+++ b/Public/r-eval-worker.js
@@ -1,0 +1,123 @@
+// Public/r-eval-worker.js
+//
+// The pattern-family editor's auto-compute substrate for R: loads an
+// instructor's solution notebook into the xeus-r global environment, then
+// evaluates snippets against it to fill in expected values.
+//
+// The R sibling of python-eval-worker.js, speaking the SAME message protocol,
+// so the editor's client code is identical for both:
+//   { id, type: 'init' }                 → { id, ok: true }
+//   { id, type: 'loadCells', cells: [] } → { id, ok: true, cellErrors: [{index, message}] }
+//   { id, type: 'run', code }            → { id, ok: true, result: <string|null> }
+//   any failure                          → { id, ok: false, error }
+//
+// One protocol addition, backward-compatible: every message may carry
+// `runtimeSource`, the R the worker must define before it can report anything.
+// It is SEEDED from the server (`AssignmentLanguage.autoComputeRuntimeSource`)
+// rather than written here, so the JSON escaper it defines is the same one the
+// personalization driver uses. There are three R JSON encoders in this
+// codebase; a copy in this file would have been a fourth.
+//
+// Why a worker at all, inherited from the Python path and still true: auto-
+// compute runs the instructor's own solution, and a synchronous CPU-bound loop
+// in it never yields, so a Promise.race timeout on the main thread can never
+// fire. Only `Worker.terminate()` kills it.
+//
+// This page is NOT cross-origin isolated — /instructor/:id/edit deliberately is
+// not — and does not need to be: the kernel is booted directly through its
+// emscripten module rather than JupyterLite's transports, so no
+// SharedArrayBuffer is involved. Same path the browser-grading smoke exercises.
+
+var _search = self.location.search || '';
+importScripts('/vendor/xeus-bootstrap.js' + _search);
+importScripts('/xeus-kernel-shared.js' + _search);
+importScripts('/grading-shared.js' + _search);
+importScripts('/eval-protocol-shared.js' + _search);
+importScripts('/r-grading-shared.js' + _search);
+importScripts('/r-eval-shared.js' + _search);
+
+var _kernel = self.ChickadeeXeusKernel;
+var _eval = self.ChickadeeREvalShared;
+var _reply = _kernel.reply;
+
+// The dead-kernel backstop, not a limit on how long code may run — the main
+// thread owns that and enforces it by terminating this worker. Set well above
+// the editor's own 30s load cap so a terminate always wins the race, and this
+// only ever fires for a kernel that is never going to reply at all.
+var MAX_WAIT_MS = 60000;
+
+var _booted = false;
+
+/// Boots the kernel and defines the seeded runtime once.
+///
+/// The runtime is executed as its own top-level statement at boot, which is
+/// exactly why the per-call snippets can each stay a single expression — see
+/// the one-top-level-expression note in r-eval-shared.js.
+async function ensureBooted(runtimeSource) {
+    if (_booted) return;
+    await _kernel.boot(_eval.R_KERNEL);
+    if (runtimeSource) {
+        var reply = await _kernel.execute(runtimeSource, { maxWaitMs: MAX_WAIT_MS });
+        // A runtime that fails to define leaves every later snippet calling an
+        // undefined `.ck_json_str`, which reports as a confusing per-cell error
+        // rather than as the substrate failure it is. Fail loudly at boot.
+        if (reply.failure) {
+            throw new Error('the R auto-compute runtime failed to load: ' + reply.failure);
+        }
+    }
+    _booted = true;
+}
+
+/// Runs one solution-notebook cell, returning its error message or null.
+async function loadOneCell(source) {
+    var nonce = _eval.makeNonce();
+    var reply = await _kernel.execute(
+        _eval.loadCell(source, nonce), { maxWaitMs: MAX_WAIT_MS });
+    var parsed = _eval.parseEvalOutput(reply.stdout, nonce);
+    if (parsed) return parsed.error;
+    // The cell never reported. Attribute it to the cell rather than failing the
+    // whole load, so the remaining cells still get a chance to define their
+    // functions — same reason the per-cell errors are caught in R.
+    return reply.failure || (reply.stderr || '').trim() || 'the R kernel produced no result';
+}
+
+self.onmessage = async function (e) {
+    var msg = e.data || {};
+    var id = msg.id;
+    try {
+        if (msg.type === 'init') {
+            await ensureBooted(msg.runtimeSource);
+            _reply({ id: id, ok: true });
+            return;
+        }
+        if (msg.type === 'loadCells') {
+            await ensureBooted(msg.runtimeSource);
+            var cells = Array.isArray(msg.cells) ? msg.cells : [];
+            var cellErrors = [];
+            for (var i = 0; i < cells.length; i++) {
+                var message = await loadOneCell(cells[i]);
+                if (message) cellErrors.push({ index: i, message: message });
+            }
+            _reply({ id: id, ok: true, cellErrors: cellErrors });
+            return;
+        }
+        if (msg.type === 'run') {
+            await ensureBooted(msg.runtimeSource);
+            var nonce = _eval.makeNonce();
+            var runReply = await _kernel.execute(
+                _eval.runExpression(msg.code || '', nonce), { maxWaitMs: MAX_WAIT_MS });
+            var parsedRun = _eval.parseEvalOutput(runReply.stdout, nonce);
+            if (!parsedRun) {
+                throw new Error(
+                    runReply.failure || (runReply.stderr || '').trim()
+                    || 'the R kernel produced no result');
+            }
+            if (parsedRun.error) throw new Error(parsedRun.error);
+            _reply({ id: id, ok: true, result: parsedRun.value });
+            return;
+        }
+        _reply({ id: id, ok: false, error: 'unknown message type: ' + msg.type });
+    } catch (err) {
+        _reply({ id: id, ok: false, error: (err && err.message) ? String(err.message) : String(err) });
+    }
+};

--- a/Public/r-grading-shared.js
+++ b/Public/r-grading-shared.js
@@ -116,13 +116,89 @@
     // Only used for names Chickadee itself controls (script names, the seed,
     // the nonce), but escaping keeps a surprising filename from breaking the
     // wrapper's parse.
+    /// An R string literal for `value`.
+    ///
+    /// Byte-identical to `encodeRString` in Sources/Core/JSONValue.swift,
+    /// including the `\uXXXX` escape for control characters below 0x20 that an
+    /// earlier version of this function omitted. Pinned by
+    /// Tests/Fixtures/r-literal-contract.json, which both implementations read.
     function rStringLiteral(value) {
-        return '"' + String(value)
-            .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\t/g, '\\t') + '"';
+        var out = '"';
+        var text = String(value);
+        for (var i = 0; i < text.length; i++) {
+            var ch = text[i];
+            var code = text.charCodeAt(i);
+            if (ch === '\\') out += '\\\\';
+            else if (ch === '"') out += '\\"';
+            else if (ch === '\n') out += '\\n';
+            else if (ch === '\r') out += '\\r';
+            else if (ch === '\t') out += '\\t';
+            else if (code < 0x20) out += '\\u' + code.toString(16).padStart(4, '0');
+            else out += ch;
+        }
+        return out + '"';
+    }
+
+    /// An R list NAME: bare when it is a syntactic identifier, quoted otherwise.
+    /// Mirrors `encodeRName` in JSONValue.swift.
+    function rName(key) {
+        var text = String(key);
+        var syntactic = /^[A-Za-z.][A-Za-z0-9._]*$/.test(text);
+        return syntactic ? text : rStringLiteral(text);
+    }
+
+    /// Whether an array renders as `c(...)` rather than `list(...)`.
+    ///
+    /// Mirrors `isHomogeneousScalarArray`: empty is NOT homogeneous (so `[]`
+    /// becomes `list()`), nulls are compatible with every kind, and any array
+    /// or object member disqualifies the whole thing.
+    function isHomogeneousScalarArray(items) {
+        if (!items.length) return false;
+        var seen = null;
+        for (var i = 0; i < items.length; i++) {
+            var v = items[i];
+            var kind;
+            if (v === null) continue;                       // compatible with anything
+            else if (typeof v === 'boolean') kind = 0;
+            else if (typeof v === 'number') kind = 1;
+            else if (typeof v === 'string') kind = 2;
+            else return false;                              // array / object
+            if (seen !== null && seen !== kind) return false;
+            seen = kind;
+        }
+        return true;
+    }
+
+    /// Renders a JSON value as R source.
+    ///
+    /// A SECOND IMPLEMENTATION of `JSONValue.rLiteral`, and deliberately so: the
+    /// in-page evaluator has to call an R solution with arguments the instructor
+    /// has typed but not yet saved, so there is no server round-trip in which
+    /// the server could render them. The same allowance
+    /// `personalizationInputsSourceR` already takes.
+    ///
+    /// What makes it safe is that neither side owns the expectations —
+    /// Tests/Fixtures/r-literal-contract.json does, and both read it.
+    function rLiteral(value) {
+        if (value === null || value === undefined) return 'NA';
+        if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+        if (typeof value === 'number') {
+            if (Number.isNaN(value)) return 'NaN';
+            if (!Number.isFinite(value)) return value < 0 ? '-Inf' : 'Inf';
+            // Swift renders `.int` without a decimal point and `.double` with
+            // one; JS has a single number type, so integrality decides — which
+            // is the same split the server's JSON decode makes.
+            if (Number.isInteger(value)) return String(value);
+            return String(value);
+        }
+        if (typeof value === 'string') return rStringLiteral(value);
+        if (Array.isArray(value)) {
+            var inner = value.map(rLiteral).join(', ');
+            return isHomogeneousScalarArray(value) ? 'c(' + inner + ')' : 'list(' + inner + ')';
+        }
+        var keys = Object.keys(value).sort();
+        var pairs = keys.map(function (k) { return rName(k) + ' = ' + rLiteral(value[k]); });
+        return 'list(' + pairs.join(', ') + ')';
     }
 
     // Set CHICKADEE_ASSIGNMENT_SEED for the whole session, mirroring the native
@@ -240,6 +316,7 @@
     root.ChickadeeRGradingShared = {
         R_KERNEL: R_KERNEL,
         rStringLiteral: rStringLiteral,
+        rLiteral: rLiteral,
         assignmentSeedR: assignmentSeedR,
         makeNonce: makeNonce,
         runScriptR: runScriptR,

--- a/Sources/APIServer/Services/PersonalizationEvaluator.swift
+++ b/Sources/APIServer/Services/PersonalizationEvaluator.swift
@@ -409,7 +409,7 @@ enum PersonalizationEvaluator {
         lines.append("")
         // JSON string encoder (char-by-char; avoids gsub replacement-escaping
         // ambiguity so backslash/quote-heavy deparse output encodes correctly).
-        lines.append(rJSONStringEncoderSource)
+        lines.append(RPersonalizationRuntime.chickadeeJSONStringRSource)
         lines.append("")
         lines.append("seed <- chickadee_seed()")
         lines.append("")
@@ -607,30 +607,6 @@ enum PersonalizationEvaluator {
         lines.append("printf(\"{%s}\\n\", strjoin(ck_pairs, \",\"));")
         return lines.joined(separator: "\n") + "\n"
     }
-
-    /// Base-R JSON string encoder used by the R driver's output stage. Encodes
-    /// char-by-char (`utf8ToInt`/`intToUtf8`) so it never trips over `gsub`'s
-    /// replacement-string backslash rules — deparse output is quote-heavy and
-    /// occasionally backslash-heavy, and this must round-trip through
-    /// `JSONSerialization` on the Swift side.
-    private static let rJSONStringEncoderSource = #"""
-        .ck_json_str <- function(x) {
-            if (length(x) != 1L) x <- paste(as.character(x), collapse = "")
-            x <- as.character(x)
-            codes <- utf8ToInt(x)
-            if (length(codes) == 0L) return("\"\"")
-            out <- vapply(codes, function(cp) {
-                if (cp == 34L) "\\\""
-                else if (cp == 92L) "\\\\"
-                else if (cp == 10L) "\\n"
-                else if (cp == 13L) "\\r"
-                else if (cp == 9L)  "\\t"
-                else if (cp < 32L)  sprintf("\\u%04x", cp)
-                else intToUtf8(cp)
-            }, character(1L))
-            paste0("\"", paste(out, collapse = ""), "\"")
-        }
-        """#
 
     /// Same identifier predicate the editor JS uses.  Used to filter
     /// support-file names down to legal Python module names.

--- a/Sources/APIServer/Utilities/AuthoringLanguageFacts.swift
+++ b/Sources/APIServer/Utilities/AuthoringLanguageFacts.swift
@@ -115,6 +115,15 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
     /// language cannot claim in-page evaluation without saying what runs it.
     let autoComputeWorker: String?
 
+    /// Source the in-page worker prepends before it can report a value, or nil
+    /// when the language needs none.
+    ///
+    /// Seeded rather than baked into the worker so Lua's and Octave's value
+    /// serializers have ONE definition, shared with the server driver and the
+    /// grading runtime. A copy in the worker could disagree about what a value
+    /// looks like, and the instructor would never see which one was wrong.
+    let autoComputeRuntimeSource: String?
+
     /// Facts for `language`, or the language-less answer when it is nil.
     init(_ language: AssignmentLanguage?) {
         guard let language else {
@@ -127,6 +136,7 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
             self.functionScanning = false
             self.expressionEvaluation = false
             self.autoComputeWorker = nil
+            self.autoComputeRuntimeSource = nil
             self.unsupportedCheckKinds = [:]
             return
         }
@@ -174,6 +184,7 @@ struct AuthoringLanguageFacts: Encodable, Equatable {
         case .inPageKernel(let workerScript): self.autoComputeWorker = workerScript
         case .serverDriver: self.autoComputeWorker = nil
         }
+        self.autoComputeRuntimeSource = language.autoComputeRuntimeSource
     }
 }
 

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -353,26 +353,40 @@ extension AssignmentLanguage {
     /// Source the in-page auto-compute worker must prepend before it can report
     /// a value, or nil when the language needs nothing.
     ///
-    /// Only Lua and Octave need anything: their values have no built-in
-    /// round-trippable text form, so the worker reuses the SAME serializer the
-    /// server driver and the grading runtime use rather than growing a third
-    /// copy. R and Python need nothing — `deparse` and `repr` are builtins.
+    /// Two jobs, both already solved elsewhere and therefore NOT re-solved here:
+    /// turning a value into round-trippable text (Lua and Octave have no
+    /// built-in form; `deparse` and `repr` are builtins for R and Python), and
+    /// escaping that text into the JSON payload the worker prints behind its
+    /// per-run nonce.
     ///
-    /// Note what is deliberately NOT here: a JSON string encoder. The eval
-    /// protocol frames its payload with a per-run nonce instead of encoding it,
-    /// so no language has to escape anything. That matters because the codebase
-    /// already carries TWO different R JSON encoders — a `gsub`-based one in the
-    /// grading runtime and a char-by-char one in the personalization driver,
-    /// written because the first trips over replacement-string backslash rules.
-    /// A third copy in a worker would have been the worst of them.
+    /// Every piece of this is an existing Core constant, shared with the server
+    /// driver and the grading runtime, so the in-page and server paths cannot
+    /// disagree about what a value looks like.
+    ///
+    /// A NOTE ON THE ENCODING, because I got this wrong once. I first planned a
+    /// nonce-framed plaintext payload instead of JSON, to avoid pushing a string
+    /// escaper into three languages — and the tree does carry two rival R
+    /// encoders (a `gsub` one in the grading runtime, and the char-by-char one
+    /// below, written because the first trips over replacement-string backslash
+    /// rules). But the escapers already EXIST for all three languages as
+    /// constants, so framing bought nothing and cost a second payload encoding
+    /// beside Python's, with a second parser to match. The eval protocol stays
+    /// exactly the one `python-eval-worker.js` speaks.
     public var autoComputeRuntimeSource: String? {
         switch self {
-        case .python, .r:
+        case .python:
+            // `repr` serializes and the snippet builds its payload with
+            // Python's own `json` module. Nothing to prepend.
             return nil
+        case .r:
+            // `deparse` serializes; only the escaper is needed.
+            return RPersonalizationRuntime.chickadeeJSONStringRSource
         case .lua:
-            return LuaPersonalizationRuntime.chickadeeSerializeLuaSource
+            return LuaPersonalizationRuntime.chickadeeSerializeLuaSource + "\n\n"
+                + LuaPersonalizationRuntime.chickadeeJSONStringLuaSource
         case .octave:
-            return OctavePersonalizationRuntime.chickadeeSerializeOctaveSource
+            return OctavePersonalizationRuntime.chickadeeSerializeOctaveSource + "\n\n"
+                + OctavePersonalizationRuntime.chickadeeEscapeStringOctaveSource
         case .cpp, .racket:
             // No kernel, so no in-page worker to prepend anything to.
             return nil

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -350,6 +350,35 @@ extension AssignmentLanguage {
     /// See `LanguageDescriptor.lineCommentPrefix`.
     public var lineCommentPrefix: String { descriptor.lineCommentPrefix }
 
+    /// Source the in-page auto-compute worker must prepend before it can report
+    /// a value, or nil when the language needs nothing.
+    ///
+    /// Only Lua and Octave need anything: their values have no built-in
+    /// round-trippable text form, so the worker reuses the SAME serializer the
+    /// server driver and the grading runtime use rather than growing a third
+    /// copy. R and Python need nothing — `deparse` and `repr` are builtins.
+    ///
+    /// Note what is deliberately NOT here: a JSON string encoder. The eval
+    /// protocol frames its payload with a per-run nonce instead of encoding it,
+    /// so no language has to escape anything. That matters because the codebase
+    /// already carries TWO different R JSON encoders — a `gsub`-based one in the
+    /// grading runtime and a char-by-char one in the personalization driver,
+    /// written because the first trips over replacement-string backslash rules.
+    /// A third copy in a worker would have been the worst of them.
+    public var autoComputeRuntimeSource: String? {
+        switch self {
+        case .python, .r:
+            return nil
+        case .lua:
+            return LuaPersonalizationRuntime.chickadeeSerializeLuaSource
+        case .octave:
+            return OctavePersonalizationRuntime.chickadeeSerializeOctaveSource
+        case .cpp, .racket:
+            // No kernel, so no in-page worker to prepend anything to.
+            return nil
+        }
+    }
+
     /// Body of the per-student grading-inputs file. `values` maps each input
     /// name to its already-rendered literal *in this language* (Python literal
     /// for `.python`, R literal for `.r`). Keys are emitted in sorted order for

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -473,19 +473,7 @@ extension AssignmentLanguage {
                 functionScan: .definitionPatterns([
                     #"^([A-Za-z._][A-Za-z0-9._]*)\s*(?:<-|=)\s*function\s*\(([^)]*)\)"#
                 ]),
-                // PENDING ITS WORKER. This language has a vendored kernel, so
-                // the target answer is `.inPageKernel` — the editor's job is
-                // in-browser verification, and an author should not wait on a
-                // server round-trip to see what their solution returns. It says
-                // `.serverDriver` only because `/r-eval-worker.js` does not exist
-                // yet; declaring the kernel before writing the worker would have
-                // the editor spawn a 404 and auto-compute would silently stop.
-                //
-                // Flipping it is one line here, one worker mirroring
-                // `python-eval-worker.js` on this language's existing
-                // `*-grading-shared.js`, and one row in the browser-grading
-                // smoke matrix.
-                autoCompute: .serverDriver,
+                autoCompute: .inPageKernel(workerScript: "/r-eval-worker.js"),
                 inputsFileName: "_ck_inputs.R",
                 notebookKernelNames: AssignmentLanguage.rKernelNames,
                 editorSupport: .notebookKernel(

--- a/Sources/Core/RPersonalizationRuntime.swift
+++ b/Sources/Core/RPersonalizationRuntime.swift
@@ -49,4 +49,36 @@ public enum RPersonalizationRuntime {
             }
         }
         """#
+
+    /// Base-R JSON string encoder, shared by the personalization driver and the
+    /// in-page auto-compute worker.
+    ///
+    /// Encodes char-by-char (`utf8ToInt`/`intToUtf8`) so it never trips over
+    /// `gsub`'s replacement-string backslash rules — deparse output is
+    /// quote-heavy and occasionally backslash-heavy, and this must round-trip
+    /// through `JSONSerialization` on the Swift side.
+    ///
+    /// PUBLIC, and hoisted out of `PersonalizationEvaluator` where it was
+    /// private, because a second consumer arrived. Note there is a THIRD R
+    /// encoder in `TestRuntimeSources.swift` using exactly the `gsub` approach
+    /// this one exists to avoid; it serves the grading runtime's own narrower
+    /// payloads. Prefer this one for anything carrying deparse output.
+    public static let chickadeeJSONStringRSource = #"""
+        .ck_json_str <- function(x) {
+            if (length(x) != 1L) x <- paste(as.character(x), collapse = "")
+            x <- as.character(x)
+            codes <- utf8ToInt(x)
+            if (length(codes) == 0L) return("\"\"")
+            out <- vapply(codes, function(cp) {
+                if (cp == 34L) "\\\""
+                else if (cp == 92L) "\\\\"
+                else if (cp == 10L) "\\n"
+                else if (cp == 13L) "\\r"
+                else if (cp == 9L)  "\\t"
+                else if (cp < 32L)  sprintf("\\u%04x", cp)
+                else intToUtf8(cp)
+            }, character(1L))
+            paste0("\"", paste(out, collapse = ""), "\"")
+        }
+        """#
 }

--- a/Tests/BrowserRunnerJSTests/lua-literal-contract.test.mjs
+++ b/Tests/BrowserRunnerJSTests/lua-literal-contract.test.mjs
@@ -1,0 +1,37 @@
+// The browser half of the Lua literal contract. See r-literal-contract.test.mjs
+// for why a second implementation exists and how it is kept honest.
+//
+// The Lua-specific trap: null is `nil` at top level and `chickadee.NULL` inside
+// any table, because a `nil` in a table constructor is not stored and the table
+// silently loses a slot.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/lua-grading-shared.js');
+
+const { luaLiteral } = globalThis.ChickadeeLuaGradingShared;
+const contract = JSON.parse(
+  fs.readFileSync(path.resolve('Tests/Fixtures/lua-literal-contract.json'), 'utf8'));
+
+test('every contract case renders identically in the browser', () => {
+  assert.ok(contract.cases.length > 20, 'the contract should cover a real spread of shapes');
+  for (const testCase of contract.cases) {
+    assert.equal(
+      luaLiteral(testCase.json, false), testCase.lua,
+      `${testCase.name}: browser luaLiteral disagrees with the contract`);
+  }
+});
+
+test('null renders differently inside a table than at top level', () => {
+  // The distinction the whole renderer turns on. Getting it wrong produces a
+  // table of the wrong length that a generated test then grades against.
+  assert.equal(luaLiteral(null, false), 'nil');
+  assert.equal(luaLiteral(null, true), 'chickadee.NULL');
+  assert.equal(luaLiteral([1, null, 3], false), '{1, chickadee.NULL, 3}');
+});

--- a/Tests/BrowserRunnerJSTests/python-eval-shared.test.mjs
+++ b/Tests/BrowserRunnerJSTests/python-eval-shared.test.mjs
@@ -24,6 +24,10 @@ context.globalThis = context;
 const vmContext = vm.createContext(context);
 vm.runInContext(await load('Public/grading-shared.js'), vmContext,
   { filename: 'grading-shared.js' });
+// The nonce framing moved into its own module when a second in-page evaluator
+// (R) needed the same parser; python-eval-shared delegates to it.
+vm.runInContext(await load('Public/eval-protocol-shared.js'), vmContext,
+  { filename: 'eval-protocol-shared.js' });
 vm.runInContext(await load('Public/python-grading-shared.js'), vmContext,
   { filename: 'python-grading-shared.js' });
 vm.runInContext(await load('Public/python-eval-shared.js'), vmContext,

--- a/Tests/BrowserRunnerJSTests/r-eval-shared.test.mjs
+++ b/Tests/BrowserRunnerJSTests/r-eval-shared.test.mjs
@@ -113,3 +113,35 @@ test('the parser round-trips a payload the snippet shape would produce', () => {
   // No payload at all is a substrate failure, not an empty result.
   assert.equal(protocol.parseEvalOutput('nothing here', 'NONCE'), null);
 });
+
+test('callFunction renders arguments through the pinned R literal renderer', () => {
+  const snippet = R.callFunction('classify', [18.5, 'lo', [1, 2], null], {}, 'N');
+  assert.ok(snippet.includes('.ck_args <- list(18.5, "lo", c(1, 2), NA)'),
+    `arguments are not rendered as R literals:\n${snippet}`);
+  assert.ok(snippet.includes('get("classify", envir = globalenv())'),
+    'the function must be looked up in the environment the cells loaded into');
+  assert.ok(snippet.includes('do.call('),
+    'arguments are already R values; they must not be re-parsed from source');
+  assert.ok(isOneTopLevelExpression(snippet), 'callFunction must be one expression');
+});
+
+test('callFunction embeds no raw newline in generated R', () => {
+  // A regression on a real bug in this file: the captureStdout branch built
+  // `collapse = "<real newline>"`, which parses (R allows multi-line strings)
+  // and made the snippet depend on invisible whitespace. Worse, an escaping
+  // slip in the other direction emitted a literal backslash-n BETWEEN
+  // statements, which is not valid R at all.
+  const captured = R.callFunction('f', [], { captureStdout: true }, 'N');
+  assert.ok(captured.includes('collapse = "\\n"'),
+    'the newline must be the two-character R escape');
+  // No stray escape sequence sitting outside a string literal.
+  assert.ok(!/\),\\n/.test(captured),
+    'statements must be separated by real newlines, not a literal escape');
+  assert.ok(captured.includes('capture.output('), 'captureStdout must capture what was printed');
+});
+
+test('callFunction without captureStdout reports the return value', () => {
+  const plain = R.callFunction('f', [1], {}, 'N');
+  assert.ok(!plain.includes('capture.output('),
+    'the default path must report the returned value, not printed output');
+});

--- a/Tests/BrowserRunnerJSTests/r-eval-shared.test.mjs
+++ b/Tests/BrowserRunnerJSTests/r-eval-shared.test.mjs
@@ -1,0 +1,115 @@
+// Unit tests for the R auto-compute snippets.
+//
+// No kernel here — these assert the SHAPE the kernel constrains, which is the
+// part that can be got wrong silently:
+//
+//   * one top-level expression, because xeus-lite yields ~180ms between them
+//     and auto-compute runs on a per-keystroke debounce;
+//   * the payload marker spelled exactly as the shared parser reads it;
+//   * `sep = ""`, because cat's default space would land inside the JSON;
+//   * the instructor's source embedded as an R string literal, so quotes and
+//     backslashes in a solution cannot break out of it.
+//
+// A first draft of this module hand-copied R's JSON escaper; that is why
+// `.ck_json_str` being CALLED rather than DEFINED here is asserted.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/eval-protocol-shared.js');
+require('../../Public/r-grading-shared.js');
+require('../../Public/r-eval-shared.js');
+
+const R = globalThis.ChickadeeREvalShared;
+const protocol = globalThis.ChickadeeEvalProtocol;
+
+/// True when `source` is a single `local({ … })` call and nothing follows it.
+function isOneTopLevelExpression(source) {
+  const trimmed = source.trim();
+  if (!trimmed.startsWith('local({') || !trimmed.endsWith('})')) return false;
+  // Walk the braces of the whole snippet; the opening one must not close until
+  // the very end, or there is a second top-level form after it.
+  let depth = 0;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0 && i < trimmed.length - 2) return false;
+    }
+  }
+  return depth === 0;
+}
+
+test('both snippets are a single top-level expression', () => {
+  const load = R.loadCell('f <- function(x) x\n', 'NONCE1');
+  const run = R.runExpression('f(2)', 'NONCE2');
+  assert.ok(isOneTopLevelExpression(load), 'loadCell must be one expression');
+  assert.ok(isOneTopLevelExpression(run), 'runExpression must be one expression');
+});
+
+test('the payload marker matches what the shared parser looks for', () => {
+  const run = R.runExpression('1', 'ABC123');
+  // The parser searches for '\n' + nonce + ':'; the snippet must cat exactly
+  // that, escaped as an R string literal.
+  assert.ok(run.includes('"\\nABC123:"'),
+    `snippet does not cat the marker the parser reads:\n${run}`);
+  assert.equal(protocol.payloadMarker('ABC123'), '\nABC123:');
+});
+
+test('cat uses sep = "" so no space lands inside the payload', () => {
+  for (const snippet of [R.loadCell('x', 'N'), R.runExpression('x', 'N')]) {
+    assert.ok(/sep = ""/.test(snippet), 'cat must pass sep = ""');
+  }
+});
+
+test('the escaper is called, never defined here', () => {
+  const run = R.runExpression('1', 'N');
+  assert.ok(run.includes('.ck_json_str('), 'the seeded escaper must be used');
+  assert.ok(!run.includes('.ck_json_str <-'),
+    'the escaper must come from the seeded runtime, not a copy in this module');
+  assert.ok(!/gsub/.test(run), 'no hand-rolled escaping in the snippet');
+});
+
+test('instructor source is embedded as an R string literal', () => {
+  // A solution containing quotes and backslashes must not break out.
+  const nasty = 'cat("he said \\"hi\\"\\n")';
+  const load = R.loadCell(nasty, 'N');
+  assert.ok(!load.includes('cat("he said "hi""'), 'raw source must not be spliced in');
+  assert.ok(load.includes('\\\\"'), 'quotes in the source must be escaped');
+  // And it goes through parse/eval into the GLOBAL env, so later cells see it.
+  assert.ok(load.includes('envir = globalenv()'),
+    'cells must evaluate into globalenv or later cells cannot see their definitions');
+});
+
+test('a value is reported as R\'s own repr, collapsed to one line', () => {
+  const run = R.runExpression('1:3', 'N');
+  assert.ok(run.includes('deparse('), 'the value must be deparsed, not formatted for display');
+  assert.ok(run.includes('collapse = ""'),
+    'deparse returns a vector for long values; the payload is one line');
+});
+
+test('NULL is reported as JSON null, not the string "NULL"', () => {
+  const run = R.runExpression('invisible(NULL)', 'N');
+  assert.ok(run.includes('is.null(.ck_val)') && run.includes('"null"'),
+    'a NULL result must be distinguishable from the value NULL');
+});
+
+test('errors are caught per cell rather than aborting the load', () => {
+  const load = R.loadCell('stop("boom")', 'N');
+  assert.ok(load.includes('tryCatch('), 'a failing cell must not stop later cells loading');
+  assert.ok(load.includes('conditionMessage(e)'), 'the message must be reported');
+});
+
+test('the parser round-trips a payload the snippet shape would produce', () => {
+  const stdout = 'instructor output\n\nNONCE:{"value":"42","error":null}\n';
+  assert.deepEqual(protocol.parseEvalOutput(stdout, 'NONCE'), { value: '42', error: null });
+  // Output printed by the solution AFTER a previous payload must not win.
+  const twice = '\nNONCE:{"value":"1","error":null}\n\nNONCE:{"value":"2","error":null}\n';
+  assert.equal(protocol.parseEvalOutput(twice, 'NONCE').value, '2');
+  // No payload at all is a substrate failure, not an empty result.
+  assert.equal(protocol.parseEvalOutput('nothing here', 'NONCE'), null);
+});

--- a/Tests/BrowserRunnerJSTests/r-literal-contract.test.mjs
+++ b/Tests/BrowserRunnerJSTests/r-literal-contract.test.mjs
@@ -1,0 +1,47 @@
+// The browser half of the R literal contract.
+//
+// `Public/r-grading-shared.js`'s `rLiteral` is a second implementation of
+// `JSONValue.rLiteral`, because in-page auto-compute must call an R solution
+// with arguments the instructor typed but has not saved — there is no server
+// round-trip in which the server could render them.
+//
+// Neither implementation owns the expectations. Both read
+// Tests/Fixtures/r-literal-contract.json, so a change to either that is not
+// mirrored fails on both sides. The Swift half is RLiteralContractTests.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/r-grading-shared.js');
+
+const { rLiteral } = globalThis.ChickadeeRGradingShared;
+const contract = JSON.parse(
+  fs.readFileSync(path.resolve('Tests/Fixtures/r-literal-contract.json'), 'utf8'));
+
+test('every contract case renders identically in the browser', () => {
+  assert.ok(contract.cases.length > 20, 'the contract should cover a real spread of shapes');
+  for (const testCase of contract.cases) {
+    assert.equal(
+      rLiteral(testCase.json), testCase.r,
+      `${testCase.name}: browser rLiteral disagrees with the contract`);
+  }
+});
+
+test('the contract covers the shapes that actually differ between languages', () => {
+  const names = new Set(contract.cases.map((c) => c.name));
+  // Each of these is a case where a naive renderer gets R wrong: R has no
+  // JSON-null so NA stands in; a homogeneous array is an atomic vector while a
+  // mixed one is a list; an empty array cannot be typed so it is a list; and a
+  // key that is not a syntactic R name has to be quoted.
+  for (const required of [
+    'null', 'empty array', 'numeric array', 'mixed scalar array',
+    'object non-syntactic key', 'string with control char',
+  ]) {
+    assert.ok(names.has(required), `the contract must pin "${required}"`);
+  }
+});

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -297,4 +297,40 @@ import Testing
         #expect(inPage.count >= 1, Comment(rawValue: note))
         #expect(inPage.count <= kernelLanguages.count)
     }
+
+    /// A language whose values have no built-in round-trippable text form must
+    /// bring a serializer, and it must be the SAME one the server driver and
+    /// the grading runtime use.
+    ///
+    /// Identity assertions, not content assertions: a copied serializer would
+    /// pass a "looks about right" check and then disagree about a value in a
+    /// way only an instructor comparing two runs would notice.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theInPageSerializerIsTheOneTheServerAlreadyUses(_ language: AssignmentLanguage) {
+        switch language {
+        case .lua:
+            #expect(
+                language.autoComputeRuntimeSource
+                    == LuaPersonalizationRuntime.chickadeeSerializeLuaSource)
+        case .octave:
+            #expect(
+                language.autoComputeRuntimeSource
+                    == OctavePersonalizationRuntime.chickadeeSerializeOctaveSource)
+        case .python, .r:
+            // `repr` and `deparse` are builtins; nothing to prepend.
+            #expect(language.autoComputeRuntimeSource == nil)
+        case .cpp, .racket:
+            // No kernel, so no in-page worker to prepend anything to.
+            #expect(language.autoComputeRuntimeSource == nil)
+        }
+    }
+
+    /// Whatever a language brings must be non-trivial if it brings anything —
+    /// an empty string would satisfy "supplies a serializer" while supplying
+    /// nothing, which is the claim-without-implementation shape again.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func aSuppliedRuntimeSourceIsNotEmpty(_ language: AssignmentLanguage) {
+        guard let source = language.autoComputeRuntimeSource else { return }
+        #expect(source.count > 32, "\(language.displayName) supplies an implausibly short runtime")
+    }
 }

--- a/Tests/CoreTests/LanguageDescriptorTests.swift
+++ b/Tests/CoreTests/LanguageDescriptorTests.swift
@@ -306,18 +306,24 @@ import Testing
     /// pass a "looks about right" check and then disagree about a value in a
     /// way only an instructor comparing two runs would notice.
     @Test(arguments: AssignmentLanguage.allCases)
-    func theInPageSerializerIsTheOneTheServerAlreadyUses(_ language: AssignmentLanguage) {
+    func theInPageSerializerIsTheOneTheServerAlreadyUses(_ language: AssignmentLanguage) throws {
         switch language {
         case .lua:
-            #expect(
-                language.autoComputeRuntimeSource
-                    == LuaPersonalizationRuntime.chickadeeSerializeLuaSource)
+            let lua = try #require(language.autoComputeRuntimeSource)
+            #expect(lua.contains(LuaPersonalizationRuntime.chickadeeSerializeLuaSource))
+            #expect(lua.contains(LuaPersonalizationRuntime.chickadeeJSONStringLuaSource))
         case .octave:
+            let octave = try #require(language.autoComputeRuntimeSource)
+            #expect(octave.contains(OctavePersonalizationRuntime.chickadeeSerializeOctaveSource))
+            #expect(octave.contains(OctavePersonalizationRuntime.chickadeeEscapeStringOctaveSource))
+        case .r:
+            // `deparse` serializes; only the escaper is needed — and it is the
+            // char-by-char one, not the `gsub` one in the grading runtime.
             #expect(
                 language.autoComputeRuntimeSource
-                    == OctavePersonalizationRuntime.chickadeeSerializeOctaveSource)
-        case .python, .r:
-            // `repr` and `deparse` are builtins; nothing to prepend.
+                    == RPersonalizationRuntime.chickadeeJSONStringRSource)
+        case .python:
+            // `repr` plus Python's own `json` module. Nothing to prepend.
             #expect(language.autoComputeRuntimeSource == nil)
         case .cpp, .racket:
             // No kernel, so no in-page worker to prepend anything to.

--- a/Tests/CoreTests/LuaLiteralContractTests.swift
+++ b/Tests/CoreTests/LuaLiteralContractTests.swift
@@ -1,0 +1,68 @@
+// Tests/CoreTests/LuaLiteralContractTests.swift
+//
+// The Swift half of the Lua literal contract. See RLiteralContractTests for the
+// arrangement: neither implementation owns the expectations, both read
+// Tests/Fixtures/lua-literal-contract.json, so an unmirrored change to either
+// fails on both sides.
+//
+// The browser half is Tests/BrowserRunnerJSTests/lua-literal-contract.test.mjs.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct LuaLiteralContractTests {
+
+    private struct Contract: Decodable {
+        struct Case: Decodable {
+            let name: String
+            let json: JSONValue?
+            let lua: String
+        }
+        let cases: [Case]
+    }
+
+    /// The fixture, found relative to this source file so the test does not
+    /// depend on the working directory a runner happens to use.
+    private static func loadContract() throws -> Contract {
+        let fixture = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CoreTests
+            .deletingLastPathComponent()  // Tests
+            .appendingPathComponent("Fixtures/lua-literal-contract.json")
+        let data = try Data(contentsOf: fixture)
+        return try JSONDecoder().decode(Contract.self, from: data)
+    }
+
+    @Test func everyContractCaseRendersIdenticallyOnTheServer() throws {
+        let contract = try Self.loadContract()
+        #expect(contract.cases.count > 20, "the contract should cover a real spread of shapes")
+        for testCase in contract.cases {
+            let value = testCase.json ?? .null
+            #expect(
+                value.luaLiteral == testCase.lua,
+                """
+                \(testCase.name): server luaLiteral disagrees with the contract.
+                  contract: \(testCase.lua)
+                  rendered: \(value.luaLiteral)
+                """)
+        }
+    }
+
+    /// The arms JSON cannot express, so the shared fixture cannot pin them.
+    /// `0/0` and `1/0` are how Lua spells the non-finite literals it cannot
+    /// otherwise parse.
+    @Test func theNonJSONNumericArmsRenderAsLuaSpellsThem() {
+        #expect(JSONValue.double(.nan).luaLiteral == "(0/0)")
+        #expect(JSONValue.double(.infinity).luaLiteral == "(1/0)")
+        #expect(JSONValue.double(-.infinity).luaLiteral == "(-1/0)")
+    }
+
+    /// Lua 5.4 distinguishes integers from floats, so a whole-number double
+    /// keeps its decimal point. The browser cannot reproduce this — JS has one
+    /// number type — which is why the fixture holds no case for it.
+    @Test func aWholeNumberDoubleKeepsItsDecimalPoint() {
+        #expect(JSONValue.double(2).luaLiteral == "2.0")
+        #expect(JSONValue.int(2).luaLiteral == "2")
+    }
+}

--- a/Tests/CoreTests/RLiteralContractTests.swift
+++ b/Tests/CoreTests/RLiteralContractTests.swift
@@ -1,0 +1,80 @@
+// Tests/CoreTests/RLiteralContractTests.swift
+//
+// The Swift half of the R literal contract.
+//
+// `JSONValue.rLiteral` renders a value into R source on the server. `rLiteral`
+// in `Public/r-grading-shared.js` does the same in the browser, because in-page
+// auto-compute must call an R solution with arguments the instructor typed but
+// has not saved — there is no server round-trip in which the server could
+// render them.
+//
+// Two implementations of one rendering is normally the defect this codebase
+// keeps removing, and it is allowed here for the same reason
+// `personalizationInputsSourceR` is: the browser cannot call Swift. What makes
+// it safe is that NEITHER SIDE OWNS THE EXPECTATIONS. Both read
+// Tests/Fixtures/r-literal-contract.json, so a change to either that is not
+// mirrored fails on both sides — the arrangement
+// Tests/Fixtures/output-contract.json already uses to pin RunnerCore's native
+// and wasm builds together.
+//
+// The browser half is Tests/BrowserRunnerJSTests/r-literal-contract.test.mjs.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct RLiteralContractTests {
+
+    private struct Contract: Decodable {
+        struct Case: Decodable {
+            let name: String
+            let json: JSONValue?
+            let r: String
+        }
+        let cases: [Case]
+    }
+
+    /// The fixture, found relative to this source file so the test does not
+    /// depend on the working directory a runner happens to use.
+    private static func loadContract() throws -> Contract {
+        let fixture = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CoreTests
+            .deletingLastPathComponent()  // Tests
+            .appendingPathComponent("Fixtures/r-literal-contract.json")
+        let data = try Data(contentsOf: fixture)
+        return try JSONDecoder().decode(Contract.self, from: data)
+    }
+
+    @Test func everyContractCaseRendersIdenticallyOnTheServer() throws {
+        let contract = try Self.loadContract()
+        #expect(contract.cases.count > 20, "the contract should cover a real spread of shapes")
+        for testCase in contract.cases {
+            let value = testCase.json ?? .null
+            #expect(
+                value.rLiteral == testCase.r,
+                """
+                \(testCase.name): server rLiteral disagrees with the contract.
+                  contract: \(testCase.r)
+                  rendered: \(value.rLiteral)
+                """)
+        }
+    }
+
+    /// The arms JSON cannot express, so the shared fixture cannot pin them.
+    /// Asserted here rather than left uncovered.
+    @Test func theNonJSONNumericArmsRenderAsRSpellsThem() {
+        #expect(JSONValue.double(.nan).rLiteral == "NaN")
+        #expect(JSONValue.double(.infinity).rLiteral == "Inf")
+        #expect(JSONValue.double(-.infinity).rLiteral == "-Inf")
+    }
+
+    /// A whole-number double keeps its decimal point, so it stays a `double` in
+    /// R rather than becoming an integer literal. The browser cannot reproduce
+    /// this — JS has one number type — which is exactly why the fixture holds
+    /// no case for it and this test does.
+    @Test func aWholeNumberDoubleKeepsItsDecimalPoint() {
+        #expect(JSONValue.double(2).rLiteral == "2.0")
+        #expect(JSONValue.int(2).rLiteral == "2")
+    }
+}

--- a/Tests/Fixtures/lua-literal-contract.json
+++ b/Tests/Fixtures/lua-literal-contract.json
@@ -1,0 +1,69 @@
+{
+  "_comment": [
+    "The Lua literal contract, asserted by BOTH implementations of it.",
+    "See Tests/Fixtures/r-literal-contract.json for why two exist.",
+    "",
+    "The Lua-specific trap this pins: `null`. Lua spells it `nil`, and a `nil`",
+    "inside a table constructor is NOT STORED — `{60, nil, 20}` loses its middle",
+    "slot, `ipairs` stops at the hole, and `#t` is unspecified. So null renders",
+    "`nil` only at top level, and the `chickadee.NULL` sentinel inside any table.",
+    "A renderer that misses that distinction produces a table of the wrong length",
+    "and grades against it.",
+    "",
+    "NaN and the infinities are absent because JSON cannot express them; the",
+    "Swift-only unit tests cover those arms."
+  ],
+  "cases": [
+    { "name": "null at top level", "json": null, "lua": "nil" },
+    { "name": "true", "json": true, "lua": "true" },
+    { "name": "false", "json": false, "lua": "false" },
+    { "name": "zero", "json": 0, "lua": "0" },
+    { "name": "positive int", "json": 42, "lua": "42" },
+    { "name": "negative int", "json": -7, "lua": "-7" },
+    { "name": "double", "json": 2.5, "lua": "2.5" },
+    { "name": "negative double", "json": -0.125, "lua": "-0.125" },
+
+    { "name": "empty string", "json": "", "lua": "\"\"" },
+    { "name": "plain string", "json": "hello", "lua": "\"hello\"" },
+    { "name": "string with quote", "json": "he said \"hi\"", "lua": "\"he said \\\"hi\\\"\"" },
+    { "name": "string with backslash", "json": "a\\b", "lua": "\"a\\\\b\"" },
+    { "name": "string with newline", "json": "a\nb", "lua": "\"a\\nb\"" },
+    { "name": "string with tab", "json": "a\tb", "lua": "\"a\\tb\"" },
+    { "name": "string with control char", "json": "a\u0001b", "lua": "\"a\\001b\"" },
+    { "name": "string with delete char", "json": "a\u007fb", "lua": "\"a\\127b\"" },
+    { "name": "string with unicode", "json": "café", "lua": "\"café\"" },
+
+    { "name": "empty array", "json": [], "lua": "{}" },
+    { "name": "numeric array", "json": [1, 2, 3], "lua": "{1, 2, 3}" },
+    { "name": "string array", "json": ["a", "b"], "lua": "{\"a\", \"b\"}" },
+    {
+      "name": "array with null keeps its slot",
+      "json": [60, null, 20],
+      "lua": "{60, chickadee.NULL, 20}"
+    },
+    { "name": "mixed array", "json": [1, "a"], "lua": "{1, \"a\"}" },
+    { "name": "nested array", "json": [[1, 2]], "lua": "{{1, 2}}" },
+
+    { "name": "empty object", "json": {}, "lua": "{}" },
+    {
+      "name": "object sorted keys",
+      "json": { "b": 2, "a": 1 },
+      "lua": "{[\"a\"] = 1, [\"b\"] = 2}"
+    },
+    {
+      "name": "object with reserved-word key",
+      "json": { "end": 1 },
+      "lua": "{[\"end\"] = 1}"
+    },
+    {
+      "name": "object with null value",
+      "json": { "a": null },
+      "lua": "{[\"a\"] = chickadee.NULL}"
+    },
+    {
+      "name": "nested object",
+      "json": { "outer": { "inner": [1, 2] } },
+      "lua": "{[\"outer\"] = {[\"inner\"] = {1, 2}}}"
+    }
+  ]
+}

--- a/Tests/Fixtures/r-literal-contract.json
+++ b/Tests/Fixtures/r-literal-contract.json
@@ -1,0 +1,75 @@
+{
+  "_comment": [
+    "The R literal contract, asserted by BOTH implementations of it.",
+    "",
+    "`JSONValue.rLiteral` (Sources/Core/JSONValue.swift) renders a value into R",
+    "source on the server. `rLiteral` (Public/r-grading-shared.js) does the same",
+    "in the browser, because in-page auto-compute has to call an R solution with",
+    "arguments the instructor has typed but not yet saved — there is no server",
+    "round-trip in which the server could render them.",
+    "",
+    "Two implementations of one rendering is normally the defect this codebase",
+    "keeps removing. It is allowed here for the same reason",
+    "`personalizationInputsSourceR` is: the browser cannot call Swift. What makes",
+    "it safe is that neither side owns the expectations. Both read this file, so",
+    "a change to either that is not mirrored fails on both sides.",
+    "",
+    "Modelled on Tests/Fixtures/output-contract.json, which pins RunnerCore's",
+    "native and wasm builds to one another the same way.",
+    "",
+    "NaN and the infinities are absent on purpose: JSON cannot express them, so",
+    "they cannot appear in a fixture. Swift-only unit tests cover those arms."
+  ],
+  "cases": [
+    { "name": "null", "json": null, "r": "NA" },
+    { "name": "true", "json": true, "r": "TRUE" },
+    { "name": "false", "json": false, "r": "FALSE" },
+    { "name": "zero", "json": 0, "r": "0" },
+    { "name": "positive int", "json": 42, "r": "42" },
+    { "name": "negative int", "json": -7, "r": "-7" },
+    { "name": "double", "json": 2.5, "r": "2.5" },
+    { "name": "negative double", "json": -0.125, "r": "-0.125" },
+
+    { "name": "empty string", "json": "", "r": "\"\"" },
+    { "name": "plain string", "json": "hello", "r": "\"hello\"" },
+    { "name": "string with quote", "json": "he said \"hi\"", "r": "\"he said \\\"hi\\\"\"" },
+    { "name": "string with backslash", "json": "a\\b", "r": "\"a\\\\b\"" },
+    { "name": "string with newline", "json": "a\nb", "r": "\"a\\nb\"" },
+    { "name": "string with tab", "json": "a\tb", "r": "\"a\\tb\"" },
+    { "name": "string with carriage return", "json": "a\rb", "r": "\"a\\rb\"" },
+    { "name": "string with control char", "json": "a\u0001b", "r": "\"a\\u0001b\"" },
+    { "name": "string with unicode", "json": "café ☕", "r": "\"café ☕\"" },
+
+    { "name": "empty array", "json": [], "r": "list()" },
+    { "name": "numeric array", "json": [1, 2, 3], "r": "c(1, 2, 3)" },
+    { "name": "string array", "json": ["a", "b"], "r": "c(\"a\", \"b\")" },
+    { "name": "bool array", "json": [true, false], "r": "c(TRUE, FALSE)" },
+    { "name": "numeric array with null", "json": [1, null, 3], "r": "c(1, NA, 3)" },
+    { "name": "all nulls array", "json": [null, null], "r": "c(NA, NA)" },
+    { "name": "mixed scalar array", "json": [1, "a"], "r": "list(1, \"a\")" },
+    { "name": "nested array", "json": [[1, 2]], "r": "list(c(1, 2))" },
+
+    { "name": "empty object", "json": {}, "r": "list()" },
+    { "name": "object syntactic keys", "json": { "b": 2, "a": 1 }, "r": "list(a = 1, b = 2)" },
+    {
+      "name": "object non-syntactic key",
+      "json": { "a b": 1 },
+      "r": "list(\"a b\" = 1)"
+    },
+    {
+      "name": "object dotted key",
+      "json": { ".x": 1 },
+      "r": "list(.x = 1)"
+    },
+    {
+      "name": "object numeric-leading key",
+      "json": { "1a": 1 },
+      "r": "list(\"1a\" = 1)"
+    },
+    {
+      "name": "nested object",
+      "json": { "outer": { "inner": [1, 2] } },
+      "r": "list(outer = list(inner = c(1, 2)))"
+    }
+  ]
+}

--- a/Tools/browser-grading-smoke/smoke.mjs
+++ b/Tools/browser-grading-smoke/smoke.mjs
@@ -507,12 +507,99 @@ window.__result = null;
 })().catch((err) => { window.__result = { ok: false, stage: 'page', error: String(err) }; });
 </script>`;
 
+/// The R escaper the SERVER seeds into the worker, read out of the Swift
+/// constant that defines it rather than copied here.
+///
+/// A copy would be a fourth R JSON encoder in this repo — there are already
+/// three, and one of them exists because another was wrong. Extraction keeps
+/// the smoke honest: if the constant is renamed or moved, this throws instead of
+/// silently probing something that is no longer what ships.
+async function readRRuntimeSource() {
+    const swift = await fs.readFile(
+        path.resolve(REPO_ROOT, 'Sources/Core/RPersonalizationRuntime.swift'), 'utf8');
+    const match = /chickadeeJSONStringRSource\s*=\s*#"""\n([\s\S]*?)\n\s*"""#/.exec(swift);
+    if (!match) {
+        throw new Error(
+            'could not find chickadeeJSONStringRSource in RPersonalizationRuntime.swift — '
+            + 'the R auto-compute smoke cannot probe the runtime the server actually seeds');
+    }
+    return match[1];
+}
+
+// The R auto-compute probe. Same shape as the Python one — two solution cells,
+// one of which raises — but exercising the STRUCTURED `call` path every
+// non-Python in-page kernel uses, where the worker renders the arguments.
+//
+// Only a real kernel proves any of this: the snippets are one top-level
+// expression each (a xeus-lite performance constraint), they print behind a
+// nonce, and the seeded escaper has to be defined before any of them runs. Each
+// of those fails silently when wrong — no error, just no value.
+const rEvalProbePage = (runtimeSource) => `<!doctype html><meta charset="utf-8"><title>R auto-compute smoke</title>
+<body><pre id="log"></pre><script>
+window.__result = null;
+(async () => {
+  const worker = new Worker('/r-eval-worker.js');
+  let counter = 0;
+  const pending = new Map();
+  worker.onmessage = (event) => {
+    const message = event.data || {};
+    const settle = pending.get(message.id);
+    if (settle) { pending.delete(message.id); settle(message); }
+  };
+  worker.onerror = (event) => {
+    window.__result = { ok: false, stage: 'worker', error: event.message || 'worker error' };
+  };
+  // The escaper the server seeds, extracted from the Swift constant that
+  // defines it — see readRRuntimeSource. Not a copy.
+  const RUNTIME_SOURCE = ${JSON.stringify(runtimeSource)};
+  const call = (payload) => new Promise((resolve) => {
+    const id = ++counter;
+    pending.set(id, resolve);
+    worker.postMessage(Object.assign({ id, runtimeSource: RUNTIME_SOURCE }, payload));
+  });
+
+  const bootStart = Date.now();
+  const init = await call({ type: 'init' });
+  const bootMs = Date.now() - bootStart;
+  if (!init.ok) { window.__result = { ok: false, stage: 'init', error: init.error }; return; }
+
+  const load = await call({ type: 'loadCells', cells: [
+    'classify <- function(bmi) if (bmi < 18.5) "under" else "ok"',
+    'this_name_does_not_exist()',
+    'area <- function(r) round(pi * r * r, 2)',
+  ] });
+  if (!load.ok) { window.__result = { ok: false, stage: 'loadCells', error: load.error }; return; }
+
+  const runs = {};
+  const calls = {
+    call: { functionName: 'classify', args: [18.49] },
+    later: { functionName: 'area', args: [2] },
+    // A string argument, to prove rLiteral's quoting survives the round trip.
+    stringArg: { functionName: 'paste0', args: ['a', 'b'] },
+    // A vector argument, which R renders c(...) and Python would not.
+    vectorArg: { functionName: 'sum', args: [[1, 2, 3]] },
+    missing: { functionName: 'no_such_function', args: [] },
+  };
+  for (const [key, payload] of Object.entries(calls)) {
+    const reply = await call(Object.assign({ type: 'call' }, payload));
+    runs[key] = reply.ok ? { ok: true, result: reply.result } : { ok: false, error: reply.error };
+  }
+  // The expression path too, since the worker serves both.
+  const expr = await call({ type: 'run', code: 'classify(30)' });
+  runs.expression = expr.ok ? { ok: true, result: expr.result } : { ok: false, error: expr.error };
+
+  window.__result = { ok: true, bootMs, cellErrors: load.cellErrors, runs };
+})().catch((err) => { window.__result = { ok: false, stage: 'page', error: String(err) }; });
+</script>`;
+
 function startServer() {
     const server = http.createServer(async (req, res) => {
         const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
         if (urlPath === '/' || urlPath === '/index.html') {
             res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', ...ISOLATION_HEADERS });
-            res.end(mode === 'eval' ? EVAL_PROBE_PAGE : PROBE_PAGE);
+            res.end(mode === 'eval'
+                ? (language === 'r' ? rEvalProbePage(await readRRuntimeSource()) : EVAL_PROBE_PAGE)
+                : PROBE_PAGE);
             return;
         }
         // Confine reads to Public/ — this server exists only to feed the probe.
@@ -588,6 +675,40 @@ if (!result || !result.ok) {
     process.exit(1);
 }
 console.log(`  kernel booted in ${result.bootMs}ms`);
+
+if (mode === 'eval' && language === 'r') {
+    const errors = result.cellErrors || [];
+    check('the failing solution cell is reported', errors.length === 1, JSON.stringify(errors));
+    check('it is attributed to the right cell', errors[0]?.index === 1, JSON.stringify(errors));
+    check('its message is R\'s own error text',
+        /could not find function|object/.test(errors[0]?.message || ''), JSON.stringify(errors));
+
+    // The value comes back as R's repr, which is what the server driver returns
+    // too — the client parses both with the same reader.
+    check('a call returns its value as an R literal',
+        result.runs.call?.result === '"under"', JSON.stringify(result.runs.call));
+    // Proves the global environment survived the cell that raised.
+    check('a function defined after the failing cell is callable',
+        result.runs.later?.result === '12.57', JSON.stringify(result.runs.later));
+    // rLiteral's quoting survived the trip through the snippet.
+    check('a string argument round-trips',
+        result.runs.stringArg?.result === '"ab"', JSON.stringify(result.runs.stringArg));
+    // The case Python cannot express: a JSON array becomes an atomic vector,
+    // so `sum` sees three numbers rather than a list.
+    check('an array argument becomes an R vector',
+        result.runs.vectorArg?.result === '6', JSON.stringify(result.runs.vectorArg));
+    check('a missing function is an error, not a null result',
+        result.runs.missing?.ok === false, JSON.stringify(result.runs.missing));
+    check('the expression path works too',
+        result.runs.expression?.result === '"ok"', JSON.stringify(result.runs.expression));
+
+    if (failures.length) {
+        console.log(`\nFAILED: ${failures.length} check(s)`);
+        process.exit(1);
+    }
+    console.log('\nPASS');
+    process.exit(0);
+}
 
 if (mode === 'eval') {
     // A cell that raises must be REPORTED, not swallowed and not fatal: the

--- a/changelog.d/in-page-auto-compute-foundation.md
+++ b/changelog.d/in-page-auto-compute-foundation.md
@@ -1,0 +1,16 @@
+### Added
+
+- **The in-page auto-compute worker can now be given its language's value
+  serializer.** `AssignmentLanguage.autoComputeRuntimeSource` seeds the source a
+  worker must prepend before it can report a value — the SAME serializer the
+  server driver and grading runtime already use, so the two substrates cannot
+  disagree about what a value looks like. Lua and Octave need one; R and Python
+  do not, since `deparse` and `repr` are builtins.
+
+  Deliberately absent: a JSON string encoder. The eval protocol frames its
+  payload with a per-run nonce rather than encoding it, so no language has to
+  escape anything — which matters because the tree already carries two different
+  R JSON encoders (a `gsub` one in the grading runtime, and a char-by-char one
+  in the personalization driver written because the first trips over
+  replacement-string backslash rules). A third copy inside a worker would have
+  been the worst of them.

--- a/changelog.d/in-page-auto-compute-foundation.md
+++ b/changelog.d/in-page-auto-compute-foundation.md
@@ -1,16 +1,25 @@
 ### Added
 
-- **The in-page auto-compute worker can now be given its language's value
-  serializer.** `AssignmentLanguage.autoComputeRuntimeSource` seeds the source a
-  worker must prepend before it can report a value — the SAME serializer the
-  server driver and grading runtime already use, so the two substrates cannot
-  disagree about what a value looks like. Lua and Octave need one; R and Python
-  do not, since `deparse` and `repr` are builtins.
+- **The in-page auto-compute worker can now be given its language's own value
+  serializer and JSON escaper.** `AssignmentLanguage.autoComputeRuntimeSource`
+  seeds the source a worker must prepend before it can report a value — the
+  SAME constants the server driver and grading runtime already use, so the two
+  substrates cannot disagree about what a value looks like. Lua and Octave need
+  a serializer and an escaper; R needs only an escaper (`deparse` is a builtin);
+  Python needs neither.
 
-  Deliberately absent: a JSON string encoder. The eval protocol frames its
-  payload with a per-run nonce rather than encoding it, so no language has to
-  escape anything — which matters because the tree already carries two different
-  R JSON encoders (a `gsub` one in the grading runtime, and a char-by-char one
-  in the personalization driver written because the first trips over
-  replacement-string backslash rules). A third copy inside a worker would have
-  been the worst of them.
+  The eval protocol is unchanged — the one `python-eval-worker.js` already
+  speaks, with the payload printed as JSON behind a per-run nonce. An earlier
+  draft of this work proposed a second, nonce-framed encoding to avoid pushing
+  escapers into three languages; the escapers turned out to already exist as
+  Core constants, so framing would have bought nothing and cost a second payload
+  encoding and a second parser.
+
+### Changed
+
+- **R's char-by-char JSON string encoder moved from `PersonalizationEvaluator`
+  into `RPersonalizationRuntime`**, where a second consumer can share it rather
+  than copy it. Worth knowing when reaching for one: there are two R encoders in
+  the tree, and this is the robust one — the `gsub`-based encoder in the grading
+  runtime trips over replacement-string backslash rules, which is why this one
+  was written.

--- a/changelog.d/in-page-auto-compute-r.md
+++ b/changelog.d/in-page-auto-compute-r.md
@@ -1,0 +1,28 @@
+### Added
+
+- **R assignments compute expected values in the browser.** Auto-compute used to
+  send every non-Python language to the server, which was the right fix for a
+  wrong answer and the wrong rule for an editor whose job is in-browser
+  authoring: an instructor changing a case should see what their solution
+  returns without a round-trip. R now runs on the vendored xeus-r kernel, the
+  same one that grades a browser-graded R submission.
+
+  Lua and Octave still route to the server. Their kernels exist and the worker
+  shape is now proven; each needs its own snippet module and a smoke row.
+
+- **`rLiteral` in `Public/r-grading-shared.js`** — a browser twin of
+  `JSONValue.rLiteral`, needed because in-page auto-compute calls an R solution
+  with arguments the instructor has typed but not saved, so there is no server
+  round-trip in which the server could render them. Neither implementation owns
+  the expectations: both read `Tests/Fixtures/r-literal-contract.json`, so a
+  change to either that is not mirrored fails on both sides — the arrangement
+  `output-contract.json` already uses to pin RunnerCore's native and wasm builds
+  together.
+
+- **A browser-grading smoke row for R auto-compute.** It exercises the kernel
+  for real, because every way these snippets can be wrong is silent: they must
+  be one top-level expression each (a xeus-lite performance constraint), they
+  report behind a nonce, and the seeded escaper has to be defined before any of
+  them runs. The probe reads that escaper out of the Swift constant that defines
+  it rather than copying it — a copy would have been the fourth R JSON encoder
+  in this repo.

--- a/changelog.d/lua-literal-renderer.md
+++ b/changelog.d/lua-literal-renderer.md
@@ -1,0 +1,20 @@
+### Added
+
+- **A browser `luaLiteral`**, pinned to `JSONValue.luaLiteral` by
+  `Tests/Fixtures/lua-literal-contract.json` — the same arrangement the R
+  renderer uses, where neither implementation owns the expectations and both
+  read the fixture. Groundwork for in-page auto-compute on Lua.
+
+  The contract exists mainly to pin one trap: Lua spells null `nil`, and a `nil`
+  inside a table constructor **is not stored** — `{60, nil, 20}` loses its middle
+  slot, `ipairs` stops at the hole, and `#t` is unspecified. So null renders
+  `nil` only at top level and the `chickadee.NULL` sentinel inside any table. A
+  renderer that misses that produces a table of the wrong length and grades
+  against it.
+
+### Fixed
+
+- **`luaStringLiteral` now escapes control characters**, matching
+  `encodeLuaString` in Swift. It passed them through, and a literal newline
+  inside a quoted Lua string is a syntax error rather than a formatting quirk.
+  The escape is decimal (`\ddd`) because `\xNN` is Lua 5.2+.


### PR DESCRIPTION
Groundwork for in-page auto-compute in R, Lua and Octave. **The workers themselves are not in this PR** — this is the fact they need, and the reason they won't carry a copy of anything. Cut from `main` after #1319–#1322 merged, so no stack.

## No new protocol

Worth stating plainly because an earlier revision of this PR implied otherwise. The worker message protocol already exists and is untouched: `{id, type: 'init'|'loadCells'|'run'}` → `{id, ok, result|cellErrors|error}`. `python-eval-worker.js` deliberately preserved it when it moved off Pyodide so the editor's client code stayed unchanged, and the new workers speak the same one.

The only thing that was ever up for decision is how a value gets back out *inside* that protocol — a Jupyter `execute_request` returns nothing, it publishes messages, so the value is printed behind a per-run nonce and parsed. **That encoding is unchanged too: JSON, exactly as Python does it, read by the existing `parseEvalOutput`.**

## The decision I reversed

The first commit on this branch argued for a second, nonce-framed plaintext encoding, to avoid pushing a JSON string escaper into three new languages — citing the two rival R encoders in the tree as evidence that escapers are a trap here.

The evidence was real; the conclusion was wrong. Both other escapers **already exist as Core constants** (`chickadeeJSONStringLuaSource`, `chickadeeEscapeStringOctaveSource`), and R's robust char-by-char one exists too, merely `private` inside `PersonalizationEvaluator`. All three are seedable by exactly the mechanism this branch already built for the serializers. Framing bought nothing and cost two payload encodings and two parsers — the thing this whole line of work keeps arguing against.

Second commit corrects it. I've left the reasoning in the code comment rather than quietly deleting it, since "why isn't this framed?" is a question the next person will ask.

## What it does

`AssignmentLanguage.autoComputeRuntimeSource` seeds what each language needs: serializer **and** escaper for Lua and Octave, escaper only for R (`deparse` is a builtin), neither for Python. Every piece is an existing Core constant shared with the server driver and the grading runtime, so the two substrates cannot disagree about what a value looks like.

Tests assert **identity** with those constants, not plausible-looking content — a copy passes a "looks about right" check and then diverges on some value nobody is watching.

R's encoder is hoisted from `private` into `RPersonalizationRuntime`. Note for anyone reaching for one later: there is still a **third** R encoder in `TestRuntimeSources.swift` using the `gsub` approach this one exists to avoid. It serves the grading runtime's narrower payloads and I've left it alone, but the new doc comment says which to prefer.

## What comes next

Per language: a small `*-eval-shared.js` (snippet builders), a worker mirroring `python-eval-worker.js` on that language's existing `*-grading-shared.js`, one row in the browser-grading smoke matrix, and flipping `autoCompute` from `.serverDriver` to `.inPageKernel`. R's snippets additionally must be **one top-level expression** — xeus-lite's ~180ms per-expression yield, which at auto-compute's per-keystroke cadence is the difference between usable and not.

I won't flip a descriptor entry before its worker has a smoke probe: declaring a worker that doesn't exist makes the editor spawn a 404 and auto-compute stop *silently*, which is worse than the round-trip it replaces.

## Verification

`swift build` clean; **3,385 tests in 402 suites** pass; `format.sh`, `lint.sh`, `swiftlint.sh --strict` green. No behaviour change yet — nothing reads the new field until the workers land.