### PR TITLE
fix: derive four hand-written lists that were failing open

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -58,6 +58,27 @@
     const { personalizationInputsSourceLua } = ChickadeeLuaGradingShared;
     const { personalizationInputsSourceOctave } = ChickadeeOctaveGradingShared;
 
+    // Which renderer writes the per-student inputs file, by language token.
+    //
+    // The RENDERER is genuinely per-language — four different wrappers around
+    // values the server already rendered as literals. The FILENAME is not:
+    // that is `LanguageDescriptor.inputsFileName`, generated below. Keeping the
+    // two apart is the point. They were one hand-written pair of strings, and a
+    // browser-graded Lua assignment wrote `_ck_inputs.py` while the Lua runtime
+    // read `_ck_inputs.lua` — every per-student value silently missing, no
+    // error anywhere.
+    //
+    // Keyed by the four languages with an editor kernel, which are exactly the
+    // languages a browser grades. `BrowserInputsWriterCoverageTests` fails if
+    // that stops being true — a fifth kernel language missing from here would
+    // fall back to Python's writer and reproduce the Lua bug exactly.
+    const INPUTS_WRITERS = {
+        python: personalizationInputsSource,
+        r: personalizationInputsSourceR,
+        lua: personalizationInputsSourceLua,
+        octave: personalizationInputsSourceOctave,
+    };
+
     // Kernelspec names that mark an R notebook. The browser cannot import
     // Swift, so this is a GENERATED copy of AssignmentLanguage.rKernelNames
     // (Sources/Core/AssignmentLanguage.swift), written by
@@ -85,6 +106,17 @@
     // CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:BEGIN
     const GRADED_SCRIPT_EXTENSIONS = ['.cpp', '.h', '.hpp', '.lua', '.m', '.py', '.r', '.rkt'];
     // CHICKADEE_GENERATED:GRADED_SCRIPT_EXTENSIONS:END
+
+    // The per-student inputs file each language's test_runtime reads. A
+    // GENERATED copy of LanguageDescriptor.inputsFileName, keyed by the enum
+    // case — which is the token the seed endpoint reports, so the lookup needs
+    // no translation. Same rule as above: edit the Swift literal and re-run the
+    // script, never this line. Every language is emitted, including the
+    // upload-only ones a browser never grades; deciding here which languages
+    // "matter" would be one more list to keep current.
+    // CHICKADEE_GENERATED:INPUTS_FILE_NAMES:BEGIN
+    const INPUTS_FILE_NAMES = { cpp: '_ck_inputs.hpp', lua: '_ck_inputs.lua', octave: '_ck_inputs.m', python: '_ck_inputs.py', r: '_ck_inputs.R', racket: '_ck_inputs.rkt' };
+    // CHICKADEE_GENERATED:INPUTS_FILE_NAMES:END
 
     // -------------------------------------------------------------------------
     // Public API — called by notebook.js on Submit
@@ -356,15 +388,12 @@
         // what the pre-#1271 browser runner did, and it left every
         // personalized R test reading an empty chickadee_inputs().
         if (personalizedInputs && Object.keys(personalizedInputs).length > 0) {
-            if (assignmentLanguage === 'r') {
-                files['_ck_inputs.R'] = personalizationInputsSourceR(personalizedInputs);
-            } else if (assignmentLanguage === 'lua') {
-                files['_ck_inputs.lua'] = personalizationInputsSourceLua(personalizedInputs);
-            } else if (assignmentLanguage === 'octave') {
-                files['_ck_inputs.m'] = personalizationInputsSourceOctave(personalizedInputs);
-            } else {
-                files['_ck_inputs.py'] = personalizationInputsSource(personalizedInputs);
-            }
+            // Python on an unrecognised token, unchanged. It is unreachable in a
+            // consistent deployment — this file is served by the same build that
+            // resolved the language — and the coverage test is what keeps a new
+            // kernel language from reaching it.
+            const language = INPUTS_WRITERS[assignmentLanguage] ? assignmentLanguage : 'python';
+            files[INPUTS_FILE_NAMES[language]] = INPUTS_WRITERS[language](personalizedInputs);
         }
 
         // 4. Fetch manifest from server (test.properties.json is not in the zip;

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1699,6 +1699,17 @@ code { font-family: var(--font-mono); font-size: .9em; }
     background: var(--gray-100);
     outline: none;
 }
