### PR TITLE
fix(language): refuse when authoring needs a language the author never declared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,12 +273,19 @@ Python-only check kind.
 enforces it in `format-lint`. Seventeen did, which is what made the two #1330
 defects possible. A caller that means Python says so.
 
-The transition is not finished: fourteen `?? .python` sites remain, and they are
-a different question from resolution — "this operation needs a language and the
-assignment declares none". See
-[docs/language-declaration.md](docs/language-declaration.md) for the state, the
-per-site split, and the rule that decides them (fail loudly while authoring,
-never while grading). Also `docs/r-support.md`.
+The `?? .python` sites that remain are a different question from resolution —
+"this operation needs a language and the assignment declares none" — and are
+settled by one rule: **fail loudly while authoring, never while grading,
+rendering a page, or extracting a student's submission.** An instructor can fix
+a missing declaration in seconds; a student cannot fix it at all. So generating
+a test, storing an `=` expression, and checking a solution file's extension all
+refuse on a declared-None assignment, while extraction, literal rendering,
+notebook scaffolding and the two display paths keep a locally-stated default.
+Corollary worth knowing: `makeWorkerManifestJSON` writes a **fresh dict**, so
+every rebuild must thread `language` *and* `languageDeclared` — carrying only
+the language turns a deliberate "None" back into "nobody has been asked". See
+[docs/language-declaration.md](docs/language-declaration.md) for the per-site
+table. Also `docs/r-support.md`.
 
 **A runner only claims a job it can actually grade — enforced, not authored
 (`RunnerLanguageGate`).** Runners are separate hosts that upgrade on their own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,23 +230,55 @@ and `racket --version`'s letter-led `v8.10` defeating the runner's version parse
 — are fixed, each with an `allCases` guard; a Racket assignment still needs a
 runner new enough to carry both. See `docs/multi-language-audit.md`.
 
