### PR TITLE
feat(editor): compute Lua expected values in the browser

### DIFF
--- a/.github/workflows/browser-grading-smoke.yml
+++ b/.github/workflows/browser-grading-smoke.yml
@@ -65,7 +65,13 @@ jobs:
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if echo "$changed" | grep -Eq '^(Public/r-grading-|Public/python-grading-|Public/lua-grading-|Public/python-eval-|Public/r-eval-|Public/eval-protocol-shared\.js|Public/pattern-family-editor\.js|Public/xeus-kernel-shared\.js|Public/browser-runner\.js|Public/grading-shared\.js|Public/vendor/xeus-|Public/jupyterlite/xeus/|Tools/browser-grading-smoke/|Tools/vendor/|Tools/runner-support/|scripts/setup-vendor\.sh|\.github/workflows/browser-grading-smoke\.yml)'; then
+          # The per-language prefixes are a PATTERN, not a list. The list they
+          # replaced had already gone stale — it named r/python/lua grading and
+          # python/r eval, while the matrix also ran octave grading, so an
+          # octave-only change skipped the job that tests it. A pattern also
+          # fails in the safe direction: an unrecognised language matches and
+          # runs the smoke rather than silently skipping it.
+          if echo "$changed" | grep -Eq '^(Public/[a-z0-9]+-(grading|eval)-|Public/eval-protocol-shared\.js|Public/pattern-family-editor\.js|Public/xeus-kernel-shared\.js|Public/browser-runner\.js|Public/grading-shared\.js|Public/vendor/xeus-|Public/jupyterlite/xeus/|Sources/Core/[A-Za-z]+PersonalizationRuntime\.swift|Sources/Core/AssignmentLanguage\.swift|Tools/browser-grading-smoke/|Tools/vendor/|Tools/runner-support/|scripts/setup-vendor\.sh|\.github/workflows/browser-grading-smoke\.yml)'; then
             echo "run_smoke=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_smoke=false" >> "$GITHUB_OUTPUT"
@@ -97,6 +103,12 @@ jobs:
           # runs — each of which fails SILENTLY when wrong. Only a real kernel
           # shows that.
           - { language: r, mode: eval }
+          # The Lua half. Its snippets are one CALL expression each — the same
+          # shape for a different reason than R's (xeus-lua's `return <cell>`
+          # probe, not the ~180ms yield) — and its seeded runtime has to export
+          # its two helpers as globals, because every kernel cell is its own
+          # chunk and a `local` does not survive one. Both fail silently.
+          - { language: lua, mode: eval }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -351,6 +351,12 @@ jobs:
       - name: Lint first-party frontend JS
         run: scripts/eslint.sh
 
