### PR TITLE
Freeze investigation follow-up: 58s-anchored stall is a distinct environmental mechanism

### DIFF
--- a/Tools/editor-smoke-test/freeze-trace-check.mjs
+++ b/Tools/editor-smoke-test/freeze-trace-check.mjs
@@ -78,6 +78,47 @@ async function buildSetupZip() {
   const zip = new JSZip();
   const code = (src) => ({ cell_type: "code", source: [src], metadata: {}, outputs: [], execution_count: null });
   const md = (src) => ({ cell_type: "markdown", source: [src], metadata: {} });
+  // FREEZE_BIG_NOTEBOOK=1: approximate a real end-of-term lab document — many
+  // cells with chunky SAVED outputs (streams, HTML tables, a base64 image),
+  // so document-size-scaled work (serialization, whole-notebook scans, full
+  // reflows) costs what it costs in production, without running anything.
+  if (process.env.FREEZE_BIG_NOTEBOOK === "1") {
+    const cells = [md("## Practice lab — reopened with saved outputs\n")];
+    const fakePng = "iVBORw0KGgoAAAANSUhEUg" + "A".repeat(60_000) + "==";
+    const tableRows = Array.from({ length: 300 }, (_, r) =>
+      `<tr><td>${r}</td><td>${(r * 1.37).toFixed(2)}</td><td>${(r % 7)}</td><td>c${r}</td></tr>`).join("");
+    for (let i = 0; i < 45; i++) {
+      const outputs = [];
+      outputs.push({ output_type: "stream", name: "stdout", text: [`step ${i}\n`.repeat(40)] });
+      if (i % 3 === 0) {
+        outputs.push({
+          output_type: "execute_result", execution_count: i + 1, metadata: {},
+          data: { "text/html": [`<table>${tableRows}</table>`], "text/plain": ["<table>"] },
+        });
+      }
+      if (i % 5 === 0) {
+        outputs.push({
+          output_type: "display_data", metadata: {},
+          data: { "image/png": fakePng, "text/plain": ["<Figure>"] },
+        });
+      }
+      cells.push({
+        cell_type: "code",
+        source: [`x${i} = ${i} * 2\nprint('step ${i}')\n`],
+        metadata: {}, outputs, execution_count: i + 1,
+      });
+    }
+    zip.file(
+      "assignment.ipynb",
+      JSON.stringify({
+        nbformat: 4, nbformat_minor: 5,
+        metadata: { kernelspec: { name: "python", display_name: "Python" } },
+        cells,
+      })
+    );
+    zip.file("test_public.py", 'print("public test ok")\n');
+    return zip.generateAsync({ type: "nodebuffer" });
+  }
   const cells = [
     md("## Blood pressure lab\n"),
     code("import numpy as np\nimport pandas as pd\nimport matplotlib.pyplot as plt\n"),

--- a/changelog.d/freeze-tracer-followup.md
+++ b/changelog.d/freeze-tracer-followup.md
@@ -1,0 +1,3 @@
+### Added
+
+- **The freeze tracer can seed a large reopened-lab notebook (`FREEZE_BIG_NOTEBOOK=1`).** Forty-five cells with chunky saved outputs (streams, HTML tables, a base64 figure, ~1.5 MB total), so document-size-scaled work costs what it costs in production without executing anything. Used to clear the page's own JavaScript of the 58 s-anchored `page_unresponsive` stalls that persisted on the fixed build — `docs/browser-freeze-investigation.md` records the follow-up: that stall is a second, distinct, client-environmental mechanism (same ±1 s anchor across pre- and post-fix builds; quiet main thread at the 58 s mark in four instrumented environments), self-recovering and affecting no submission.

--- a/docs/browser-freeze-investigation.md
+++ b/docs/browser-freeze-investigation.md
@@ -153,6 +153,45 @@ step is a frame-global queue that batches all reads before all writes — not
 done now, because 0.56 s at laptop-equivalent throttle sits ~14x under the
 8 s watchdog line.
 
+## Follow-up, same evening: the 58 s-anchored stall is a second, distinct mechanism
+
+The mitigation's effects were visible in production within hours (zero
+`kernel_error` rows and zero `below_matrix` warnings across the post-deploy
+editor loads, run-all sessions clean). But an evening burst of 12
+`page_unresponsive` beacons arrived on the FIXED build — spread one per
+session across many review labs on exam eve, stopping after ~2 h. A recovered
+sample reads `stalled_ms=8832` at 58.8 s after `boot_start`: the same ±1 s
+anchor as the pre-fix events. Five production stalls across pre-fix and
+post-fix builds now share that anchor — too synchronized to be student-paced
+activity, and NOT explained by the run-all rendering stall (which struck at
+whatever moment the heavy cells executed).
+
+Hunting it directly came back clean: a 45-cell, ~1.5 MB saved-output notebook
+(`FREEZE_BIG_NOTEBOOK=1`), 6x CPU throttle, no run-all, a 100 ms report
+threshold, watched 186 s from load — worst main-thread task 0.12 s, nothing at
+all near t=58 s, no heartbeat gaps. That is the fourth instrumented
+environment (idle-small, run-all-small twice, idle-big) in which the page's
+own JavaScript is quiet at the 58 s mark, and the vendored bundles contain no
+40–55 s timer (the only `interval:` constants are the two exonerated 61 s
+polls, measured at ~1 ms).
+
+Working conclusion: the 58 s-anchored stall is client-environmental — a
+fixed-offset-from-load cost on struggling student machines that a clean
+container cannot reproduce. Candidates that fit the shape (Chromium-skewed,
+fixed offset, machine-dependent): antivirus scanning the ~85 MB of kernel-env
+bytes the browser writes to storage right after boot, memory-pressure/swap on
+loaded laptops, or extension DOM scans. The affected cohort's kernel boots
+ran 10–33 s that evening (5–20x the container), consistent with machines
+under duress. Every stall self-recovered; no funnel or submission was
+affected.
+
+If the beacons persist at a rate that matters, the next lever is to make
+production name the culprit itself: Chromium's JS Self-Profiling API can run a
+low-overhead sampler on the student page and attach the stall window's hot
+frames to a follow-up diagnostic when the freeze watchdog's heartbeat
+resumes — one occurrence would then settle whether it is page code, an
+extension, GC, or IO.
+
 ## If it comes back
 
 `page_unresponsive` beacons carry the page-build version; check byAppVersion
@@ -165,12 +204,14 @@ SMOKE_CHECK=freeze-trace-check.mjs ./run-smoke.sh
 ```
 
 Knobs: `FREEZE_THROTTLE` (default 3x), `FREEZE_WATCH_MS` (default 150 s),
-`FREEZE_RUN_ALL=0` to watch an idle editor, `FREEZE_STALL_MS` for the
+`FREEZE_RUN_ALL=0` to watch an idle editor, `FREEZE_BIG_NOTEBOOK=1` to seed a
+large reopened-lab notebook with saved outputs, `FREEZE_STALL_MS` for the
 long-task report threshold. It prints long tasks with attribution, heartbeat
 gaps, any real watchdog beacons, and the dominant profile stacks inside each
 stall, and saves the raw `.cpuprofile`.
 
-Residual candidates the mitigation does not cover: genuine memory-pressure
-freezes on low-RAM machines with several kernel tabs (the preflight low-memory
-hint and the wasm-crash recovery own that), and any future upstream regression
-of the same shape — which now has a named tracer pointed at it.
+Residual candidates the mitigation does not cover: the 58 s-anchored
+environmental stall above, genuine memory-pressure freezes on low-RAM
+machines with several kernel tabs (the preflight low-memory hint and the
+wasm-crash recovery own that), and any future upstream regression of the same
+shape — which now has a named tracer pointed at it.


### PR DESCRIPTION
Documentation + tracer follow-up to #1328, from the evening's telemetry on the fixed build.

## What happened after the deploy

The #1328 mitigations verified cleanly in production (zero `kernel_error` rows and zero `below_matrix` warnings across post-deploy loads; run-all sessions clean). But an evening burst of 12 `page_unresponsive` beacons arrived **on the fixed build** — one per session across many exam-eve review labs, stopping after ~2h. A recovered sample reads `stalled_ms=8832` at **58.8s after `boot_start`** — the same ±1s anchor as the pre-fix events. Five production stalls across pre- and post-fix builds now share that anchor, which is too synchronized to be student-paced activity and is not explained by the run-all rendering stall #1328 fixed (that one struck whenever the heavy cells happened to execute).

## What this PR adds

- **`FREEZE_BIG_NOTEBOOK=1` mode for the freeze tracer** — seeds a 45-cell, ~1.5MB reopened-lab notebook with chunky *saved* outputs (streams, HTML tables, a base64 figure), so document-size-scaled work costs what it costs in production without executing anything.
- **The investigation doc records the follow-up hunt and conclusion.** Running that mode at 6x throttle with no run-all and a 100ms report threshold, watched 186s from load: worst main-thread task **0.12s**, nothing at the 58s mark, no heartbeat gaps — the fourth instrumented environment to clear the page's own JavaScript, while the vendored bundles contain no 40–55s timer (the only `interval:` constants are the two 61s polls, measured at ~1ms). Working conclusion: the 58s-anchored stall is client-environmental (candidates that fit the Chromium-skew and fixed offset: antivirus scanning the ~85MB post-boot kernel-env write-back, memory pressure/swap, extension DOM scans; the affected cohort's kernel boots ran 10–33s that evening, 5–20x the container). Every stall self-recovered; no funnel or submission was affected. The doc also names the next lever if the rate ever matters: a JS Self-Profiling beacon that attaches the stall window's hot frames to a follow-up diagnostic, so one occurrence settles the question.

No production code changes — tracer + docs + a changelog fragment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqD3BP869mrJ9G52C1ubQ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqD3BP869mrJ9G52C1ubQ8)_