-**Assignments are Python, R, Lua, Octave, C++ *or* Racket; language is first-class (`AssignmentLanguage`).**
-`AssignmentLanguage` (`.python | .r | .lua | .octave | .cpp | .racket`, Core) is resolved from the manifest
-(any `.R` graded script → `.r`, any `.lua` → `.lua`, any `.m` → `.octave`; else
-a notebook kernel in that language's `notebookKernelNames` — `{ir,r,webr,xr}`
-for R, `{xlua,lua}` for Lua, `{xoctave,octave}` for Octave; else `.python`) and every language-specific path dispatches through it — literal
+**Every assignment DECLARES its language. Nothing infers one (v0.5.59, #1331).**
+`AssignmentLanguage` (`.python | .r | .lua | .octave | .cpp | .racket`, Core) is
+read from the manifest and nowhere else: `resolve(manifest:)` returns
+`manifest.language`, full stop. Declaration is a **requirement**, and every door
+that creates an assignment enforces it — the web create page's `required`
+language select (with an explicit "None"), MCP `create_assignment`'s required
+`language`, `POST /api/v1/testsetups`, and course-bundle import.
+`BackfillDeclaredLanguage` answered it for everything that predates the rule, so
+`languageDeclared` is true everywhere and a **nil language means the author said
+"none"** — a plain `.sh` suite — never "nobody has been asked".
+
+Resolution used to sniff: a `.R` graded script, else a notebook kernel, else
+`.python`. That made "the author chose Python" and "we guessed from a `.py`
+file" the same answer, and every silent misroute in the multi-language arc
+descended from it — a Lua assignment resolving to Python, an R author's first
+`=` expression sent to `python3`, a browser writing `_ck_inputs.py` for an R
+runtime. **Do not reintroduce inference.** If a call site does not know the
+language, the answer is to ask the author, not to guess.
+
+Derivation survives in exactly one place, deliberately not called `resolve`:
+`AssignmentLanguage.derivedDeclaration` runs at the three boundaries where
+content arrives with no author answer (the REST zip upload, bundle import, the
+backfill) and each records the result immediately. It is a boundary step, not a
+resolution strategy. `rederive` is gone: a declaration does not go stale when
+content changes, so replacing a starter notebook no longer rewrites the language
+underneath the author.
+
+Every language-specific path dispatches on the declared value — literal
 rendering (`pythonLiteral`/`rLiteral`), the per-student inputs file
 (`_ck_inputs.py`/`_ck_inputs.R` via `renderInputsFile`), and the expression
 driver. Personalization is evaluated **per-language on the server**:
 `PersonalizationEvaluator` spawns `python3`, `Rscript`, `lua` or `octave-cli`
 (all on the server image), preserving the property that expression source +
-the solution never reach the runner. Base R has no bignum, so the seed is a deterministic
-Horner-fold reduction (`RPersonalizationRuntime.chickadeeSeedRSource`, shared by
-the server driver and the grading runtime so they never drift). The default is
-`.python` at every call site, so existing Python bytes are byte-for-byte
-unchanged. R pattern-family / notebook-check renderers and literal-globals
-inlined into hand-authored `.R` scripts shipped in #1207 (v0.4.636);
-`astStructure` remains the one Python-only check kind. See `docs/r-support.md`.
+the solution never reach the runner. Base R has no bignum, so the seed is a
+deterministic Horner-fold reduction
+(`RPersonalizationRuntime.chickadeeSeedRSource`, shared by the server driver and
+the grading runtime so they never drift). `astStructure` remains the one
+Python-only check kind.
+
+**No function may default a `language:` parameter** — `scripts/no-language-defaults.sh`
+enforces it in `format-lint`. Seventeen did, which is what made the two #1330
+defects possible. A caller that means Python says so.
+
+The transition is not finished: fourteen `?? .python` sites remain, and they are
+a different question from resolution — "this operation needs a language and the
+assignment declares none". See
+[docs/language-declaration.md](docs/language-declaration.md) for the state, the
+per-site split, and the rule that decides them (fail loudly while authoring,
+never while grading). Also `docs/r-support.md`.
 
 **A runner only claims a job it can actually grade — enforced, not authored
 (`RunnerLanguageGate`).** Runners are separate hosts that upgrade on their own
@@ -1346,6 +1378,7 @@ shim); and archived finished-era docs under `docs/archive/`.
 - `docs/adding-a-xeus-kernel.md` — runbook for teaching Chickadee another in-browser language: which xeus kernels exist on emscripten-forge (with sizes and xeus-ABI pins), why availability is not the same as working, the browser-half steps and the check that proves each, the traps that have cost a day each, and where the irreducible per-language work begins — plus "What the Lua run actually cost", the measured postmortem of doing it once (what held, and which of R's expensive lessons turned out to be xeus-r properties that do not generalise). Now covers BOTH halves end to end: the 27 compiler-named switch arms across 17 files, the **nine** the compiler cannot see (the fifth being boolean sniffs like `isRNotebook(nb) ? .r : .python`, which type-check forever and route the new language to Python; the sixth runner capability matching, which fails in both directions and whose worse direction queues an assignment's jobs forever; the seventh the submission policy; the ninth whether the generated scripts DISPATCH at all, which the RunnerCore/Core dependency direction means the compiler probably never will see), the authoring-UI section that exists to stop you working (a seventh language needs ZERO JavaScript edits, and the failure mode is going to look for one), the browser half's own checklist, the one judgement (`moduleResolution`) that replaced three and the scorecard that sized it against Octave/Java/C++ — including the two axes the model cannot see (interpreted-vs-compiled, and dynamically-vs-statically-typed literals) and the reframe that a language need not be an `AssignmentLanguage` to be graded at all, the submission-guarantee policy (a policy value with named exemptions rather than a protocol, because a protocol makes opting out invisible), and a done test that requires the generated code be executed rather than parsed. Extended after the in-page auto-compute and `differential` work: the eval-worker half a kernel language also owes the editor (renderer → snippets → worker → smoke row → and only THEN the descriptor, because a descriptor naming a worker that does not exist makes the editor spawn a 404 silently), a per-kernel eval-quirk table (each of the three kernels needed a different shape rule and none inherited its neighbour's), the per-language literal traps (three of four are a null-ish value silently changing a container's length, and all three needed different rules), and a **parity checklist** separating what a seventh language now gets free from `allCases` — all 9 pattern kinds, both Add Test renderings, the authoring UI, the whole MCP surface, the browser inputs filename, the vendoring guard — from the four things that remain genuinely per-language
 - `docs/kernel-boot-cost.md` — what a kernel boot costs, measured per package and per environment; the failure-driven on-demand install design and why predicting the package set cannot work; why cross-user caching is unavailable; why the editor is deliberately excluded
 - `docs/r-support.md` — first-class R support: `AssignmentLanguage` resolution + strategy, per-language personalization (`Rscript` expression driver, base-R `chickadee_seed()`, `_ck_inputs.R` delivery, R-literal notebook substitution), the R grading runtime, and the R renderers for pattern families / notebook checks (#1207; `astStructure` stays Python-only)
+- `docs/language-declaration.md` — where the multi-language transition stands: language is **declared, not inferred** (`resolve(manifest:)` reads `manifest.language` and nothing else; nil means the author said "none", not "nobody has been asked"), the four doors that declare and the one boundary that still derives (`derivedDeclaration`, three callers, each recording immediately), what was deleted and why each deleted shape was compiler-invisible, and a per-site table of the fourteen remaining `?? .python` fallbacks split by the rule that decides them — fail loudly while authoring, never while grading, rendering, or extracting a student's submission
 - `docs/language-handling-review.md` — second-opinion design review of the assignment-language dispatch surface: verdicts on R extraction in RunnerCore, the Swift↔JS drift-guard hierarchy, the resolution API surface, the third-language census, and process rules. Written before Lua existed, so §4's prediction is now **scored against the real third language** — what held (bucket A never changed; every bucket-B site failed to compile) and what did not (the compiler-invisible surface is a recurring shape, not a checklist)
 - `docs/multi-course-roles.md` — per-course roles design (#417 arc): enrollment-row `CourseRole`, gates, staff invites
 - `docs/assignment-versioning.md` — content version history: snapshot capture, read/restore, lifecycle

--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -264,6 +264,36 @@ let languageChangeAfterGenerationMessage =
     + "extension. Declare the language before authoring pattern families or notebook checks, or "
     + "delete the generated families/checks first."
 
+/// Refusal for a save that would GENERATE a test script on an assignment whose
+/// author declared no language.
+///
+/// A generated script is written in a language, so this question cannot answer
+/// "none" the way resolution can. The old behaviour rendered Python, justified
+/// by a circularity that only existed while the language was inferred from
+/// content ("a family is often the first thing authored, so there is no graded
+/// script to sniff yet"). Every door that creates an assignment declares now,
+/// so nil means the author chose None and there is nothing to wait for.
+///
+/// Deliberately an authoring-time refusal. Nothing on the grading path refuses
+/// for want of a declaration: an instructor can fix this from the dropdown, and
+/// a student cannot fix it at all.
+let undeclaredLanguageGenerationMessage =
+    "This assignment declares no language, so there is no syntax to generate a test in. "
+    + "Set the assignment's language before adding pattern families or notebook checks — "
+    + "an assignment set to \"None\" can hold hand-written shell scripts only."
+
+/// Refusal for a save that would store a per-student `=` expression on an
+/// assignment whose author declared no language.
+///
+/// Same rule as `undeclaredLanguageGenerationMessage`, one step further out: an
+/// expression is source code, so it needs a language the way a generated script
+/// does. The refusal lives on the save; notebook substitution at student
+/// first-open keeps its stated default and never refuses.
+let undeclaredLanguageExpressionMessage =
+    "This assignment declares no language, so a per-student `=` expression has no interpreter "
+    + "to run in. Set the assignment's language before adding expressions — literal variables "
+    + "work without one."
+
 /// Reads the `submissionMode` field straight from a manifest JSON string,
 /// defaulting to "notebook" (TestProperties' own default) when the field is
 /// absent or the manifest can't be parsed.

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -162,25 +162,24 @@ struct UpdateSolutionTool: ContentTool {
         // language, not by the caller's preference: a language with no notebook
         // workflow has no `.ipynb` to extract source from, so a notebook
         // solution would be stored and then grade as an empty submission.
-        // An assignment with no language signal keeps the notebook workflow:
-        // only `.uploadOnly` languages need a source file, and nothing that has
-        // not named itself is upload-only.
-        let language =
-            setup?.decodedManifest().flatMap {
-                AssignmentLanguage.resolve(manifest: $0)
-            } ?? .python
-        let wantsSourceFile: Bool
-        if case .uploadOnly = language.editorSupport {
-            wantsSourceFile = true
-        } else {
-            wantsSourceFile = false
+        // An assignment that declares no language keeps the notebook workflow:
+        // only `.uploadOnly` languages need a source file, and a declaration of
+        // "none" is not upload-only. So the question is answered WITHOUT a
+        // fallback — this used to read `?? .python`, which named a language it
+        // did not mean in order to reach `.editorSupport`.
+        let language = setup?.decodedManifest().flatMap {
+            AssignmentLanguage.resolve(manifest: $0)
         }
-        if wantsSourceFile, input.notebook != nil {
+        let uploadOnlyLanguage: AssignmentLanguage? = {
+            guard let language, case .uploadOnly = language.editorSupport else { return nil }
+            return language
+        }()
+        if let uploadOnlyLanguage, input.notebook != nil {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
                 detail:
-                    "\(language.rawValue) has no notebook workflow, so a notebook cannot serve as its "
-                    + "reference solution. Pass solutionFile ({filename, content}) instead.")
+                    "\(uploadOnlyLanguage.rawValue) has no notebook workflow, so a notebook cannot "
+                    + "serve as its reference solution. Pass solutionFile ({filename, content}) instead.")
         }
 
         let data: Data
@@ -194,6 +193,20 @@ struct UpdateSolutionTool: ContentTool {
                 throw MCPToolError.invalidArguments(
                     tool: Self.name,
                     detail: "solutionFile.filename must be a bare filename with no path separators.")
+            }
+            // Which extensions are acceptable IS a language question, and it
+            // cannot be answered for an assignment that declares none — the
+            // previous `?? .python` answered it as Python, so a `.sh`-suite
+            // assignment accepted `solution.py` and rejected everything else
+            // for a reason nothing in the assignment supported. Refusing is an
+            // authoring-time refusal that names its own fix.
+            guard let language else {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail:
+                        "This assignment declares no language, so there is no set of solution-file "
+                        + "extensions to check \"\(name)\" against. Set the assignment's language "
+                        + "with set_assignment_language first.")
             }
             let ext = URL(fileURLWithPath: name).pathExtension.lowercased()
             guard language.scriptExtensions.contains(ext) else {

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -327,7 +327,16 @@ extension DraftAssignmentRoutes {
             gradingMode: sectionGradingMode,
             patternFamilies: preserved.families,
             notebookChecks: preserved.checks,
-            sections: preserved.sections
+            sections: preserved.sections,
+            // The draft already carries the author's language — the select on
+            // the create page is `required` and `updateNewAssignmentDraft`
+            // records it before this save runs. Preserving it here is not
+            // belt-and-braces: this builder writes a fresh dict, so leaving it
+            // out silently discarded the declaration at the moment of publish,
+            // and the assignment came out with the language the author picked
+            // erased.
+            language: preserved.props?.language,
+            languageDeclared: preserved.props?.languageDeclared == true
         )
         let setup = try await persistNewAssignmentSetup(
             req: req,

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -242,6 +242,16 @@ func makeWorkerManifestJSON(
     builtInAchievementsSeeded: Bool = false,
     datasets: [DatasetSpec] = [],
     language: AssignmentLanguage? = nil,
+    // Whether the assignment's author has ANSWERED the language question, which
+    // is a different fact from the answer and has to travel with it.
+    //
+    // This builder writes a fresh dict, so every field it does not know about is
+    // dropped by a rebuild. `languageDeclared` was one of them, and dropping it
+    // is what turns "the author picked None" back into "nobody has been asked" —
+    // the exact conflation the declaration rule exists to remove. Rebuild
+    // callers pass the previous manifest's value; a caller creating a manifest
+    // from nothing leaves it false and declares separately.
+    languageDeclared: Bool = false,
     minimumRunnerVersion: String? = nil
 ) throws -> String {
     // Topologically sort so the runner can process dependencies with a single
@@ -268,6 +278,9 @@ func makeWorkerManifestJSON(
     // it — Python included — so the answer is stated, not re-inferred later.
     if let language {
         manifest["language"] = language.rawValue
+    }
+    if languageDeclared {
+        manifest["languageDeclared"] = true
     }
     // Optional minimum-runner-version gate.  Threaded through like `language`
     // so a suite/script/family rebuild never silently un-gates an assignment;

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+NotebookTools.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+NotebookTools.swift
@@ -83,8 +83,9 @@ extension PublishedAssignmentRoutes {
         // recognisable is a hand-crafted one that used to scan fine. The
         // distinction being restored is between the languages we can read and
         // the ones we cannot — not between declared and undeclared.
+        let scannedLanguage = requestedLanguage ?? notebookLanguage
         let scan = scanNotebookForSectionsAndFunctions(
-            notebookData, language: requestedLanguage ?? notebookLanguage ?? .python)
+            notebookData, language: scannedLanguage ?? .python)
 
         // Forward ALL fields the scanner produces — not just a hand-picked
         // subset.  Pre-v0.4.94 this DTO dropped `paramTypes`, `returnType`,
@@ -123,7 +124,18 @@ extension PublishedAssignmentRoutes {
                 hasDocstring: fn.hasDocstring,
                 isShadowed: fn.isShadowed,
                 sectionName: entry.sectionName,
-                templates: allTemplateInfos(functionName: fn.name, paramNames: fn.paramNames)
+                // The language, PASSED. Omitting it took `allTemplateInfos`'
+                // default and handed every author — R, Lua, Octave, C++,
+                // Racket — the Python shell templates, which is the exact
+                // defect `shellTestScript` was taught to render per-language
+                // for. The default is gone now, so this cannot silently
+                // regress. Unlike the scan itself, an unrecognised notebook
+                // does NOT become Python here: a template with no language is
+                // a shell scaffold, which is a better answer than a confident
+                // `python3` for a suite nobody has claimed.
+                templates: allTemplateInfos(
+                    functionName: fn.name, paramNames: fn.paramNames,
+                    language: scannedLanguage)
             )
         }
 

--- a/Sources/APIServer/Services/GlobalInputsService.swift
+++ b/Sources/APIServer/Services/GlobalInputsService.swift
@@ -215,10 +215,10 @@ enum GlobalInputsService {
         testSetupsDirectory: String,
         // Defaulted to nil, not to `.python`. The old `= .python` default meant
         // an omitted argument produced a confident wrong answer for an R or Lua
-        // assignment; omitting it now produces "unknown", which lands on the
-        // same explicit fallback below as any other unknown. (Both callers pass
-        // it explicitly regardless; the default is here so the parameter count
-        // stays inside the lint threshold.)
+        // assignment; omitting it now produces "unknown", which the refusal
+        // below reports. (Both callers pass it explicitly regardless; the
+        // default is here so the parameter count stays inside the lint
+        // threshold.)
         language: AssignmentLanguage? = nil,
         seedDB: any Database
     ) async throws {
@@ -226,10 +226,19 @@ enum GlobalInputsService {
             let userID = actingUserID,
             let assignmentID = assignment.id
         else { return }
-        // See the matching line in `SectionInputsService.evaluateForActingSeed`:
-        // evaluation needs an interpreter, so a language-less assignment
-        // evaluates as Python rather than refusing.
-        let language = language ?? .python
+        // An `=` expression is SOURCE CODE, so storing one on an assignment that
+        // declares no language has no meaning: there is no interpreter to run it
+        // in and no syntax to write it in. This used to evaluate as Python,
+        // which is how an author could store an expression that only ever ran
+        // one way regardless of what the assignment was.
+        //
+        // Refusing HERE and not at substitution time is the whole point: this
+        // runs on the save, where an instructor can act on the message.
+        // `PersonalizationSubstitution.resolve` keeps its stated default,
+        // because it runs when a student opens the notebook.
+        guard let language else {
+            throw WebAssignmentError.unprocessable(reason: undeclaredLanguageExpressionMessage)
+        }
         let seedHex = try await AssignmentSeedStore.ensureSeed(
             userID: userID, assignmentID: assignmentID, on: seedDB)
         // Combine globals + section vars so expressions can reference the same

--- a/Sources/APIServer/Services/NewAssignmentDraftService.swift
+++ b/Sources/APIServer/Services/NewAssignmentDraftService.swift
@@ -325,11 +325,18 @@ struct NewAssignmentDraftService {
         let starterNotebook =
             setup.notebookPath.map { URL(fileURLWithPath: $0).lastPathComponent }
             ?? "assignment.ipynb"
+        // The declaration survives a suite replacement. Uploading test files
+        // says nothing about which language the author chose, and this builder
+        // writes a fresh dict — so not threading these two erased the choice
+        // the create page had already recorded.
+        let declared = declaredLanguage()
         setup.manifest = try makeWorkerManifestJSON(
             testSuites: setupPackage.testSuites,
             includeMakefile: setupPackage.hasMakefile,
             gradingMode: sectionGradingMode,
-            starterNotebook: starterNotebook
+            starterNotebook: starterNotebook,
+            language: declared.language,
+            languageDeclared: declared.declared
         )
         try await setup.save(on: req.db)
         extractSupportFilesToSharedDirectory(
@@ -345,13 +352,28 @@ struct NewAssignmentDraftService {
             setup.notebookPath.map { URL(fileURLWithPath: $0).lastPathComponent }
             ?? "assignment.ipynb"
         _ = try createRunnerSetupZip(suiteFiles: [], suiteConfigJSON: nil, zipPath: setup.zipPath)
+        // Clearing the suite empties the test files, not the author's choice of
+        // language — see `replaceSuiteFiles`.
+        let declared = declaredLanguage()
         setup.manifest = try makeWorkerManifestJSON(
             testSuites: [],
             includeMakefile: false,
             gradingMode: try await newAssignmentSectionGradingMode(
                 req: req, courseID: courseID, sectionIDRaw: payload.sectionIDRaw),
-            starterNotebook: starterNotebook
+            starterNotebook: starterNotebook,
+            language: declared.language,
+            languageDeclared: declared.declared
         )
         try await setup.save(on: req.db)
+    }
+
+    /// The draft's recorded declaration, read back off its own manifest.
+    ///
+    /// Both halves travel together on purpose: `language` alone cannot express
+    /// "the author picked None", so a rebuild that carried only the language
+    /// would still turn a deliberate None back into an unanswered question.
+    private func declaredLanguage() -> (language: AssignmentLanguage?, declared: Bool) {
+        guard let props = setup.decodedManifest() else { return (nil, false) }
+        return (props.language, props.languageDeclared == true)
     }
 }

--- a/Sources/APIServer/Services/SectionInputsService.swift
+++ b/Sources/APIServer/Services/SectionInputsService.swift
@@ -170,13 +170,16 @@ enum SectionInputsService {
             let userID = seed.actingUserID,
             let assignmentID = seed.assignmentID
         else { return }
-        // An assignment that names no language evaluates its `=` expressions as
-        // Python — the same explicit render-site fallback as
-        // `PersonalizationSubstitution.resolve`, and for the same reason:
-        // evaluation needs an interpreter, so this question cannot answer
-        // "none". Refusing instead would be circular, since inputs are often
-        // authored before the first graded script exists.
-        let language = language ?? .python
+        // Refused rather than evaluated as Python — see the matching guard in
+        // `GlobalInputsService.evaluateForActingSeed`. An `=` expression is
+        // source code, and an assignment that declares no language has no
+        // interpreter to run it in. The "refusing would be circular" note that
+        // used to sit here was written when the language was inferred from
+        // content and inputs could genuinely precede the first graded script;
+        // creation declares now, so there is nothing to wait for.
+        guard let language else {
+            throw WebAssignmentError.unprocessable(reason: undeclaredLanguageExpressionMessage)
+        }
 
         let seedHex = try await AssignmentSeedStore.ensureSeed(
             userID: userID, assignmentID: assignmentID, on: seedDB)

--- a/Sources/APIServer/Utilities/PatternFamilyApplication+Inputs.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+Inputs.swift
@@ -184,7 +184,12 @@ func buildAuthoredOrdering(
 /// written in (which the deletion diff needs so old-extension scripts aren't
 /// stranded when an assignment changes language).
 struct AuthoringLanguageResolution {
-    let language: AssignmentLanguage
+    /// nil means the assignment declares no language — the author picked
+    /// "None", which is a real answer and the right one for a suite of plain
+    /// `.sh` scripts. It is NOT "nobody has been asked": every door that
+    /// creates an assignment declares, so by the time a save reaches here the
+    /// question has an answer.
+    let language: AssignmentLanguage?
     let previous: AssignmentLanguage?
 }
 
@@ -215,21 +220,26 @@ func resolveAuthoringLanguage(
     }
     let resolved = AssignmentLanguage.allCases.first { authoredLanguages.contains($0) } ?? previous
 
-    // Authoring falls back to Python, deliberately and locally — this is NOT
-    // the old resolution default leaking back in.
+    // NO PYTHON FALLBACK. This used to end `?? .python`, justified as follows:
     //
-    // Refusing here would be circular: a pattern family is frequently the FIRST
-    // thing authored on an assignment, and generating its scripts is how the
-    // suite acquires a graded script in the first place. "Add a graded script
-    // before you can add a family" asks the instructor for the output as a
-    // precondition of the input. So when nothing names a language yet, author
-    // in Python — and the save RECORDS the choice into the manifest, so the
-    // ambiguity exists for exactly one save and never silently again.
+    //     Refusing here would be circular: a pattern family is frequently the
+    //     FIRST thing authored on an assignment, and generating its scripts is
+    //     how the suite acquires a graded script in the first place.
     //
-    // What the Optional buys is upstream of this line: an `.R`/`.lua`/`.m`
-    // assignment can no longer arrive here as Python by fallthrough, because
-    // those signals now resolve positively and nil means only "nothing said".
-    return AuthoringLanguageResolution(language: resolved ?? .python, previous: previous)
+    // That was true while the language was INFERRED from content, when nil
+    // honestly meant "nothing has named a language yet". Declaration dissolves
+    // it: every door that creates an assignment declares, so nil here means the
+    // author picked "None" and the circularity is gone — there is nothing to
+    // wait for, only an answer to respect.
+    //
+    // The fallback was also actively wrong, not merely redundant. Every suite
+    // save runs through this function, including saves that touch only raw
+    // scripts and ordering, and the manifest rebuild ALWAYS records the value
+    // it is handed — so reordering two `.sh` scripts on a declared-None
+    // assignment silently rewrote its declaration to Python. The caller now
+    // refuses only when the save would actually GENERATE something (which needs
+    // a syntax) and persists nil otherwise.
+    return AuthoringLanguageResolution(language: resolved, previous: previous)
 }
 
 /// Every save-time validation, in the order the pre-split function ran them.

--- a/Sources/APIServer/Utilities/PatternFamilyApplication+Manifest.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+Manifest.swift
@@ -21,7 +21,7 @@ func rebuildPatternFamilyManifest(
     previousProps props: TestProperties,
     families: [PatternFamily],
     inputs: ResolvedApplyInputs,
-    language: AssignmentLanguage
+    language: AssignmentLanguage?
 ) throws -> String {
     let newManifest = try makeWorkerManifestJSON(
         testSuites: entries,
@@ -40,15 +40,24 @@ func rebuildPatternFamilyManifest(
         disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
         builtInAchievementsSeeded: props.builtInAchievementsSeeded,
         datasets: props.datasets,
-        // Always record the language, Python included. An explicit answer is
-        // the point: a suite that later holds only pattern families has no
-        // `.R` script left to sniff, and "we inferred Python" and "this is a
-        // Python assignment" should not be the same state. The first save of
-        // a pre-existing assignment therefore changes its manifest hash once,
-        // which re-keys the runner's TestSetupCache and triggers one
-        // revision-retest fan-out for that assignment — a bounded, one-time
-        // cost accepted in exchange for the language never being re-inferred.
+        // Always record the language the author DECLARED, Python included —
+        // and nil when they declared none. An explicit answer is the point: a
+        // suite that later holds only pattern families has no `.R` script left
+        // to sniff, and "we inferred Python" and "this is a Python assignment"
+        // should not be the same state. The first save of a pre-existing
+        // assignment therefore changes its manifest hash once, which re-keys
+        // the runner's TestSetupCache and triggers one revision-retest fan-out
+        // for that assignment — a bounded, one-time cost accepted in exchange
+        // for the language never being re-inferred.
+        //
+        // This used to be handed a non-optional that had already been
+        // `?? .python`'d, so reordering two `.sh` scripts on an assignment
+        // whose author chose "None" rewrote its declaration to Python.
         language: language,
+        // Preserved, not recomputed: a rebuild must not un-declare an
+        // assignment, least of all one whose declaration is "none" — which is
+        // exactly the case where `language` alone carries no evidence.
+        languageDeclared: props.languageDeclared == true,
         minimumRunnerVersion: props.minimumRunnerVersion
     )
 

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -186,11 +186,31 @@ func applyPatternFamilies(
     // ── 3. Resolve the language, then validate the whole save ───────────
     let language = resolveAuthoringLanguage(
         setup: setup, props: props, authoredItems: authoredItems)
+
+    // A generated script has to be written in SOME syntax, so a save that
+    // generates one needs a declared language. A save that generates nothing
+    // does not — and refusing it would make a plain `.sh` suite uneditable,
+    // which is a supported assignment shape, not an oversight.
+    //
+    // This is the authoring half of the rule the fallback census settled on:
+    // fail loudly while authoring, never while grading. An instructor can fix a
+    // missing declaration from the dropdown in seconds and this message says
+    // so; a student cannot fix it at all.
+    let generatesScripts =
+        nextFamilies.contains { $0.cases.contains(where: \.enabled) } || !inputs.checks.isEmpty
+    if language.language == nil, generatesScripts {
+        throw Abort(.badRequest, reason: undeclaredLanguageGenerationMessage)
+    }
+    // Inert on the declared-None path: the guard above means nothing is
+    // rendered there, and the manifest below records `language.language`, not
+    // this — so the standin cannot leak into the declaration.
+    let renderLanguage = language.language ?? .python
+
     try validatePatternFamilySave(
         families: nextFamilies,
         ordering: ordering,
         inputs: inputs,
-        language: language.language
+        language: renderLanguage
     )
 
     // ── 4. Render generated scripts ONCE, then diff and mutate the zip ──
@@ -203,7 +223,7 @@ func applyPatternFamilies(
             globalVariables: inputs.globalVariables,
             perStudentNames: inputs.perStudentExpressionNames,
             itemsForOrdering: ordering.items,
-            language: language.language,
+            language: renderLanguage,
             previousLanguage: language.previous
         ),
         previousProps: props,

--- a/Sources/APIServer/Utilities/TestScriptTemplates.swift
+++ b/Sources/APIServer/Utilities/TestScriptTemplates.swift
@@ -141,11 +141,21 @@ func pythonTestScript(
 /// filename comes from `sourceFileExtension` and the invocation from
 /// `interpreterProbe`, so no new per-language table exists to go stale.
 ///
-/// nil keeps Python, which is the previous output byte-for-byte and the right
-/// answer for a suite that declares no language.
-func shellTestScript(type: ShellTestTemplateType, language: AssignmentLanguage? = nil) -> String {
-    let language = language ?? .python
-    let solutionFile = "solution.\(language.sourceFileExtension)"
+/// nil — the author declared NO language — renders in plain shell rather than
+/// falling back to Python. A `.sh` suite is the one case where there is no
+/// language to name, so the two language-shaped values become ordinary shell
+/// variables with a TODO apiece: `FILE` for what the student submits, `RUN` for
+/// the command that runs it. That is a scaffold the author completes, where
+/// `solution.py` + `python3` was a scaffold they had to notice was wrong first.
+///
+/// No default on `language:`. The parameter had one, and the scan endpoint
+/// omitted the argument — so every author of every language got the Python
+/// templates anyway, and the per-language work above never reached a browser.
+func shellTestScript(type: ShellTestTemplateType, language: AssignmentLanguage?) -> String {
+    // A language names the file it grades; a language-less suite cannot, so the
+    // name becomes a placeholder the author replaces — the TODO beside it is
+    // already there and now means something.
+    let solutionFile = language.map { "solution.\($0.sourceFileExtension)" } ?? "submission"
 
     switch type {
 
@@ -190,14 +200,33 @@ func shellTestScript(type: ShellTestTemplateType, language: AssignmentLanguage? 
 
 /// The shell lines that run the submission and leave its output in `$ACTUAL`.
 ///
-/// Two shapes, chosen by `capabilityRequiresExecutableOutput` — the fact that
-/// already means "grading this language builds something before running it".
-/// Asking it here rather than switching on `.cpp` keeps the one judgement in
-/// one place; a seventh compiled language gets the compile form for free.
+/// Three shapes. The two language ones are chosen by
+/// `capabilityRequiresExecutableOutput` — the fact that already means "grading
+/// this language builds something before running it". Asking it here rather
+/// than switching on `.cpp` keeps the one judgement in one place; a seventh
+/// compiled language gets the compile form for free.
+///
+/// The third is for an assignment that declares no language, where there is no
+/// interpreter to name and guessing `python3` would be a guess the author has
+/// to catch. It spends two shell variables instead — the same currency the rest
+/// of the template is written in — so what has to be decided is visible as a
+/// TODO rather than buried in a plausible-looking command.
 private func runSubmissionShellFragment(
-    language: AssignmentLanguage, solutionFile: String
+    language: AssignmentLanguage?, solutionFile: String
 ) -> String {
-    let interpreter = language.descriptor.interpreterProbe.command
+    guard let language else {
+        return """
+            FILE="\(solutionFile)"  # TODO: set to the filename students submit
+            RUN="./$FILE"  # TODO: set to the command that runs the submission
+            ACTUAL=$($RUN 2>&1)
+            """
+    }
+    // `scriptRunCommand`, not `interpreterProbe.command`. The two agree for
+    // every language but R, where the probe is `R` and the runner spawns
+    // `Rscript` — and `R solution.R` does not run the file, it warns that the
+    // argument is ignored and waits on stdin. So every R author's scaffold was
+    // a command that cannot work.
+    let interpreter = language.descriptor.scriptRunCommand
     guard language.descriptor.capabilityRequiresExecutableOutput else {
         // Run the file directly. This replaced a Python-only
         // `python3 -c "import solution; print(solution.main())"`, which had no
@@ -225,8 +254,11 @@ struct TestTemplateInfo: Codable {
 
 /// Returns all template types as `TestTemplateInfo` values for the given function.
 /// Used by the scan-notebook and template-picker endpoints.
+/// No default on `language:` — the scan endpoint omitted the argument, which is
+/// how the shell templates stayed Python for every assignment in every language
+/// long after they learned to render per-language.
 func allTemplateInfos(
-    functionName: String, paramNames: [String], language: AssignmentLanguage? = nil
+    functionName: String, paramNames: [String], language: AssignmentLanguage?
 ) -> [TestTemplateInfo] {
     let pyTypes = PythonTestTemplateType.allCases.map { t in
         TestTemplateInfo(

--- a/Sources/Core/LanguageDescriptor.swift
+++ b/Sources/Core/LanguageDescriptor.swift
@@ -415,6 +415,21 @@ public struct LanguageDescriptor: Equatable, Sendable {
     /// the step after `g++`.
     public let capabilityRequiresExecutableOutput: Bool
 
+    /// The command that RUNS a source file in this language, which is not
+    /// always the command that PROBES for it.
+    ///
+    /// They differ for exactly one language today and the difference is total:
+    /// `R --version` is the right probe, and `R solution.R` does not run
+    /// anything — it warns that the argument is ignored and then reads the
+    /// REPL from stdin. The runner has always spawned `Rscript`
+    /// (`ScriptInvocation`), but the shell test-script scaffold reached for
+    /// `interpreterProbe.command` because it was the interpreter-shaped value
+    /// in reach, and handed every R author a template that cannot run.
+    ///
+    /// `RunCommandMatchesInvocationTests` pins this against what the worker
+    /// actually spawns, so the two cannot drift apart again.
+    public let scriptRunCommand: String
+
     public struct InterpreterProbe: Equatable, Sendable {
         public let command: String
         public let versionArguments: [String]
@@ -437,6 +452,7 @@ public struct LanguageDescriptor: Equatable, Sendable {
         notebookKernelNames: Set<String>,
         editorSupport: EditorSupport,
         interpreterProbe: InterpreterProbe,
+        scriptRunCommand: String,
         moduleResolution: ModuleResolution,
         workingDirectoryIsOnDefaultSearchPath: Bool,
         capabilityRequiresExecutableOutput: Bool
@@ -452,6 +468,7 @@ public struct LanguageDescriptor: Equatable, Sendable {
         self.notebookKernelNames = notebookKernelNames
         self.editorSupport = editorSupport
         self.interpreterProbe = interpreterProbe
+        self.scriptRunCommand = scriptRunCommand
         self.moduleResolution = moduleResolution
         self.workingDirectoryIsOnDefaultSearchPath = workingDirectoryIsOnDefaultSearchPath
         self.capabilityRequiresExecutableOutput = capabilityRequiresExecutableOutput
@@ -509,6 +526,7 @@ extension AssignmentLanguage {
             missingDependencyFailureDescription: "an ImportError",
             gradingWorkerScript: "/python-grading-worker.js"),
         interpreterProbe: .init(command: "python3", versionArguments: ["--version"]),
+        scriptRunCommand: "python3",
         moduleResolution: .byName(
             searchPathVariable: "PYTHONPATH",
             interpreterHookModules: ["sitecustomize"]),
@@ -539,6 +557,7 @@ extension AssignmentLanguage {
             missingDependencyFailureDescription: "an error from library()",
             gradingWorkerScript: "/r-grading-worker.js"),
         interpreterProbe: .init(command: "R", versionArguments: ["--version"]),
+        scriptRunCommand: "Rscript",
         // `source("test_runtime.R")` is a file read, not a module load:
         // there is no name to resolve, so nothing is importable and no
         // guard could reject anything.
@@ -569,6 +588,7 @@ extension AssignmentLanguage {
             gradingWorkerScript: "/lua-grading-worker.js"),
         // `-v`, not `--version` — see `interpreterProbe`'s note.
         interpreterProbe: .init(command: "lua", versionArguments: ["-v"]),
+        scriptRunCommand: "lua",
         // `require("test_runtime")` IS a module load — the same shape as
         // R's and the opposite answer, which is why this is asked per
         // language rather than inherited.
@@ -606,6 +626,7 @@ extension AssignmentLanguage {
         // exits 0 (verified on 8.4.0). The worker invokes the same
         // binary, so probe and invocation cannot skew.
         interpreterProbe: .init(command: "octave-cli", versionArguments: ["--version"]),
+        scriptRunCommand: "octave-cli",
         // `chickadee = test_runtime()` IS a by-name load: the file is
         // found through Octave's load path, not read by filename.
         moduleResolution: .byName(searchPathVariable: "OCTAVE_PATH"),
@@ -653,6 +674,7 @@ extension AssignmentLanguage {
         // (verified on 13.3.0). The generated wrappers invoke the
         // same binary, so probe and invocation cannot skew.
         interpreterProbe: .init(command: "g++", versionArguments: ["--version"]),
+        scriptRunCommand: "g++",
         // `#include` IS a file read — at compile time rather than
         // run time, but the shape is R's, not Python's: nothing is
         // name-addressable, no search-path variable exists to set,
@@ -700,6 +722,7 @@ extension AssignmentLanguage {
         // execute afterwards, so probe and invocation genuinely cannot
         // skew here.
         interpreterProbe: .init(command: "racket", versionArguments: ["--version"]),
+        scriptRunCommand: "racket",
         // `(require "student.rkt")` is a FILE path, resolved relative
         // to the requiring module — R's shape, not Python's. Nothing
         // is name-addressable and no search-path variable applies.

--- a/Tests/APITests/AssignmentLanguageResolutionTests.swift
+++ b/Tests/APITests/AssignmentLanguageResolutionTests.swift
@@ -40,7 +40,7 @@ import Vapor
     /// knows better, and it has to reach the save path or the assignment is
     /// recorded wrong forever.
     @Test func firstSaveOfAnRNotebookAssignmentRecordsR() async throws {
-        try await withPatternFamilyFixture { fixture in
+        try await withPatternFamilyFixture(declaredLanguage: nil) { fixture in
             let manifest = try pfDecodeManifest(fixture.setup.manifest)
             // nil, not `.python`: an empty suite says nothing about the
             // language, and saying nothing used to be spelled "Python".
@@ -93,7 +93,7 @@ import Vapor
     /// is content too. `derivedDeclaration` still reads it, because that is
     /// what the creation boundaries call to answer the question once.
     @Test func resolutionReadsTheDeclarationAndNothingElse() async throws {
-        try await withPatternFamilyFixture { fixture in
+        try await withPatternFamilyFixture(declaredLanguage: nil) { fixture in
             #expect(fixture.setup.notebookPath == nil)
             let manifest = try pfDecodeManifest(fixture.setup.manifest)
             #expect(AssignmentLanguage.resolve(for: fixture.setup, manifest: manifest) == nil)
@@ -107,7 +107,7 @@ import Vapor
     /// A `notebookPath` pointing at a file that is gone (or isn't a notebook)
     /// must not throw or flip the answer — it falls back to the manifest.
     @Test func missingOrUnparseableNotebookFallsBackToTheManifest() async throws {
-        try await withPatternFamilyFixture { fixture in
+        try await withPatternFamilyFixture(declaredLanguage: nil) { fixture in
             let manifest = try pfDecodeManifest(fixture.setup.manifest)
 
             fixture.setup.notebookPath = fixture.app.testSetupsDirectory + "does-not-exist.ipynb"

--- a/Tests/APITests/MCP/AuthorNotebookCheckToolTests.swift
+++ b/Tests/APITests/MCP/AuthorNotebookCheckToolTests.swift
@@ -18,7 +18,8 @@ import Vapor
         )
     }
 
-    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+    private let emptyManifest =
+        #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
 
     private func fixture(on app: Application) async throws -> APIAssignment {
         let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")

--- a/Tests/APITests/MCP/CreateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/CreateAssignmentToolTests.swift
@@ -110,6 +110,110 @@ import Vapor
         }
     }
 
+    // MARK: - The language is REQUIRED
+
+    /// An agent must state the language, and this is what makes "must" true.
+    ///
+    /// Every other test here passes `language: "python"` through the typed
+    /// `Input`, so the requirement was enforced only by the schema and by the
+    /// non-optional `let language: String` — neither of which any test
+    /// exercised. An agent does not build an `Input`; it sends an arguments
+    /// object, which the dispatcher decodes. So the omission is asserted at
+    /// that seam, on the same `decoded(as:)` call the transport makes.
+    @Test func languageIsARequiredArgument() throws {
+        guard case .object(let schema) = CreateAssignmentTool.inputSchema,
+            case .array(let required) = try #require(schema["required"])
+        else {
+            Issue.record("create_assignment's input schema is not an object with a required list")
+            return
+        }
+        #expect(required.contains(.string("language")))
+
+        let withoutLanguage = JSONValue.object([
+            "courseCode": .string("CS246"),
+            "title": .string("Lab"),
+            "notebook": try json(twoCellNotebook),
+        ])
+        #expect(throws: (any Error).self) {
+            _ = try withoutLanguage.decoded(as: CreateAssignmentTool.Input.self)
+        }
+
+        // And the same arguments WITH it decode, so the assertion above is
+        // failing for the missing field rather than for the shape.
+        var withLanguage: [String: JSONValue] = [
+            "courseCode": .string("CS246"),
+            "title": .string("Lab"),
+            "notebook": try json(twoCellNotebook),
+        ]
+        withLanguage["language"] = .string("python")
+        let decoded = try JSONValue.object(withLanguage).decoded(as: CreateAssignmentTool.Input.self)
+        #expect(decoded.language == "python")
+    }
+
+    /// Every language the schema offers is one the tool accepts.
+    ///
+    /// Derived from `allCases` rather than listed, so a seventh language is
+    /// covered the day it exists — and so a schema `enum` that grew a token the
+    /// parser rejects (or the reverse) fails here rather than at an agent.
+    @Test func everyOfferedLanguageChoiceParses() throws {
+        guard case .object(let schema) = CreateAssignmentTool.inputSchema,
+            case .object(let properties) = try #require(schema["properties"]),
+            case .object(let language) = try #require(properties["language"]),
+            case .array(let offered) = try #require(language["enum"])
+        else {
+            Issue.record("create_assignment's language property does not declare an enum")
+            return
+        }
+        let expected =
+            AssignmentLanguage.allCases.map { JSONValue.string($0.rawValue) }
+            + [.string(noLanguageChoice)]
+        #expect(offered == expected)
+        for choice in offered {
+            guard case .string(let raw) = choice else { continue }
+            #expect(throws: Never.self) { _ = try parseLanguageChoice(raw) }
+        }
+    }
+
+    @Test func anUnknownLanguageIsRejectedBeforeAnythingIsCreated() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            try await enrolledCourse(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateAssignmentTool().execute(
+                    CreateAssignmentTool.Input(
+                        courseCode: "CS246", title: "Lab", notebook: try json(twoCellNotebook),
+                        language: "cobol"),
+                    context(app))
+            }
+            // Parsed before the course lookup and the setup write, so a bad
+            // language leaves nothing half-created behind.
+            #expect(try await APITestSetup.query(on: app.db).count() == 0)
+        }
+    }
+
+    /// `"none"` is an ANSWER, and it round-trips as one.
+    ///
+    /// nil `language` plus `languageDeclared` is the state the whole rule rests
+    /// on: it has to be distinguishable from an assignment nobody has been
+    /// asked about, because every downstream refusal reads that difference.
+    @Test func declaringNoneRecordsAnAnsweredQuestionWithNoLanguage() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            try await enrolledCourse(on: app)
+            let output = try await CreateAssignmentTool().execute(
+                CreateAssignmentTool.Input(
+                    courseCode: "CS246", title: "Shell Lab", notebook: try json(twoCellNotebook),
+                    language: noLanguageChoice),
+                context(app))
+
+            let assignment = try #require(try await assignmentByPublicID(output.publicID, on: app.db))
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let props = try #require(setup.decodedManifest())
+            #expect(props.language == nil)
+            #expect(props.languageDeclared == true)
+        }
+    }
+
     @Test func deniesWhenSubjectNotEnrolled() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/CreatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/CreatePatternFamilyToolTests.swift
@@ -18,7 +18,12 @@ import Vapor
         )
     }
 
-    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+    // Declared, because `create_assignment` requires a language and there is no
+    // door that produces an assignment without an answer. A family save on an
+    // assignment whose author chose "None" is refused, and that case has its own
+    // test rather than being every test's accidental starting state.
+    private let emptyManifest =
+        #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
 
     /// Course + enrolled instructor + setup with an EMPTY suite + assignment.
     /// Optionally seeds global `=` expressions so personalized cases can resolve.

--- a/Tests/APITests/MCP/DeleteSuiteItemToolTests.swift
+++ b/Tests/APITests/MCP/DeleteSuiteItemToolTests.swift
@@ -18,7 +18,8 @@ import Vapor
         )
     }
 
-    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+    private let emptyManifest =
+        #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
 
     /// Course + enrolled instructor + setup + assignment.  When `seedFamily` is
     /// true the BMI family is applied; `seedScript` adds a hand-written script.

--- a/Tests/APITests/MCP/PreviewPersonalizationToolTests.swift
+++ b/Tests/APITests/MCP/PreviewPersonalizationToolTests.swift
@@ -48,7 +48,7 @@ import Vapor
 
     @Test func resolvesLiteralsAndExpressionsForExplicitSeed() async throws {
         let manifest = #"""
-            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"cap","value":5}],"globalExpressions":[{"name":"offset","expression":"seed % 3"}]}
+            {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"cap","value":5}],"globalExpressions":[{"name":"offset","expression":"seed % 3"}]}
             """#
         let app = try await makeTestApp()
         try await withApp(app) { app in
@@ -69,7 +69,7 @@ import Vapor
 
     @Test func literalOnlyNeedsNoSeed() async throws {
         let manifest = #"""
-            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"cap","value":5}]}
+            {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"cap","value":5}]}
             """#
         let app = try await makeTestApp()
         try await withApp(app) { app in
@@ -84,7 +84,8 @@ import Vapor
     }
 
     @Test func invalidSeedThrows() async throws {
-        let manifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+        let manifest =
+            #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let assignment = try await enrolledFixture(on: app, id: "setup_pv", manifest: manifest)
@@ -105,7 +106,7 @@ import Vapor
         // markers added via `update_notebook`. A *different* notebook in the zip
         // proves the audit prefers the blob.
         let manifest = #"""
-            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"starterNotebook":"starter.ipynb","globalVariables":[{"name":"cap","value":5}]}
+            {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,"starterNotebook":"starter.ipynb","globalVariables":[{"name":"cap","value":5}]}
             """#
         let blobNotebook = #"""
             {"cells":[{"cell_type":"code","metadata":{},"source":["x = {{cap}}\n","y = {{missing}}"]}],"metadata":{},"nbformat":4,"nbformat_minor":5}
@@ -135,7 +136,7 @@ import Vapor
         // to the zip's starter entry, matching notebookData(for:) and the
         // student first-open path.
         let manifest = #"""
-            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"starterNotebook":"starter.ipynb","globalVariables":[{"name":"cap","value":5}]}
+            {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,"starterNotebook":"starter.ipynb","globalVariables":[{"name":"cap","value":5}]}
             """#
         let notebook = #"""
             {"cells":[{"cell_type":"code","metadata":{},"source":["x = {{cap}}"]}],"metadata":{},"nbformat":4,"nbformat_minor":5}
@@ -161,7 +162,7 @@ import Vapor
         // case that references per-student inputs (argVarRefs / expectedVarRef)
         // shows up in `used`, and resolves when the inputs are declared.
         let manifest = #"""
-            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,
+            {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,
             "globalExpressions":[{"name":"patients","expression":"[1, 2, 3]"},
             {"name":"adults_expected","expression":"2"}]}
             """#
@@ -193,7 +194,8 @@ import Vapor
     }
 
     @Test func deniesWhenSubjectNotEnrolled() async throws {
-        let manifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+        let manifest =
+            #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")

--- a/Tests/APITests/MCP/SuiteSectionToolsTests.swift
+++ b/Tests/APITests/MCP/SuiteSectionToolsTests.swift
@@ -21,7 +21,7 @@ import Vapor
     }
 
     private let manifest = """
-        {"schemaVersion":1,"testSuites":[\
+        {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[\
         {"tier":"public","script":"test_a.sh","points":1},\
         {"tier":"public","script":"test_b.sh","points":1}\
         ],"timeLimitSeconds":10}

--- a/Tests/APITests/MCP/UpdateGlobalInputsToolTests.swift
+++ b/Tests/APITests/MCP/UpdateGlobalInputsToolTests.swift
@@ -20,7 +20,8 @@ import Vapor
         )
     }
 
-    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+    private let emptyManifest =
+        #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
 
     /// Course + enrolled instructor + setup (empty manifest, rebuildable zip) +
     /// assignment.

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -18,7 +18,8 @@ import Vapor
         )
     }
 
-    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+    private let emptyManifest =
+        #"{"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10}"#
 
     /// Course + enrolled instructor + setup seeded with the BMI pattern family
     /// (three cases, all enabled) + assignment.  Returns the assignment.

--- a/Tests/APITests/MCP/UpdateSectionVariablesToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSectionVariablesToolTests.swift
@@ -22,7 +22,7 @@ import Vapor
     /// One section ("sec1"), one global variable ("g") to exercise the
     /// cross-scope clash check.
     private let manifest = #"""
-        {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"g","value":1}],"sections":[{"id":"sec1","name":"Part A"}]}
+        {"schemaVersion":1,"language":"python","languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"g","value":1}],"sections":[{"id":"sec1","name":"Part A"}]}
         """#
 
     private func fixture(on app: Application) async throws -> APIAssignment {

--- a/Tests/APITests/NewAssignmentDraftServiceTests.swift
+++ b/Tests/APITests/NewAssignmentDraftServiceTests.swift
@@ -255,6 +255,49 @@ import VaporTesting
         }
     }
 
+    // MARK: - The declaration survives a suite action
+
+    /// Both suite actions rebuild the manifest with `makeWorkerManifestJSON`,
+    /// which writes a FRESH dict — so anything it is not handed is dropped.
+    /// `language` and `languageDeclared` were among them, which meant the
+    /// create page's required language select recorded the author's choice and
+    /// the very next suite action erased it.
+    ///
+    /// `clear-suite-files` is the cheaper of the two to drive (no zip round
+    /// trip) and takes the identical path.
+    @Test func clearingSuiteFilesKeepsTheDeclaredLanguage() async throws {
+        try await withApp(app) { _ in
+            let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_lang_keep")
+            try await declareManifestLanguage(setup: setup, to: .r, on: app.db)
+
+            var service = makeService(
+                courseID: courseID, setup: setup, payload: makePayload(action: "clear-suite-files"))
+            #expect(try await service.perform() == .applied)
+
+            let props = try #require(setup.decodedManifest())
+            #expect(props.language == .r)
+            #expect(props.languageDeclared == true)
+        }
+    }
+
+    /// The "None" half of the same rule: an author who declared no language
+    /// must not come out of a suite action looking like one who was never
+    /// asked, because that is the distinction every downstream refusal reads.
+    @Test func clearingSuiteFilesKeepsADeclarationOfNone() async throws {
+        try await withApp(app) { _ in
+            let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_lang_none")
+            try await declareManifestLanguage(setup: setup, to: nil, on: app.db)
+
+            var service = makeService(
+                courseID: courseID, setup: setup, payload: makePayload(action: "clear-suite-files"))
+            #expect(try await service.perform() == .applied)
+
+            let props = try #require(setup.decodedManifest())
+            #expect(props.language == nil)
+            #expect(props.languageDeclared == true)
+        }
+    }
+
     // MARK: - Unknown / empty action
 
     @Test func unknownActionIsNoOpReturningApplied() async throws {

--- a/Tests/APITests/NotebookScanRoutesTests.swift
+++ b/Tests/APITests/NotebookScanRoutesTests.swift
@@ -66,6 +66,24 @@ import VaporTesting
         }
         """
 
+    /// R source, so an R scan actually finds a function — a Python-source
+    /// notebook scanned as R yields no functions and therefore no templates,
+    /// which would make a template assertion vacuous.
+    private let rNotebookWithOneFunction = """
+        {
+          "cells": [
+            {
+              "cell_type": "code",
+              "metadata": {},
+              "source": "add <- function(a, b) {\\n  a + b\\n}\\n"
+            }
+          ],
+          "metadata": {},
+          "nbformat": 4,
+          "nbformat_minor": 5
+        }
+        """
+
     private let notebookWithTypeHints = """
         {
           "cells": [
@@ -195,6 +213,45 @@ import VaporTesting
                 }
             )
 
+        }
+    }
+
+    /// The templates come back in the assignment's language.
+    ///
+    /// They did not. `allTemplateInfos` learned to render its three shell
+    /// templates per-language — `solution.R` and `Rscript` for an R assignment,
+    /// and so on for Lua, Octave, C++ and Racket — and this endpoint then
+    /// omitted the argument, taking a `= nil` default that meant Python. So the
+    /// per-language work never reached a browser: every author of every
+    /// language was handed `FILE="solution.py"` and a `python3` invocation,
+    /// which is the exact defect it was written to fix.
+    ///
+    /// The default is gone, so a future caller that forgets gets a compile
+    /// error instead. This asserts the wiring end to end, because a compile
+    /// error cannot see a caller passing the WRONG language.
+    @Test func scanNotebookTemplatesUseTheRequestedLanguage() async throws {
+        try await withApp(try await makeApp()) { app in
+            let cookie = try await loginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/instructor/scan-notebook?language=r",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: rNotebookWithOneFunction)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("\"add\""), "the R scan must find a function first")
+                    #expect(body.contains("solution.R"))
+                    #expect(body.contains("Rscript"))
+                    #expect(!body.contains("solution.py"))
+                    #expect(!body.contains("python3 solution"))
+                }
+            )
         }
     }
 

--- a/Tests/APITests/PatternFamilyApplyTests.swift
+++ b/Tests/APITests/PatternFamilyApplyTests.swift
@@ -91,7 +91,8 @@ import Vapor
                 dependsOn: [], points: 1, displayName: nil
             )
             fixture.setup.manifest = try makeWorkerManifestJSON(
-                testSuites: [rawEntry], includeMakefile: false
+                testSuites: [rawEntry], includeMakefile: false,
+                language: .python, languageDeclared: true
             )
             try await fixture.setup.save(on: fixture.app.db)
             _ = try await applyPatternFamilies(
@@ -117,7 +118,8 @@ import Vapor
             }
             fixture.setup.manifest = try makeWorkerManifestJSON(
                 testSuites: [rawEntry], includeMakefile: false,
-                patternFamilies: existingFamilies
+                patternFamilies: existingFamilies,
+                language: .python, languageDeclared: true
             )
             try await fixture.setup.save(on: fixture.app.db)
 
@@ -1086,7 +1088,11 @@ import Vapor
             ]
             fixture.setup.manifest = try makeWorkerManifestJSON(
                 testSuites: newRawEntries, includeMakefile: false,
-                patternFamilies: draftProps.patternFamilies
+                patternFamilies: draftProps.patternFamilies,
+                // Threaded exactly as `saveNewAssignment` now does: the publish
+                // rebuild used to drop the declaration on the floor.
+                language: draftProps.language,
+                languageDeclared: draftProps.languageDeclared == true
             )
             try await fixture.setup.save(on: fixture.app.db)
 

--- a/Tests/APITests/PatternFamilyFixtures.swift
+++ b/Tests/APITests/PatternFamilyFixtures.swift
@@ -110,13 +110,26 @@ struct PFFixture {
 /// `withApp` (it builds its app directly), so it arms `WedgeWatchdog` itself
 /// — otherwise a wedge whose only in-flight bodies were pattern-family ones
 /// would find the watchdog disarmed.
-func withPatternFamilyFixture(_ body: (PFFixture) async throws -> Void) async throws {
+///
+/// The fixture DECLARES Python, because every door that creates a real
+/// assignment declares something and a fixture that skips it is not modelling
+/// anything a user can produce. Pass `declaredLanguage: nil` for the
+/// author-said-None case — a suite of plain `.sh` scripts — which is a real
+/// state with its own rules (no generated tests, no `=` expressions), not the
+/// absence of an answer.
+func withPatternFamilyFixture(
+    declaredLanguage: AssignmentLanguage? = .python,
+    _ body: (PFFixture) async throws -> Void
+) async throws {
     try await WedgeWatchdog.track {
-        try await runPatternFamilyFixture(body)
+        try await runPatternFamilyFixture(declaredLanguage: declaredLanguage, body)
     }
 }
 
-private func runPatternFamilyFixture(_ body: (PFFixture) async throws -> Void) async throws {
+private func runPatternFamilyFixture(
+    declaredLanguage: AssignmentLanguage?,
+    _ body: (PFFixture) async throws -> Void
+) async throws {
     let app = try await Application.make(.testing)
     let tmpDir = NSTemporaryDirectory() + "pattern-family-tests-\(UUID().uuidString)/"
 
@@ -135,7 +148,9 @@ private func runPatternFamilyFixture(_ body: (PFFixture) async throws -> Void) a
         let zipPath = tmpDir + "\(UUID().uuidString).zip"
         try pfWriteEmptyZip(at: zipPath)
 
-        let initialManifest = try makeWorkerManifestJSON(testSuites: [], includeMakefile: false)
+        let initialManifest = try makeWorkerManifestJSON(
+            testSuites: [], includeMakefile: false,
+            language: declaredLanguage, languageDeclared: true)
         let setup = APITestSetup(
             id: "pf_test_\(UUID().uuidString.prefix(8))",
             manifest: initialManifest, zipPath: zipPath, courseID: courseID

--- a/Tests/APITests/PatternFamilySectionsTests.swift
+++ b/Tests/APITests/PatternFamilySectionsTests.swift
@@ -160,7 +160,9 @@ import Vapor
                 includeMakefile: false,
                 patternFamilies: draftProps.patternFamilies,
                 notebookChecks: draftProps.notebookChecks,
-                sections: draftProps.sections
+                sections: draftProps.sections,
+                language: draftProps.language,
+                languageDeclared: draftProps.languageDeclared == true
             )
             try await fixture.setup.save(on: fixture.app.db)
 

--- a/Tests/APITests/SuiteRouteTests.swift
+++ b/Tests/APITests/SuiteRouteTests.swift
@@ -45,7 +45,11 @@ import VaporTesting
                     dependsOn: [], points: 1, displayName: nil
                 ))
         }
-        let manifest = try makeWorkerManifestJSON(testSuites: entries, includeMakefile: false)
+        // Declared, like every assignment a real door produces. An undeclared
+        // fixture would model nothing and would refuse the first family save.
+        let manifest = try makeWorkerManifestJSON(
+            testSuites: entries, includeMakefile: false,
+            language: .python, languageDeclared: true)
         let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, courseID: courseID)
         try await setup.save(on: app.db)
         let assignment = APIAssignment(

--- a/Tests/APITests/TestScriptTemplatesTests.swift
+++ b/Tests/APITests/TestScriptTemplatesTests.swift
@@ -159,14 +159,14 @@ import Testing
     }
 
     @Test func shellAlwaysPass() {
-        let s = shellTestScript(type: .alwaysPass)
+        let s = shellTestScript(type: .alwaysPass, language: .python)
         #expect(s.contains("exit 0"))
         #expect(s.contains("#!/bin/sh"))
 
     }
 
     @Test func shellFileExists() {
-        let s = shellTestScript(type: .fileExists)
+        let s = shellTestScript(type: .fileExists, language: .python)
         #expect(s.contains("#!/bin/sh"))
         #expect(s.contains("exit 0"))
         #expect(s.contains("exit 1"))
@@ -175,7 +175,7 @@ import Testing
     }
 
     @Test func shellCommandOutput() {
-        let s = shellTestScript(type: .commandOutput)
+        let s = shellTestScript(type: .commandOutput, language: .python)
         #expect(s.contains("#!/bin/sh"))
         #expect(s.contains("exit 0"))
         #expect(s.contains("exit 1"))
@@ -194,7 +194,10 @@ import Testing
         #expect(fileExists.contains("solution.\(language.sourceFileExtension)"))
 
         let commandOutput = shellTestScript(type: .commandOutput, language: language)
-        #expect(commandOutput.contains(language.descriptor.interpreterProbe.command))
+        // `scriptRunCommand`, not the probe command. This asserted the probe
+        // and passed, which is how `ACTUAL=$(R solution.R 2>&1)` shipped: the
+        // right probe for "is R installed" and a command that runs nothing.
+        #expect(commandOutput.contains(language.descriptor.scriptRunCommand))
         #expect(commandOutput.contains("solution.\(language.sourceFileExtension)"))
 
         guard language != .python else { return }
@@ -217,15 +220,48 @@ import Testing
         #expect(!shellTestScript(type: .commandOutput, language: .lua).contains("-o "))
     }
 
-    /// No declared language keeps the previous bytes exactly.
+    /// An assignment whose author declared NO language gets a scaffold written
+    /// in shell, not in Python.
+    ///
+    /// This asserted the opposite until v0.5.60 — that a language-less suite
+    /// kept the Python bytes exactly — which was the reasonable answer while
+    /// nil meant "nobody has been asked". It means "the author chose None" now,
+    /// and None is precisely the case with no language to name, so the two
+    /// language-shaped values become shell variables the author fills in.
     @Test(arguments: ShellTestTemplateType.allCases)
-    func aLanguagelessSuiteGetsThePythonScaffoldUnchanged(_ type: ShellTestTemplateType) {
-        #expect(shellTestScript(type: type) == shellTestScript(type: type, language: .python))
+    func aLanguagelessSuiteGetsAShellScaffoldNamingNoLanguage(_ type: ShellTestTemplateType) {
+        let none = shellTestScript(type: type, language: nil)
+        #expect(none.contains("#!/bin/sh"))
+        // Python by name, because Python is what it used to emit.
+        #expect(!none.contains("solution.py"))
+        #expect(!none.contains("python3"))
+        // And not any other language's scaffold either. Compared whole rather
+        // than by searching for interpreter names: R's probe command is the
+        // single letter `R`, which matches inside `RUN=` and would pass a
+        // substring check for the wrong reason.
+        for language in AssignmentLanguage.allCases {
+            #expect(!none.contains("solution.\(language.sourceFileExtension)"))
+            if type != .alwaysPass {
+                #expect(
+                    none != shellTestScript(type: type, language: language),
+                    "the language-less scaffold must not be \(language)'s scaffold")
+            }
+        }
+    }
+
+    /// The two decisions a language would have made are handed to the author as
+    /// shell variables with a TODO apiece, rather than guessed.
+    @Test func theLanguagelessCommandTemplateSpendsShellVariables() {
+        let none = shellTestScript(type: .commandOutput, language: nil)
+        #expect(none.contains("FILE=\"submission\""))
+        #expect(none.contains("RUN=\"./$FILE\""))
+        #expect(none.contains("ACTUAL=$($RUN"))
+        #expect(none.components(separatedBy: "TODO").count - 1 >= 2)
     }
 
     @Test func allShellTemplateTypes_nonEmpty() {
         for type in ShellTestTemplateType.allCases {
-            let s = shellTestScript(type: type)
+            let s = shellTestScript(type: type, language: .python)
             #expect(
                 s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
                 "Shell template \(type.rawValue) should not be empty")
@@ -236,14 +272,14 @@ import Testing
     // MARK: - allTemplateInfos
 
     @Test func allTemplateInfos_countMatchesTypes() {
-        let infos = allTemplateInfos(functionName: "foo", paramNames: ["x"])
+        let infos = allTemplateInfos(functionName: "foo", paramNames: ["x"], language: .python)
         let expectedCount = PythonTestTemplateType.allCases.count + ShellTestTemplateType.allCases.count
         #expect(infos.count == expectedCount)
 
     }
 
     @Test func allTemplateInfos_eachHasContent() {
-        let infos = allTemplateInfos(functionName: "bar", paramNames: [])
+        let infos = allTemplateInfos(functionName: "bar", paramNames: [], language: .python)
         for info in infos {
             #expect(
                 info.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
@@ -253,7 +289,7 @@ import Testing
     }
 
     @Test func allTemplateInfos_pythonContainFunctionName() {
-        let infos = allTemplateInfos(functionName: "special_fn", paramNames: ["x"])
+        let infos = allTemplateInfos(functionName: "special_fn", paramNames: ["x"], language: .python)
         // Every remaining Python template is function-scoped. `variable_equality`
         // was the one exception and it is gone — the `variableEquality` pattern
         // kind does that job, in all six languages.

--- a/Tests/APITests/UndeclaredLanguageRefusalTests.swift
+++ b/Tests/APITests/UndeclaredLanguageRefusalTests.swift
@@ -1,0 +1,193 @@
+// Tests/APITests/UndeclaredLanguageRefusalTests.swift
+//
+// What an assignment whose author declared NO language can and cannot do.
+//
+// "None" is a real declaration — a suite of hand-written `.sh` scripts — and it
+// is not the same thing as an unanswered question. Every door that creates an
+// assignment declares, so nothing reaching these paths is merely undecided.
+//
+// The rule these pin: an operation that needs a SYNTAX (a generated test, an
+// `=` expression, a solution file's extension) refuses; an operation that does
+// not (reordering scripts, literal variables, a notebook solution) proceeds —
+// and, critically, proceeds WITHOUT quietly writing a language down.
+//
+// All of these are authoring paths. Nothing on the grading path refuses for
+// want of a declaration: an instructor can fix this from the dropdown in
+// seconds, and a student cannot fix it at all.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct UndeclaredLanguageRefusalTests {
+
+    /// The message, matched on the part that names the fix rather than the
+    /// whole sentence, so rewording the copy doesn't fail the test.
+    private func mentionsMissingDeclaration(_ error: any Error) -> Bool {
+        "\(error)".contains("declares no language")
+    }
+
+    // MARK: - Generated tests
+
+    @Test func addingAFamilyIsRefusedWhenTheAuthorDeclaredNoLanguage() async throws {
+        try await withPatternFamilyFixture(declaredLanguage: nil) { fixture in
+            do {
+                _ = try await applyPatternFamilies(
+                    to: fixture.setup, nextFamilies: [pfBMIFamily()], on: fixture.app.db)
+                Issue.record("a family save must not succeed with no declared language")
+            } catch {
+                #expect(mentionsMissingDeclaration(error))
+            }
+
+            // And it refused before touching anything.
+            let props = try pfDecodeManifest(fixture.setup.manifest)
+            #expect(props.patternFamilies.isEmpty)
+            #expect(props.language == nil)
+        }
+    }
+
+    /// THE REGRESSION THIS PAIR EXISTS FOR. Every suite save runs through
+    /// `applyPatternFamilies`, including saves that generate nothing — so the
+    /// old `?? .python` meant reordering two shell scripts rewrote a
+    /// declared-None assignment's language to Python, silently and stickily.
+    ///
+    /// A save that generates nothing must still be allowed, and must leave the
+    /// declaration exactly as the author left it.
+    @Test func aScriptOnlySaveIsAllowedAndLeavesTheDeclarationAlone() async throws {
+        try await withPatternFamilyFixture(declaredLanguage: nil) { fixture in
+            try updateScriptInZip(
+                zipPath: fixture.setup.zipPath,
+                filename: "publictest_handmade.sh",
+                content: "#!/bin/sh\nexit 0\n"
+            )
+            let authored: [AuthoredSuiteItem] = [
+                .script(
+                    AuthoredRawScript(
+                        script: "publictest_handmade.sh", tier: .pub, points: 1,
+                        displayName: nil, dependsOn: [], sectionID: nil))
+            ]
+
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [], authoredItems: authored, on: fixture.app.db)
+
+            let props = try pfDecodeManifest(fixture.setup.manifest)
+            #expect(props.testSuites.map(\.script) == ["publictest_handmade.sh"])
+            #expect(
+                props.language == nil,
+                "a save that generates nothing must not declare a language on the author's behalf")
+            // And must not un-declare one either: "none" is an answer, so the
+            // rebuild has to carry the fact that it was given.
+            #expect(props.languageDeclared == true)
+        }
+    }
+
+    // MARK: - Per-student expressions
+
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    /// Declared, with no language — the state `BackfillDeclaredLanguage` writes
+    /// for a plain `.sh` suite and the create page's "None" option produces.
+    private let undeclaredManifest =
+        #"{"schemaVersion":1,"languageDeclared":true,"testSuites":[],"timeLimitSeconds":10,"sections":[{"id":"sec1","name":"Part A"}]}"#
+
+    private func fixture(on app: Application, id: String) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: id, courseID: courseID, manifest: undeclaredManifest)
+        try pfWriteEmptyZip(at: app.testSetupsDirectory + "\(id).zip")
+        return try await makeTestAssignment(
+            on: app, testSetupID: id, courseID: courseID, title: "Lab")
+    }
+
+    @Test func aGlobalExpressionIsRefusedButALiteralVariableIsNot() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, id: "setup_undeclared_g")
+
+            // A literal needs a syntax only when it is RENDERED, which is a
+            // later question with its own stated default. Storing one is fine.
+            let ok = try await UpdateGlobalInputsTool().execute(
+                UpdateGlobalInputsTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    variables: [FamilyVariable(name: "limit", value: .int(5))],
+                    expressions: nil),
+                context(app))
+            #expect(ok.variables.map(\.name) == ["limit"])
+
+            // An expression is source code. There is no interpreter to run it
+            // in, so this refuses rather than quietly running `python3`.
+            do {
+                _ = try await UpdateGlobalInputsTool().execute(
+                    UpdateGlobalInputsTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        variables: [],
+                        expressions: [
+                            PersonalizationExpression(name: "offset", expression: "seed % 3")
+                        ]),
+                    context(app))
+                Issue.record("an `=` expression must not be storable with no declared language")
+            } catch {
+                #expect(mentionsMissingDeclaration(error))
+            }
+        }
+    }
+
+    @Test func aSectionExpressionIsRefusedToo() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, id: "setup_undeclared_s")
+            do {
+                _ = try await UpdateSectionVariablesTool().execute(
+                    UpdateSectionVariablesTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        sectionID: "sec1",
+                        variables: [],
+                        expressions: [
+                            PersonalizationExpression(name: "offset", expression: "seed % 3")
+                        ]),
+                    context(app))
+                Issue.record("a section `=` expression must not be storable with no declared language")
+            } catch {
+                #expect(mentionsMissingDeclaration(error))
+            }
+        }
+    }
+
+    // MARK: - Reference solutions
+
+    /// `update_solution` used to resolve the language as `?? .python` purely to
+    /// reach `.scriptExtensions`, so a `.sh`-suite assignment accepted
+    /// `solution.py` and rejected everything else for a reason nothing in the
+    /// assignment supported. The notebook path never needed the answer and
+    /// still doesn't.
+    @Test func aSolutionFileIsRefusedWhileANotebookSolutionIsNot() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, id: "setup_undeclared_x")
+            do {
+                _ = try await UpdateSolutionTool().execute(
+                    UpdateSolutionTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        notebook: nil,
+                        solutionFile: UpdateSolutionTool.SolutionFile(
+                            filename: "solution.py", content: "x = 1\n")),
+                    context(app))
+                Issue.record("a solution file's extension cannot be checked with no declared language")
+            } catch {
+                #expect(mentionsMissingDeclaration(error))
+            }
+        }
+    }
+}

--- a/Tests/WorkerTests/RunCommandMatchesInvocationTests.swift
+++ b/Tests/WorkerTests/RunCommandMatchesInvocationTests.swift
@@ -1,0 +1,56 @@
+// Tests/WorkerTests/RunCommandMatchesInvocationTests.swift
+//
+// `LanguageDescriptor.scriptRunCommand` must be the command the worker actually
+// spawns for that language's source files.
+//
+// The descriptor exists in Core, the invocation table in Worker, and only this
+// target can see both — which is why the two drifted in the first place. R's
+// entry claimed the probe command `R` was also the run command, on the stated
+// reasoning that "the runner spawns the probed interpreter on a script, so
+// probing IS invoking". For R it does not: `Rscript` runs a file, `R` reads a
+// REPL from stdin and prints that the filename argument was ignored. The shell
+// test-script scaffold believed the descriptor and handed every R author a
+// command that cannot run.
+//
+// The guard is per-language and derived from `allCases`, so a seventh language
+// is covered the day it is added.
+
+import Core
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite struct RunCommandMatchesInvocationTests {
+
+    /// Compiled languages are excluded, and the exclusion is derived rather
+    /// than spelled `.cpp`: `capabilityRequiresExecutableOutput` already means
+    /// "grading this builds something before running it", so its source file
+    /// is handed to a compiler by a generated wrapper, not spawned directly.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func theRunCommandIsWhatTheWorkerSpawns(_ language: AssignmentLanguage) throws {
+        guard !language.descriptor.capabilityRequiresExecutableOutput else { return }
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("run-command-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let script = dir.appendingPathComponent("solution.\(language.sourceFileExtension)")
+        try Data("\n".utf8).write(to: script)
+
+        let invocation = scriptInvocation(for: script)
+        // `env` is the spawn shape for most of these, so the interpreter is an
+        // argument rather than the executable — check both places.
+        let named =
+            invocation.executableURL.lastPathComponent == language.descriptor.scriptRunCommand
+            || invocation.arguments.contains(language.descriptor.scriptRunCommand)
+        #expect(
+            named,
+            """
+            \(language) declares scriptRunCommand \
+            "\(language.descriptor.scriptRunCommand)" but the worker spawns \
+            \(invocation.executableURL.lastPathComponent) \(invocation.arguments).
+            """)
+    }
+}

--- a/changelog.d/language-declaration-doc.md
+++ b/changelog.d/language-declaration-doc.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Documented the assignment-language transition.** `docs/language-declaration.md`
+  records the rule the multi-language arc landed on — every assignment declares
+  its language and nothing infers one — along with the four creation doors that
+  enforce it, the single boundary that still derives a declaration before
+  recording it, the shapes deleted because the compiler could never see them go
+  wrong, and a per-site table of the remaining `?? .python` fallbacks separated
+  by whether they sit on an authoring path or a grading one.

--- a/changelog.d/language-declaration-doc.md
+++ b/changelog.d/language-declaration-doc.md
@@ -1,9 +1,0 @@
-### Changed
-
-- **Documented the assignment-language transition.** `docs/language-declaration.md`
-  records the rule the multi-language arc landed on — every assignment declares
-  its language and nothing infers one — along with the four creation doors that
-  enforce it, the single boundary that still derives a declaration before
-  recording it, the shapes deleted because the compiler could never see them go
-  wrong, and a per-site table of the remaining `?? .python` fallbacks separated
-  by whether they sit on an authoring path or a grading one.

--- a/changelog.d/undeclared-language-refusals.md
+++ b/changelog.d/undeclared-language-refusals.md
@@ -1,0 +1,32 @@
+### Fixed
+
+- **A suite save no longer rewrites a "None" assignment's language to Python.**
+  Every suite save runs through the pattern-family apply path, which recorded
+  whatever language it resolved — and that resolution ended in a Python
+  fallback. Reordering two shell scripts on an assignment whose author chose
+  "None" therefore declared it Python, silently and stickily. The apply path now
+  carries the declaration as an optional and persists it unchanged.
+- **The new-assignment page no longer erases the language it just asked for.**
+  The manifest builder writes a fresh object, so the draft's suite actions and
+  the publish rebuild dropped both `language` and `languageDeclared` on the
+  floor — the author picked R, uploaded a suite, and the choice was gone. Both
+  fields are threaded through every rebuild.
+- **`update_solution` no longer checks a solution filename against Python's
+  extensions on an assignment that declares no language**, which accepted
+  `solution.py` and rejected everything else for a reason nothing in the
+  assignment supported.
+
+### Changed
+
+- **Authoring refuses, with a message naming the fix, where it used to guess
+  Python.** Adding a pattern family or notebook check, and storing a per-student
+  `=` expression, now require the assignment to declare a language: a generated
+  test and an expression are both source code, and an assignment set to "None"
+  has no syntax to write them in. Saves that generate nothing — reordering raw
+  scripts, editing literal variables — are unaffected, and nothing on the
+  grading path refuses: an instructor can fix a missing declaration from the
+  dropdown, a student cannot.
+- **`docs/language-declaration.md`** records the rule the multi-language arc
+  landed on (every assignment declares its language; nothing infers one), the
+  doors that enforce it, and a per-site table of the remaining Python fallbacks
+  split by whether they sit on an authoring path or a grading one.

--- a/docs/language-declaration.md
+++ b/docs/language-declaration.md
@@ -1,8 +1,8 @@
 # Assignment language: declared, not inferred
 
 Where the multi-language transition stands as of v0.5.59 (#1330, #1331), what
-the rule now is, and the fourteen call sites that are still answering a
-different question.
+the rule now is, and what became of the fourteen call sites that were still
+answering a different question.
 
 ---
 
@@ -105,7 +105,7 @@ path.
 
 ## The `?? .python` sites
 
-There were fourteen. Four are gone; eleven lines remain and are correct as they
+There were fourteen. Five are gone; ten lines remain and are correct as they
 stand.
 
 These are **not** resolution fallbacks. Resolution has no fallback. They are
@@ -113,7 +113,7 @@ sites asking a different question:
 
 > This operation needs a language, and the assignment declares none. Now what?
 
-They divide into three groups, and the decision rule that separates them is:
+They divide into four groups, and the decision rule that separates them is:
 
 **Fail loudly while authoring. Never fail while grading, rendering a page, or
 extracting a student's submission.**
@@ -170,6 +170,37 @@ never refuses.
   nothing in the assignment supported. It refuses now, naming
   `set_assignment_language` as the fix.
 
+### Group 4 — "none" is a real answer here. **Done.**
+
+`shellTestScript` renders the three `.sh` scaffolds. Its nil case fell back to
+Python, which was defensible only while nil meant "nobody has been asked": a
+declared-None assignment *is* the one case with no language to name, so the two
+language-shaped values become ordinary shell variables with a TODO apiece —
+`FILE` for what the student submits, `RUN` for the command that runs it. That is
+a scaffold the author completes, where `solution.py` + `python3` was one they had
+to notice was wrong first.
+
+Two defects fell out of touching it:
+
+- **The per-language scaffolds never reached a browser.** `allTemplateInfos`
+  and `shellTestScript` both defaulted `language:` to nil, and the scan endpoint
+  omitted the argument — so the work that taught these templates to render
+  `solution.R` / `Rscript` for R, and so on for Lua, Octave, C++ and Racket,
+  was dead on arrival: every author of every language got the Python ones. Both
+  defaults are gone, so a caller that forgets now fails to compile.
+- **R's scaffold could not run.** It invoked `interpreterProbe.command`, which
+  for R is `R` — the right probe for "is R installed", and a command that runs
+  nothing: `R solution.R` reports the argument ignored and reads a REPL from
+  stdin. The runner has always spawned `Rscript`. `LanguageDescriptor` carries
+  `scriptRunCommand` now, and `RunCommandMatchesInvocationTests` (in WorkerTests,
+  the one target that can see both Core's descriptor and Worker's invocation
+  table) pins it against what the worker actually spawns.
+
+The second is the general lesson, not an R quirk: a value in reach that is
+*shaped* like the one you need is not the one you need. "Probe for it" and "run
+it" are different questions, and the descriptor answered them with one field
+because for five of six languages the answers coincide.
+
 ### An adjacent defect the work surfaced
 
 `makeWorkerManifestJSON` builds a **fresh dict**, so any field it is not handed
@@ -184,7 +215,7 @@ question.
 
 ### Group 3 — keep the explicit default, and keep the comment
 
-Eleven lines where "none" is not an answerable value and failing is worse than
+Ten lines where "none" is not an answerable value and failing is worse than
 defaulting. Each states the default locally rather than inheriting it, which is
 the property the Optional bought.
 
@@ -193,7 +224,7 @@ the property the Optional bought.
 | `Worker/NotebookExtractor.swift:130` | Extraction has to write a file in *some* syntax; grading path |
 | `Worker/RunnerDaemon+JobProcessing.swift:652` | The student-module hint must name the file the extractor actually wrote |
 | `PersonalizationSubstitution.swift:55` | There is no literal without a syntax |
-| `TestScriptTemplates.swift:147` | Scaffold text; nil output byte-for-byte matches the previous Python |
+| ~~`TestScriptTemplates.swift`~~ | **Gone.** A language-less suite gets a *shell* scaffold — see below |
 | `NotebookScaffoldHelpers.swift:165,167,174` | A notebook needs a kernelspec; nil already returns nil for upload-only |
 | `PublishedAssignmentRoutes+NotebookTools.swift:87` | Scans an *arbitrary* notebook, not an assignment: the fallback chain is `?language=` → kernelspec → Python, and the distinction being drawn is between kernels we can read and ones we cannot |
 | `SubmissionResultPresenter.swift:517` | Display; computes generated filenames, which only exist when families do, which requires a recorded language — unreachable with effect |

--- a/docs/language-declaration.md
+++ b/docs/language-declaration.md
@@ -1,0 +1,188 @@
+# Assignment language: declared, not inferred
+
+Where the multi-language transition stands as of v0.5.59 (#1330, #1331), what
+the rule now is, and the fourteen call sites that are still answering a
+different question.
+
+---
+
+## The rule
+
+**Every assignment declares its language. Nothing infers one.**
+
+`AssignmentLanguage.resolve(manifest:)` returns `manifest.language` and nothing
+else. There is no extension sniff, no kernelspec read, no `.python` tail. A
+call site that wants to know an assignment's language reads the declaration.
+
+`manifest.language` is an `Optional<AssignmentLanguage>`, and the Optional is
+load-bearing: **nil means the author said "none"**, which is a real and
+supported state — a suite of plain `.sh` scripts. It does not mean "nobody has
+been asked", because `languageDeclared` records that the question has an
+answer, and `BackfillDeclaredLanguage` stamped it on every assignment that
+predates the rule.
+
+Conflating those two states is where every silent misroute in this arc came
+from. When resolution ended in `?? .python`, "the author chose Python" and "we
+guessed Python because nothing said otherwise" were the same value, so a Lua
+assignment resolved to Python, an R author's first `=` expression went to
+`python3`, and the browser wrote `_ck_inputs.py` for an R runtime — each of them
+type-checking perfectly and failing at the student.
+
+### Do not reintroduce inference
+
+If a call site does not know the language, the answer is to make the author
+declare it, not to work it out from content. Content is content: a `.R` file in
+the suite, an `xr` kernelspec in the starter notebook, and a `library(dplyr)`
+call are all things an assignment may contain without being an R assignment.
+
+Two guards hold the line mechanically:
+
+- `scripts/no-language-defaults.sh` (wired into the `format-lint` CI job) fails
+  on any `language:` parameter with a default value. Seventeen functions had
+  one, and that is what made both #1330 defects possible — an omitted argument
+  produced a confident wrong answer instead of a compile error. A caller that
+  means Python now says so.
+- `AssignmentLanguageTests` runs `allCases`-driven assertions: every language
+  must resolve from its own graded script and its own notebook kernel, so a
+  seventh language cannot silently fall through to Python.
+
+Two shapes are deleted rather than kept for convenience, because both are
+invisible to the compiler:
+
+- `isRNotebook(_:)` / `isRNotebookMetadata(_:)` — a `Bool` return invites
+  `isRNotebook(nb) ? .r : .python`, which type-checks forever however many
+  languages exist and routes all the others to Python.
+- `rederive(manifest:notebookData:)` — re-derivation that ignored the recorded
+  language, so replacing a starter notebook changed the assignment's language
+  under its author. It existed because the recorded value was a *memo* of what
+  resolution last computed, and a memo goes stale. A declaration does not.
+
+---
+
+## Who declares
+
+Four doors create an assignment, and all four answer the question:
+
+| Door | How |
+|---|---|
+| Web create page (`POST /instructor/new`) | `required` `<select name="assignmentLanguage">`, with an explicit **None** option; declared *before* the draft service runs, so families authored in the same save render in the chosen language |
+| MCP `create_assignment` | required `language` argument |
+| REST zip upload (`POST /api/v1/testsetups`) | `derivedDeclaration` at the boundary, recorded immediately |
+| Course-bundle import | `derivedDeclaration` at the boundary, recorded immediately |
+
+Plus two paths that change an existing declaration:
+
+- Web edit save (`PublishedAssignmentRoutes+SaveEdit`) — refuses a change once
+  generated scripts exist, because changing the language rewrites every
+  generated filename.
+- MCP `set_assignment_language` — same guard.
+
+All of them go through `declareManifestLanguage(setup:to:on:)`
+(`Helpers/ManifestFieldEdits.swift`), which is the only writer. It sets
+`languageDeclared`, writes or removes `language`, and — for an `.uploadOnly`
+language — moves `submissionMode` and `gradingMode` with it, so creation cannot
+produce the incoherent `uploadOnly` + `browser` pair.
+
+### The one remaining sniff
+
+`AssignmentLanguage.derivedDeclaration` is derivation, deliberately not named
+`resolve`. Three callers, all boundaries where content arrives with no author
+answer attached:
+
+1. the REST zip upload,
+2. course-bundle import,
+3. `BackfillDeclaredLanguage` (one-time).
+
+Each **records the result immediately**, so the guess is made once and becomes a
+declaration. Precedence is the old resolution order — a graded script's
+extension in `allCases` order, then the starter notebook's kernel, then nil — so
+what gets written down matches what the system used to compute on the fly.
+
+It is a boundary step, not a resolution strategy. Do not call it from a read
+path.
+
+---
+
+## What is still open: the fourteen `?? .python` sites
+
+These are **not** resolution fallbacks. Resolution has no fallback. They are
+sites asking a different question:
+
+> This operation needs a language, and the assignment declares none. Now what?
+
+They divide into three groups, and the decision rule that separates them is:
+
+**Fail loudly while authoring. Never fail while grading, rendering a page, or
+extracting a student's submission.**
+
+An author can fix a missing declaration in ten seconds and a refusal tells them
+how. A student cannot fix it at all, and a refusal on their path turns an
+instructor's omission into a failed submission.
+
+### Group 1 — authoring: a refusal is the right answer
+
+The justification written at these sites ("refusing would be circular — a
+pattern family is frequently the FIRST thing authored, and generating its
+scripts is how the suite acquires a graded script") was written **under
+inference**, when nil genuinely meant "nothing has named a language yet". It is
+dissolved by declaration: creation always declares, so nil at these sites means
+the author chose *None*, and authoring a Python pattern family on an assignment
+whose author said it has no language is the exact silent-wrong-answer shape this
+arc removed.
+
+| Site | Currently |
+|---|---|
+| `PatternFamilyApplication+Inputs.swift:232` | Generates `.py` scripts on a declared-none assignment |
+| `GlobalInputsService.swift:232` | Evaluates `=` expressions with `python3` |
+| `SectionInputsService.swift:179` | Same, for section variables |
+
+Note the seam for the two inputs services: they run at **evaluation** time,
+which is on the acting seed and can be reached by a student page load. The
+refusal belongs at the **save** that stores the expression, not here. Leave the
+evaluator's stated default alone and add the guard where the expression is
+authored.
+
+### Group 2 — sites that should stop naming a language at all
+
+These do not need a fallback; they need a rewrite that never asks the question.
+
+| Site | Fix |
+|---|---|
+| `UpdateSolutionTool.swift:171` | Only asks whether the language is `.uploadOnly`. `if case .uploadOnly = language?.editorSupport` answers it with no default and no behaviour change |
+
+### Group 3 — keep the explicit default, and keep the comment
+
+Nine sites where "none" is not an answerable value and failing is worse than
+defaulting. Each already states the default locally rather than inheriting it,
+which is the property the Optional bought.
+
+| Site | Why the default stays |
+|---|---|
+| `Worker/NotebookExtractor.swift:130` | Extraction has to write a file in *some* syntax; grading path |
+| `Worker/RunnerDaemon+JobProcessing.swift:652` | The student-module hint must name the file the extractor actually wrote |
+| `PersonalizationSubstitution.swift:55` | There is no literal without a syntax |
+| `TestScriptTemplates.swift:147` | Scaffold text; nil output byte-for-byte matches the previous Python |
+| `NotebookScaffoldHelpers.swift:165,167,174` | A notebook needs a kernelspec; nil already returns nil for upload-only |
+| `PublishedAssignmentRoutes+NotebookTools.swift:87` | Scans an *arbitrary* notebook, not an assignment: the fallback chain is `?language=` → kernelspec → Python, and the distinction being drawn is between kernels we can read and ones we cannot |
+| `SubmissionResultPresenter.swift:517` | Display; computes generated filenames, which only exist when families do, which requires a recorded language — unreachable with effect |
+| `PublishedAssignmentRoutes+Suite.swift:133` | Same, for the author-facing suite view |
+
+---
+
+## Status at merge
+
+Closed:
+
+- `resolve(manifest:)` reads the declaration only; the sniff is gone from every
+  read path.
+- `rederive`, `isRNotebook`, `isRNotebookMetadata` deleted.
+- All four creation doors declare; `BackfillDeclaredLanguage` covers the rest.
+- The seventeen `language:` parameter defaults are gone and guarded.
+- The browser runner boots only the declared language's substrate
+  (`ensureReady`), rather than every kind present.
+
+Deliberately open:
+
+- The Group 1 refusals above. They are authoring-behaviour changes on a branch
+  that auto-deploys, and they want their own change with their own tests.
+- Group 3 stays as it is. Those defaults are correct, not debt.

--- a/docs/language-declaration.md
+++ b/docs/language-declaration.md
@@ -103,7 +103,10 @@ path.
 
 ---
 
-## What is still open: the fourteen `?? .python` sites
+## The `?? .python` sites
+
+There were fourteen. Four are gone; eleven lines remain and are correct as they
+stand.
 
 These are **not** resolution fallbacks. Resolution has no fallback. They are
 sites asking a different question:
@@ -119,7 +122,7 @@ An author can fix a missing declaration in ten seconds and a refusal tells them
 how. A student cannot fix it at all, and a refusal on their path turns an
 instructor's omission into a failed submission.
 
-### Group 1 — authoring: a refusal is the right answer
+### Group 1 — authoring: refuse. **Done.**
 
 The justification written at these sites ("refusing would be circular — a
 pattern family is frequently the FIRST thing authored, and generating its
@@ -130,31 +133,60 @@ the author chose *None*, and authoring a Python pattern family on an assignment
 whose author said it has no language is the exact silent-wrong-answer shape this
 arc removed.
 
-| Site | Currently |
+| Site | Now |
 |---|---|
-| `PatternFamilyApplication+Inputs.swift:232` | Generates `.py` scripts on a declared-none assignment |
-| `GlobalInputsService.swift:232` | Evaluates `=` expressions with `python3` |
-| `SectionInputsService.swift:179` | Same, for section variables |
+| `PatternFamilyApplication+Inputs.swift` | Returns the declaration, optional. `applyPatternFamilies` refuses (`undeclaredLanguageGenerationMessage`) when the save would generate a script |
+| `GlobalInputsService.swift` | Refuses an `=` expression (`undeclaredLanguageExpressionMessage`); literal variables are unaffected |
+| `SectionInputsService.swift` | Same, for section variables |
 
-Note the seam for the two inputs services: they run at **evaluation** time,
-which is on the acting seed and can be reached by a student page load. The
-refusal belongs at the **save** that stores the expression, not here. Leave the
-evaluator's stated default alone and add the guard where the expression is
-authored.
+Two properties of the pattern-family refusal are load-bearing:
 
-### Group 2 — sites that should stop naming a language at all
+- **It is conditional on generation.** Every suite save runs through
+  `applyPatternFamilies`, including saves that only reorder raw scripts, so an
+  unconditional refusal would make a plain `.sh` suite uneditable. The guard
+  fires only when there is an enabled family case or a notebook check to render.
+- **It is not the whole bug.** The fallback was also *writing Python down*:
+  `rebuildPatternFamilyManifest` always records the language it is handed, so
+  reordering two `.sh` scripts silently rewrote a declared-None assignment's
+  declaration to Python. The manifest rebuild now takes an optional and persists
+  nil.
 
-These do not need a fallback; they need a rewrite that never asks the question.
+The inputs services refuse inside `evaluateForActingSeed`, which despite the
+name is reached only from `apply` — the save. Notebook substitution at student
+first-open (`PersonalizationSubstitution.resolve`) keeps its stated default and
+never refuses.
 
-| Site | Fix |
-|---|---|
-| `UpdateSolutionTool.swift:171` | Only asks whether the language is `.uploadOnly`. `if case .uploadOnly = language?.editorSupport` answers it with no default and no behaviour change |
+### Group 2 — stop naming a language at all. **Done.**
+
+`UpdateSolutionTool` asked two questions through one `?? .python`:
+
+- *Is this language upload-only?* — answered now by
+  `if case .uploadOnly = language?.editorSupport`, with no default: a
+  declaration of "none" is not upload-only, so the notebook workflow is kept
+  exactly as before.
+- *Is this solution filename's extension acceptable?* — a real language
+  question, and the old fallback answered it as Python, so a `.sh`-suite
+  assignment accepted `solution.py` and rejected everything else for a reason
+  nothing in the assignment supported. It refuses now, naming
+  `set_assignment_language` as the fix.
+
+### An adjacent defect the work surfaced
+
+`makeWorkerManifestJSON` builds a **fresh dict**, so any field it is not handed
+is dropped by a rebuild. `languageDeclared` was never handed to it, and
+`language` was not handed to it by the draft paths — so the create page's
+`required` language select recorded the author's choice and the next suite
+action (`replace-suite-files`, `clear-suite-files`, or the publish rebuild in
+`saveNewAssignment`) erased it. Both fields are threaded now, and both halves
+travel together: `language` alone cannot express "the author picked None", so
+carrying only it would still turn a deliberate None back into an unanswered
+question.
 
 ### Group 3 — keep the explicit default, and keep the comment
 
-Nine sites where "none" is not an answerable value and failing is worse than
-defaulting. Each already states the default locally rather than inheriting it,
-which is the property the Optional bought.
+Eleven lines where "none" is not an answerable value and failing is worse than
+defaulting. Each states the default locally rather than inheriting it, which is
+the property the Optional bought.
 
 | Site | Why the default stays |
 |---|---|
@@ -166,6 +198,7 @@ which is the property the Optional bought.
 | `PublishedAssignmentRoutes+NotebookTools.swift:87` | Scans an *arbitrary* notebook, not an assignment: the fallback chain is `?language=` → kernelspec → Python, and the distinction being drawn is between kernels we can read and ones we cannot |
 | `SubmissionResultPresenter.swift:517` | Display; computes generated filenames, which only exist when families do, which requires a recorded language — unreachable with effect |
 | `PublishedAssignmentRoutes+Suite.swift:133` | Same, for the author-facing suite view |
+| `PatternFamilyApplication.swift:207` | The render standin on the declared-None path, inert by the guard above: nothing is rendered there, and the manifest records the declaration rather than this |
 
 ---
 
@@ -181,8 +214,17 @@ Closed:
 - The browser runner boots only the declared language's substrate
   (`ensureReady`), rather than every kind present.
 
+- The Group 1 authoring refusals and the Group 2 rewrite, with
+  `UndeclaredLanguageRefusalTests` pinning both halves of each rule (what is
+  refused *and* what must still be allowed).
+- Manifest rebuilds preserve `language` + `languageDeclared`.
+
 Deliberately open:
 
-- The Group 1 refusals above. They are authoring-behaviour changes on a branch
-  that auto-deploys, and they want their own change with their own tests.
 - Group 3 stays as it is. Those defaults are correct, not debt.
+- `resolveAuthoringLanguage` still lets an authored non-Python raw script
+  outrank the stored declaration — the last content sniff on an authoring path.
+  It is harmless while it agrees with the declaration and wrong when it does
+  not (adding `test_extra.R` to a declared-Python assignment would re-render its
+  families as R), but removing it is a separate behaviour change with its own
+  reachability question, so it is named here rather than done quietly.


### PR DESCRIPTION
## What this is

The multi-language arc (#1330, #1331) landed a rule that was not written down
anywhere a reader would find it: **an assignment declares its language, and
nothing infers one.** This PR writes it down, then applies its one open
consequence — the `?? .python` sites — and fixes four live defects found doing so.

## The rule the fallbacks are settled by

> **Fail loudly while authoring. Never fail while grading, rendering a page, or
> extracting a student's submission.**

An instructor can fix a missing declaration from the dropdown in seconds and a
refusal tells them how. A student cannot fix it at all, and a refusal on their
path turns an instructor's omission into a failed submission.

Fourteen `?? .python` lines were surveyed; five are gone, ten stay and the doc
says why per site.

## Authoring now refuses (was: guessed Python)

Three sites carried this justification:

> Refusing here would be circular: a pattern family is frequently the FIRST
> thing authored on an assignment, and generating its scripts is how the suite
> acquires a graded script in the first place.

True while the language was **inferred from content**, when nil honestly meant
"nothing has named a language yet". Declaration dissolves it: every door that
creates an assignment declares, so nil means the author picked **None** and
there is nothing to wait for.

- Adding a pattern family or notebook check on a declared-None assignment →
  refused (`undeclaredLanguageGenerationMessage`).
- Storing a per-student `=` expression, global or section → refused
  (`undeclaredLanguageExpressionMessage`). A generated test and an expression
  are both source code; "None" has no syntax to write them in. Literal
  variables are unaffected.
- `update_solution` stops naming Python to ask whether a language is
  upload-only (`if case .uploadOnly = language?.editorSupport`), and refuses to
  check a solution filename against Python's extensions on an assignment that
  declares no language — which had been accepting `solution.py` and rejecting
  everything else for a reason nothing in the assignment supported.

Both inputs services refuse inside `evaluateForActingSeed`, which despite the
name is reached only from `apply` — the save. Notebook substitution at student
first-open keeps its stated default and never refuses.

## And where "none" is a real answer, it is answered

`shellTestScript` renders the three `.sh` scaffolds, and its nil case fell back
to Python. A declared-None assignment is the one case with no language to name,
so the two language-shaped values become ordinary shell variables with a TODO
apiece — `FILE` for what the student submits, `RUN` for the command that runs
it. That is a scaffold the author completes, where `solution.py` + `python3` was
one they had to notice was wrong first.

## Four live defects this surfaced

**1. A suite save rewrote a "None" assignment's language to Python.** The
fallback was not only guessing, it was writing the guess down: every suite save
runs through `applyPatternFamilies`, and `rebuildPatternFamilyManifest` records
whatever language it is handed. Reordering two `.sh` scripts therefore declared
the assignment Python, silently and stickily. So the refusal is **conditional on
the save actually generating something** — an unconditional one would make a
plain `.sh` suite uneditable — and the rebuild takes an optional and persists
nil.

**2. The new-assignment page erased the language it had just asked for.**
`makeWorkerManifestJSON` builds a fresh dict, so any field it is not handed is
dropped by a rebuild. `languageDeclared` was never handed to it, and `language`
was not handed to it by the draft paths — so the create page's `required` select
recorded the author's choice and `replace-suite-files` / `clear-suite-files` /
the publish rebuild wiped it. Both fields are threaded now, and both travel
together: `language` alone cannot express "None", so carrying only it would
still turn a deliberate None back into an unanswered question.

**3. The per-language shell scaffolds never reached a browser.**
`allTemplateInfos` and `shellTestScript` both defaulted `language:` to nil, and
the scan-notebook endpoint omitted the argument — so the work that taught these
templates to render `solution.R` / `Rscript` for R, and the equivalent for Lua,
Octave, C++ and Racket, was dead on arrival. Every author of every language got
the Python ones, which is the exact defect that work existed to fix. Both
defaults are gone, so forgetting is now a compile error, and the endpoint is
covered end to end — a compile error cannot see a caller passing the *wrong*
language.

**4. R's scaffold could not run.** It invoked `interpreterProbe.command`, which
for R is `R` — the right probe for "is R installed", and a command that runs
nothing: `R solution.R` reports the argument ignored and reads a REPL from
stdin. The runner has always spawned `Rscript`. `LanguageDescriptor` carries
`scriptRunCommand` now, and the descriptor's claim that "probing IS invoking" is
corrected where it was written.

The general lesson in 3 and 4 is not an R quirk: **a value in reach that is
*shaped* like the one you need is not the one you need.** Probe-for-it and
run-it are different questions, and one field answered both because for five of
six languages the answers coincide — the same shape as `isRNotebook`'s `Bool`
return.

## Docs

- **`docs/language-declaration.md`** (new) — the rule and why nil is
  load-bearing; the four doors that declare and the one boundary that still
  derives (`derivedDeclaration`, three callers, each recording immediately);
  what was deleted and why each shape was invisible to the compiler; the
  per-site fallback table; and a "Status at merge" section separating closed
  from deliberately open.
- **`CLAUDE.md`** — language section rewritten to the declaration rule, with an
  explicit "do not reintroduce inference" instruction and the
  `makeWorkerManifestJSON` corollary.

## Testing

- `UndeclaredLanguageRefusalTests` (new, 5 tests) pins **both halves** of each
  rule — what is refused, and what must still be allowed. The script-only-save
  case asserts the manifest comes back with `language == nil` and
  `languageDeclared == true`, the regression guard for defect 1.
- `NewAssignmentDraftServiceTests` gains two cases for defect 2, one for a
  declared language and one for a declared "None".
- `RunCommandMatchesInvocationTests` (new, WorkerTests — the only target that
  can see both Core's descriptor and Worker's invocation table, which is why
  they could drift) pins `scriptRunCommand` against what the worker spawns,
  derived from `allCases`. Negative-tested by reverting R to the probe command.
- `CreateAssignmentToolTests` gains four cases pinning that the MCP tool really
  requires a language: the omission asserted at the `decoded(as:)` seam the
  dispatcher uses, the schema `enum` equalling `allCases + "none"` with every
  token parsing, an unknown language leaving nothing half-created, and `"none"`
  round-tripping as nil `language` **with** `languageDeclared`. The two schema
  assertions were negative-tested.
- Test fixtures that modelled an *undeclared* assignment now declare: that state
  is no longer reachable through any door, so a fixture in it was modelling
  nothing. `withPatternFamilyFixture` takes `declaredLanguage:` (default
  `.python`, `nil` for the author-said-None case).
- Full suite green locally: **3,429 tests in 413 suites**, plus
  `scripts/lint.sh`, `scripts/swiftlint.sh --strict`, `scripts/check-styles.sh`
  and `scripts/no-language-defaults.sh`.

## Deliberately not done

`resolveAuthoringLanguage` still lets an authored non-Python raw script outrank
the stored declaration — the last content sniff on an authoring path. Harmless
while it agrees with the declaration, wrong when it does not (adding
`test_extra.R` to a declared-Python assignment would re-render its families as
R). It is named in the doc rather than changed quietly, since it is a separate
behaviour change with its own reachability question.