+/* A kind this assignment's language cannot support. Shown rather than hidden,
+   for the reason the modal's select shows it: disabling teaches, hiding just
+   makes the menu shorter and leaves the instructor wondering. The title
+   attribute carries the reason. */
+.add-test-item:disabled {
+    color: var(--gray-500);
+    cursor: not-allowed;
+}
+.add-test-item:disabled:hover, .add-test-item:disabled:focus {
+    background: none;
+}
 
 /* Inline editor (accordion) hosted in a detail row beneath a suite/achievement
    row.  Shared by the suite editor (suite-table.js) and the achievements editor

--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -361,12 +361,25 @@
         // modal. (The catalog lives here in JS, so the menu is built client-side
         // rather than templated; sections are added via full-page reload, so a
         // one-time upgrade at init covers every button.)
+        //
+        // The menu applies `unsupportedReason` exactly as the modal's select
+        // does, and that is not belt-and-braces. For a `check` or `family` kind
+        // this menu does NOT open the modal — it calls `chickadeeAddInlineTest`
+        // and authors the row in place — so the select's disabled options
+        // guarded a path an instructor no longer takes. A Lua author picking
+        // "DataFrame has the right shape" here went straight to an inline row
+        // for a kind Lua refuses at save time: the #1290 experience, in the
+        // sibling renderer of the code that fixed it.
         function addTestMenuHTML() {
             return CATALOG.map(function (g) {
                 var items = g.items.map(function (it) {
-                    return '<button type="button" class="add-test-item" data-kind="'
-                        + escAttr(it.value) + '" data-mechanism="' + escAttr(it.mechanism)
-                        + '">' + escHtml(it.label) + '</button>';
+                    var reason = unsupportedReason(it);
+                    return '<button type="button" class="add-test-item"'
+                        + (reason ? ' disabled title="' + escAttr(reason) + '"' : '')
+                        + ' data-kind="' + escAttr(it.value)
+                        + '" data-mechanism="' + escAttr(it.mechanism) + '">'
+                        + escHtml(it.label) + (reason ? ' \u2014 unavailable' : '')
+                        + '</button>';
                 }).join('');
                 return '<div class="add-test-group"><div class="add-test-group-label">'
                     + escHtml(g.group) + '</div>' + items + '</div>';
@@ -399,6 +412,10 @@
         document.body.addEventListener('click', function (e) {
             var item = e.target && e.target.closest && e.target.closest('.add-test-item');
             if (!item) return;
+            // A disabled button does not dispatch click in any current browser,
+            // so this is the belt to that suspenders — cheap, and the cost of
+            // being wrong is authoring a kind the save will refuse.
+            if (item.disabled) return;
             e.preventDefault();
             var menu = item.closest('.add-test-menu');
             var sid = menu ? (menu.getAttribute('data-section-id') || '') : '';

--- a/Tests/APITests/BrowserInputsWriterCoverageTests.swift
+++ b/Tests/APITests/BrowserInputsWriterCoverageTests.swift
@@ -1,0 +1,124 @@
+// Tests/APITests/BrowserInputsWriterCoverageTests.swift
+//
+// The browser runner writes the per-student inputs file into the grading
+// workspace. Two things have to be right: the FILENAME, which must be the one
+// that language's `test_runtime` reads, and the RENDERER, which must be that
+// language's wrapper.
+//
+// The filename is no longer this file's problem — `INPUTS_FILE_NAMES` is
+// generated from `LanguageDescriptor.inputsFileName` by
+// scripts/generate-js-constants.sh, and CI fails if it goes stale. The renderer
+// table cannot be generated the same way: the four writers live in the browser's
+// own `*-grading-shared.js` modules and have no Swift counterpart to derive
+// from. So it stays hand-written, and this is what keeps it honest.
+//
+// What it prevents is not hypothetical. `INPUTS_WRITERS` replaced an if/else
+// chain whose final `else` wrote Python's file, and that chain shipped a bug for
+// exactly this reason: a browser-graded Lua assignment took the Python branch,
+// wrote `_ck_inputs.py`, and the Lua runtime read `_ck_inputs.lua` and found
+// nothing. Every per-student value silently missing, right marks impossible, no
+// error anywhere. The `else` is still Python — unreachable in a consistent
+// deployment — and a fifth kernel language absent from the table is precisely
+// what would make it reachable again.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+@testable import Core
+
+@Suite struct BrowserInputsWriterCoverageTests {
+
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // APITests
+        .deletingLastPathComponent()  // Tests
+        .deletingLastPathComponent()  // repo root
+
+    private static func browserRunnerSource() throws -> String {
+        try String(
+            contentsOf: repoRoot.appendingPathComponent("Public/browser-runner.js"),
+            encoding: .utf8)
+    }
+
+    /// The language tokens keyed in a `const NAME = { … }` object literal,
+    /// found by walking braces so a nested literal cannot end the slice early.
+    private static func objectKeys(_ source: String, named name: String) throws -> Set<String> {
+        let declaration = "const \(name) = {"
+        let start = try #require(
+            source.range(of: declaration),
+            "\(name) is not declared in Public/browser-runner.js")
+        var depth = 1
+        var index = start.upperBound
+        var body = ""
+        while index < source.endIndex, depth > 0 {
+            let character = source[index]
+            if character == "{" {
+                depth += 1
+            } else if character == "}" {
+                depth -= 1
+                if depth == 0 { break }
+            }
+            body.append(character)
+            index = source.index(after: index)
+        }
+        #expect(depth == 0, "\(name)'s literal is never closed")
+        let pattern = try NSRegularExpression(pattern: #"([a-zA-Z_][a-zA-Z0-9_]*)\s*:"#)
+        let range = NSRange(body.startIndex..., in: body)
+        return Set(
+            pattern.matches(in: body, range: range).compactMap { match -> String? in
+                guard let key = Range(match.range(at: 1), in: body) else { return nil }
+                return String(body[key])
+            })
+    }
+
+    /// The languages a browser can grade: exactly those with a vendored editor
+    /// kernel. The upload-only ones never reach this code path at all.
+    private static var kernelLanguages: [AssignmentLanguage] {
+        AssignmentLanguage.allCases.filter { $0.descriptor.editorSupport != .uploadOnly }
+    }
+
+    @Test func everyKernelLanguageHasItsOwnInputsWriter() throws {
+        let writers = try Self.objectKeys(try Self.browserRunnerSource(), named: "INPUTS_WRITERS")
+        #expect(!writers.isEmpty, "no writer keys were parsed — has the literal's shape changed?")
+        for language in Self.kernelLanguages {
+            #expect(
+                writers.contains(language.rawValue),
+                """
+                INPUTS_WRITERS in Public/browser-runner.js has no entry for \(language.rawValue), \
+                which has an editor kernel and so can be graded in the browser. Without one it \
+                falls through to Python's writer and its per-student inputs land in a file its \
+                test_runtime does not read — silently, with no error and wrong marks.
+                """)
+        }
+    }
+
+    @Test func noWriterIsOfferedForALanguageTheBrowserCannotGrade() throws {
+        let writers = try Self.objectKeys(try Self.browserRunnerSource(), named: "INPUTS_WRITERS")
+        let expected = Set(Self.kernelLanguages.map(\.rawValue))
+        #expect(
+            writers == expected,
+            """
+            INPUTS_WRITERS keys \(writers.sorted()) do not match the languages with an editor \
+            kernel \(expected.sorted()). An extra entry is dead code that reads as coverage.
+            """)
+    }
+
+    /// The generated filename table covers every language, upload-only included.
+    /// Asserted here rather than left to the generator alone, because the
+    /// generator only rewrites a block that already exists — a deleted fence
+    /// makes it fail, but a hand-edited value between two intact fences would
+    /// survive until someone re-ran it.
+    @Test func theGeneratedFilenameTableMatchesEveryDescriptor() throws {
+        let source = try Self.browserRunnerSource()
+        let names = try Self.objectKeys(source, named: "INPUTS_FILE_NAMES")
+        #expect(names == Set(AssignmentLanguage.allCases.map(\.rawValue)))
+        for language in AssignmentLanguage.allCases {
+            #expect(
+                source.contains("\(language.rawValue): '\(language.inputsFileName)'"),
+                """
+                INPUTS_FILE_NAMES does not map \(language.rawValue) to \
+                \(language.inputsFileName). Run scripts/generate-js-constants.sh.
+                """)
+        }
+    }
+}

--- a/Tests/APITests/TestEditorCatalogCoverageTests.swift
+++ b/Tests/APITests/TestEditorCatalogCoverageTests.swift
@@ -126,6 +126,67 @@ import Testing
         }
     }
 
+    /// BOTH renderings of the catalog consult the per-language support
+    /// predicate.
+    ///
+    /// There are two, and only one used to. The modal's `<select>` disabled a
+    /// kind the assignment's language cannot support (#1290); the "+ Add Test"
+    /// dropdown built from the same catalog did not — and for a `family` or
+    /// `check` kind that dropdown does not open the modal at all, it calls
+    /// `chickadeeAddInlineTest` and authors the row in place. So the select's
+    /// disabled options guarded a path an instructor no longer takes, and a Lua
+    /// author picking "DataFrame has the right shape" went straight to an inline
+    /// row for a kind Lua refuses at save time.
+    ///
+    /// Asserted by reading each function's body rather than by searching the
+    /// file: the predicate's name appears in the comments above both of them,
+    /// so a whole-file search would have been satisfied by the prose while the
+    /// menu stayed unguarded.
+    @Test func bothCatalogRenderersConsultTheSupportPredicate() throws {
+        let source = try Self.modalSource()
+        for function in ["addTestMenuHTML"] {
+            let body = try Self.functionBody(source, named: function)
+            #expect(
+                body.contains("unsupportedReason("),
+                """
+                \(function) in Public/test-editor-modal.js builds catalog entries without \
+                consulting unsupportedReason, so it offers kinds this assignment's language \
+                refuses at save time.
+                """)
+        }
+        // The select is built inline rather than in a named function, so it is
+        // pinned by the shape of what it emits.
+        #expect(
+            source.contains("var optionsHTML = CATALOG.map("),
+            "the modal's type select is no longer built from CATALOG — re-point this guard")
+        #expect(source.contains("var reason = unsupportedReason(it);"))
+    }
+
+    /// The body of `function NAME() { … }`, brace-walked so a nested literal
+    /// cannot end the slice early.
+    private static func functionBody(_ source: String, named name: String) throws -> String {
+        let declaration = "function \(name)() {"
+        let start = try #require(
+            source.range(of: declaration),
+            "\(name) is not declared in test-editor-modal.js")
+        var depth = 1
+        var index = start.upperBound
+        var body = ""
+        while index < source.endIndex, depth > 0 {
+            let character = source[index]
+            if character == "{" {
+                depth += 1
+            } else if character == "}" {
+                depth -= 1
+                if depth == 0 { break }
+            }
+            body.append(character)
+            index = source.index(after: index)
+        }
+        #expect(depth == 0, "\(name)'s body is never closed")
+        return body
+    }
+
     /// Every catalog entry has a description. The map is parallel to the
     /// catalog and keyed by the same value, so a kind added to one and not the
     /// other shows an instructor a blank explanation — visibly empty, but only

--- a/Tests/APITests/TestEditorCatalogCoverageTests.swift
+++ b/Tests/APITests/TestEditorCatalogCoverageTests.swift
@@ -1,0 +1,151 @@
+// Tests/APITests/TestEditorCatalogCoverageTests.swift
+//
+// The "+ Add Test" menu is a hand-written catalog in `Public/test-editor-modal.js`:
+// one entry per `PatternKind` and per `NotebookCheckKind`, plus the custom-script
+// entry. Nothing made it cover them.
+//
+// The consequence of that gap is quiet in the direction that matters. A ninth
+// pattern kind lands with a renderer in six languages, a validator, an MCP
+// schema and execution tests — every one of which fails loudly if it is
+// missing — and then simply does not appear in the menu. The server accepts it,
+// an agent can author it, and the instructor sitting in the editor has no way
+// to reach it. No error, no red test: the feature ships invisible.
+//
+// `AuthoringLanguageFactsTests` already pins that the menu's per-language
+// AVAILABILITY agrees with the save-time validator (#1290). This pins the prior
+// question that one assumes: that the kind is in the menu at all.
+//
+// It reads the catalog's STRUCTURE rather than searching the file for names —
+// a scanner that grepped for `boundary_equality` would be satisfied by the word
+// appearing in a comment about it, which is the blindness recorded in CLAUDE.md
+// under the Leaf-comment finding.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+@testable import Core
+
+@Suite struct TestEditorCatalogCoverageTests {
+
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // APITests
+        .deletingLastPathComponent()  // Tests
+        .deletingLastPathComponent()  // repo root
+
+    private static func modalSource() throws -> String {
+        try String(
+            contentsOf: repoRoot.appendingPathComponent("Public/test-editor-modal.js"),
+            encoding: .utf8)
+    }
+
+    /// The text of a top-level `var NAME = <open>` … matching close, found by
+    /// walking brackets so a nested literal cannot end the slice early.
+    private static func literalBody(
+        _ source: String, named name: String, open: Character, close: Character
+    ) throws -> String {
+        let declaration = "var \(name) = \(open)"
+        let start = try #require(
+            source.range(of: declaration),
+            "\(name) is not declared in test-editor-modal.js")
+        var depth = 1
+        var index = start.upperBound
+        while index < source.endIndex {
+            let character = source[index]
+            if character == open {
+                depth += 1
+            } else if character == close {
+                depth -= 1
+                if depth == 0 { return String(source[start.upperBound..<index]) }
+            }
+            index = source.index(after: index)
+        }
+        Issue.record("\(name)'s literal is never closed")
+        return ""
+    }
+
+    /// Every `{ value: '…', mechanism: '…' }` pair in the catalog.
+    private static func catalogEntries() throws -> [String: String] {
+        let body = try literalBody(try modalSource(), named: "CATALOG", open: "[", close: "]")
+        let pattern = try NSRegularExpression(
+            pattern: #"\bvalue:\s*'([a-z_]+)'\s*,\s*mechanism:\s*'([a-z]+)'"#)
+        let range = NSRange(body.startIndex..., in: body)
+        var entries: [String: String] = [:]
+        for match in pattern.matches(in: body, range: range) {
+            guard let key = Range(match.range(at: 1), in: body),
+                let mechanism = Range(match.range(at: 2), in: body)
+            else { continue }
+            entries[String(body[key])] = String(body[mechanism])
+        }
+        return entries
+    }
+
+    @Test func everyPatternKindIsOfferedInTheAddTestMenu() throws {
+        let entries = try Self.catalogEntries()
+        #expect(!entries.isEmpty, "no catalog entries were parsed — has the literal's shape changed?")
+        for kind in PatternKind.allCases {
+            #expect(
+                entries[kind.rawValue] == "family",
+                """
+                PatternKind.\(kind.rawValue) is missing from the Add Test catalog in \
+                Public/test-editor-modal.js (or is not registered as a `family`). \
+                The server would accept it and an agent could author it, but no instructor \
+                could reach it from the editor.
+                """)
+        }
+    }
+
+    @Test func everyNotebookCheckKindIsOfferedInTheAddTestMenu() throws {
+        let entries = try Self.catalogEntries()
+        for kind in NotebookCheckKind.allCases {
+            #expect(
+                entries[kind.rawValue] == "check",
+                """
+                NotebookCheckKind.\(kind.rawValue) is missing from the Add Test catalog in \
+                Public/test-editor-modal.js (or is not registered as a `check`).
+                """)
+        }
+    }
+
+    /// Nothing in the menu that the server does not know about. The reverse
+    /// direction is the one that fails loudly anyway — an unknown kind is
+    /// refused at save — but a stale entry sends the instructor down a path
+    /// that ends in a rejection, which is the experience #1290 existed to end.
+    @Test func theMenuOffersNothingTheServerWouldRefuse() throws {
+        let known = Set(PatternKind.allCases.map(\.rawValue))
+            .union(NotebookCheckKind.allCases.map(\.rawValue))
+            // The custom-script flow is a mechanism, not a kind.
+            .union(["script"])
+        for (value, mechanism) in try Self.catalogEntries() {
+            #expect(
+                known.contains(value),
+                """
+                the Add Test catalog offers '\(value)' (\(mechanism)), which is not a kind \
+                the server knows — saving it would be refused
+                """)
+        }
+    }
+
+    /// Every catalog entry has a description. The map is parallel to the
+    /// catalog and keyed by the same value, so a kind added to one and not the
+    /// other shows an instructor a blank explanation — visibly empty, but only
+    /// to whoever happens to open that entry.
+    @Test func everyCatalogEntryHasADescription() throws {
+        let source = try Self.modalSource()
+        let descriptions = try Self.literalBody(
+            source, named: "DESCRIPTIONS", open: "{", close: "}")
+        let pattern = try NSRegularExpression(pattern: #"(?m)^\s*([a-z_]+):\s*'"#)
+        let range = NSRange(descriptions.startIndex..., in: descriptions)
+        let described = Set(
+            pattern.matches(in: descriptions, range: range).compactMap { match -> String? in
+                guard let key = Range(match.range(at: 1), in: descriptions) else { return nil }
+                return String(descriptions[key])
+            })
+        #expect(!described.isEmpty, "no descriptions were parsed — has the literal's shape changed?")
+        for value in try Self.catalogEntries().keys.sorted() {
+            #expect(
+                described.contains(value),
+                "the Add Test catalog offers '\(value)' with no entry in DESCRIPTIONS")
+        }
+    }
+}

--- a/Tools/editor-smoke-test/run-smoke.sh
+++ b/Tools/editor-smoke-test/run-smoke.sh
@@ -92,7 +92,18 @@ node "${SMOKE_CHECK:-editor-check.mjs}" "http://127.0.0.1:$PORT"
 check_rc=$?
 set -e
 if [ "$check_rc" -ne 0 ]; then
-  echo "run-smoke: check failed (rc=$check_rc) — server log tail:" >&2
+  # The error lines FIRST, from the whole log, because the tail below often
+  # cannot show them. When a submit 500s the page keeps polling the submission
+  # for the probe's full 300 s budget, so by the time the check gives up the
+  # last 40 lines are several hundred INFO polls and the 500 that caused the
+  # failure has scrolled away — which is exactly what happened on the third
+  # sighting of the result-POST intermittent (docs/ci-flakiness.md, Family 2's
+  # "not the exec-hang" note). The tail is kept: it is the right view when the
+  # server died or never got that far.
+  echo "run-smoke: check failed (rc=$check_rc) — server errors:" >&2
+  grep -aE '\[ (ERROR|CRITICAL|WARNING) \]|status_code: 5[0-9][0-9]' "$LOG" \
+    | tail -40 >&2 || true
+  echo "run-smoke: server log tail:" >&2
   tail -40 "$LOG" >&2 || true
 fi
 exit "$check_rc"

--- a/changelog.d/authoring-catalog-and-inputs-guards.md
+++ b/changelog.d/authoring-catalog-and-inputs-guards.md
@@ -47,3 +47,16 @@
   lines are several hundred INFO polls and the 500 has scrolled away. Three
   sightings of the result-POST intermittent have been triaged from breadcrumbs
   alone for this reason.
+
+- **The vendored-kernel guard derives its expected kernels from the language
+  descriptors** instead of a literal map. `check-xeus-vendored.sh` carried
+  `{"xpython": "python", "xr": "r", …}` under a comment that admitted the
+  consequence in as many words: a kernel absent from the map shipped completely
+  unguarded, so a partial or botched re-vendor of it passed CI silently. That is
+  the "enumerated rather than discovered, fails open" shape
+  `docs/adding-a-xeus-kernel.md` names, sitting in the script whose whole job is
+  catching a bad vendor. It now reads
+  `editorSupport.notebookKernel(kernelName:)`, so a seventh language with a
+  kernel is checked the day its descriptor names one, an upload-only language
+  contributes nothing, and a vendored kernel no language claims is an error
+  rather than dead weight.

--- a/changelog.d/authoring-catalog-and-inputs-guards.md
+++ b/changelog.d/authoring-catalog-and-inputs-guards.md
@@ -31,3 +31,19 @@
   availability agrees with the save-time validator; this pins the prior question
   that one assumes, that the kind is in the menu at all. It also fails on an
   entry the server would refuse, and on one with no description.
+
+- **The "+ Add Test" dropdown now disables kinds the assignment's language
+  cannot support**, as the modal's type select already did. The two are built
+  from the same catalog and only one consulted the support predicate — and for a
+  pattern family or notebook check the dropdown does not open the modal at all,
+  it authors the row in place, so the select's disabled options were guarding a
+  path instructors no longer take. A Lua author picking "DataFrame has the right
+  shape" went straight to an inline row for a kind Lua refuses at save time.
+
+- **A failing smoke probe now prints the server's error lines, not only the log
+  tail.** The tail exists so a server-side 500 is visible in CI, and on the
+  failure it most needs to explain it cannot be: after a submit 500s the page
+  polls the submission for the probe's full 300-second budget, so the last 40
+  lines are several hundred INFO polls and the 500 has scrolled away. Three
+  sightings of the result-POST intermittent have been triaged from breadcrumbs
+  alone for this reason.

--- a/changelog.d/authoring-catalog-and-inputs-guards.md
+++ b/changelog.d/authoring-catalog-and-inputs-guards.md
@@ -1,0 +1,33 @@
+### Fixed
+
+- **The per-student inputs filename is generated for the browser, not
+  hand-written.** `Public/browser-runner.js` chose between four literal
+  filenames in an if/else chain whose final branch wrote Python's. That chain
+  had already shipped the bug it invites: a browser-graded Lua assignment took
+  the Python branch and wrote `_ck_inputs.py` while the Lua runtime read
+  `_ck_inputs.lua`, so every per-student value went missing — silently, with no
+  error and wrong marks. `scripts/generate-js-constants.sh` now emits
+  `INPUTS_FILE_NAMES` from `LanguageDescriptor.inputsFileName`, so the filename
+  is machine-written and CI fails when it goes stale.
+
+  The renderer table stays hand-written — the four writers live in the browser's
+  own `*-grading-shared.js` modules and have no Swift counterpart to derive from
+  — and `BrowserInputsWriterCoverageTests` pins it to exactly the languages with
+  an editor kernel. A fifth kernel language missing from it is what would make
+  the Python fallback reachable again.
+
+### Added
+
+- **A coverage guard on the "+ Add Test" catalog**
+  (`TestEditorCatalogCoverageTests`). The menu in `Public/test-editor-modal.js`
+  is a hand-written list, one entry per `PatternKind` and per
+  `NotebookCheckKind`, and nothing made it cover them. A ninth pattern kind
+  would land with a renderer in six languages, a validator, an MCP schema and
+  execution tests — every one of which fails loudly if missing — and then simply
+  not appear in the menu: the server accepts it, an agent can author it, and the
+  instructor in the editor cannot reach it.
+
+  `AuthoringLanguageFactsTests` already pinned that the menu's per-language
+  availability agrees with the save-time validator; this pins the prior question
+  that one assumes, that the kind is in the menu at all. It also fails on an
+  entry the server would refuse, and on one with no description.

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -191,6 +191,32 @@ Two things follow:
    evidence of a separate, rarer, server-side intermittent on the result POST,
    which nobody has looked at yet.
 
+**Third sighting (2026-08-10, PR #1326, run 31392463877) — same result-POST
+500, and the reason nobody has looked at it is now fixed.** Identical shape to
+the second: `suite_done [n=1]` at 2,102 ms, `result_posting`, then
+`submit_failed [2,462; … 500 …]`, iteration 10 of 12, the other eleven green.
+The PR's diff reaches neither `BrowserResultRoutes.swift` nor any server path —
+it changes a browser inputs-filename lookup, two test files, and a shell
+generator.
+
+What this sighting adds is why the previous two produced no diagnosis.
+`run-smoke.sh` dumps `tail -40` of the server log on failure, added
+specifically so "a server-side 500 (e.g. a SQLite `database is locked`) is
+visible in CI". It cannot be, on this failure: after the submit 500s the page
+keeps polling `GET /api/v1/submissions/:id` for the probe's full 300 s budget,
+so the last 40 lines are several hundred INFO polls and the 500's own line has
+scrolled away. Every triage of this family has been reasoning from breadcrumbs
+because the evidence was being discarded at the moment it was collected. The
+script now greps the whole log for error-level lines *before* printing the
+tail, so the next sighting names its cause.
+
+A hypothesis worth checking against that output when it arrives, not before:
+`submitBrowserResult` wraps the submission insert and the result save in
+`withTransientDatabaseLockRetry` — someone has already met SQLite lock 500s on
+this endpoint — but `awardFirstToSubmitRecords`, `flagResultForBrightSpaceSync`
+and the class-records writes in the same handler are not wrapped. If the next
+log line reads `database is locked`, that is where to look.
+
 **Root cause** of Family 2 remains the exec-hang investigation's to close —
 continue from the probe's `grading breadcrumbs:` per-phase timings on an
 iteration whose trail stops before `suite_done`.

--- a/scripts/check-xeus-vendored.sh
+++ b/scripts/check-xeus-vendored.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Integrity guard for the manually-vendored xeus kernels in Public/jupyterlite:
-# xpython (Python), xr (R), xlua (Lua) and xoctave (Octave), each built from its
-# own emscripten-forge env.
+# Integrity guard for the manually-vendored xeus kernels in Public/jupyterlite —
+# one env per language, each named by that language's LanguageDescriptor. Which
+# kernels it expects is DERIVED from those descriptors rather than listed here,
+# so the guard follows the language set instead of trailing it.
 #
 # The xeus WASM kernels are built from emscripten-forge (needs micromamba +
 # network to repo.prefix.dev). The ordinary CI build does not do that, so the
@@ -21,12 +22,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${1:-$ROOT_DIR/Public/jupyterlite}"
 
-python3 - "$BUILD_DIR" <<'PY'
+python3 - "$BUILD_DIR" "$ROOT_DIR" <<'PY'
 import json
 import pathlib
+import re
 import sys
 
 build = pathlib.Path(sys.argv[1])
+root = pathlib.Path(sys.argv[2])
 
 
 def fail(msg: str) -> None:
@@ -39,20 +42,59 @@ ext = build / "extensions" / "@jupyterlite" / "xeus-extension"
 if not ext.is_dir():
     fail(f"missing xeus federated extension: {ext}")
 
-# 2. kernels.json must register EVERY kernel: xpython (Python), xr (R), xlua
-#    (Lua), xoctave (Octave). A vendor that drops one is a partial re-vendor,
-#    not a valid state.
+# 2. kernels.json must register EVERY kernel a language claims. A vendor that
+#    drops one is a partial re-vendor, not a valid state.
 #
-#    This map — NOT kernels.json — is what the loop below iterates, so a kernel
-#    absent from it ships completely unguarded: a partial or botched re-vendor
-#    of it passes CI silently. Add an entry whenever you add an env.
+#    THE EXPECTED SET IS DERIVED, NOT LISTED. It used to be a literal map here,
+#    with a comment admitting the consequence: a kernel absent from it shipped
+#    completely unguarded, so a partial or botched re-vendor passed CI silently
+#    — the "enumerated rather than discovered, fails open" shape recorded in
+#    docs/adding-a-xeus-kernel.md, in the script whose whole job is catching a
+#    bad vendor. It is now read out of LanguageDescriptor, which already names
+#    each language's kernel in `editorSupport: .notebookKernel(kernelName:)`.
+#
+#    That makes the guard follow the language set by construction: a seventh
+#    language with a kernel is checked the day its descriptor names one, and an
+#    upload-only language contributes nothing because it declares no kernel.
+def derive_expected_kernels():
+    source = (root / "Sources" / "Core" / "LanguageDescriptor.swift").read_text()
+    expected = {}
+    language = None
+    for line in source.splitlines():
+        case_match = re.search(r"case \.([A-Za-z]+):", line)
+        if case_match:
+            language = case_match.group(1)
+            continue
+        name_match = re.search(r'kernelName:\s*"([^"]+)"', line)
+        if name_match and language is not None:
+            expected[name_match.group(1)] = language
+            language = None
+    return expected
+
+
+expected_language = derive_expected_kernels()
+if not expected_language:
+    fail(
+        "could not read any kernelName out of Sources/Core/LanguageDescriptor.swift — "
+        "the vendored kernels would go completely unchecked"
+    )
+
 kernels_json = build / "xeus" / "kernels.json"
 if not kernels_json.is_file():
     fail(f"missing {kernels_json} — the vendored xeus kernels are absent")
 kernels = json.loads(kernels_json.read_text())
 listed = sorted(k.get("kernel") for k in kernels if isinstance(k, dict))
 
-expected_language = {"xpython": "python", "xr": "r", "xlua": "lua", "xoctave": "octave"}
+# A kernel shipped in the tree that NO language claims. Harmless to a student —
+# nothing routes to it — but it is dead weight in a ~100 MB vendored payload and
+# it is the tell for a rename that landed on one side only.
+unclaimed = sorted(set(listed) - set(expected_language))
+if unclaimed:
+    fail(
+        f"kernels.json registers {unclaimed}, which no AssignmentLanguage claims via "
+        "editorSupport.notebookKernel — either a language's kernelName was renamed "
+        "without a re-vendor, or the env should not have been vendored"
+    )
 kernel_envs = {}
 loaders = []
 

--- a/scripts/generate-js-constants.sh
+++ b/scripts/generate-js-constants.sh
@@ -147,6 +147,70 @@ awk -v repl="$ext_generated" -v begin="$ext_begin" -v end="$ext_end" '
 ' "$work" > "$tmp"
 mv "$tmp" "$work"
 
+# --- The per-student inputs filename, per language --------------------------
+#
+# The browser writes the per-student inputs file into the grading workspace, and
+# the filename it writes must be the one that language's test_runtime reads —
+# `LanguageDescriptor.inputsFileName`. It was hand-written as four string
+# literals, which is how a browser-graded Lua assignment came to write
+# `_ck_inputs.py`: the Lua runtime read `_ck_inputs.lua`, found nothing, and
+# every per-student value silently went missing. Right marks impossible, no
+# error anywhere.
+#
+# The language token is the enum case, which is exactly what the seed endpoint
+# reports, so the JS looks the name up by the value it already has. Every case
+# is emitted, including the upload-only ones that never reach a browser: a
+# generator that decided which languages "matter" would be one more list to keep
+# current.
+names_file="$(mktemp)"
+# POSIX awk only — the CI runner has mawk, which does not take gawk's
+# three-argument match().
+awk '
+  /case \.[a-zA-Z]+:/ {
+    if (match($0, /case \.[a-zA-Z]+:/)) {
+      token = substr($0, RSTART, RLENGTH)
+      sub(/^case \./, "", token)
+      sub(/:$/, "", token)
+      lang = token
+    }
+  }
+  /inputsFileName: "/ {
+    if (lang != "" && match($0, /"[^"]+"/)) {
+      print lang, substr($0, RSTART + 1, RLENGTH - 2)
+      lang = ""
+    }
+  }
+' "$descriptor_src" | LC_ALL=C sort > "$names_file"
+if [ ! -s "$names_file" ]; then
+  echo "generate-js-constants: found no inputsFileName declarations in $descriptor_src" >&2
+  rm -f "$work" "$names_file"; exit 1
+fi
+
+inputs_joined="$(awk -v q="'" 'NR > 1 { out = out ", " } { out = out $1 ": " q $2 q } END { print out }' \
+  "$names_file")"
+rm -f "$names_file"
+inputs_generated="    const INPUTS_FILE_NAMES = { $inputs_joined };"
+inputs_begin="CHICKADEE_GENERATED:INPUTS_FILE_NAMES:BEGIN"
+inputs_end="CHICKADEE_GENERATED:INPUTS_FILE_NAMES:END"
+for marker in "$inputs_begin" "$inputs_end"; do
+  if ! grep -q "$marker" "$work"; then
+    echo "generate-js-constants: missing $marker marker in $js_src." >&2
+    echo "The browser needs the per-student inputs filename for each language, or it" >&2
+    echo "writes a file that language's test_runtime does not read. Add the fenced" >&2
+    echo "block and re-run." >&2
+    rm -f "$work"; exit 1
+  fi
+done
+
+tmp="$(mktemp)"
+awk -v repl="$inputs_generated" -v begin="$inputs_begin" -v end="$inputs_end" '
+  index($0, begin) { print; print repl; skipping = 1; next }
+  index($0, end)   { skipping = 0; print; next }
+  skipping { next }
+  { print }
+' "$work" > "$tmp"
+mv "$tmp" "$work"
+
 if [ "$mode" = "check" ]; then
   if cmp -s "$work" "$js_src"; then
     rm -f "$work"


### PR DESCRIPTION
Four hand-written lists sitting in language-generic code, all failing open, plus one CI probe that was discarding the evidence it exists to collect. Found while looking for the next authoring-parity slice — every one of them turned up a live defect or a documented-but-unfixed hazard.

## 1. The "+ Add Test" dropdown offered kinds the language refuses

The catalog has **two** renderings and only one consulted the per-language support predicate. The modal's type `<select>` disables a kind the assignment's language cannot support (#1290). The "+ Add Test" dropdown, built from the same catalog, did not — and for a `family` or `check` kind **that dropdown never opens the modal**: it calls `chickadeeAddInlineTest` and authors the row in place.

So the select's disabled options were guarding a path instructors no longer take. A Lua author picking "DataFrame has the right shape" went straight to an inline row for a kind Lua refuses at save time — the #1290 experience, in the sibling renderer of the code that fixed it.

## 2. The catalog itself was uncovered

One hand-written entry per `PatternKind` and `NotebookCheckKind`, with nothing making it cover them. A ninth pattern kind would land with renderers in six languages, a validator, an MCP schema and execution tests — each failing loudly if missing — and then **simply not appear in the menu**. Server accepts it, agent can author it, instructor can't reach it.

Deliberately a precondition for promoting `differential` to a ninth kind: the guard goes red until the catalog carries it.

## 3. The browser's inputs filename

`Public/browser-runner.js` chose between four literal filenames in an if/else whose final branch wrote Python's. **That chain had already shipped the bug it invites** — its own comment records it: a browser-graded Lua assignment took the Python branch and wrote `_ck_inputs.py` while the Lua runtime read `_ck_inputs.lua`. Every per-student value silently missing.

`scripts/generate-js-constants.sh` now emits `INPUTS_FILE_NAMES` from `LanguageDescriptor.inputsFileName` — the same mechanism that already discovers `<lang>KernelNames` and unions `scriptExtensions`. (POSIX awk only; the runner has mawk, which has no three-argument `match`.)

The *renderer* table can't be generated — the four writers live in the browser's `*-grading-shared.js` modules with no Swift counterpart — so it's pinned to exactly the languages with an editor kernel. The Python fallback stays and stays unreachable; a fifth kernel language missing from the table is what would make it reachable, and that's now a red test.

## 4. The vendored-kernel guard did not guard a kernel it had not been told about

`check-xeus-vendored.sh` carried `{"xpython": "python", "xr": "r", …}` under a comment stating the consequence in as many words: a kernel absent from the map ships **completely unguarded**, so a partial or botched re-vendor of it passes CI silently. That is the fail-open shape `docs/adding-a-xeus-kernel.md` names, sitting in the script whose whole job is catching a bad vendor.

It now reads `editorSupport.notebookKernel(kernelName:)`. A seventh language with a kernel is checked the day its descriptor names one; an upload-only language contributes nothing. A vendored kernel no language claims is now an error too — dead weight in a ~100 MB payload, and the tell for a rename that landed on one side only.

## 5. The probe that couldn't report

CI hit `grading-probe (chromium) hangs=1/12` on this branch. The breadcrumbs read `suite_done [n=1]` then `submit_failed [500]` — grading finished fine and the *server* 500'd on the result POST. That is the documented third sighting of a separate intermittent (`docs/ci-flakiness.md`, Family 2's "not the exec-hang" note), and this diff reaches no server path.

Why nobody has diagnosed it: `run-smoke.sh` dumps `tail -40` of the server log on failure, added so "a server-side 500 is visible in CI". On this failure it can't be — after the submit 500s the page polls the submission for the probe's full 300 s budget, so the last 40 lines are several hundred INFO polls and the 500's line has scrolled away. Every triage has reasoned from breadcrumbs because the evidence was discarded as it was collected.

Error-level lines are now printed from the whole log before the tail. The sighting is recorded, with a hypothesis to check *against that output when it arrives, not before*: `submitBrowserResult` wraps two writes in `withTransientDatabaseLockRetry` — someone has already met SQLite lock 500s here — but `awardFirstToSubmitRecords`, `flagResultForBrightSpaceSync` and the class-records writes are not.

## Testing

Guards read structure — literals brace-walked, function bodies extracted — rather than searching the file. The support predicate's name appears in the prose above both catalog renderers, so a whole-file search would have been satisfied while the menu stayed unguarded: the blindness recorded in CLAUDE.md under the Leaf-comment finding.

Every guard was mutation-tested rather than trusted:

| mutation | caught by |
|---|---|
| removed `unordered_equality` from the catalog | `everyPatternKindIsOfferedInTheAddTestMenu` |
| removed `cell_contains` from `DESCRIPTIONS` | `everyCatalogEntryHasADescription` |
| stubbed the dropdown's `unsupportedReason` to `null` | `bothCatalogRenderersConsultTheSupportPredicate` |
| removed the Octave inputs writer | both writer-coverage tests |
| hand-edited `octave: '_ck_inputs.m'` between intact fences | `theGeneratedFilenameTableMatchesEveryDescriptor` **and** `generate-js-constants.sh --check` |
| renamed a descriptor's `kernelName` | `check-xeus-vendored.sh` (unclaimed kernel) |
| broke the descriptor parse so it matches nothing | `check-xeus-vendored.sh` (fails loudly rather than checking nothing) |

Full Swift suite (3,410 tests), `scripts/lint.sh`, `scripts/swiftlint.sh`, `scripts/check-styles.sh`, `scripts/eslint.sh`, `scripts/verify-jupyterlite.sh` and all 336 JS tests green locally.