+      # The Lua auto-compute snippets are EXECUTED, not just shape-checked
+      # (lua-eval-execution.test.mjs). That suite skips silently without an
+      # interpreter, so a missing package here would look like a pass.
+      - name: Install Lua
+        run: sudo apt-get update && sudo apt-get install -y lua5.4
+
       - name: Run browser runner execution tests
         run: node --test Tests/BrowserRunnerJSTests/*.mjs
 

--- a/Public/lua-eval-shared.js
+++ b/Public/lua-eval-shared.js
@@ -1,0 +1,275 @@
+// Public/lua-eval-shared.js
+//
+// The snippets the pattern-family editor's auto-compute runs on the xeus-lua
+// kernel. The Lua sibling of r-eval-shared.js and python-eval-shared.js; the
+// nonce framing all three share lives in eval-protocol-shared.js.
+//
+// Loading: classic script (importScripts). Requires /lua-grading-shared.js
+// first (kernel spec, `makeNonce`, `luaStringLiteral`, `luaLiteral`) and
+// /eval-protocol-shared.js. Exposes exactly one global: ChickadeeLuaEvalShared.
+//
+// THREE LUA FACTS SHAPE EVERY SNIPPET BELOW, and only one of them is R's.
+//
+// 1. EVERY CELL IS ITS OWN CHUNK, so `local` does not persist. That is why the
+//    seeded runtime ends by re-binding its two helpers as globals (in Swift, in
+//    `LuaPersonalizationRuntime.chickadeeAutoComputeExportsLuaSource`) and why
+//    the snippets here reach them by bare name.
+//
+// 2. ONE CALL EXPRESSION PER CELL — the same shape lua-grading-shared.js uses,
+//    for the same reason and NOT for R's. xeus-lua first tries to compile a
+//    cell as `return <cell>` so it can report a value and falls back to running
+//    it as a block; a cell that opens with a `local` declaration and then uses
+//    it satisfies neither reading, and the fallback reports the name as an
+//    undefined global. Wrapping the body in a function the kernel never
+//    re-parses sidesteps the question. R's ~180ms inter-expression yield, the
+//    reason ITS snippets are one expression, does not exist here: measured, 20
+//    top-level statements cost 5ms on this kernel.
+//
+// 3. VALUES COME BACK AS LUA SOURCE (`chickadee_serialize`), which is exactly
+//    what the SERVER driver returns for Lua — it writes that text verbatim into
+//    `_ck_inputs.lua`. The client parses both with the same language-aware
+//    reader, so in-page and server auto-compute cannot disagree about what a
+//    value looks like. Lua has no JSON and no `deparse`; this is its `repr`.
+
+(function (root) {
+    'use strict';
+
+    var grading = root.ChickadeeLuaGradingShared;
+    var protocol = root.ChickadeeEvalProtocol;
+
+    /// Wraps the seeded runtime so the kernel accepts it — see fact 2.
+    ///
+    /// The runtime is otherwise executed verbatim: its bytes come from
+    /// `AssignmentLanguage.autoComputeRuntimeSource`, so the serializer that
+    /// reports a value here is the one the personalization driver uses on the
+    /// server, not a copy written in this file.
+    function bootCell(runtimeSource) {
+        return '(function()\n' + runtimeSource + '\nend)()';
+    }
+
+    /// Statements binding `<jsonName>` to a JSON string for `<varName>`, or the
+    /// bare token `null` when it holds nothing.
+    ///
+    /// `chickadee_json_str` is the SEEDED encoder. A copy written here would be
+    /// a third Lua JSON encoder in this codebase, and the one that gets a
+    /// solution's error message — the text most likely to contain a quote.
+    function jsonOrNull(varName, jsonName) {
+        return [
+            '  local ' + jsonName + ' = "null"',
+            '  if ' + varName + ' ~= nil then '
+                + jsonName + ' = chickadee_json_str(' + varName + ') end'
+        ];
+    }
+
+    /// One `io.write` printing the marker, the JSON, and a newline.
+    ///
+    /// `io.write` concatenates its arguments with no separator, so unlike R's
+    /// `cat` there is nothing to switch off.
+    function payloadWrite(nonce, chunks) {
+        var args = [grading.luaStringLiteral(protocol.payloadMarker(nonce))]
+            .concat(chunks)
+            .concat([grading.luaStringLiteral('\n')]);
+        return '  io.write(' + args.join(', ') + ')';
+    }
+
+    /// Run one solution-notebook cell, reporting whether it raised.
+    ///
+    /// `load` with no environment argument compiles against the globals, so a
+    /// `function f() end` in the cell defines a global `f` that later cells and
+    /// the call snippet can see — the entire point of loading it.
+    ///
+    /// A syntax error and a runtime error are both reported, and neither is
+    /// propagated: cells load in order, and an early failure must not stop
+    /// later cells from defining their functions. The editor explains a
+    /// downstream "not defined" in terms of the earlier cell that crashed,
+    /// which it can only do if it got that far.
+    function loadCellLua(source, nonce) {
+        return [
+            '(function()',
+            '  local ck_err = nil',
+            '  local ck_chunk, ck_syntax = load('
+                + grading.luaStringLiteral(source) + ', "solution", "t")',
+            '  if ck_chunk == nil then',
+            '    ck_err = tostring(ck_syntax)',
+            '  else',
+            '    local ck_ok, ck_raised = pcall(ck_chunk)',
+            '    if not ck_ok then ck_err = tostring(ck_raised) end',
+            '  end'
+        ].concat(jsonOrNull('ck_err', 'ck_err_json')).concat([
+            payloadWrite(nonce, [
+                grading.luaStringLiteral('{"error":'),
+                'ck_err_json',
+                grading.luaStringLiteral('}')
+            ]),
+            'end)()'
+        ]).join('\n');
+    }
+
+    /// Evaluate `source` and report its value as Lua source.
+    ///
+    /// Lua has no `eval`: a chunk is the only way to turn text into a value, so
+    /// the source is compiled as `return (<source>)` first and as a plain block
+    /// only if that will not compile. Same two-step the server's Lua expression
+    /// driver takes, and it is what makes a statement (which yields nothing)
+    /// report a null value rather than a syntax error.
+    function runExpressionLua(source, nonce) {
+        return [
+            '(function()',
+            '  local ck_err = nil',
+            '  local ck_val = nil',
+            '  local ck_chunk, ck_syntax = load('
+                + grading.luaStringLiteral('return (' + source + ')')
+                + ', "expression", "t")',
+            '  if ck_chunk == nil then',
+            '    ck_chunk, ck_syntax = load('
+                + grading.luaStringLiteral(source) + ', "expression", "t")',
+            '  end',
+            '  if ck_chunk == nil then',
+            '    ck_err = tostring(ck_syntax)',
+            '  else',
+            '    local ck_ok, ck_res = pcall(ck_chunk)',
+            '    if ck_ok then',
+            '      if ck_res ~= nil then ck_val = chickadee_serialize(ck_res) end',
+            '    else',
+            '      ck_err = tostring(ck_res)',
+            '    end',
+            '  end'
+        ].concat(jsonOrNull('ck_val', 'ck_val_json'))
+            .concat(jsonOrNull('ck_err', 'ck_err_json'))
+            .concat([
+                payloadWrite(nonce, [
+                    grading.luaStringLiteral('{"value":'),
+                    'ck_val_json',
+                    grading.luaStringLiteral(',"error":'),
+                    'ck_err_json',
+                    grading.luaStringLiteral('}')
+                ]),
+                'end)()'
+            ]).join('\n');
+    }
+
+    /// The `print` / `io` swap that makes `captureStdout` work, and its undo.
+    ///
+    /// Lua has no `capture.output`. This is the generated `.stdoutEquality`
+    /// test's capture, moved from the student's environment table into `_G` —
+    /// the eval worker loads solution cells straight into the globals, so there
+    /// is no per-submission table to shadow. It covers `print`, `io.write`,
+    /// `io.stdout:write` and chained `io.write(a):write(b)`: the proxy's
+    /// `write` drops a leading self argument and returns the handle. The one
+    /// path it cannot reach is a solution that bound `local print = print`
+    /// before the call — an upvalue frozen at load time, uncapturable by any
+    /// per-call swap, in the generated test too.
+    var CAPTURE_INSTALL = [
+        '    local ck_captured = {}',
+        '    local ck_real_print, ck_real_io = print, io',
+        '    local ck_stdout = {}',
+        '    function ck_stdout.write(...)',
+        '      local n = select("#", ...)',
+        '      local first = (n >= 1 and select(1, ...) == ck_stdout) and 2 or 1',
+        '      for i = first, n do',
+        '        ck_captured[#ck_captured + 1] = tostring((select(i, ...)))',
+        '      end',
+        '      return ck_stdout',
+        '    end',
+        '    _G.print = function(...)',
+        '      local parts = {}',
+        '      for i = 1, select("#", ...) do',
+        '        parts[#parts + 1] = tostring((select(i, ...)))',
+        '      end',
+        '      ck_captured[#ck_captured + 1] = table.concat(parts, "\\t") .. "\\n"',
+        '    end',
+        '    _G.io = setmetatable(',
+        '      { write = ck_stdout.write, stdout = ck_stdout },',
+        '      { __index = ck_real_io })'
+    ];
+
+    /// Call `functionName` in the loaded solution with `args`, reporting the
+    /// result as Lua source.
+    ///
+    /// THE ARGUMENTS ARE RENDERED HERE, in the browser, by the JS twin of
+    /// `JSONValue.luaLiteral` — because an instructor changing a case has not
+    /// saved it, so there is no server round-trip in which the server could
+    /// render them. Both renderers are pinned to
+    /// Tests/Fixtures/lua-literal-contract.json.
+    ///
+    /// Each argument gets its own `local`, exactly as the generated test binds
+    /// `arg_1`, `arg_2`, …, rather than going into a table: a JSON null is
+    /// `nil` at top level, and a table constructor does not store `nil` at all.
+    /// Building an argument table would silently drop the slot and call the
+    /// solution with the wrong arity.
+    function callFunctionLua(functionName, args, options, nonce) {
+        var captureStdout = !!(options && options.captureStdout);
+        var nameLiteral = grading.luaStringLiteral(functionName);
+        var argValues = args || [];
+        var bindings = argValues.map(function (value, index) {
+            return '    local ck_a' + (index + 1) + ' = '
+                + grading.luaLiteral(value, false);
+        });
+        var argNames = argValues.map(function (_, index) { return 'ck_a' + (index + 1); });
+        var invocation = ['ck_fn'].concat(argNames).join(', ');
+
+        var body;
+        if (captureStdout) {
+            body = CAPTURE_INSTALL.concat([
+                '    local ck_ok, ck_res = pcall(' + invocation + ')',
+                '    _G.print, _G.io = ck_real_print, ck_real_io',
+                '    if ck_ok then',
+                '      local ck_text = table.concat(ck_captured)',
+                // One trailing newline is dropped, matching what the Python
+                // path stores. No further normalisation: the generated test
+                // normalises BOTH sides, so trailing whitespace cannot decide a
+                // comparison and duplicating its normaliser here would buy
+                // nothing but a second copy to keep in step.
+                '      if ck_text:sub(-1) == "\\n" then ck_text = ck_text:sub(1, -2) end',
+                '      ck_val = chickadee_serialize(ck_text)',
+                '    else',
+                '      ck_err = tostring(ck_res)',
+                '    end'
+            ]);
+        } else {
+            body = [
+                '    local ck_ok, ck_res = pcall(' + invocation + ')',
+                '    if ck_ok then',
+                '      if ck_res ~= nil then ck_val = chickadee_serialize(ck_res) end',
+                '    else',
+                '      ck_err = tostring(ck_res)',
+                '    end'
+            ];
+        }
+
+        return [
+            '(function()',
+            '  local ck_err = nil',
+            '  local ck_val = nil',
+            '  local ck_fn = _G[' + nameLiteral + ']',
+            '  if type(ck_fn) ~= "function" then',
+            // "not defined" is the phrase describeCallFailure looks for when it
+            // decides whether to fold in the first failing solution cell.
+            '    ck_err = ' + nameLiteral + ' .. " is not defined in the solution notebook"',
+            '  else'
+        ].concat(bindings).concat(body).concat([
+            '  end'
+        ]).concat(jsonOrNull('ck_val', 'ck_val_json'))
+            .concat(jsonOrNull('ck_err', 'ck_err_json'))
+            .concat([
+                payloadWrite(nonce, [
+                    grading.luaStringLiteral('{"value":'),
+                    'ck_val_json',
+                    grading.luaStringLiteral(',"error":'),
+                    'ck_err_json',
+                    grading.luaStringLiteral('}')
+                ]),
+                'end)()'
+            ]).join('\n');
+    }
+
+    root.ChickadeeLuaEvalShared = {
+        LUA_KERNEL: grading.LUA_KERNEL,
+        makeNonce: grading.makeNonce,
+        bootCell: bootCell,
+        loadCell: loadCellLua,
+        runExpression: runExpressionLua,
+        callFunction: callFunctionLua,
+        parseEvalOutput: protocol.parseEvalOutput,
+    };
+})(typeof self !== 'undefined' ? self : globalThis);

--- a/Public/lua-eval-worker.js
+++ b/Public/lua-eval-worker.js
@@ -1,0 +1,144 @@
+// Public/lua-eval-worker.js
+//
+// The pattern-family editor's auto-compute substrate for Lua: loads an
+// instructor's solution notebook into the xeus-lua globals, then evaluates
+// snippets against it to fill in expected values.
+//
+// The Lua sibling of r-eval-worker.js and python-eval-worker.js, speaking the
+// SAME message protocol, so the editor's client code is identical for all three:
+//   { id, type: 'init' }                 → { id, ok: true }
+//   { id, type: 'loadCells', cells: [] } → { id, ok: true, cellErrors: [{index, message}] }
+//   { id, type: 'call', functionName, args, captureStdout }
+//                                        → { id, ok: true, result: <string|null> }
+//   { id, type: 'run', code }            → { id, ok: true, result: <string|null> }
+//   any failure                          → { id, ok: false, error }
+//
+// Every message may carry `runtimeSource`, the Lua the worker must define
+// before it can report anything. It is SEEDED from the server
+// (`AssignmentLanguage.autoComputeRuntimeSource`) rather than written here, so
+// the serializer that renders a value is the one the personalization driver
+// uses and the JSON encoder is not a third copy.
+//
+// Why a worker at all, inherited from the Python path and still true: auto-
+// compute runs the instructor's own solution, and a synchronous CPU-bound loop
+// in it never yields, so a Promise.race timeout on the main thread can never
+// fire. Only `Worker.terminate()` kills it.
+//
+// This page is NOT cross-origin isolated — /instructor/:id/edit deliberately is
+// not — and does not need to be: the kernel is booted directly through its
+// emscripten module rather than JupyterLite's transports, so no
+// SharedArrayBuffer is involved. Same path the browser-grading smoke exercises.
+
+var _search = self.location.search || '';
+importScripts('/vendor/xeus-bootstrap.js' + _search);
+importScripts('/xeus-kernel-shared.js' + _search);
+importScripts('/grading-shared.js' + _search);
+importScripts('/eval-protocol-shared.js' + _search);
+importScripts('/lua-grading-shared.js' + _search);
+importScripts('/lua-eval-shared.js' + _search);
+
+var _kernel = self.ChickadeeXeusKernel;
+var _eval = self.ChickadeeLuaEvalShared;
+var _reply = _kernel.reply;
+
+// The dead-kernel backstop, not a limit on how long code may run — the main
+// thread owns that and enforces it by terminating this worker. Set well above
+// the editor's own 30s load cap so a terminate always wins the race, and this
+// only ever fires for a kernel that is never going to reply at all.
+var MAX_WAIT_MS = 60000;
+
+var _booted = false;
+
+/// Boots the kernel and defines the seeded runtime once.
+async function ensureBooted(runtimeSource) {
+    if (_booted) return;
+    await _kernel.boot(_eval.LUA_KERNEL);
+    if (runtimeSource) {
+        var reply = await _kernel.execute(
+            _eval.bootCell(runtimeSource), { maxWaitMs: MAX_WAIT_MS });
+        // A runtime that fails to define leaves every later snippet calling a
+        // nil `chickadee_json_str`, which reports as a confusing per-cell error
+        // rather than as the substrate failure it is. Fail loudly at boot.
+        if (reply.failure) {
+            throw new Error('the Lua auto-compute runtime failed to load: ' + reply.failure);
+        }
+    }
+    _booted = true;
+}
+
+/// Runs one solution-notebook cell, returning its error message or null.
+async function loadOneCell(source) {
+    var nonce = _eval.makeNonce();
+    var reply = await _kernel.execute(
+        _eval.loadCell(source, nonce), { maxWaitMs: MAX_WAIT_MS });
+    var parsed = _eval.parseEvalOutput(reply.stdout, nonce);
+    if (parsed) return parsed.error;
+    // The cell never reported. Attribute it to the cell rather than failing the
+    // whole load, so the remaining cells still get a chance to define their
+    // functions — same reason the per-cell errors are caught in Lua.
+    return reply.failure || (reply.stderr || '').trim() || 'the Lua kernel produced no result';
+}
+
+/// Runs one snippet that reports a value, unwrapping the payload.
+///
+/// `build` receives the nonce and returns the snippet, so the nonce the parser
+/// reads and the nonce the snippet prints cannot drift apart.
+async function evaluateSnippet(build) {
+    var nonce = _eval.makeNonce();
+    var reply = await _kernel.execute(build(nonce), { maxWaitMs: MAX_WAIT_MS });
+    var parsed = _eval.parseEvalOutput(reply.stdout, nonce);
+    if (!parsed) {
+        throw new Error(
+            reply.failure || (reply.stderr || '').trim()
+            || 'the Lua kernel produced no result');
+    }
+    if (parsed.error) throw new Error(parsed.error);
+    return parsed.value;
+}
+
+self.onmessage = async function (e) {
+    var msg = e.data || {};
+    var id = msg.id;
+    try {
+        if (msg.type === 'init') {
+            await ensureBooted(msg.runtimeSource);
+            _reply({ id: id, ok: true });
+            return;
+        }
+        if (msg.type === 'loadCells') {
+            await ensureBooted(msg.runtimeSource);
+            var cells = Array.isArray(msg.cells) ? msg.cells : [];
+            var cellErrors = [];
+            for (var i = 0; i < cells.length; i++) {
+                var message = await loadOneCell(cells[i]);
+                if (message) cellErrors.push({ index: i, message: message });
+            }
+            _reply({ id: id, ok: true, cellErrors: cellErrors });
+            return;
+        }
+        if (msg.type === 'call') {
+            // The language-neutral request: call this function with these JSON
+            // args. The SNIPPET is built here rather than on the main thread,
+            // so rendering Lua values stays in the Lua module.
+            await ensureBooted(msg.runtimeSource);
+            var callResult = await evaluateSnippet(function (nonce) {
+                return _eval.callFunction(
+                    msg.functionName, msg.args || [],
+                    { captureStdout: !!msg.captureStdout }, nonce);
+            });
+            _reply({ id: id, ok: true, result: callResult });
+            return;
+        }
+        if (msg.type === 'run') {
+            await ensureBooted(msg.runtimeSource);
+            var runResult = await evaluateSnippet(function (nonce) {
+                return _eval.runExpression(msg.code || '', nonce);
+            });
+            _reply({ id: id, ok: true, result: runResult });
+            return;
+        }
+        _reply({ id: id, ok: false, error: 'unknown message type: ' + msg.type });
+    } catch (err) {
+        _reply({ id: id, ok: false, error: (err && err.message) ? String(err.message) : String(err) });
+    }
+};

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -382,8 +382,21 @@ extension AssignmentLanguage {
             // `deparse` serializes; only the escaper is needed.
             return RPersonalizationRuntime.chickadeeJSONStringRSource
         case .lua:
-            return LuaPersonalizationRuntime.chickadeeSerializeLuaSource + "\n\n"
-                + LuaPersonalizationRuntime.chickadeeJSONStringLuaSource
+            // Four pieces, and the order matters. The sentinel comes first: a
+            // rendered argument may mention `chickadee.NULL`, and the eval
+            // worker loads no `test_runtime` to bind it. The exports come last,
+            // because they are the only place the two `local` declarations
+            // above are still in scope.
+            //
+            // `Tools/browser-grading-smoke` rebuilds this list from the same
+            // constants; `LuaAutoComputeRuntimeTests` fails if a fifth piece is
+            // added here without updating it.
+            return [
+                LuaPersonalizationRuntime.chickadeeNullTableLuaSource,
+                LuaPersonalizationRuntime.chickadeeSerializeLuaSource,
+                LuaPersonalizationRuntime.chickadeeJSONStringLuaSource,
+                LuaPersonalizationRuntime.chickadeeAutoComputeExportsLuaSource,
+            ].joined(separator: "\n\n")
         case .octave:
             return OctavePersonalizationRuntime.chickadeeSerializeOctaveSource + "\n\n"
                 + OctavePersonalizationRuntime.chickadeeEscapeStringOctaveSource

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -502,19 +502,7 @@ extension AssignmentLanguage {
                     #"^(?:local\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#,
                     #"^(?:local\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\s*\(([^)]*)\)"#,
                 ]),
-                // PENDING ITS WORKER. This language has a vendored kernel, so
-                // the target answer is `.inPageKernel` — the editor's job is
-                // in-browser verification, and an author should not wait on a
-                // server round-trip to see what their solution returns. It says
-                // `.serverDriver` only because `/lua-eval-worker.js` does not exist
-                // yet; declaring the kernel before writing the worker would have
-                // the editor spawn a 404 and auto-compute would silently stop.
-                //
-                // Flipping it is one line here, one worker mirroring
-                // `python-eval-worker.js` on this language's existing
-                // `*-grading-shared.js`, and one row in the browser-grading
-                // smoke matrix.
-                autoCompute: .serverDriver,
+                autoCompute: .inPageKernel(workerScript: "/lua-eval-worker.js"),
                 inputsFileName: "_ck_inputs.lua",
                 notebookKernelNames: AssignmentLanguage.luaKernelNames,
                 editorSupport: .notebookKernel(

--- a/Sources/Core/LuaPersonalizationRuntime.swift
+++ b/Sources/Core/LuaPersonalizationRuntime.swift
@@ -105,4 +105,49 @@ public enum LuaPersonalizationRuntime {
             return '"' .. s .. '"'
         end
         """#
+
+    /// The `chickadee.NULL` sentinel VALUE, as Lua source.
+    ///
+    /// Lua has no missing-value scalar and a bare `nil` in a table constructor
+    /// is not stored at all, so `JSONValue.luaLiteral` emits `chickadee.NULL`
+    /// for a null inside any table — which requires something to exist under
+    /// that name wherever a rendered literal is evaluated.
+    ///
+    /// Two places evaluate them: the grading runtime (`test_runtime.lua`, which
+    /// binds this as `M.NULL`) and the in-page auto-compute worker (which has no
+    /// `test_runtime` loaded and binds it as `chickadee.NULL` directly). Only
+    /// the expression is shared, because the two bind it differently.
+    ///
+    /// Compared by identity, so nothing a student can construct equals it.
+    public static let chickadeeNullSentinelLuaSource =
+        #"setmetatable({}, { __tostring = function() return "NULL" end })"#
+
+    /// What the in-page auto-compute worker must define before it evaluates a
+    /// rendered Lua literal: the `chickadee` table carrying the sentinel.
+    ///
+    /// The grading path gets this from `require("test_runtime")`. The eval
+    /// worker loads no such module — it evaluates the instructor's solution
+    /// cells and nothing else — so without this a null inside any argument
+    /// would index a nil `chickadee` and report as a confusing solution error.
+    public static let chickadeeNullTableLuaSource = """
+        chickadee = chickadee or {}
+        chickadee.NULL = chickadee.NULL or \(chickadeeNullSentinelLuaSource)
+        """
+
+    /// Re-binds the two helper functions above as globals.
+    ///
+    /// `chickadee_serialize` and `chickadee_json_str` are declared `local`,
+    /// which is right for the server driver — one script, one chunk, and a
+    /// driver that leaks globals into an instructor's expression scope would be
+    /// a surprise. In a kernel it is not enough: EVERY CELL IS ITS OWN CHUNK, so
+    /// a `local` declared while seeding the runtime is gone by the time the
+    /// first snippet runs, and the snippet's call reads as "attempt to call a
+    /// nil value" — a per-cell error rather than the substrate failure it is.
+    ///
+    /// This tail runs inside the same chunk as the declarations, which is the
+    /// only place the locals are still in scope.
+    public static let chickadeeAutoComputeExportsLuaSource = """
+        _G.chickadee_serialize = chickadee_serialize
+        _G.chickadee_json_str = chickadee_json_str
+        """
 }

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -801,7 +801,7 @@ let testRuntimeLua =
     -- emits `chickadee.NULL` and is what requires this to exist under that name).
     --
     -- Compared by identity, so nothing a student can construct is equal to it.
-    M.NULL = setmetatable({}, { __tostring = function() return "NULL" end })
+    M.NULL = \#(LuaPersonalizationRuntime.chickadeeNullSentinelLuaSource)
 
     -- Exact equality, with Lua 5.4's integer/float split handled the way a student
     -- would expect: 1 and 1.0 are the same answer. `==` already says so for

--- a/Tests/BrowserRunnerJSTests/lua-eval-execution.test.mjs
+++ b/Tests/BrowserRunnerJSTests/lua-eval-execution.test.mjs
@@ -1,0 +1,197 @@
+// Executes the Lua auto-compute snippets under a real Lua interpreter.
+//
+// lua-eval-shared.test.mjs asserts the snippets' SHAPE; this one asserts they
+// run. Everything below is the real thing: the seeded runtime is extracted from
+// the Swift constants the server sends, the snippets come from the shipped
+// module, and each is `load`ed as its OWN CHUNK — because that is what a kernel
+// cell is, and it is the only way a `local` that should have been exported
+// shows up as a failure rather than as an accident of file scope.
+//
+// The kernel-side proof is still Tools/browser-grading-smoke (`--language lua
+// --mode eval`): only a real kernel can show that stdout reaches the stream and
+// that the boot cell survives xeus-lua's `return <cell>` probe. This is the
+// cheap half — it catches a Lua syntax error or a wrong helper name in seconds.
+//
+// Skips silently when no `lua` is on PATH, so a checkout without one is not a
+// red suite.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readAutoComputeRuntimeSource } from
+    '../../Tools/browser-grading-smoke/auto-compute-runtime.mjs';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/eval-protocol-shared.js');
+require('../../Public/lua-grading-shared.js');
+require('../../Public/lua-eval-shared.js');
+
+const Lua = globalThis.ChickadeeLuaEvalShared;
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const LUA = ['lua', 'lua5.4', 'lua5.3'].find(
+    (name) => spawnSync(name, ['-v'], { stdio: 'ignore' }).status === 0);
+
+// A silent skip is right on a laptop and wrong in CI, where it would report a
+// green suite that executed nothing. The workflow installs lua5.4 for exactly
+// this file; if that step ever goes away, this says so.
+test('CI has a Lua interpreter for these tests to use', { skip: !process.env.CI }, () => {
+    assert.ok(LUA, 'no lua on PATH — the browser-runner-tests job must install lua5.4');
+});
+
+const runtimeSource = LUA ? await readAutoComputeRuntimeSource('lua', REPO_ROOT) : null;
+
+/// Runs `cells` as separate chunks in one Lua state and returns its stdout.
+///
+/// The driver `load`s each cell exactly as the kernel does, so a helper that
+/// only works because everything happened to share a file scope fails here.
+function runCells(cells) {
+    const driver = [
+        'local function cell(src)',
+        '  local chunk, err = load(src, "cell", "t")',
+        '  if chunk == nil then error("compile: " .. tostring(err)) end',
+        '  chunk()',
+        'end',
+    ].concat(cells.map((source) => {
+        assert.ok(!source.includes(']====]'), 'a snippet must not close the driver bracket');
+        return 'cell([====[\n' + source + '\n]====])';
+    })).join('\n');
+    const file = path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'ck-lua-eval-')), 'driver.lua');
+    fs.writeFileSync(file, driver);
+    return execFileSync(LUA, [file], { encoding: 'utf8' });
+}
+
+/// Boots the runtime, loads `cells`, then evaluates `snippet`, returning the
+/// parsed payload.
+function evaluate(snippet, nonce, cells = []) {
+    const solutionCells = cells.map((source, index) => Lua.loadCell(source, 'LOAD' + index));
+    const stdout = runCells([Lua.bootCell(runtimeSource)].concat(solutionCells, [snippet]));
+    return globalThis.ChickadeeEvalProtocol.parseEvalOutput(stdout, nonce);
+}
+
+const SOLUTION = [
+    'function classify(bmi) if bmi < 18.5 then return "under" else return "ok" end end',
+    'this_name_does_not_exist()',
+    'function double_it(x) return x * 2 end',
+    'function shout(word) print(word .. "!") end',
+    'function count(items) return #items end',
+];
+
+test('the seeded runtime defines its helpers for LATER chunks', { skip: !LUA }, () => {
+    // The whole reason the exports tail exists. Without it the runtime's two
+    // `local function` declarations die with the boot cell and every snippet
+    // below fails on a nil call.
+    const stdout = runCells([
+        Lua.bootCell(runtimeSource),
+        'io.write(type(chickadee_serialize), " ", type(chickadee_json_str), " ",'
+        + ' type(chickadee.NULL), "\\n")',
+    ]);
+    assert.equal(stdout.trim(), 'function function table');
+});
+
+test('a solution cell that raises is reported, and later cells still load',
+    { skip: !LUA }, () => {
+        const payload = evaluate(
+            Lua.callFunction('double_it', [21], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, '42');
+    });
+
+test('a failing cell reports its own message', { skip: !LUA }, () => {
+    const stdout = runCells([
+        Lua.bootCell(runtimeSource),
+        Lua.loadCell('this_name_does_not_exist()', 'BAD'),
+    ]);
+    const payload = globalThis.ChickadeeEvalProtocol.parseEvalOutput(stdout, 'BAD');
+    assert.match(payload.error, /nil value/);
+});
+
+test('a value comes back as Lua source, the same repr the server driver returns',
+    { skip: !LUA }, () => {
+        const payload = evaluate(
+            Lua.callFunction('classify', [18.49], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '"under"');
+    });
+
+test('an array argument becomes a table the solution can measure',
+    { skip: !LUA }, () => {
+        const payload = evaluate(
+            Lua.callFunction('count', [[1, 2, 3]], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '3');
+    });
+
+test('a null inside an argument keeps its slot', { skip: !LUA }, () => {
+    // The trap the literal contract pins, executed: `{60, nil, 20}` would be a
+    // two-element table (or worse), so `count` would answer 2.
+    const payload = evaluate(
+        Lua.callFunction('count', [[60, null, 20]], {}, 'N'), 'N', SOLUTION);
+    assert.equal(payload.value, '3');
+});
+
+test('a missing function is an error naming the phrase the editor keys on',
+    { skip: !LUA }, () => {
+        const payload = evaluate(
+            Lua.callFunction('no_such_function', [], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, null);
+        assert.match(payload.error, /not defined/);
+    });
+
+test('a raising solution is an error, not a null value', { skip: !LUA }, () => {
+    const payload = evaluate(
+        Lua.callFunction('double_it', ['nope'], {}, 'N'), 'N', SOLUTION);
+    assert.equal(payload.value, null);
+    assert.match(payload.error, /attempt to mul|arithmetic/);
+});
+
+test('captureStdout reports what was printed, minus one trailing newline',
+    { skip: !LUA }, () => {
+        const payload = evaluate(
+            Lua.callFunction('shout', ['go'], { captureStdout: true }, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '"go!"');
+    });
+
+test('the payload is written through the real io after the capture is undone',
+    { skip: !LUA }, () => {
+        // If the restore came after the write, the marker would land in the
+        // capture buffer and the parser would see nothing at all.
+        const stdout = runCells([
+            Lua.bootCell(runtimeSource),
+            Lua.loadCell('function shout(word) print(word .. "!") end', 'L'),
+            Lua.callFunction('shout', ['hi'], { captureStdout: true }, 'N'),
+        ]);
+        const marker = stdout.indexOf('\nN:');
+        assert.ok(marker >= 0, `no payload on stdout:\n${stdout}`);
+        // The captured text appears inside the payload, so the check is that it
+        // did not ALSO escape to stdout before it.
+        assert.ok(!stdout.slice(0, marker).includes('hi!'),
+            `captured output escaped to stdout:\n${stdout}`);
+    });
+
+test('the expression path evaluates and reports a value', { skip: !LUA }, () => {
+    const payload = evaluate(Lua.runExpression('classify(30)', 'N'), 'N', SOLUTION);
+    assert.equal(payload.value, '"ok"');
+});
+
+test('a statement runs and yields no value rather than a syntax error',
+    { skip: !LUA }, () => {
+        const payload = evaluate(Lua.runExpression('local x = 1', 'N'), 'N');
+        assert.equal(payload.value, null);
+        assert.equal(payload.error, null);
+    });
+
+test('a quote in a solution cannot break out of the embedded literal',
+    { skip: !LUA }, () => {
+        const payload = evaluate(
+            Lua.callFunction('quoted', [], {}, 'N'), 'N',
+            ['function quoted() return "he said \\"hi\\"" end']);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, '"he said \\"hi\\""');
+    });

--- a/Tests/BrowserRunnerJSTests/lua-eval-shared.test.mjs
+++ b/Tests/BrowserRunnerJSTests/lua-eval-shared.test.mjs
@@ -1,0 +1,172 @@
+// Unit tests for the Lua auto-compute snippets.
+//
+// No kernel here — these assert the SHAPE the kernel constrains, which is the
+// part that can be got wrong silently:
+//
+//   * one call expression per cell, because xeus-lua's `return <cell>` probe
+//     mis-reads a cell that opens with a `local` declaration;
+//   * the payload marker spelled exactly as the shared parser reads it;
+//   * the seeded helpers CALLED and never defined here;
+//   * arguments bound one per `local`, because a JSON null in a table
+//     constructor is not stored at all.
+//
+// The kernel-side proof is Tools/browser-grading-smoke with `--language lua
+// --mode eval`.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/eval-protocol-shared.js');
+require('../../Public/lua-grading-shared.js');
+require('../../Public/lua-eval-shared.js');
+
+const Lua = globalThis.ChickadeeLuaEvalShared;
+const protocol = globalThis.ChickadeeEvalProtocol;
+
+/// True when `source` is a single `(function() … end)()` call and nothing
+/// follows it.
+function isOneCallExpression(source) {
+  const trimmed = source.trim();
+  if (!trimmed.startsWith('(function()') || !trimmed.endsWith('end)()')) return false;
+  // Walk the parens of the whole snippet; the opening one must not close until
+  // the very end, or there is a second top-level form after it. String
+  // literals in the snippet can hold parens, so they are skipped.
+  let depth = 0;
+  let quoted = false;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (quoted) {
+      if (ch === '\\') i++;
+      else if (ch === '"') quoted = false;
+      continue;
+    }
+    if (ch === '"') quoted = true;
+    else if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      // The function expression's own paren closes just before the `()` that
+      // calls it; anything else after depth reaches zero is a second form.
+      if (depth === 0 && trimmed.slice(i + 1) !== '()' && i < trimmed.length - 1) return false;
+    }
+  }
+  return depth === 0;
+}
+
+const SNIPPETS = () => ({
+  loadCell: Lua.loadCell('function f(x) return x end\n', 'NONCE1'),
+  runExpression: Lua.runExpression('f(2)', 'NONCE2'),
+  call: Lua.callFunction('f', [1], {}, 'NONCE3'),
+  captured: Lua.callFunction('f', [1], { captureStdout: true }, 'NONCE4'),
+});
+
+test('every snippet is a single call expression', () => {
+  for (const [name, snippet] of Object.entries(SNIPPETS())) {
+    assert.ok(isOneCallExpression(snippet), `${name} must be one call expression:\n${snippet}`);
+  }
+});
+
+test('the payload marker matches what the shared parser looks for', () => {
+  const run = Lua.runExpression('1', 'ABC123');
+  assert.ok(run.includes('"\\nABC123:"'),
+    `snippet does not write the marker the parser reads:\n${run}`);
+  assert.equal(protocol.payloadMarker('ABC123'), '\nABC123:');
+});
+
+test('the seeded helpers are called, never defined here', () => {
+  for (const [name, snippet] of Object.entries(SNIPPETS())) {
+    assert.ok(!/local function chickadee_/.test(snippet),
+      `${name} must use the seeded runtime, not a copy`);
+  }
+  assert.ok(SNIPPETS().runExpression.includes('chickadee_serialize('),
+    'a value must be reported through the seeded serializer');
+  assert.ok(SNIPPETS().runExpression.includes('chickadee_json_str('),
+    'the payload must be encoded by the seeded JSON encoder');
+});
+
+test('the boot cell wraps the seeded runtime without rewriting it', () => {
+  const runtime = 'local function chickadee_json_str(v) return v end\n_G.x = 1';
+  const cell = Lua.bootCell(runtime);
+  assert.ok(cell.includes(runtime), 'the seeded bytes must be executed verbatim');
+  assert.ok(isOneCallExpression(cell), 'the boot cell must be one call expression too');
+});
+
+test('instructor source is embedded as a Lua string literal', () => {
+  const nasty = 'print("he said \\"hi\\"")';
+  const load = Lua.loadCell(nasty, 'N');
+  assert.ok(!load.includes('print("he said "hi"")'), 'raw source must not be spliced in');
+  assert.ok(load.includes('\\\\"'), 'quotes in the source must be escaped');
+  // `load` with no environment compiles against the globals, which is what lets
+  // a later cell (and the call snippet) see what this one defined.
+  assert.ok(/load\(.*, "solution", "t"\)/s.test(load),
+    'cells must compile against the globals or later cells cannot see them');
+});
+
+test('a syntax error and a runtime error are both reported per cell', () => {
+  const load = Lua.loadCell('error("boom")', 'N');
+  assert.ok(load.includes('pcall('), 'a failing cell must not stop later cells loading');
+  assert.ok(load.includes('ck_syntax'), 'a cell that will not compile must report its message');
+});
+
+test('runExpression compiles as an expression first, then as a block', () => {
+  const run = Lua.runExpression('x + 1', 'N');
+  assert.ok(run.includes('"return (x + 1)"'),
+    'Lua has no eval; the source must be compiled as a return expression');
+  assert.ok(run.includes('"x + 1"'),
+    'a statement that will not compile as an expression must still run');
+});
+
+test('callFunction binds one local per argument, never a table', () => {
+  const snippet = Lua.callFunction('classify', [18.5, 'lo', [1, 2], null], {}, 'N');
+  assert.ok(snippet.includes('local ck_a1 = 18.5'), `argument 1 not bound:\n${snippet}`);
+  assert.ok(snippet.includes('local ck_a2 = "lo"'), 'a string argument must be quoted');
+  assert.ok(snippet.includes('local ck_a3 = {1, 2}'), 'an array argument must be a table');
+  // THE TRAP: null is `nil` at top level and the sentinel inside a table. A
+  // renderer that put the arguments in a table would drop this slot and call
+  // the solution with three arguments instead of four.
+  assert.ok(snippet.includes('local ck_a4 = nil'), 'a top-level null must stay nil');
+  assert.ok(snippet.includes('pcall(ck_fn, ck_a1, ck_a2, ck_a3, ck_a4)'),
+    `arguments must be passed positionally:\n${snippet}`);
+  assert.ok(!/table.unpack/.test(snippet), 'an argument table would lose the nil slot');
+});
+
+test('a null inside an argument becomes the sentinel, which the runtime seeds', () => {
+  const snippet = Lua.callFunction('f', [[60, null, 20]], {}, 'N');
+  assert.ok(snippet.includes('{60, chickadee.NULL, 20}'),
+    `a null inside a table must keep its slot:\n${snippet}`);
+});
+
+test('a missing function says "not defined", which the editor keys on', () => {
+  // describeCallFailure folds the first failing solution cell into the message
+  // only when it recognises the "not defined" / "not found" shape.
+  const snippet = Lua.callFunction('nope', [], {}, 'N');
+  assert.ok(snippet.includes('is not defined in the solution notebook'),
+    'the missing-function message must carry the phrase the editor matches');
+  assert.ok(snippet.includes('type(ck_fn) ~= "function"'),
+    'a non-function global must be reported the same way as a missing one');
+});
+
+test('captureStdout swaps print and io, and puts them back', () => {
+  const captured = Lua.callFunction('f', [], { captureStdout: true }, 'N');
+  assert.ok(captured.includes('_G.print = function'), 'print must be captured');
+  assert.ok(captured.includes('stdout = ck_stdout'),
+    'io.stdout:write must be captured too, not just io.write');
+  assert.ok(captured.includes('_G.print, _G.io = ck_real_print, ck_real_io'),
+    'the swap must be undone before the payload is written');
+  assert.ok(captured.indexOf('_G.print, _G.io = ck_real_print, ck_real_io')
+    < captured.indexOf('io.write("\\nN:'),
+    'the payload must be written through the REAL io, after the restore');
+  const plain = Lua.callFunction('f', [], {}, 'N');
+  assert.ok(!plain.includes('_G.print = function'),
+    'the default path must report the returned value, not printed output');
+});
+
+test('the parser round-trips a payload the snippet shape would produce', () => {
+  const stdout = 'solution output\n\nNONCE:{"value":"42","error":null}\n';
+  assert.deepEqual(protocol.parseEvalOutput(stdout, 'NONCE'), { value: '42', error: null });
+  const twice = '\nNONCE:{"value":"1","error":null}\n\nNONCE:{"value":"2","error":null}\n';
+  assert.equal(protocol.parseEvalOutput(twice, 'NONCE').value, '2');
+  assert.equal(protocol.parseEvalOutput('nothing here', 'NONCE'), null);
+});

--- a/Tests/CoreTests/LuaAutoComputeRuntimeTests.swift
+++ b/Tests/CoreTests/LuaAutoComputeRuntimeTests.swift
@@ -1,0 +1,82 @@
+// Tests/CoreTests/LuaAutoComputeRuntimeTests.swift
+//
+// The Lua auto-compute runtime is composed in Swift and re-composed in
+// JavaScript. `AssignmentLanguage.autoComputeRuntimeSource` is what the server
+// sends the in-page eval worker; `Tools/browser-grading-smoke/auto-compute-runtime.mjs`
+// rebuilds the same bytes from the same constants so the smoke and the Node
+// execution suite probe what actually ships rather than a paraphrase of it.
+//
+// That is two statements of one composition, and the failure mode is quiet: add
+// a fifth piece in Swift and the browser tests keep passing against a runtime
+// that is missing it. This suite is the guard — it fails on the Swift side and
+// names the file to update.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct LuaAutoComputeRuntimeTests {
+
+    /// The pieces, in order. Kept as a literal list rather than derived from the
+    /// implementation, because a test that recomputed the implementation would
+    /// agree with any change.
+    private static let pieces: [String] = [
+        LuaPersonalizationRuntime.chickadeeNullTableLuaSource,
+        LuaPersonalizationRuntime.chickadeeSerializeLuaSource,
+        LuaPersonalizationRuntime.chickadeeJSONStringLuaSource,
+        LuaPersonalizationRuntime.chickadeeAutoComputeExportsLuaSource,
+    ]
+
+    @Test func theSeededRuntimeIsExactlyTheFourSharedConstants() throws {
+        let composed = try #require(AssignmentLanguage.lua.autoComputeRuntimeSource)
+        #expect(
+            composed == Self.pieces.joined(separator: "\n\n"),
+            """
+            The Lua auto-compute runtime changed shape.
+
+            Tools/browser-grading-smoke/auto-compute-runtime.mjs rebuilds these bytes
+            from the same Swift constants, for the browser-grading smoke and for
+            Tests/BrowserRunnerJSTests/lua-eval-execution.test.mjs. Update its
+            COMPOSITION table to match, or those suites will keep passing against a
+            runtime the server no longer sends.
+            """)
+    }
+
+    /// The two helpers are declared `local`, which is correct for the server
+    /// driver (one script, one chunk) and fatal in a kernel, where every cell is
+    /// its own chunk. The exports tail is what bridges that, and it has to come
+    /// last: it is the only place the locals are still in scope.
+    @Test func theHelpersAreExportedAfterTheyAreDeclared() throws {
+        let composed = try #require(AssignmentLanguage.lua.autoComputeRuntimeSource)
+        for helper in ["chickadee_serialize", "chickadee_json_str"] {
+            let declaration = try #require(composed.range(of: "local function \(helper)"))
+            let export = try #require(composed.range(of: "_G.\(helper) = \(helper)"))
+            #expect(
+                declaration.lowerBound < export.lowerBound,
+                "\(helper) is exported before it is declared, so the export binds nil")
+        }
+    }
+
+    /// The sentinel a rendered argument may name. The eval worker loads no
+    /// `test_runtime`, so if this is not seeded, a case containing a JSON null
+    /// indexes a nil `chickadee` and reports as a solution error.
+    @Test func theNullSentinelIsSeededBeforeAnythingCanReferenceIt() throws {
+        let composed = try #require(AssignmentLanguage.lua.autoComputeRuntimeSource)
+        #expect(composed.hasPrefix("chickadee = chickadee or {}"))
+        #expect(composed.contains("chickadee.NULL = chickadee.NULL or setmetatable("))
+        // The literal renderer's output has to name what is seeded here.
+        #expect(JSONValue.array([.null]).luaLiteral == "{chickadee.NULL}")
+    }
+
+    /// The one language whose descriptor still routes auto-compute to the server
+    /// alongside C++ and Racket is Octave, and only until its worker exists.
+    /// Pinned so flipping Lua's substrate cannot be half-done — a descriptor
+    /// claiming a worker that is not there makes the editor spawn a 404 and
+    /// auto-compute stop with no message.
+    @Test func luaDeclaresItsInPageWorker() {
+        #expect(
+            AssignmentLanguage.lua.descriptor.autoCompute
+                == .inPageKernel(workerScript: "/lua-eval-worker.js"))
+    }
+}

--- a/Tools/browser-grading-smoke/auto-compute-runtime.mjs
+++ b/Tools/browser-grading-smoke/auto-compute-runtime.mjs
@@ -1,0 +1,83 @@
+// Tools/browser-grading-smoke/auto-compute-runtime.mjs
+//
+// Reads the auto-compute runtime a language's in-page eval worker is seeded
+// with, out of the Swift constants that define it.
+//
+// `AssignmentLanguage.autoComputeRuntimeSource` is what the server actually
+// sends the worker. Anything testing that worker has to send the same bytes, or
+// it proves a runtime nobody runs — so this extracts them rather than restating
+// them. Two consumers: the browser-grading smoke (which boots a real kernel)
+// and Tests/BrowserRunnerJSTests (which runs the snippets under a plain
+// interpreter).
+//
+// The COMPOSITION — which constants, in what order — is still written twice,
+// here and in the Swift switch. `LuaAutoComputeRuntimeTests` is the guard: it
+// fails if the Swift arm stops being exactly this list, naming this file.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/// Which Swift constants compose each language's runtime, in order.
+/// Mirrors the arms of `AssignmentLanguage.autoComputeRuntimeSource`.
+const COMPOSITION = {
+    r: {
+        file: 'Sources/Core/RPersonalizationRuntime.swift',
+        constants: ['chickadeeJSONStringRSource'],
+    },
+    lua: {
+        file: 'Sources/Core/LuaPersonalizationRuntime.swift',
+        constants: [
+            'chickadeeNullTableLuaSource',
+            'chickadeeSerializeLuaSource',
+            'chickadeeJSONStringLuaSource',
+            'chickadeeAutoComputeExportsLuaSource',
+        ],
+    },
+};
+
+/// The text of one multi-line Swift string constant, dedented as the compiler
+/// dedents it (by the closing delimiter's own indentation) and with any
+/// `\(otherConstant)` interpolation resolved from the same file.
+///
+/// The interpolation step is not decoration: the Lua null sentinel is defined
+/// once and spliced into the table that binds it, so an extractor that took the
+/// raw text would seed `chickadee.NULL = chickadee.NULL or \(…)` — a syntax
+/// error, and one that only shows up when a case actually contains a null.
+function extractConstant(swift, name, seen = new Set()) {
+    if (seen.has(name)) {
+        throw new Error(`circular Swift constant interpolation at ${name}`);
+    }
+    seen.add(name);
+    const assignment = String.raw`\b${name}\s*(?::\s*String\s*)?=\s*`;
+    const multiline = new RegExp(assignment + String.raw`#?"""\n([\s\S]*?)\n([ \t]*)"""#?`);
+    // A one-line RAW literal (`#"…"#`), which is how the null sentinel is
+    // written. Only the raw form is read: a plain `"…"` would need Swift's
+    // escape processing, and no runtime constant is written that way.
+    const singleLine = new RegExp(assignment + String.raw`#"([^\n]*)"#`);
+    const match = multiline.exec(swift) || singleLine.exec(swift);
+    if (!match) {
+        throw new Error(
+            `could not find the Swift constant ${name} — the auto-compute runtime `
+            + 'cannot be probed with the bytes the server actually seeds');
+    }
+    const [, body, closingIndent] = match;
+    const dedented = closingIndent
+        ? body.split('\n').map(
+            (line) => (line.startsWith(closingIndent) ? line.slice(closingIndent.length) : line)
+        ).join('\n')
+        : body;
+    return dedented.replace(/\\\((\w+)\)/g, (_, reference) =>
+        extractConstant(swift, reference, seen));
+}
+
+/// The runtime source for `language`, exactly as the server composes it.
+export async function readAutoComputeRuntimeSource(language, repoRoot) {
+    const composition = COMPOSITION[language];
+    if (!composition) {
+        throw new Error(`no auto-compute runtime composition recorded for ${language}`);
+    }
+    const swift = await fs.readFile(path.resolve(repoRoot, composition.file), 'utf8');
+    return composition.constants
+        .map((name) => extractConstant(swift, name))
+        .join('\n\n');
+}

--- a/Tools/browser-grading-smoke/smoke.mjs
+++ b/Tools/browser-grading-smoke/smoke.mjs
@@ -34,6 +34,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 
+import { readAutoComputeRuntimeSource } from './auto-compute-runtime.mjs';
+
 const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..');
 const PUBLIC_DIR = path.join(REPO_ROOT, 'Public');
 const PORT = Number(process.env.R_SMOKE_PORT || 8131);
@@ -507,38 +509,63 @@ window.__result = null;
 })().catch((err) => { window.__result = { ok: false, stage: 'page', error: String(err) }; });
 </script>`;
 
-/// The R escaper the SERVER seeds into the worker, read out of the Swift
-/// constant that defines it rather than copied here.
-///
-/// A copy would be a fourth R JSON encoder in this repo — there are already
-/// three, and one of them exists because another was wrong. Extraction keeps
-/// the smoke honest: if the constant is renamed or moved, this throws instead of
-/// silently probing something that is no longer what ships.
-async function readRRuntimeSource() {
-    const swift = await fs.readFile(
-        path.resolve(REPO_ROOT, 'Sources/Core/RPersonalizationRuntime.swift'), 'utf8');
-    const match = /chickadeeJSONStringRSource\s*=\s*#"""\n([\s\S]*?)\n\s*"""#/.exec(swift);
-    if (!match) {
-        throw new Error(
-            'could not find chickadeeJSONStringRSource in RPersonalizationRuntime.swift — '
-            + 'the R auto-compute smoke cannot probe the runtime the server actually seeds');
-    }
-    return match[1];
-}
-
-// The R auto-compute probe. Same shape as the Python one — two solution cells,
-// one of which raises — but exercising the STRUCTURED `call` path every
-// non-Python in-page kernel uses, where the worker renders the arguments.
+// The auto-compute probe for a kernel language — R and Lua so far, and Octave
+// next. Same shape as the Python one (solution cells, one of which raises) but
+// exercising the STRUCTURED `call` path every non-Python in-page kernel uses,
+// where the worker renders the arguments.
 //
-// Only a real kernel proves any of this: the snippets are one top-level
-// expression each (a xeus-lite performance constraint), they print behind a
-// nonce, and the seeded escaper has to be defined before any of them runs. Each
-// of those fails silently when wrong — no error, just no value.
-const rEvalProbePage = (runtimeSource) => `<!doctype html><meta charset="utf-8"><title>R auto-compute smoke</title>
+// Only a real kernel proves any of this: the snippets print behind a nonce, the
+// seeded runtime has to be defined before any of them runs, and each language
+// has a per-kernel shape constraint on the cell (R: one top-level expression,
+// for the ~180ms yield; Lua: one call expression, for the `return <cell>`
+// probe). Every one of those fails silently when wrong — no error, just no
+// value.
+const EVAL_PROBES = {
+    r: {
+        worker: '/r-eval-worker.js',
+        cells: [
+            'classify <- function(bmi) if (bmi < 18.5) "under" else "ok"',
+            'this_name_does_not_exist()',
+            'area <- function(r) round(pi * r * r, 2)',
+        ],
+        calls: {
+            call: { functionName: 'classify', args: [18.49] },
+            later: { functionName: 'area', args: [2] },
+            // A string argument, to prove the quoting survives the round trip.
+            stringArg: { functionName: 'paste0', args: ['a', 'b'] },
+            // A vector argument, which R renders c(...) and Python would not.
+            vectorArg: { functionName: 'sum', args: [[1, 2, 3]] },
+            missing: { functionName: 'no_such_function', args: [] },
+        },
+        expression: 'classify(30)',
+    },
+    lua: {
+        worker: '/lua-eval-worker.js',
+        cells: [
+            'function classify(bmi) if bmi < 18.5 then return "under" else return "ok" end end',
+            'this_name_does_not_exist()',
+            'function area(r) return math.floor(math.pi * r * r * 100 + 0.5) / 100 end',
+            'function count(items) return #items end',
+        ],
+        calls: {
+            call: { functionName: 'classify', args: [18.49] },
+            later: { functionName: 'area', args: [2] },
+            stringArg: { functionName: 'count', args: ['abcd'] },
+            // A table argument WITH A NULL IN IT. Lua stores no nil in a table
+            // constructor, so a renderer that missed the sentinel would call
+            // this with a two-element table and answer 2.
+            nullSlot: { functionName: 'count', args: [[60, null, 20]] },
+            missing: { functionName: 'no_such_function', args: [] },
+        },
+        expression: 'classify(30)',
+    },
+};
+
+const kernelEvalProbePage = (probe, runtimeSource) => `<!doctype html><meta charset="utf-8"><title>auto-compute smoke</title>
 <body><pre id="log"></pre><script>
 window.__result = null;
 (async () => {
-  const worker = new Worker('/r-eval-worker.js');
+  const worker = new Worker(${JSON.stringify(probe.worker)});
   let counter = 0;
   const pending = new Map();
   worker.onmessage = (event) => {
@@ -549,8 +576,8 @@ window.__result = null;
   worker.onerror = (event) => {
     window.__result = { ok: false, stage: 'worker', error: event.message || 'worker error' };
   };
-  // The escaper the server seeds, extracted from the Swift constant that
-  // defines it — see readRRuntimeSource. Not a copy.
+  // The runtime the server seeds, extracted from the Swift constants that
+  // define it — see auto-compute-runtime.mjs. Not a copy.
   const RUNTIME_SOURCE = ${JSON.stringify(runtimeSource)};
   const call = (payload) => new Promise((resolve) => {
     const id = ++counter;
@@ -563,29 +590,17 @@ window.__result = null;
   const bootMs = Date.now() - bootStart;
   if (!init.ok) { window.__result = { ok: false, stage: 'init', error: init.error }; return; }
 
-  const load = await call({ type: 'loadCells', cells: [
-    'classify <- function(bmi) if (bmi < 18.5) "under" else "ok"',
-    'this_name_does_not_exist()',
-    'area <- function(r) round(pi * r * r, 2)',
-  ] });
+  const load = await call({ type: 'loadCells', cells: ${JSON.stringify(probe.cells)} });
   if (!load.ok) { window.__result = { ok: false, stage: 'loadCells', error: load.error }; return; }
 
   const runs = {};
-  const calls = {
-    call: { functionName: 'classify', args: [18.49] },
-    later: { functionName: 'area', args: [2] },
-    // A string argument, to prove rLiteral's quoting survives the round trip.
-    stringArg: { functionName: 'paste0', args: ['a', 'b'] },
-    // A vector argument, which R renders c(...) and Python would not.
-    vectorArg: { functionName: 'sum', args: [[1, 2, 3]] },
-    missing: { functionName: 'no_such_function', args: [] },
-  };
+  const calls = ${JSON.stringify(probe.calls)};
   for (const [key, payload] of Object.entries(calls)) {
     const reply = await call(Object.assign({ type: 'call' }, payload));
     runs[key] = reply.ok ? { ok: true, result: reply.result } : { ok: false, error: reply.error };
   }
   // The expression path too, since the worker serves both.
-  const expr = await call({ type: 'run', code: 'classify(30)' });
+  const expr = await call({ type: 'run', code: ${JSON.stringify(probe.expression)} });
   runs.expression = expr.ok ? { ok: true, result: expr.result } : { ok: false, error: expr.error };
 
   window.__result = { ok: true, bootMs, cellErrors: load.cellErrors, runs };
@@ -598,7 +613,11 @@ function startServer() {
         if (urlPath === '/' || urlPath === '/index.html') {
             res.writeHead(200, { 'content-type': 'text/html; charset=utf-8', ...ISOLATION_HEADERS });
             res.end(mode === 'eval'
-                ? (language === 'r' ? rEvalProbePage(await readRRuntimeSource()) : EVAL_PROBE_PAGE)
+                ? (EVAL_PROBES[language]
+                    ? kernelEvalProbePage(
+                        EVAL_PROBES[language],
+                        await readAutoComputeRuntimeSource(language, REPO_ROOT))
+                    : EVAL_PROBE_PAGE)
                 : PROBE_PAGE);
             return;
         }
@@ -676,31 +695,55 @@ if (!result || !result.ok) {
 }
 console.log(`  kernel booted in ${result.bootMs}ms`);
 
-if (mode === 'eval' && language === 'r') {
+// What each kernel language's auto-compute probe must produce. The value is the
+// language's own repr — R's `deparse`, Lua's `chickadee_serialize` — because
+// that is what the SERVER driver returns for it, and the client parses both with
+// the same reader.
+const EVAL_EXPECTATIONS = {
+    r: {
+        cellError: /could not find function|object/,
+        results: {
+            call: ['a call returns its value as an R literal', '"under"'],
+            later: ['a function defined after the failing cell is callable', '12.57'],
+            // rLiteral's quoting survived the trip through the snippet.
+            stringArg: ['a string argument round-trips', '"ab"'],
+            // The case Python cannot express: a JSON array becomes an atomic
+            // vector, so `sum` sees three numbers rather than a list.
+            vectorArg: ['an array argument becomes an R vector', '6'],
+        },
+        expression: '"ok"',
+    },
+    lua: {
+        cellError: /nil value|attempt to call/,
+        results: {
+            call: ['a call returns its value as a Lua literal', '"under"'],
+            later: ['a function defined after the failing cell is callable', '12.57'],
+            stringArg: ['a string argument round-trips', '4'],
+            // THE LUA TRAP, executed on a real kernel: a table constructor
+            // stores no nil, so a renderer that emitted one here would hand the
+            // solution a two-element table and this would answer 2.
+            nullSlot: ['a null inside a table argument keeps its slot', '3'],
+        },
+        expression: '"ok"',
+    },
+};
+
+if (mode === 'eval' && EVAL_EXPECTATIONS[language]) {
+    const expected = EVAL_EXPECTATIONS[language];
     const errors = result.cellErrors || [];
     check('the failing solution cell is reported', errors.length === 1, JSON.stringify(errors));
     check('it is attributed to the right cell', errors[0]?.index === 1, JSON.stringify(errors));
-    check('its message is R\'s own error text',
-        /could not find function|object/.test(errors[0]?.message || ''), JSON.stringify(errors));
+    check(`its message is ${language}'s own error text`,
+        expected.cellError.test(errors[0]?.message || ''), JSON.stringify(errors));
 
-    // The value comes back as R's repr, which is what the server driver returns
-    // too — the client parses both with the same reader.
-    check('a call returns its value as an R literal',
-        result.runs.call?.result === '"under"', JSON.stringify(result.runs.call));
-    // Proves the global environment survived the cell that raised.
-    check('a function defined after the failing cell is callable',
-        result.runs.later?.result === '12.57', JSON.stringify(result.runs.later));
-    // rLiteral's quoting survived the trip through the snippet.
-    check('a string argument round-trips',
-        result.runs.stringArg?.result === '"ab"', JSON.stringify(result.runs.stringArg));
-    // The case Python cannot express: a JSON array becomes an atomic vector,
-    // so `sum` sees three numbers rather than a list.
-    check('an array argument becomes an R vector',
-        result.runs.vectorArg?.result === '6', JSON.stringify(result.runs.vectorArg));
+    for (const [key, [label, want]] of Object.entries(expected.results)) {
+        check(label, result.runs[key]?.result === want, JSON.stringify(result.runs[key]));
+    }
     check('a missing function is an error, not a null result',
         result.runs.missing?.ok === false, JSON.stringify(result.runs.missing));
     check('the expression path works too',
-        result.runs.expression?.result === '"ok"', JSON.stringify(result.runs.expression));
+        result.runs.expression?.result === expected.expression,
+        JSON.stringify(result.runs.expression));
 
     if (failures.length) {
         console.log(`\nFAILED: ${failures.length} check(s)`);

--- a/changelog.d/in-page-auto-compute-lua.md
+++ b/changelog.d/in-page-auto-compute-lua.md
@@ -1,0 +1,49 @@
+### Added
+
+- **Lua assignments compute expected values in the browser.** Auto-compute runs
+  on the vendored xeus-lua kernel — the same one that grades a browser-graded
+  Lua submission — instead of round-tripping to the server. Octave is now the
+  last kernel language still on the server driver; C++ and Racket have no kernel
+  to run and stay there by construction.
+
+  Two Lua facts shape the implementation, and neither is R's:
+
+  Every kernel cell is its own chunk, so the `local function` declarations in
+  the seeded runtime do not survive it. The runtime now ends by re-binding its
+  serializer and JSON encoder as globals, in the same chunk that declares them —
+  the only place they are still in scope. Without it every snippet fails on a
+  nil call, reported as a per-cell error rather than as the substrate failure it
+  is.
+
+  Each snippet is one *call* expression, matching the grading wrapper, because
+  xeus-lua first tries to compile a cell as `return <cell>` and mis-reads a cell
+  that opens with a `local` declaration. R's snippets are one expression for an
+  unrelated reason (its ~180ms inter-expression yield), which Lua does not have.
+
+- **Arguments are rendered one `local` per argument, never into a table.** A
+  JSON null is `nil` at top level and the `chickadee.NULL` sentinel inside a
+  table, because a table constructor does not store `nil` at all; building an
+  argument table would silently drop the slot and call the solution with the
+  wrong arity. The sentinel is seeded from the same Swift expression
+  `test_runtime.lua` binds, since the eval worker loads no `test_runtime`.
+
+- **The Lua snippets are executed under a real interpreter in CI**
+  (`Tests/BrowserRunnerJSTests/lua-eval-execution.test.mjs`), with each snippet
+  `load`ed as its own chunk so a helper that only works by sharing a file scope
+  fails. It runs the runtime the server actually seeds, extracted from the Swift
+  constants that define it. A browser-grading smoke row covers the kernel half.
+
+### Changed
+
+- **The browser-grading smoke's auto-compute probe is one parameterized page**
+  rather than one per language, and the Swift-constant extraction it depends on
+  moved to `Tools/browser-grading-smoke/auto-compute-runtime.mjs`, shared with
+  the Node execution suite.
+
+### Fixed
+
+- **The browser-grading smoke's path filter named languages by hand and had
+  already gone stale** — it listed r/python/lua grading and python/r eval while
+  the matrix also ran octave grading, so an octave-only change skipped the job
+  that tests it. It is now a pattern, which also fails in the safe direction: an
+  unrecognised language matches and runs the smoke rather than skipping it.

--- a/docs/authoring-parity.md
+++ b/docs/authoring-parity.md
@@ -24,6 +24,12 @@ these gaps are correct as they stand, and have been re-litigated more than once.
 | Auto-compute expected | in-page kernel | server | server | server | server | server |
 | Solution function scan | yes | no | no | no | n/a | n/a |
 
+**Both bottom rows have since moved.** The scan row was closed by the parity
+work (R, Lua and Octave parsers behind `FunctionScanSyntax`), and auto-compute
+now reads *in-page kernel* for Python, R and Lua, with Octave the last kernel
+language still on the server driver. The table is left as measured so the
+sections below, which argue from it, still read straight.
+
 Two rows mislead as stated:
 
 - **Templates.** Three *shell* templates are offered on every language, but
@@ -163,10 +169,18 @@ asserted against. The old reason to move it (retiring `Public/pyodide`) no
 longer applies; that worker already migrated. **CLAUDE.md's roadmap note listing
 `pyodide-worker.js` as a Pyodide blocker is stale.**
 
-**In-page kernels for R/Lua/Octave auto-compute.** Five more kernel boots on the
-edit page, paid by every author on every visit, to close a fidelity gap those
-languages do not have — their kernels ship bare, so there is no package-version
-surface to diverge on.
+**In-page kernels for R/Lua/Octave auto-compute — OVERRULED, and the reasoning
+above is why it was worth writing down.** The argument here weighed only
+fidelity, and on fidelity it is correct: those kernels ship bare, so there is no
+package-version surface for a server driver to diverge on. It weighed the wrong
+thing. The edit page exists to support in-browser authoring, and an author
+changing a case should see what their solution returns without a server
+round-trip — a kernel boot the author waits for once is a better trade than a
+round-trip they pay for on every case. The boot is also lazy: it happens when
+auto-compute is first used, not on every visit as this claimed.
+
+R shipped first, then Lua; Octave is the one kernel language still on the server
+driver.
 
 **Per-language custom-script template sets.** Seven of the nine Python templates
 are already available in every language as pattern-family kinds, in a better


### PR DESCRIPTION
Auto-compute for Lua ran on the server driver; it now runs on the vendored **xeus-lua** kernel — the same one that grades a browser-graded Lua submission. Octave is the last kernel language still routing to the server; C++ and Racket have no kernel and stay there by construction.

Follows #1323 (R), and reuses its worker shape and message protocol unchanged.

## Two Lua facts shape it, and neither is R's

**Every kernel cell is its own chunk**, so the seeded runtime's `local function` declarations do not survive it. The runtime now ends by re-binding its serializer and JSON encoder as globals, from inside the chunk that declares them — the only place they are still in scope. Without that, every snippet fails on a nil call, reported as a per-cell error rather than as the substrate failure it is.

**Each snippet is one CALL expression**, matching `lua-grading-shared.js`, because xeus-lua first tries to compile a cell as `return <cell>` and mis-reads a cell that opens with a `local`. R's snippets are one expression for an unrelated reason — its ~180ms inter-expression yield — which Lua measurably does not have.

## Arguments

Bound one `local` each, never into a table. A JSON null is `nil` at top level and the `chickadee.NULL` sentinel inside a table, because a table constructor stores no `nil` at all: an argument table would silently drop the slot and call the solution with the wrong arity. The sentinel is seeded from the same Swift expression `test_runtime.lua` binds — the eval worker loads no `test_runtime`, so without seeding it a case containing a null indexes a nil `chickadee`.

`RuntimeSourceDriftTests` confirms splicing the shared expression into `test_runtime.lua` leaves it byte-identical.

## Testing

- `Tests/BrowserRunnerJSTests/lua-eval-shared.test.mjs` — snippet shape (one call expression, the marker the shared parser reads, the seeded helpers called and never defined, one `local` per argument).
- `Tests/BrowserRunnerJSTests/lua-eval-execution.test.mjs` — **executes** the snippets under a real `lua`, each `load`ed as its own chunk so a helper that only works by sharing a file scope fails. Runs the runtime the server actually seeds, extracted from the Swift constants. Skips silently without an interpreter, and asserts one is present under `CI`.
- Browser-grading smoke row `{ language: lua, mode: eval }` for the kernel half.
- `Tests/CoreTests/LuaAutoComputeRuntimeTests.swift` — the seeded composition is exactly the four shared constants, the exports come after the declarations, and the sentinel is seeded before anything can name it. Its failure message names the JS reader to update.

Full Swift suite (3,395 tests), `scripts/lint.sh`, `scripts/swiftlint.sh` and `scripts/eslint.sh` all green locally.

## Also in here

- The smoke's auto-compute probe is **one parameterized page** instead of one per language, and the Swift-constant extraction moved to `Tools/browser-grading-smoke/auto-compute-runtime.mjs`, shared with the Node execution suite.
- **Fixed: the smoke's path filter named languages by hand and had gone stale.** It listed r/python/lua grading and python/r eval while the matrix also ran *octave* grading, so an octave-only change skipped the job that tests it. It is now a pattern, which also fails in the safe direction — an unrecognised language matches and runs the smoke rather than skipping it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcV8dFXd1H9476AxSwpeam)_