### PR TITLE
feat(editor): compute Octave expected values in the browser

### DIFF
--- a/.github/workflows/browser-grading-smoke.yml
+++ b/.github/workflows/browser-grading-smoke.yml
@@ -109,6 +109,13 @@ jobs:
           # its two helpers as globals, because every kernel cell is its own
           # chunk and a `local` does not survive one. Both fail silently.
           - { language: lua, mode: eval }
+          # The Octave half. Its boot cell needs the `1;` script guard or its
+          # function definitions never register (a script FILE accepts them
+          # either way, so no local test can show this), and a command-line
+          # function must be called by NAME — `str2func` hands back a BUILT-IN
+          # of the same name, which is how a solution defining `area` would
+          # silently be graded against Octave's plotting function.
+          - { language: octave, mode: eval }
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -351,11 +351,15 @@ jobs:
       - name: Lint first-party frontend JS
         run: scripts/eslint.sh
 
-      # The Lua auto-compute snippets are EXECUTED, not just shape-checked
-      # (lua-eval-execution.test.mjs). That suite skips silently without an
-      # interpreter, so a missing package here would look like a pass.
-      - name: Install Lua
-        run: sudo apt-get update && sudo apt-get install -y lua5.4
+      # The Lua and Octave auto-compute snippets are EXECUTED, not just
+      # shape-checked (*-eval-execution.test.mjs). Those suites skip silently
+      # without an interpreter, so a missing package here would look like a
+      # pass — each asserts its interpreter is present when CI is set.
+      # --no-install-recommends keeps Octave from pulling a desktop stack.
+      - name: Install Lua and Octave
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends lua5.4 octave
 
       - name: Run browser runner execution tests
         run: node --test Tests/BrowserRunnerJSTests/*.mjs

--- a/Public/octave-eval-shared.js
+++ b/Public/octave-eval-shared.js
@@ -1,0 +1,269 @@
+// Public/octave-eval-shared.js
+//
+// The snippets the pattern-family editor's auto-compute runs on the xeus-octave
+// kernel. The Octave sibling of r-eval-shared.js and lua-eval-shared.js; the
+// nonce framing all of them share lives in eval-protocol-shared.js.
+//
+// Loading: classic script (importScripts). Requires /octave-grading-shared.js
+// first (kernel spec, `makeNonce`, `octaveStringLiteral`, `octaveLiteral`) and
+// /eval-protocol-shared.js. Exposes exactly one global:
+// ChickadeeOctaveEvalShared.
+//
+// WHAT OCTAVE COSTS, AND WHAT IT DOES NOT.
+//
+// It does not cost either of the other kernels' shape constraints. R's snippets
+// are one top-level expression because xeus-r yields ~180ms between them; Lua's
+// are one call expression because xeus-lua mis-reads a cell opening with a
+// `local`. Octave has neither problem, and its cells share one base workspace,
+// so a plain statement list is fine and a variable set in one cell is visible in
+// the next. Only the BOOT cell needs a shape: `1;` first, so the cell reads as a
+// script and the `function` definitions in it register as command-line functions
+// rather than making the cell a function file. That is the same guard
+// `SETUP_OCTAVE` opens with in the grading module.
+//
+// What it does cost is the submission contract, which is Octave's alone: a
+// solution cell is evaluated as `["1;" newline text]` so its definitions
+// register under their OWN names whatever the cell looks like — the rule
+// `test_runtime.m` already uses, quoted in its header as "THE SUBMISSION
+// CONTRACT". Without the prefix, a cell holding one function would be read as a
+// function file and bind under the file's name instead.
+//
+// VALUES COME BACK AS OCTAVE SOURCE (`chickadee_serialize`), which is what the
+// SERVER driver returns for Octave — it writes that text into `_ck_inputs.m`.
+// The client parses both with the same reader, so in-page and server
+// auto-compute cannot disagree about what a value looks like.
+//
+// Every payload is written with `fputs`, never `printf`: an Octave error
+// message can contain a literal `%` (`error("bad %s", "100%")` produces one),
+// and a `printf` whose format string carried the payload would consume it.
+
+(function (root) {
+    'use strict';
+
+    var grading = root.ChickadeeOctaveGradingShared;
+    var protocol = root.ChickadeeEvalProtocol;
+
+    /// Prefixes the `1;` script guard so the seeded runtime's `function`
+    /// definitions register as command-line functions. The runtime itself is
+    /// executed verbatim: its bytes come from
+    /// `AssignmentLanguage.autoComputeRuntimeSource`, so the serializer that
+    /// reports a value here is the one the personalization driver uses.
+    function bootCell(runtimeSource) {
+        return '1;\n' + runtimeSource;
+    }
+
+    /// Statements binding `<jsonName>` to a JSON string for `<varName>`, or the
+    /// bare token `null` when the matching `<haveName>` flag is false.
+    ///
+    /// A separate flag rather than `isempty`, because the empty string is a
+    /// legitimate value — a solution that returns "" would otherwise report as
+    /// having returned nothing.
+    ///
+    /// `chickadee_escape_string` is the SEEDED escaper, not one written here.
+    function jsonOrNull(varName, haveName, jsonName) {
+        return [
+            'if ' + haveName,
+            '  ' + jsonName + ' = chickadee_escape_string(' + varName + ');',
+            'else',
+            '  ' + jsonName + ' = "null";',
+            'end'
+        ];
+    }
+
+    /// One `fputs` writing the marker, the JSON, and a newline.
+    function payloadWrite(nonce, parts) {
+        var pieces = [grading.octaveStringLiteral(protocol.payloadMarker(nonce))]
+            .concat(parts)
+            .concat([grading.octaveStringLiteral('\n')]);
+        return 'fputs(stdout, [' + pieces.join(', ') + ']);';
+    }
+
+    /// Run one solution-notebook cell, reporting whether it raised.
+    ///
+    /// Evaluated at the top level of the cell, so its variables land in the base
+    /// workspace and its functions register globally — both visible to later
+    /// cells and to the call snippet, which is the entire point of loading it.
+    ///
+    /// Errors are caught rather than propagated: cells load in order, and an
+    /// early failure must not stop later cells from defining their functions.
+    /// The editor explains a downstream "not defined" in terms of the earlier
+    /// cell that crashed, which it can only do if it got that far.
+    function loadCellOctave(source, nonce) {
+        return [
+            'ck_err_ = "";',
+            'ck_have_err_ = false;',
+            'try',
+            // See the header: the `1;` prefix is the submission contract, not
+            // decoration.
+            '  eval(["1;" sprintf("\\n") ' + grading.octaveStringLiteral(source) + ']);',
+            'catch ck_e_',
+            '  ck_err_ = ck_e_.message;',
+            '  ck_have_err_ = true;',
+            'end'
+        ].concat(jsonOrNull('ck_err_', 'ck_have_err_', 'ck_err_json_')).concat([
+            payloadWrite(nonce, [
+                grading.octaveStringLiteral('{"error":'),
+                'ck_err_json_',
+                grading.octaveStringLiteral('}')
+            ])
+        ]).join('\n');
+    }
+
+    /// Evaluate `source` and report its value as Octave source.
+    ///
+    /// `eval` yields a value only for an expression, so a statement is run in a
+    /// second attempt and reports no value — the same two-step the Lua module
+    /// takes for the same reason. The editor's own path is `callFunction`; this
+    /// exists because the worker protocol serves both.
+    function runExpressionOctave(source, nonce) {
+        var sourceLiteral = grading.octaveStringLiteral(source);
+        return [
+            'ck_err_ = "";',
+            'ck_have_err_ = false;',
+            'ck_val_ = "";',
+            'ck_have_val_ = false;',
+            'try',
+            '  ck_res_ = eval(' + sourceLiteral + ');',
+            '  ck_val_ = chickadee_serialize(ck_res_);',
+            '  ck_have_val_ = true;',
+            'catch',
+            '  try',
+            '    eval(' + sourceLiteral + ');',
+            '  catch ck_e_',
+            '    ck_err_ = ck_e_.message;',
+            '    ck_have_err_ = true;',
+            '  end',
+            'end'
+        ].concat(jsonOrNull('ck_val_', 'ck_have_val_', 'ck_val_json_'))
+            .concat(jsonOrNull('ck_err_', 'ck_have_err_', 'ck_err_json_'))
+            .concat([
+                payloadWrite(nonce, [
+                    grading.octaveStringLiteral('{"value":'),
+                    'ck_val_json_',
+                    grading.octaveStringLiteral(',"error":'),
+                    'ck_err_json_',
+                    grading.octaveStringLiteral('}')
+                ])
+            ]).join('\n');
+    }
+
+    /// Call `functionName` in the loaded solution with `args`, reporting the
+    /// result as Octave source.
+    ///
+    /// THE ARGUMENTS ARE RENDERED HERE, in the browser, by the JS twin of
+    /// `JSONValue.octaveLiteral` — because an instructor changing a case has not
+    /// saved it, so there is no server round-trip in which the server could
+    /// render them. Both renderers are pinned to
+    /// Tests/Fixtures/octave-literal-contract.json.
+    ///
+    /// Each argument gets its own variable, which is how the generated test
+    /// binds them too, and it keeps the brackets-vs-braces question inside the
+    /// renderer rather than in an argument list this file would have to build.
+    ///
+    /// The lookup admits both shapes a solution can define: a command-line
+    /// function (`exist` 103, or a file at 2) and a handle assigned to a
+    /// variable (`exist` 1) — the same pair `test_runtime.m`'s `require_fn`
+    /// accepts, so auto-compute does not refuse a solution the grader would run.
+    ///
+    /// A COMMAND-LINE FUNCTION IS CALLED BY NAME, never through `str2func`.
+    /// Measured: after defining `area`, `exist("area")` answers 103 — the
+    /// command-line function — while `str2func("area")` hands back Octave's
+    /// BUILT-IN `area`, the plotting one. `feval` and `nargout` given the name
+    /// resolve it correctly. A solution that defines a function sharing a
+    /// builtin's name is ordinary (`area`, `count`, `mean`), so this is not an
+    /// edge case; the failure it prevents is auto-compute silently reporting
+    /// what a completely different function returned.
+    function callFunctionOctave(functionName, args, options, nonce) {
+        var captureStdout = !!(options && options.captureStdout);
+        var nameLiteral = grading.octaveStringLiteral(functionName);
+        var argValues = args || [];
+        var bindings = argValues.map(function (value, index) {
+            return '    ck_a' + (index + 1) + '_ = ' + grading.octaveLiteral(value) + ';';
+        });
+        var argList = argValues.map(function (_, index) { return 'ck_a' + (index + 1) + '_'; });
+        var invocation = ['ck_callee_'].concat(argList).join(', ');
+
+        var body;
+        if (captureStdout) {
+            // `evalc` captures what the call printed. The trailing semicolon
+            // suppresses the `ans = …` echo a value-returning function would
+            // otherwise add to the capture.
+            body = [
+                '    ck_out_ = evalc(' + grading.octaveStringLiteral(
+                    'feval(' + invocation + ');') + ');',
+                // One trailing newline is dropped, matching what the other
+                // languages store.
+                '    if numel(ck_out_) > 0 && ck_out_(end) == sprintf("\\n")',
+                '      ck_out_ = ck_out_(1:end-1);',
+                '    end',
+                '    ck_val_ = chickadee_serialize(ck_out_);',
+                '    ck_have_val_ = true;'
+            ];
+        } else {
+            body = [
+                // A function declaring no output cannot be assigned from —
+                // `ck_res_ = feval(…)` would raise "value on right hand side of
+                // assignment is undefined", which reads as a solution error
+                // rather than as "it returned nothing".
+                '    if nargout(ck_callee_) == 0',
+                '      feval(' + invocation + ');',
+                '    else',
+                '      ck_res_ = feval(' + invocation + ');',
+                '      ck_val_ = chickadee_serialize(ck_res_);',
+                '      ck_have_val_ = true;',
+                '    end'
+            ];
+        }
+
+        return [
+            'ck_err_ = "";',
+            'ck_have_err_ = false;',
+            'ck_val_ = "";',
+            'ck_have_val_ = false;',
+            'ck_callee_ = [];',
+            'ck_kind_ = exist(' + nameLiteral + ');',
+            'if ck_kind_ == 1',
+            '  ck_tmp_ = eval(' + nameLiteral + ');',
+            '  if is_function_handle(ck_tmp_)',
+            '    ck_callee_ = ck_tmp_;',
+            '  end',
+            'elseif ck_kind_ != 0',
+            // The name itself, not str2func — see the note above.
+            '  ck_callee_ = ' + nameLiteral + ';',
+            'end',
+            'if isempty(ck_callee_)',
+            // "not defined" is the phrase describeCallFailure looks for when it
+            // decides whether to fold in the first failing solution cell.
+            '  ck_err_ = [' + nameLiteral + ' " is not defined in the solution notebook"];',
+            '  ck_have_err_ = true;',
+            'else',
+            '  try'
+        ].concat(bindings).concat(body).concat([
+            '  catch ck_e_',
+            '    ck_err_ = ck_e_.message;',
+            '    ck_have_err_ = true;',
+            '  end',
+            'end'
+        ]).concat(jsonOrNull('ck_val_', 'ck_have_val_', 'ck_val_json_'))
+            .concat(jsonOrNull('ck_err_', 'ck_have_err_', 'ck_err_json_'))
+            .concat([
+                payloadWrite(nonce, [
+                    grading.octaveStringLiteral('{"value":'),
+                    'ck_val_json_',
+                    grading.octaveStringLiteral(',"error":'),
+                    'ck_err_json_',
+                    grading.octaveStringLiteral('}')
+                ])
+            ]).join('\n');
+    }
+
+    root.ChickadeeOctaveEvalShared = {
+        OCTAVE_KERNEL: grading.OCTAVE_KERNEL,
+        makeNonce: grading.makeNonce,
+        bootCell: bootCell,
+        loadCell: loadCellOctave,
+        runExpression: runExpressionOctave,
+        callFunction: callFunctionOctave,
+        parseEvalOutput: protocol.parseEvalOutput,
+    };
+})(typeof self !== 'undefined' ? self : globalThis);

--- a/Public/octave-eval-worker.js
+++ b/Public/octave-eval-worker.js
@@ -1,0 +1,147 @@
+// Public/octave-eval-worker.js
+//
+// The pattern-family editor's auto-compute substrate for Octave: loads an
+// instructor's solution notebook into the xeus-octave session, then evaluates
+// snippets against it to fill in expected values.
+//
+// The Octave sibling of r-eval-worker.js and lua-eval-worker.js, speaking the
+// SAME message protocol, so the editor's client code is identical for all of
+// them:
+//   { id, type: 'init' }                 → { id, ok: true }
+//   { id, type: 'loadCells', cells: [] } → { id, ok: true, cellErrors: [{index, message}] }
+//   { id, type: 'call', functionName, args, captureStdout }
+//                                        → { id, ok: true, result: <string|null> }
+//   { id, type: 'run', code }            → { id, ok: true, result: <string|null> }
+//   any failure                          → { id, ok: false, error }
+//
+// Every message may carry `runtimeSource`, the Octave the worker must define
+// before it can report anything. It is SEEDED from the server
+// (`AssignmentLanguage.autoComputeRuntimeSource`) rather than written here, so
+// the serializer that renders a value is the one the personalization driver
+// uses and the string escaper is not a second copy.
+//
+// Why a worker at all, inherited from the Python path and still true: auto-
+// compute runs the instructor's own solution, and a synchronous CPU-bound loop
+// in it never yields, so a Promise.race timeout on the main thread can never
+// fire. Only `Worker.terminate()` kills it.
+//
+// This page is NOT cross-origin isolated — /instructor/:id/edit deliberately is
+// not — and does not need to be: the kernel is booted directly through its
+// emscripten module rather than JupyterLite's transports, so no
+// SharedArrayBuffer is involved. Same path the browser-grading smoke exercises.
+
+var _search = self.location.search || '';
+importScripts('/vendor/xeus-bootstrap.js' + _search);
+importScripts('/xeus-kernel-shared.js' + _search);
+importScripts('/grading-shared.js' + _search);
+importScripts('/eval-protocol-shared.js' + _search);
+importScripts('/octave-grading-shared.js' + _search);
+importScripts('/octave-eval-shared.js' + _search);
+
+var _kernel = self.ChickadeeXeusKernel;
+var _eval = self.ChickadeeOctaveEvalShared;
+var _reply = _kernel.reply;
+
+// The dead-kernel backstop, not a limit on how long code may run — the main
+// thread owns that and enforces it by terminating this worker. Set well above
+// the editor's own 30s load cap so a terminate always wins the race, and this
+// only ever fires for a kernel that is never going to reply at all. Octave is
+// the largest vendored env (142 MB) and the slowest to boot, so this matters
+// more here than elsewhere.
+var MAX_WAIT_MS = 90000;
+
+var _booted = false;
+
+/// Boots the kernel and defines the seeded runtime once.
+async function ensureBooted(runtimeSource) {
+    if (_booted) return;
+    await _kernel.boot(_eval.OCTAVE_KERNEL);
+    if (runtimeSource) {
+        var reply = await _kernel.execute(
+            _eval.bootCell(runtimeSource), { maxWaitMs: MAX_WAIT_MS });
+        // A runtime that fails to define leaves every later snippet calling an
+        // undefined `chickadee_serialize`, which reports as a confusing per-cell
+        // error rather than as the substrate failure it is. Fail loudly at boot.
+        if (reply.failure) {
+            throw new Error('the Octave auto-compute runtime failed to load: ' + reply.failure);
+        }
+    }
+    _booted = true;
+}
+
+/// Runs one solution-notebook cell, returning its error message or null.
+async function loadOneCell(source) {
+    var nonce = _eval.makeNonce();
+    var reply = await _kernel.execute(
+        _eval.loadCell(source, nonce), { maxWaitMs: MAX_WAIT_MS });
+    var parsed = _eval.parseEvalOutput(reply.stdout, nonce);
+    if (parsed) return parsed.error;
+    // The cell never reported. Attribute it to the cell rather than failing the
+    // whole load, so the remaining cells still get a chance to define their
+    // functions.
+    return reply.failure || (reply.stderr || '').trim() || 'the Octave kernel produced no result';
+}
+
+/// Runs one snippet that reports a value, unwrapping the payload.
+///
+/// `build` receives the nonce and returns the snippet, so the nonce the parser
+/// reads and the nonce the snippet prints cannot drift apart.
+async function evaluateSnippet(build) {
+    var nonce = _eval.makeNonce();
+    var reply = await _kernel.execute(build(nonce), { maxWaitMs: MAX_WAIT_MS });
+    var parsed = _eval.parseEvalOutput(reply.stdout, nonce);
+    if (!parsed) {
+        throw new Error(
+            reply.failure || (reply.stderr || '').trim()
+            || 'the Octave kernel produced no result');
+    }
+    if (parsed.error) throw new Error(parsed.error);
+    return parsed.value;
+}
+
+self.onmessage = async function (e) {
+    var msg = e.data || {};
+    var id = msg.id;
+    try {
+        if (msg.type === 'init') {
+            await ensureBooted(msg.runtimeSource);
+            _reply({ id: id, ok: true });
+            return;
+        }
+        if (msg.type === 'loadCells') {
+            await ensureBooted(msg.runtimeSource);
+            var cells = Array.isArray(msg.cells) ? msg.cells : [];
+            var cellErrors = [];
+            for (var i = 0; i < cells.length; i++) {
+                var message = await loadOneCell(cells[i]);
+                if (message) cellErrors.push({ index: i, message: message });
+            }
+            _reply({ id: id, ok: true, cellErrors: cellErrors });
+            return;
+        }
+        if (msg.type === 'call') {
+            // The language-neutral request: call this function with these JSON
+            // args. The SNIPPET is built here rather than on the main thread, so
+            // rendering Octave values stays in the Octave module.
+            await ensureBooted(msg.runtimeSource);
+            var callResult = await evaluateSnippet(function (nonce) {
+                return _eval.callFunction(
+                    msg.functionName, msg.args || [],
+                    { captureStdout: !!msg.captureStdout }, nonce);
+            });
+            _reply({ id: id, ok: true, result: callResult });
+            return;
+        }
+        if (msg.type === 'run') {
+            await ensureBooted(msg.runtimeSource);
+            var runResult = await evaluateSnippet(function (nonce) {
+                return _eval.runExpression(msg.code || '', nonce);
+            });
+            _reply({ id: id, ok: true, result: runResult });
+            return;
+        }
+        _reply({ id: id, ok: false, error: 'unknown message type: ' + msg.type });
+    } catch (err) {
+        _reply({ id: id, ok: false, error: (err && err.message) ? String(err.message) : String(err) });
+    }
+};

--- a/Public/octave-grading-shared.js
+++ b/Public/octave-grading-shared.js
@@ -96,17 +96,89 @@
     // is in xeus-octave's own transitive closure (plotly drags in the Python
     // payload), so a seed list would select all eleven and save nothing.
 
-    // Escape a JS string for embedding in Octave source as a double-quoted
-    // literal.  Only used for names Chickadee itself controls (script names,
-    // the seed, the nonce), but escaping keeps a surprising filename from
-    // breaking the wrapper's parse.
+    /// An Octave double-quoted string literal for `value`.
+    ///
+    /// Byte-identical to `encodeOctaveString` in Sources/Core/JSONValue.swift,
+    /// including the EXACTLY-THREE-DIGIT OCTAL escape for control characters and
+    /// DEL that an earlier version omitted. Octal rather than `\\x` is not a
+    /// style choice: Octave's `\\x` consumes every hex digit that follows, so
+    /// `"\\x0abc"` swallows four characters of payload, while octal stops at
+    /// three by rule. Pinned by Tests/Fixtures/octave-literal-contract.json,
+    /// which both implementations read.
+    ///
+    /// This used to escape only the five common characters, which was enough
+    /// while its callers were names Chickadee controls (script names, the seed,
+    /// the nonce). `octaveLiteral` below hands it instructor and student text,
+    /// where a raw control character would end the string mid-literal.
     function octaveStringLiteral(value) {
-        return '"' + String(value)
-            .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\t/g, '\\t') + '"';
+        var out = '"';
+        var text = String(value);
+        for (var i = 0; i < text.length; i++) {
+            var ch = text[i];
+            var code = text.charCodeAt(i);
+            if (ch === '\\') out += '\\\\';
+            else if (ch === '"') out += '\\"';
+            else if (ch === '\n') out += '\\n';
+            else if (ch === '\r') out += '\\r';
+            else if (ch === '\t') out += '\\t';
+            else if (code < 0x20 || code === 0x7f) {
+                out += '\\' + code.toString(8).padStart(3, '0');
+            } else out += ch;
+        }
+        return out + '"';
+    }
+
+    /// True when every element is a numeric or boolean scalar (JSON null
+    /// admitted — it renders `NA`, a double, and occupies its slot), so the
+    /// array can render as an Octave row vector without any silent char
+    /// coercion. Strings are deliberately NOT admitted — see `octaveLiteral`.
+    /// An empty array falls through to the cell rendering: nothing says what it
+    /// would have held.
+    function isOctaveNumericArray(items) {
+        if (items.length === 0) return false;
+        return items.every(function (item) {
+            return item === null || item === undefined
+                || typeof item === 'boolean' || typeof item === 'number';
+        });
+    }
+
+    /// Renders a JSON value as Octave source.
+    ///
+    /// A SECOND IMPLEMENTATION of `JSONValue.octaveLiteral`, for the reason
+    /// `rLiteral` and `luaLiteral` are: in-page auto-compute calls a solution
+    /// with arguments the instructor typed but has not saved, so there is no
+    /// server round-trip in which the server could render them. Neither side
+    /// owns the expectations — Tests/Fixtures/octave-literal-contract.json does,
+    /// and both read it.
+    ///
+    /// THE BRACKETS-VS-BRACES SPLIT IS THE WHOLE TRAP. `[...]` in Octave
+    /// concatenates rather than collecting, and a number beside a string is
+    /// coerced to its character: `[65, "bc"]` is the char array `"Abc"`, not a
+    /// two-element list. So brackets are used only when every element is a
+    /// numeric or boolean scalar; anything else — any string, any mixing, any
+    /// nesting, the empty array — is a cell.
+    function octaveLiteral(value) {
+        if (value === null || value === undefined) return 'NA';
+        if (typeof value === 'boolean') return value ? 'true' : 'false';
+        if (typeof value === 'number') {
+            if (Number.isNaN(value)) return 'NaN';
+            if (!Number.isFinite(value)) return value < 0 ? '-Inf' : 'Inf';
+            return String(value);
+        }
+        if (typeof value === 'string') return octaveStringLiteral(value);
+        if (Array.isArray(value)) {
+            var inner = value.map(octaveLiteral).join(', ');
+            return isOctaveNumericArray(value) ? '[' + inner + ']' : '{' + inner + '}';
+        }
+        var keys = Object.keys(value).sort();
+        if (keys.length === 0) return 'containers.Map()';
+        // A Map is built from two cells, not from pairs: containers.Map takes
+        // all the keys and then all the values.
+        return 'containers.Map({'
+            + keys.map(octaveStringLiteral).join(', ')
+            + '}, {'
+            + keys.map(function (k) { return octaveLiteral(value[k]); }).join(', ')
+            + '})';
     }
 
     // The one-time cell that installs the harness into the kernel's session.
@@ -260,6 +332,7 @@
         OCTAVE_KERNEL: OCTAVE_KERNEL,
         SETUP_OCTAVE: SETUP_OCTAVE,
         octaveStringLiteral: octaveStringLiteral,
+        octaveLiteral: octaveLiteral,
         assignmentSeedOctave: assignmentSeedOctave,
         makeNonce: makeNonce,
         runScriptOctave: runScriptOctave,

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -534,19 +534,7 @@ extension AssignmentLanguage {
                     #"^function\s*(?:\[[^\]]*\]|[A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#,
                     #"^function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"#,
                 ]),
-                // PENDING ITS WORKER. This language has a vendored kernel, so
-                // the target answer is `.inPageKernel` — the editor's job is
-                // in-browser verification, and an author should not wait on a
-                // server round-trip to see what their solution returns. It says
-                // `.serverDriver` only because `/octave-eval-worker.js` does not exist
-                // yet; declaring the kernel before writing the worker would have
-                // the editor spawn a 404 and auto-compute would silently stop.
-                //
-                // Flipping it is one line here, one worker mirroring
-                // `python-eval-worker.js` on this language's existing
-                // `*-grading-shared.js`, and one row in the browser-grading
-                // smoke matrix.
-                autoCompute: .serverDriver,
+                autoCompute: .inPageKernel(workerScript: "/octave-eval-worker.js"),
                 inputsFileName: "_ck_inputs.m",
                 notebookKernelNames: AssignmentLanguage.octaveKernelNames,
                 editorSupport: .notebookKernel(

--- a/Tests/APITests/LanguageConformanceMatrixTests.swift
+++ b/Tests/APITests/LanguageConformanceMatrixTests.swift
@@ -417,8 +417,18 @@ import Testing
             and every \(language) execution-path assertion skips silently.
             """)
 
-        let installs = lines.filter { $0.contains("--no-install-recommends") }
-        #expect(!installs.isEmpty, "swift-tests.yml has no fallback install to check.")
+        // The fallback installs are the ones the PROBE guards — the `apt-get`
+        // that runs when `command -v` says the image is stale. Identified by
+        // that pairing rather than by `--no-install-recommends` alone, which
+        // also matches unrelated installs: the browser-runner-tests job
+        // installs lua5.4 and octave for the eval-snippet execution suites, on
+        // a plain ubuntu runner with no swift-ci image and no reason to carry
+        // r-base or racket. Matching it here demanded every language be
+        // installed in a job that needs two of them.
+        let installs = lines.filter {
+            $0.contains("--no-install-recommends") && $0.contains("apt-get update")
+        }
+        #expect(!installs.isEmpty, "swift-tests.yml has no probe-guarded fallback install.")
         #expect(
             installs.allSatisfy { $0.contains(adapter.debianPackage) },
             """

--- a/Tests/BrowserRunnerJSTests/octave-eval-execution.test.mjs
+++ b/Tests/BrowserRunnerJSTests/octave-eval-execution.test.mjs
@@ -1,0 +1,214 @@
+// Executes the Octave auto-compute snippets under a real Octave interpreter.
+//
+// The Octave sibling of lua-eval-execution.test.mjs, and it exists for the same
+// reason: shape assertions cannot tell you that `eval(["1;" …])` registers a
+// command-line function, that `nargout` answers 0 for a printing solution, or
+// that `evalc` captures what it printed. Everything below runs the real seeded
+// runtime, extracted from the Swift constants the server sends.
+//
+// One difference from the Lua suite, and it is a property of the language
+// rather than a shortcut: Octave cells share one base workspace, so
+// concatenating the snippets into a single script is a faithful emulation of a
+// kernel session. What it cannot show is the `1;` guard on the BOOT cell (a
+// script file accepts function definitions either way) — only the kernel proves
+// that, in Tools/browser-grading-smoke with `--language octave --mode eval`.
+//
+// Skips silently when no `octave` is on PATH.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readAutoComputeRuntimeSource } from
+    '../../Tools/browser-grading-smoke/auto-compute-runtime.mjs';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/eval-protocol-shared.js');
+require('../../Public/octave-grading-shared.js');
+require('../../Public/octave-eval-shared.js');
+
+const Octave = globalThis.ChickadeeOctaveEvalShared;
+const protocol = globalThis.ChickadeeEvalProtocol;
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const OCTAVE = ['octave-cli', 'octave'].find(
+    (name) => spawnSync(name, ['--version'], { stdio: 'ignore' }).status === 0);
+
+// A silent skip is right on a laptop and wrong in CI, where it would report a
+// green suite that executed nothing.
+test('CI has an Octave interpreter for these tests to use',
+    { skip: !process.env.CI }, () => {
+        assert.ok(OCTAVE, 'no octave on PATH — the browser-runner-tests job must install it');
+    });
+
+const runtimeSource = OCTAVE ? await readAutoComputeRuntimeSource('octave', REPO_ROOT) : null;
+
+/// Runs `cells` in one Octave session and returns its stdout.
+function runCells(cells) {
+    const file = path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'ck-octave-eval-')), 'driver.m');
+    fs.writeFileSync(file, cells.join('\n') + '\n');
+    return execFileSync(OCTAVE, ['--no-gui', '-q', file], { encoding: 'utf8' });
+}
+
+/// Boots the runtime, loads `cells`, then evaluates `snippet`.
+function evaluate(snippet, nonce, cells = []) {
+    const loaded = cells.map((source, index) => Octave.loadCell(source, 'LOAD' + index));
+    return protocol.parseEvalOutput(
+        runCells([Octave.bootCell(runtimeSource)].concat(loaded, [snippet])), nonce);
+}
+
+const SOLUTION = [
+    'function r = classify(bmi)\n if bmi < 18.5\n  r = "under";\n else\n  r = "ok";\n end\nend',
+    'this_name_does_not_exist()',
+    'function r = double_it(x)\n r = x * 2;\nend',
+    'function shout(word)\n printf("%s!\\n", word);\nend',
+    'function n = count(items)\n n = numel(items);\nend',
+    'threshold = 18.5;',
+];
+
+test('the seeded runtime defines its helpers for later cells', { skip: !OCTAVE }, () => {
+    const stdout = runCells([
+        Octave.bootCell(runtimeSource),
+        'fputs(stdout, [num2str(exist("chickadee_serialize")) " "'
+        + ' num2str(exist("chickadee_escape_string")) "\\n"]);',
+    ]);
+    // 103 is a command-line function, which is what the `1;` guard produces.
+    assert.equal(stdout.trim(), '103 103');
+});
+
+test('a solution cell that raises is reported, and later cells still load',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(
+            Octave.callFunction('double_it', [21], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, '42');
+    });
+
+test('a failing cell reports its own message', { skip: !OCTAVE }, () => {
+    const stdout = runCells([
+        Octave.bootCell(runtimeSource),
+        Octave.loadCell('this_name_does_not_exist()', 'BAD'),
+    ]);
+    const payload = protocol.parseEvalOutput(stdout, 'BAD');
+    assert.match(payload.error, /undefined/i);
+});
+
+test('a value comes back as Octave source, the repr the server driver returns',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(
+            Octave.callFunction('classify', [18.49], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '"under"');
+    });
+
+test('a numeric array argument stays a row vector', { skip: !OCTAVE }, () => {
+    const payload = evaluate(
+        Octave.callFunction('count', [[1, 2, 3]], {}, 'N'), 'N', SOLUTION);
+    assert.equal(payload.value, '3');
+});
+
+test('THE TRAP: a mixed array is a cell, not a concatenated char array',
+    { skip: !OCTAVE }, () => {
+        // `[65, "bc"]` in Octave is the char array "Abc" — three characters, not
+        // two elements. The cell rendering is what keeps `count` answering 2.
+        const payload = evaluate(
+            Octave.callFunction('count', [[65, 'bc']], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '2');
+    });
+
+test('a missing function says "not defined", which the editor keys on',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(
+            Octave.callFunction('no_such_function', [], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, null);
+        assert.match(payload.error, /not defined/);
+    });
+
+test('a solution function shadowing an Octave builtin is the one that is called',
+    { skip: !OCTAVE }, () => {
+        // `area` is Octave's plotting function. After the solution defines one,
+        // `exist("area")` answers 103 — but `str2func("area")` hands back the
+        // BUILT-IN, so a handle-based lookup would call the plotting function
+        // and report "no graphics toolkits are available" as a solution error.
+        // Calling by name resolves it correctly.
+        const payload = evaluate(
+            Octave.callFunction('area', [2], {}, 'N'), 'N',
+            ['function r = area(rad)\n r = round(pi * rad * rad * 100) / 100;\nend']);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, '12.57');
+    });
+
+test('a solution that is a handle in a variable is callable too',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(
+            Octave.callFunction('triple', [4], {}, 'N'), 'N', ['triple = @(x) x * 3;']);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, '12');
+    });
+
+test('a raising solution is an error, not a null value', { skip: !OCTAVE }, () => {
+    const payload = evaluate(
+        Octave.callFunction('boom', [], {}, 'N'), 'N',
+        // A `%` in the message is the reason every payload uses fputs: a printf
+        // carrying it in the format string would consume it.
+        ['function boom()\n error("bad %s thing", "100%");\nend']);
+    assert.equal(payload.value, null);
+    assert.equal(payload.error, 'bad 100% thing');
+});
+
+test('a function that returns nothing reports no value, not an error',
+    { skip: !OCTAVE }, () => {
+        // `ck_res_ = feval(…)` on a zero-output function raises "value on right
+        // hand side of assignment is undefined", which would read as a broken
+        // solution. The nargout check is what keeps it honest.
+        const payload = evaluate(
+            Octave.callFunction('shout', ['hi'], {}, 'N'), 'N', SOLUTION);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, null);
+    });
+
+test('captureStdout reports what was printed, minus one trailing newline',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(
+            Octave.callFunction('shout', ['go'], { captureStdout: true }, 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '"go!"');
+    });
+
+test('captured output does not also escape to stdout', { skip: !OCTAVE }, () => {
+    const stdout = runCells([
+        Octave.bootCell(runtimeSource),
+        Octave.loadCell('function shout(word)\n printf("%s!\\n", word);\nend', 'L'),
+        Octave.callFunction('shout', ['hi'], { captureStdout: true }, 'N'),
+    ]);
+    const marker = stdout.indexOf('\nN:');
+    assert.ok(marker >= 0, `no payload on stdout:\n${stdout}`);
+    assert.ok(!stdout.slice(0, marker).includes('hi!'),
+        `captured output escaped to stdout:\n${stdout}`);
+});
+
+test('a solution variable set in one cell is visible to a later one',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(Octave.runExpression('threshold', 'N'), 'N', SOLUTION);
+        assert.equal(payload.value, '18.5');
+    });
+
+test('a statement runs and yields no value rather than an error',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(Octave.runExpression('ck_probe_ = 1;', 'N'), 'N');
+        assert.equal(payload.error, null);
+    });
+
+test('a quote in a solution cannot break out of the embedded literal',
+    { skip: !OCTAVE }, () => {
+        const payload = evaluate(
+            Octave.callFunction('quoted', [], {}, 'N'), 'N',
+            ['function r = quoted()\n r = "he said \\"hi\\"";\nend']);
+        assert.equal(payload.error, null);
+        assert.equal(payload.value, '"he said \\"hi\\""');
+    });

--- a/Tests/BrowserRunnerJSTests/octave-eval-shared.test.mjs
+++ b/Tests/BrowserRunnerJSTests/octave-eval-shared.test.mjs
@@ -1,0 +1,142 @@
+// Unit tests for the Octave auto-compute snippets.
+//
+// octave-eval-execution.test.mjs runs these under a real interpreter; this file
+// asserts the things execution cannot show, because they are about what the
+// snippet must NOT contain:
+//
+//   * `str2func` nowhere — it resolves a BUILT-IN over a command-line function
+//     of the same name, so a solution defining `area` would silently be graded
+//     against Octave's plotting function;
+//   * `printf` nowhere in the payload path — an error message can carry a `%`;
+//   * the seeded helpers called, never defined here;
+//   * the `1;` guard on the boot cell, which the execution suite cannot prove
+//     because a script file accepts function definitions either way.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/eval-protocol-shared.js');
+require('../../Public/octave-grading-shared.js');
+require('../../Public/octave-eval-shared.js');
+
+const Octave = globalThis.ChickadeeOctaveEvalShared;
+const protocol = globalThis.ChickadeeEvalProtocol;
+
+const SNIPPETS = () => ({
+  loadCell: Octave.loadCell('function r = f(x)\n r = x;\nend', 'NONCE1'),
+  runExpression: Octave.runExpression('f(2)', 'NONCE2'),
+  call: Octave.callFunction('f', [1], {}, 'NONCE3'),
+  captured: Octave.callFunction('f', [1], { captureStdout: true }, 'NONCE4'),
+});
+
+test('the boot cell opens with the 1; script guard', () => {
+  const cell = Octave.bootCell('function s = helper()\n s = 1;\nend');
+  assert.ok(cell.startsWith('1;\n'),
+    'without the guard the cell is a function file and nothing registers');
+  assert.ok(cell.includes('function s = helper()'), 'the seeded bytes run verbatim');
+});
+
+test('str2func appears nowhere — a builtin would win the lookup', () => {
+  for (const [name, snippet] of Object.entries(SNIPPETS())) {
+    assert.ok(!snippet.includes('str2func'),
+      `${name} must resolve a command-line function by NAME, not through str2func`);
+  }
+  assert.ok(SNIPPETS().call.includes('feval(ck_callee_'),
+    'the call must go through feval on the resolved callee');
+});
+
+test('the payload is written with fputs, never printf', () => {
+  // An Octave error message can contain a literal `%`; a printf carrying the
+  // payload in its format string would consume it.
+  for (const [name, snippet] of Object.entries(SNIPPETS())) {
+    assert.ok(snippet.includes('fputs(stdout, ['), `${name} must write with fputs`);
+    // `sprintf` is fine and used — it is the only way to spell a newline
+    // outside a double-quoted literal. It is `printf` writing to stdout that
+    // must not appear.
+    assert.ok(!/(^|[^s])printf\(/.test(snippet),
+      `${name} must not build its payload with printf`);
+  }
+});
+
+test('the payload marker matches what the shared parser looks for', () => {
+  const run = Octave.runExpression('1', 'ABC123');
+  assert.ok(run.includes('"\\nABC123:"'),
+    `snippet does not write the marker the parser reads:\n${run}`);
+  assert.equal(protocol.payloadMarker('ABC123'), '\nABC123:');
+});
+
+test('the seeded helpers are called, never defined here', () => {
+  for (const [name, snippet] of Object.entries(SNIPPETS())) {
+    assert.ok(!/function \w+ = chickadee_/.test(snippet),
+      `${name} must use the seeded runtime, not a copy`);
+  }
+  assert.ok(SNIPPETS().runExpression.includes('chickadee_serialize('),
+    'a value must be reported through the seeded serializer');
+  assert.ok(SNIPPETS().call.includes('chickadee_escape_string('),
+    'the payload must be escaped by the seeded escaper');
+});
+
+test('a solution cell is evaluated behind the 1; submission contract', () => {
+  const load = Octave.loadCell('function r = f(x)\n r = x;\nend', 'N');
+  assert.ok(load.includes('eval(["1;" sprintf("\\n")'),
+    'without the prefix a one-function cell binds under the file name, not its own');
+  // And the source rides as a string literal, so quotes cannot break out.
+  const nasty = Octave.loadCell('r = "he said \\"hi\\"";', 'N');
+  assert.ok(nasty.includes('\\\\"'), 'quotes in the source must be escaped');
+});
+
+test('a value and an error are distinguished by a flag, not by emptiness', () => {
+  // The empty string is a legitimate return value; `isempty` would report it as
+  // "returned nothing".
+  const call = SNIPPETS().call;
+  assert.ok(call.includes('ck_have_val_'), 'a returned value needs its own flag');
+  assert.ok(call.includes('ck_have_err_'), 'an error needs its own flag');
+});
+
+test('a zero-output function is called without assignment', () => {
+  // `ck_res_ = feval(…)` on one raises "value on right hand side of assignment
+  // is undefined", which reads as a broken solution rather than as no value.
+  const call = SNIPPETS().call;
+  assert.ok(call.includes('if nargout(ck_callee_) == 0'),
+    'the nargout check is what keeps a printing solution from reporting an error');
+});
+
+test('captureStdout uses evalc and drops one trailing newline', () => {
+  const captured = SNIPPETS().captured;
+  assert.ok(captured.includes('evalc('), 'captureStdout must capture what was printed');
+  assert.ok(captured.includes('ck_out_(1:end-1)'), 'one trailing newline is dropped');
+  // The trailing semicolon inside the evalc'd code suppresses the `ans = …`
+  // echo a value-returning function would otherwise add to the capture.
+  assert.ok(/evalc\("feval\([^"]*\);"\)/.test(captured),
+    `the evalc'd call must end in a semicolon:\n${captured}`);
+  assert.ok(!SNIPPETS().call.includes('evalc('),
+    'the default path must report the returned value, not printed output');
+});
+
+test('callFunction renders arguments through the pinned Octave renderer', () => {
+  const snippet = Octave.callFunction('classify', [18.5, 'lo', [1, 2], [65, 'bc']], {}, 'N');
+  assert.ok(snippet.includes('ck_a1_ = 18.5;'), `argument 1 not bound:\n${snippet}`);
+  assert.ok(snippet.includes('ck_a2_ = "lo";'), 'a string argument must be quoted');
+  assert.ok(snippet.includes('ck_a3_ = [1, 2];'), 'an all-numeric array is a row vector');
+  // THE TRAP: brackets here would concatenate into the char array "Abc".
+  assert.ok(snippet.includes('ck_a4_ = {65, "bc"};'), 'a mixed array must be a cell');
+  assert.ok(snippet.includes('feval(ck_callee_, ck_a1_, ck_a2_, ck_a3_, ck_a4_)'),
+    `arguments must be passed positionally:\n${snippet}`);
+});
+
+test('a missing function says "not defined", which the editor keys on', () => {
+  const snippet = Octave.callFunction('nope', [], {}, 'N');
+  assert.ok(snippet.includes('is not defined in the solution notebook'),
+    'the missing-function message must carry the phrase the editor matches');
+});
+
+test('the parser round-trips a payload the snippet shape would produce', () => {
+  const stdout = 'solution output\n\nNONCE:{"value":"42","error":null}\n';
+  assert.deepEqual(protocol.parseEvalOutput(stdout, 'NONCE'), { value: '42', error: null });
+  const twice = '\nNONCE:{"value":"1","error":null}\n\nNONCE:{"value":"2","error":null}\n';
+  assert.equal(protocol.parseEvalOutput(twice, 'NONCE').value, '2');
+  assert.equal(protocol.parseEvalOutput('nothing here', 'NONCE'), null);
+});

--- a/Tests/BrowserRunnerJSTests/octave-literal-contract.test.mjs
+++ b/Tests/BrowserRunnerJSTests/octave-literal-contract.test.mjs
@@ -1,0 +1,58 @@
+// The browser half of the Octave literal contract. See r-literal-contract.test.mjs
+// for why a second implementation exists and how it is kept honest.
+//
+// The Octave-specific trap: `[...]` concatenates rather than collecting, and a
+// number beside a string is coerced to its character — `[65, "bc"]` is the char
+// array "Abc". So brackets are used only for an all-numeric/boolean array and
+// everything else is a cell.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+require('../../Public/grading-shared.js');
+require('../../Public/octave-grading-shared.js');
+
+const { octaveLiteral, octaveStringLiteral } = globalThis.ChickadeeOctaveGradingShared;
+const contract = JSON.parse(
+  fs.readFileSync(path.resolve('Tests/Fixtures/octave-literal-contract.json'), 'utf8'));
+
+test('every contract case renders identically in the browser', () => {
+  assert.ok(contract.cases.length > 20, 'the contract should cover a real spread of shapes');
+  for (const testCase of contract.cases) {
+    assert.equal(
+      octaveLiteral(testCase.json), testCase.octave,
+      `${testCase.name}: browser octaveLiteral disagrees with the contract`);
+  }
+});
+
+test('a string anywhere in an array forces a cell', () => {
+  // The distinction the whole renderer turns on. Brackets here would hand the
+  // solution the char array "Abc" where the author wrote a two-element list.
+  assert.equal(octaveLiteral([65, 'bc']), '{65, "bc"}');
+  assert.equal(octaveLiteral(['a']), '{"a"}');
+  assert.equal(octaveLiteral([1, 2]), '[1, 2]');
+  // Nesting too: `[[1,2],[3,4]]` would concatenate into one four-element row.
+  assert.equal(octaveLiteral([[1, 2], [3, 4]]), '{[1, 2], [3, 4]}');
+  // And the empty array, which says nothing about what it would have held.
+  assert.equal(octaveLiteral([]), '{}');
+});
+
+test('control characters are escaped as three-digit octal, never \\x', () => {
+  // Octave's \x consumes every hex digit that follows, so "\x0abc" would
+  // swallow four characters of payload. Octal stops at three by rule.
+  assert.equal(octaveStringLiteral('a\u0001b'), '"a\\001b"');
+  assert.equal(octaveStringLiteral('\u007f'), '"\\177"');
+  assert.ok(!octaveStringLiteral('\u0001').includes('\\x'));
+  // Exactly three digits even when fewer would read the same alone.
+  assert.equal(octaveStringLiteral('\u0000'), '"\\000"');
+});
+
+test('a null keeps its slot rather than collapsing the array', () => {
+  // NA is a double in Octave, so it occupies a position in a row vector — the
+  // opposite of Lua, where a nil would vanish from a table constructor.
+  assert.equal(octaveLiteral([60, null, 20]), '[60, NA, 20]');
+});

--- a/Tests/CoreTests/OctaveAutoComputeRuntimeTests.swift
+++ b/Tests/CoreTests/OctaveAutoComputeRuntimeTests.swift
@@ -1,0 +1,71 @@
+// Tests/CoreTests/OctaveAutoComputeRuntimeTests.swift
+//
+// The Octave sibling of LuaAutoComputeRuntimeTests, and it exists for the same
+// reason: `AssignmentLanguage.autoComputeRuntimeSource` is composed in Swift and
+// re-composed in `Tools/browser-grading-smoke/auto-compute-runtime.mjs`, so the
+// smoke and the Node execution suite probe what actually ships. Add a piece on
+// one side only and the browser tests keep passing against a runtime that is
+// missing it.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct OctaveAutoComputeRuntimeTests {
+
+    /// The pieces, in order. A literal list rather than a re-derivation, because
+    /// a test that recomputed the implementation would agree with any change.
+    private static let pieces: [String] = [
+        OctavePersonalizationRuntime.chickadeeSerializeOctaveSource,
+        OctavePersonalizationRuntime.chickadeeEscapeStringOctaveSource,
+    ]
+
+    @Test func theSeededRuntimeIsExactlyTheTwoSharedConstants() throws {
+        let composed = try #require(AssignmentLanguage.octave.autoComputeRuntimeSource)
+        #expect(
+            composed == Self.pieces.joined(separator: "\n\n"),
+            """
+            The Octave auto-compute runtime changed shape.
+
+            Tools/browser-grading-smoke/auto-compute-runtime.mjs rebuilds these bytes
+            from the same Swift constants, for the browser-grading smoke and for
+            Tests/BrowserRunnerJSTests/octave-eval-execution.test.mjs. Update its
+            COMPOSITION table to match, or those suites will keep passing against a
+            runtime the server no longer sends.
+            """)
+    }
+
+    /// Both pieces are `function` definitions, which is what makes the eval
+    /// worker's `1;` guard load-bearing: without it the boot cell reads as a
+    /// function FILE and nothing registers. `octave-eval-shared.js` supplies the
+    /// guard; this pins the premise it rests on.
+    @Test func theRuntimeIsNothingButFunctionDefinitions() throws {
+        let composed = try #require(AssignmentLanguage.octave.autoComputeRuntimeSource)
+        #expect(composed.hasPrefix("function "))
+        #expect(composed.contains("function s = chickadee_serialize(value)"))
+        #expect(composed.contains("function s = chickadee_escape_string(value)"))
+    }
+
+    /// A descriptor claiming a worker that is not there makes the editor spawn a
+    /// 404 and auto-compute stop with no message, so the flip is pinned rather
+    /// than left to a reader to notice.
+    @Test func octaveDeclaresItsInPageWorker() {
+        #expect(
+            AssignmentLanguage.octave.descriptor.autoCompute
+                == .inPageKernel(workerScript: "/octave-eval-worker.js"))
+    }
+
+    /// Every language with a vendored editor kernel now computes in the page.
+    /// The two that route to the server are the two with no kernel to run — a
+    /// property of the language, not a gap left to close.
+    @Test func onlyTheKernellessLanguagesRouteToTheServer() {
+        for language in AssignmentLanguage.allCases {
+            let usesServer = language.descriptor.autoCompute == .serverDriver
+            let hasEditorKernel = language.descriptor.editorSupport != .uploadOnly
+            #expect(
+                usesServer != hasEditorKernel,
+                "\(language): a language with an editor kernel should compute in the page")
+        }
+    }
+}

--- a/Tests/CoreTests/OctaveLiteralContractTests.swift
+++ b/Tests/CoreTests/OctaveLiteralContractTests.swift
@@ -1,0 +1,73 @@
+// Tests/CoreTests/OctaveLiteralContractTests.swift
+//
+// The Swift half of the Octave literal contract.
+//
+// `JSONValue.octaveLiteral` renders a value into Octave source on the server.
+// `octaveLiteral` in `Public/octave-grading-shared.js` does the same in the
+// browser, because in-page auto-compute must call an Octave solution with
+// arguments the instructor typed but has not saved — there is no server
+// round-trip in which the server could render them.
+//
+// Two implementations of one rendering is normally the defect this codebase
+// keeps removing, and it is allowed here for the reason
+// `personalizationInputsSourceOctave` is: the browser cannot call Swift. What
+// makes it safe is that NEITHER SIDE OWNS THE EXPECTATIONS. Both read
+// Tests/Fixtures/octave-literal-contract.json.
+//
+// The browser half is Tests/BrowserRunnerJSTests/octave-literal-contract.test.mjs.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct OctaveLiteralContractTests {
+
+    private struct Contract: Decodable {
+        struct Case: Decodable {
+            let name: String
+            let json: JSONValue?
+            let octave: String
+        }
+        let cases: [Case]
+    }
+
+    private static func loadContract() throws -> Contract {
+        let fixture = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CoreTests
+            .deletingLastPathComponent()  // Tests
+            .appendingPathComponent("Fixtures/octave-literal-contract.json")
+        let data = try Data(contentsOf: fixture)
+        return try JSONDecoder().decode(Contract.self, from: data)
+    }
+
+    @Test func everyContractCaseRendersIdenticallyOnTheServer() throws {
+        let contract = try Self.loadContract()
+        #expect(contract.cases.count > 20, "the contract should cover a real spread of shapes")
+        for testCase in contract.cases {
+            let value = testCase.json ?? .null
+            #expect(
+                value.octaveLiteral == testCase.octave,
+                """
+                \(testCase.name): server octaveLiteral disagrees with the contract.
+                  contract: \(testCase.octave)
+                  rendered: \(value.octaveLiteral)
+                """)
+        }
+    }
+
+    /// The arms JSON cannot express, so the shared fixture cannot pin them.
+    @Test func theNonJSONNumericArmsRenderAsOctaveSpellsThem() {
+        #expect(JSONValue.double(.nan).octaveLiteral == "NaN")
+        #expect(JSONValue.double(.infinity).octaveLiteral == "Inf")
+        #expect(JSONValue.double(-.infinity).octaveLiteral == "-Inf")
+    }
+
+    /// A whole-number double keeps its decimal point. The browser cannot
+    /// reproduce this — JS has one number type — which is why the fixture holds
+    /// no case for it and this test does.
+    @Test func aWholeNumberDoubleKeepsItsDecimalPoint() {
+        #expect(JSONValue.double(2).octaveLiteral == "2.0")
+        #expect(JSONValue.int(2).octaveLiteral == "2")
+    }
+}

--- a/Tests/Fixtures/octave-literal-contract.json
+++ b/Tests/Fixtures/octave-literal-contract.json
@@ -1,0 +1,83 @@
+{
+  "_comment": [
+    "The Octave literal contract, asserted by BOTH implementations of it.",
+    "See Tests/Fixtures/r-literal-contract.json for why two exist.",
+    "",
+    "The Octave-specific trap this pins: `[65, \"bc\"]` is not a two-element",
+    "list, it is the CHAR ARRAY \"Abc\" — square brackets concatenate, and a",
+    "number beside a string is coerced to its character. So an array renders",
+    "`[...]` only when every element is a numeric or boolean scalar, and",
+    "everything else — any string, any mixing, any nesting, and the empty array",
+    "— renders as a cell `{...}`. A renderer that reached for `[...]` by default",
+    "would silently hand the solution a string where the author wrote a list.",
+    "",
+    "The second pin is escaping. Control characters take EXACTLY-THREE-DIGIT",
+    "OCTAL, not `\\x`: Octave's `\\x` consumes every hex digit that follows, so",
+    "`\"\\x0abc\"` swallows four characters of payload, while octal stops at three",
+    "by rule.",
+    "",
+    "NaN and the infinities are absent because JSON cannot express them; the",
+    "Swift-only unit tests cover those arms."
+  ],
+  "cases": [
+    { "name": "null at top level", "json": null, "octave": "NA" },
+    { "name": "true", "json": true, "octave": "true" },
+    { "name": "false", "json": false, "octave": "false" },
+    { "name": "zero", "json": 0, "octave": "0" },
+    { "name": "positive int", "json": 42, "octave": "42" },
+    { "name": "negative int", "json": -7, "octave": "-7" },
+    { "name": "double", "json": 2.5, "octave": "2.5" },
+    { "name": "negative double", "json": -0.125, "octave": "-0.125" },
+
+    { "name": "empty string", "json": "", "octave": "\"\"" },
+    { "name": "plain string", "json": "hello", "octave": "\"hello\"" },
+    { "name": "string with quote", "json": "he said \"hi\"", "octave": "\"he said \\\"hi\\\"\"" },
+    { "name": "string with backslash", "json": "a\\b", "octave": "\"a\\\\b\"" },
+    { "name": "string with newline", "json": "a\nb", "octave": "\"a\\nb\"" },
+    { "name": "string with tab", "json": "a\tb", "octave": "\"a\\tb\"" },
+    { "name": "string with control char", "json": "a\u0001b", "octave": "\"a\\001b\"" },
+    { "name": "string with delete char", "json": "a\u007fb", "octave": "\"a\\177b\"" },
+    { "name": "string with unicode", "json": "café", "octave": "\"café\"" },
+
+    {
+      "name": "empty array is a cell, not an empty matrix",
+      "json": [],
+      "octave": "{}"
+    },
+    { "name": "numeric array", "json": [1, 2, 3], "octave": "[1, 2, 3]" },
+    { "name": "boolean array", "json": [true, false], "octave": "[true, false]" },
+    {
+      "name": "null keeps its slot in a numeric array",
+      "json": [60, null, 20],
+      "octave": "[60, NA, 20]"
+    },
+    {
+      "name": "string array is a cell",
+      "json": ["a", "b"],
+      "octave": "{\"a\", \"b\"}"
+    },
+    {
+      "name": "THE TRAP: a number beside a string is a cell, never brackets",
+      "json": [65, "bc"],
+      "octave": "{65, \"bc\"}"
+    },
+    { "name": "nested array is a cell", "json": [[1, 2]], "octave": "{[1, 2]}" },
+
+    { "name": "empty object", "json": {}, "octave": "containers.Map()" },
+    {
+      "name": "object sorted keys",
+      "json": { "b": 2, "a": 1 },
+      "octave": "containers.Map({\"a\", \"b\"}, {1, 2})"
+    },
+    {
+      "name": "object with null value",
+      "json": { "a": null },
+      "octave": "containers.Map({\"a\"}, {NA})"
+    },
+    {
+      "name": "nested object",
+      "json": { "outer": { "inner": [1, 2] } },
+      "octave": "containers.Map({\"outer\"}, {containers.Map({\"inner\"}, {[1, 2]})})"
+    }
+  ]
+}

--- a/Tools/browser-grading-smoke/auto-compute-runtime.mjs
+++ b/Tools/browser-grading-smoke/auto-compute-runtime.mjs
@@ -24,6 +24,13 @@ const COMPOSITION = {
         file: 'Sources/Core/RPersonalizationRuntime.swift',
         constants: ['chickadeeJSONStringRSource'],
     },
+    octave: {
+        file: 'Sources/Core/OctavePersonalizationRuntime.swift',
+        constants: [
+            'chickadeeSerializeOctaveSource',
+            'chickadeeEscapeStringOctaveSource',
+        ],
+    },
     lua: {
         file: 'Sources/Core/LuaPersonalizationRuntime.swift',
         constants: [

--- a/Tools/browser-grading-smoke/smoke.mjs
+++ b/Tools/browser-grading-smoke/smoke.mjs
@@ -559,6 +559,26 @@ const EVAL_PROBES = {
         },
         expression: 'classify(30)',
     },
+    octave: {
+        worker: '/octave-eval-worker.js',
+        cells: [
+            'function r = classify(bmi)\n if bmi < 18.5\n  r = "under";\n else\n  r = "ok";\n end\nend',
+            'this_name_does_not_exist()',
+            'function r = area(rad)\n r = round(pi * rad * rad * 100) / 100;\nend',
+            'function n = count(items)\n n = numel(items);\nend',
+        ],
+        calls: {
+            call: { functionName: 'classify', args: [18.49] },
+            later: { functionName: 'area', args: [2] },
+            stringArg: { functionName: 'count', args: ['abcd'] },
+            // THE OCTAVE TRAP. `[65, "bc"]` is the char array "Abc" — three
+            // characters — so a renderer reaching for brackets would answer 3
+            // where the author wrote a two-element list.
+            mixedArray: { functionName: 'count', args: [[65, 'bc']] },
+            missing: { functionName: 'no_such_function', args: [] },
+        },
+        expression: 'classify(30)',
+    },
 };
 
 const kernelEvalProbePage = (probe, runtimeSource) => `<!doctype html><meta charset="utf-8"><title>auto-compute smoke</title>
@@ -723,6 +743,18 @@ const EVAL_EXPECTATIONS = {
             // stores no nil, so a renderer that emitted one here would hand the
             // solution a two-element table and this would answer 2.
             nullSlot: ['a null inside a table argument keeps its slot', '3'],
+        },
+        expression: '"ok"',
+    },
+    octave: {
+        cellError: /undefined/i,
+        results: {
+            call: ['a call returns its value as an Octave literal', '"under"'],
+            later: ['a function defined after the failing cell is callable', '12.57'],
+            stringArg: ['a string argument round-trips', '4'],
+            // THE OCTAVE TRAP, executed on a real kernel: brackets would make
+            // this the char array "Abc" and answer 3.
+            mixedArray: ['a mixed array argument is a cell, not a char array', '2'],
         },
         expression: '"ok"',
     },

--- a/changelog.d/in-page-auto-compute-octave.md
+++ b/changelog.d/in-page-auto-compute-octave.md
@@ -1,0 +1,49 @@
+### Added
+
+- **Octave assignments compute expected values in the browser**, on the vendored
+  xeus-octave kernel. That closes the set: every language with an editor kernel —
+  Python, R, Lua, Octave — now computes in the page, and the two that route to
+  the server are the two with no kernel to run. `OctaveAutoComputeRuntimeTests`
+  pins that correspondence, so a future kernel language cannot quietly ship on
+  the server driver.
+
+  Octave costs neither of the other kernels' shape constraints — no
+  inter-expression yield, no `return <cell>` mis-read, and its cells share one
+  base workspace — so its snippets are plain statement lists. Its one shape
+  requirement is the `1;` guard on the boot cell, without which the cell reads
+  as a function file and the seeded runtime never registers.
+
+- **`octaveLiteral` in `Public/octave-grading-shared.js`**, pinned to
+  `JSONValue.octaveLiteral` by `Tests/Fixtures/octave-literal-contract.json`,
+  which both implementations read. The trap it exists for: `[...]` in Octave
+  concatenates rather than collecting, and a number beside a string is coerced
+  to its character, so `[65, "bc"]` is the char array `"Abc"`. Brackets are used
+  only for an all-numeric/boolean array; anything else is a cell.
+
+- **The Octave snippets are executed under a real interpreter in CI**
+  (`Tests/BrowserRunnerJSTests/octave-eval-execution.test.mjs`), against the
+  runtime the server actually seeds. A browser-grading smoke row covers the
+  kernel half.
+
+### Fixed
+
+- **A solution function sharing a builtin's name is now the one that gets
+  called.** `exist("area")` reports the solution's command-line function while
+  `str2func("area")` hands back Octave's *plotting* `area` — so a handle-based
+  lookup would have graded against a completely different function, reporting
+  "no graphics toolkits are available" as though the instructor's solution had
+  raised it. Command-line functions are resolved by name. Found by executing the
+  snippets rather than inspecting them.
+
+- **`octaveStringLiteral` now escapes control characters**, matching
+  `encodeOctaveString` in Swift. It passed them through, which was survivable
+  while its callers were names Chickadee controls and is not once it renders
+  instructor text. The escape is exactly-three-digit octal, not `\x`, because
+  Octave's `\x` consumes every hex digit that follows — `"\x0abc"` would swallow
+  four characters of payload.
+
+- **The language-conformance guard no longer demands every interpreter of every
+  apt-get in the workflow.** It matched any `--no-install-recommends` line,
+  including a job that installs two interpreters on a plain runner for the
+  eval-snippet execution suites; it now matches the probe-guarded fallback
+  installs it was written for.

--- a/docs/authoring-parity.md
+++ b/docs/authoring-parity.md
@@ -25,10 +25,12 @@ these gaps are correct as they stand, and have been re-litigated more than once.
 | Solution function scan | yes | no | no | no | n/a | n/a |
 
 **Both bottom rows have since moved.** The scan row was closed by the parity
-work (R, Lua and Octave parsers behind `FunctionScanSyntax`), and auto-compute
-now reads *in-page kernel* for Python, R and Lua, with Octave the last kernel
-language still on the server driver. The table is left as measured so the
-sections below, which argue from it, still read straight.
+work (R, Lua and Octave parsers behind `FunctionScanSyntax`), and the
+auto-compute row reads *in-page kernel* for every language that has an editor
+kernel — Python, R, Lua and Octave. The two on the server driver are C++ and
+Racket, which have no kernel to run; `OctaveAutoComputeRuntimeTests` pins that
+correspondence, so the split cannot quietly become a gap again. The table is
+left as measured so the sections below, which argue from it, still read straight.
 
 Two rows mislead as stated:
 
@@ -179,8 +181,8 @@ round-trip — a kernel boot the author waits for once is a better trade than a
 round-trip they pay for on every case. The boot is also lazy: it happens when
 auto-compute is first used, not on every visit as this claimed.
 
-R shipped first, then Lua; Octave is the one kernel language still on the server
-driver.
+R shipped first, then Lua, then Octave. Every kernel language now computes in
+the page; only C++ and Racket route to the server, because neither has a kernel.
 
 **Per-language custom-script template sets.** Seven of the nine Python templates
 are already available in every language as pattern-family kinds, in a better


### PR DESCRIPTION
Octave auto-compute ran on the server driver; it now runs on the vendored **xeus-octave** kernel.

That closes the set. Every language with an editor kernel — Python, R, Lua, Octave — computes in the page, and the two on the server driver are the two with no kernel to run. `OctaveAutoComputeRuntimeTests` pins that correspondence over `allCases`, so a future kernel language cannot quietly ship on the server driver.

Follows #1323 (R) and #1324 (Lua).

## What Octave costs, and what it does not

Neither of the other kernels' shape constraints: no inter-expression yield (R), no `return <cell>` mis-read (Lua), and its cells share one base workspace. So its snippets are plain statement lists. Its one shape requirement is the `1;` guard on the **boot cell** — without it the cell reads as a function *file* and the seeded runtime never registers.

What it does cost is the submission contract, which is Octave's alone: a solution cell is evaluated as `["1;" newline text]` so its definitions register under their **own** names — the rule `test_runtime.m` already documents in its header.

## The defect only execution could find

`exist("area")` reports the solution's command-line function, while **`str2func("area")` hands back Octave's built-in `area`** — the plotting one. A handle-based lookup therefore graded against a completely different function and surfaced `no graphics toolkits are available` as though the instructor's solution had raised it. Command-line functions are now resolved by **name**; `feval` and `nargout` given the name resolve correctly. Solutions naming a function `area`, `count` or `mean` are ordinary, so this is not an edge case.

## `octaveLiteral`

A browser twin of `JSONValue.octaveLiteral`, pinned by `Tests/Fixtures/octave-literal-contract.json` which both sides read. Its trap: `[...]` concatenates rather than collecting and coerces a number beside a string to its character, so `[65, "bc"]` is the char array `"Abc"`. Brackets are used only when every element is a numeric or boolean scalar; anything else — any string, any mixing, any nesting, the empty array — is a cell.

## Testing

- `octave-eval-execution.test.mjs` — **executes** every snippet under a real Octave against the runtime the server actually seeds. Covers the builtin-shadowing fix, the `nargout`-0 case (a printing solution must report no value, not an error), a handle assigned to a variable, `evalc` capture, and an error message containing `%`.
- `octave-eval-shared.test.mjs` — the things execution cannot show, because they are about what the snippet must *not* contain: no `str2func`, no `printf` in the payload path, the `1;` guard on the boot cell.
- `octave-literal-contract.test.mjs` + `OctaveLiteralContractTests.swift` — the shared fixture, both sides.
- Browser-grading smoke row `{ language: octave, mode: eval }`, whose `area` probe is deliberately the shadowed builtin.

Full Swift suite (3,402 tests), `scripts/lint.sh`, `scripts/swiftlint.sh`, `scripts/eslint.sh` and all 336 JS tests green locally, with Lua and Octave both installed so nothing skipped.

## Also fixed

- **`octaveStringLiteral` passed control characters through.** Survivable while its callers were names Chickadee controls; not once it renders instructor text. Now exactly-three-digit octal, matching Swift — not `\x`, because Octave's `\x` consumes every hex digit that follows and `"\x0abc"` would swallow four characters of payload.
- **The language-conformance guard demanded every interpreter of every apt-get in the workflow.** It matched any `--no-install-recommends` line, including the job that installs two interpreters on a plain runner for the eval-snippet execution suites. It now matches the probe-guarded fallback installs it was written for, and still fails loudly if that shape changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcV8dFXd1H9476AxSwpeam)_