### PR TITLE
fix(language): a declared language governs generation, not the suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,41 @@ the language turns a deliberate "None" back into "nobody has been asked". See
 [docs/language-declaration.md](docs/language-declaration.md) for the per-site
 table. Also `docs/r-support.md`.
 
+**A declared language is NOT exclusive. Shell is the substrate every assignment
+sits on.** Two concepts do two jobs and are routinely confused for one:
+`ScriptInterpreter` (RunnerCore) is **per script**, derived from extension →
+shebang → content, and has thirteen cases including `sh`, `bash`, `zsh`, `ruby`,
+`perl`, `node` and `php` — interpreters the runner dispatches but Chickadee
+cannot author in. `AssignmentLanguage` (Core) is **per assignment**, declared,
+and has six. The declaration governs what Chickadee **generates**; the script's
+own extension governs how it **runs**. `TestSuiteEntry` carries no language
+field precisely because of this: `scriptInvocation(for:)` takes only a URL, and
+the runner stages *every* language's `test_runtime.*` into every job workspace,
+so a hand-written `.R` helper inside a Python assignment runs under `Rscript`
+and always has. No authoring surface refuses an off-language script, and
+`KernelImportGuard` is explicitly per-file. This is the original design — "test
+suites are shell scripts; the runner executes them generically" — with
+per-language generation layered on top, not replacing it.
+
+Two consequences that were each once a defect. **Content does not vote on the
+declaration:** `resolveAuthoringLanguage` used to let an authored `.R` script
+outrank the stored language, silently re-rendering every generated script and
+deleting the old ones — a migration triggered by adding a helper. It returns the
+declaration now; changing language stays the dropdown's job. **The capability
+gate reads the suite, not just the declaration:**
+`AssignmentLanguage.languagesRequiredToGrade(manifest:)` unions the declared
+language with every language the suite's extensions imply, because asking only
+the declaration let a `.R` helper in a Python assignment be claimed by an R-less
+runner and die at exit 127 in front of a student. An empty set — a plain `.sh`
+suite, or one of `.rb`/`.js` — still fails open, which is what keeps the
+original mode claimable by anyone.
+
+So **"None" means "nothing is generated"**, which in practice means hand-written
+scripts only. Do not turn it into a `.shell` language case: `sh` must keep
+carrying no language signal (C++'s generated cases *are* `.sh` wrappers), and
+the field that would have to claim it, `scriptExtensions`, is also what
+`update_solution` reads to decide which solution filenames are acceptable.
+
 **A runner only claims a job it can actually grade — enforced, not authored
 (`RunnerLanguageGate`).** Runners are separate hosts that upgrade on their own
 schedule, so several `chickadee-runner` builds poll at once and claim order
@@ -294,14 +329,17 @@ decides which one grades a job. That used to make an assignment in a newer
 language nondeterministic: it validated green because a capable runner happened
 to claim it, then failed for the one student whose job an older runner claimed —
 with a symptom (exit 127, "interpreter not found") that reads as a broken test
-script and gets debugged as one. The claim seam now resolves the assignment's
-language from its manifest and refuses a runner whose advertised profile lacks
-it, so the job waits for a runner that can grade it. No authoring step: the
+script and gets debugged as one. The claim seam now asks
+`languagesRequiredToGrade` for every language the job needs — the declared one
+*plus* every language the suite's own script extensions imply — and refuses a
+runner whose advertised profile lacks any of them, so the job waits for a runner
+that can grade it. No authoring step: the
 manifest already knows the language, and `RunnerProfileDetector` discovers its
 probes from `AssignmentLanguage.allCases`, so every runner advertises every
 language it has and a runner whose *build* predates one advertises a profile
-without it. Two deliberate fail-opens — an assignment with no language (a plain
-`.sh` suite) and a runner advertising no profile at all (discovery switched off,
+without it. Two deliberate fail-opens — nothing requiring an interpreter (a plain
+`.sh` suite, or one of the interpreters that has no capability token) and a
+runner advertising no profile at all (discovery switched off,
 an operator's choice; an old runner still has discovery on and is caught by the
 closed path). It catches strictly more than a version gate: a *current* runner
 whose host lacks the interpreter never advertises it either. `minimumRunnerVersion`

--- a/Sources/APIServer/Compatibility/RunnerLanguageGate.swift
+++ b/Sources/APIServer/Compatibility/RunnerLanguageGate.swift
@@ -33,13 +33,27 @@ import Foundation
 /// runs the server's own vended WASM bundle and has no runner profile to check.
 enum RunnerLanguageGate {
 
-    /// Whether `runnerProfile` advertises the language this assignment is in.
+    /// Whether `runnerProfile` advertises every language this assignment needs.
+    ///
+    /// EVERY language, not just the declared one. The declaration says what
+    /// Chickadee generates; the suite says what the runner will be asked to
+    /// execute, and a suite may legitimately mix — the runner classifies each
+    /// script independently and stages every language's `test_runtime.*`, so a
+    /// hand-written `.R` helper inside a Python assignment runs under `Rscript`
+    /// and always has. Checking only the declaration let exactly that job be
+    /// claimed by an R-less runner, where it died at `exit 127 /
+    /// Rscript: not found` in front of a student — this gate's own failure mode,
+    /// in a shape it could not see. `languagesRequiredToGrade` answers both
+    /// halves at once.
     ///
     /// Compatible — with no check performed — in two cases:
     ///
-    /// 1. **The assignment names no language** (`language == nil`). A suite of
-    ///    plain `.sh` scripts has no interpreter to require; that is the
-    ///    system's original mode and stays claimable by anyone.
+    /// 1. **Nothing requires an interpreter** (the required set is empty): no
+    ///    declared language and a suite whose extensions name none, i.e. plain
+    ///    `.sh`. That is the system's original mode and stays claimable by
+    ///    anyone. Extensions the runner can dispatch but Chickadee cannot author
+    ///    in (`.rb`, `.js`, `.pl`) also contribute nothing, so a suite of those
+    ///    keeps failing open exactly as it did before.
     /// 2. **The runner advertises no profile at all.** That means capability
     ///    discovery is switched off (`RUNNER_CAPABILITY_DISCOVERY_ENABLED=false`),
     ///    an explicit operator choice, and treating it as incompatible would
@@ -48,22 +62,31 @@ enum RunnerLanguageGate {
     ///    know the language still *has* discovery on, so it advertises a profile
     ///    without the language and is caught by the closed path below.
     ///
-    /// Everything else is checked: a profile that is present and does not list
-    /// the language is refused, whatever the reason it is missing (build too old
-    /// to probe for it, or host without the interpreter installed).
+    /// Everything else is checked: a profile that is present and does not list a
+    /// required language is refused, whatever the reason it is missing (build too
+    /// old to probe for it, or host without the interpreter installed).
     static func evaluate(
         runnerProfile: RunnerCapabilityProfile?,
-        language: AssignmentLanguage?
+        manifest: TestProperties
     ) -> CompatibilityResult {
-        guard let language else { return CompatibilityResult(isCompatible: true) }
+        let required = AssignmentLanguage.languagesRequiredToGrade(manifest: manifest)
+        guard !required.isEmpty else { return CompatibilityResult(isCompatible: true) }
         guard let runnerProfile else { return CompatibilityResult(isCompatible: true) }
 
-        let required = normalized(language.capabilityName)
         let advertised = Set(runnerProfile.languageVersions.map { normalized($0.language) })
-        guard advertised.contains(required) else {
+        // `allCases` order, so a runner missing two languages names them in a
+        // stable order rather than a Set's arbitrary one.
+        let missing = AssignmentLanguage.allCases
+            .filter { required.contains($0) && !advertised.contains(normalized($0.capabilityName)) }
+        guard missing.isEmpty else {
             return CompatibilityResult(
                 isCompatible: false,
-                reasons: ["runner does not provide \(required) (assignment language)"]
+                reasons: missing.map {
+                    let role =
+                        manifest.language == $0
+                        ? "assignment language" : "used by a test script in the suite"
+                    return "runner does not provide \(normalized($0.capabilityName)) (\(role))"
+                }
             )
         }
         return CompatibilityResult(isCompatible: true)

--- a/Sources/APIServer/Services/WorkerClaimEvaluation.swift
+++ b/Sources/APIServer/Services/WorkerClaimEvaluation.swift
@@ -185,7 +185,7 @@ func evaluateAndClaimCandidate(
         )
         let languageResult = RunnerLanguageGate.evaluate(
             runnerProfile: runnerProfile,
-            language: AssignmentLanguage.resolve(for: setup, manifest: manifest)
+            manifest: manifest
         )
         let compatibilityResult = RunnerVersionGate.combine(
             RunnerVersionGate.combine(capabilityResult, versionResult),

--- a/Sources/APIServer/Utilities/PatternFamilyApplication+Inputs.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication+Inputs.swift
@@ -193,53 +193,44 @@ struct AuthoringLanguageResolution {
     let previous: AssignmentLanguage?
 }
 
-/// Decides which language the generated scripts render in.
+/// Decides which language the generated scripts render in: the one the author
+/// declared, and nothing else.
 ///
-/// The authored items carry the edit being applied, which may be the very
-/// first non-Python graded script — the `.R` or `.lua` that establishes the
-/// language before the manifest has recorded anything. Any non-Python language
-/// wins, in `allCases` order for a deterministic answer on a mixed edit.
-/// Checking only `.r` here is what made the first `.lua` script save as Python.
-/// Python is excluded by name so adding a `.py` helper to an R assignment
-/// cannot flip the render language; the stored manifest stays authoritative.
+/// THE SUITE'S CONTENTS DO NOT VOTE. This used to scan the authored items for a
+/// non-Python script extension and let it outrank the stored declaration, on
+/// the reasoning that the edit being applied "may be the very first non-Python
+/// graded script — the `.R` or `.lua` that establishes the language before the
+/// manifest has recorded anything". Nothing has been in that state since
+/// declaration became a requirement: every door that creates an assignment
+/// declares, so there is no un-established language for a script to establish.
+///
+/// What the scan did instead was migrate assignments nobody asked to migrate.
+/// It ran on EVERY suite save, including reorders, so authoring one
+/// `helper_test.R` into an assignment declaring Python re-rendered every
+/// generated script in R, DELETED the `.py` ones (the deletion diff reads
+/// `previous`), and wrote `.r` into the manifest. It was asymmetric on top of
+/// that — a `.py` helper could not flip an R assignment, because Python was
+/// excluded by name — so the same act had opposite consequences depending on
+/// which language you already had.
+///
+/// A mixed-language suite is legitimate and always has been: the runner
+/// classifies every script independently (`classifyScriptInterpreter`) and
+/// stages every language's `test_runtime.*` into the workspace, so an `.R`
+/// helper in a Python assignment runs under `Rscript` and always did. The
+/// declaration governs what Chickadee GENERATES, not what the author may write
+/// by hand. Changing it is the language dropdown's job (and
+/// `set_assignment_language`'s), both of which refuse once generated scripts
+/// exist — a guard this scan quietly went around.
 func resolveAuthoringLanguage(
     setup: APITestSetup,
-    props: TestProperties,
-    authoredItems: [AuthoredSuiteItem]?
+    props: TestProperties
 ) -> AuthoringLanguageResolution {
-    let previous = AssignmentLanguage.resolve(for: setup, manifest: props)
-
-    var authoredLanguages: Set<AssignmentLanguage> = []
-    for item in authoredItems ?? [] {
-        guard case .script(let raw) = item,
-            let language = AssignmentLanguage(
-                scriptExtension: URL(fileURLWithPath: raw.script).pathExtension),
-            language != .python
-        else { continue }
-        authoredLanguages.insert(language)
-    }
-    let resolved = AssignmentLanguage.allCases.first { authoredLanguages.contains($0) } ?? previous
-
-    // NO PYTHON FALLBACK. This used to end `?? .python`, justified as follows:
-    //
-    //     Refusing here would be circular: a pattern family is frequently the
-    //     FIRST thing authored on an assignment, and generating its scripts is
-    //     how the suite acquires a graded script in the first place.
-    //
-    // That was true while the language was INFERRED from content, when nil
-    // honestly meant "nothing has named a language yet". Declaration dissolves
-    // it: every door that creates an assignment declares, so nil here means the
-    // author picked "None" and the circularity is gone — there is nothing to
-    // wait for, only an answer to respect.
-    //
-    // The fallback was also actively wrong, not merely redundant. Every suite
-    // save runs through this function, including saves that touch only raw
-    // scripts and ordering, and the manifest rebuild ALWAYS records the value
-    // it is handed — so reordering two `.sh` scripts on a declared-None
-    // assignment silently rewrote its declaration to Python. The caller now
-    // refuses only when the save would actually GENERATE something (which needs
-    // a syntax) and persists nil otherwise.
-    return AuthoringLanguageResolution(language: resolved, previous: previous)
+    let declared = AssignmentLanguage.resolve(for: setup, manifest: props)
+    // `previous` is retained as a separate field even though it now always
+    // equals `language`: the deletion diff consumes it to find generated
+    // scripts written under a DIFFERENT extension, which is still reachable
+    // when `set_assignment_language` changes the declaration between saves.
+    return AuthoringLanguageResolution(language: declared, previous: declared)
 }
 
 /// Every save-time validation, in the order the pre-split function ran them.

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -184,8 +184,7 @@ func applyPatternFamilies(
     try validateAuthoredSectionContiguity(ordering.items)
 
     // ── 3. Resolve the language, then validate the whole save ───────────
-    let language = resolveAuthoringLanguage(
-        setup: setup, props: props, authoredItems: authoredItems)
+    let language = resolveAuthoringLanguage(setup: setup, props: props)
 
     // A generated script has to be written in SOME syntax, so a save that
     // generates one needs a declared language. A save that generates nothing

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -265,6 +265,40 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
         return best?.language
     }
 
+    /// Every language an interpreter must exist for before this manifest can be
+    /// graded: the declared one, plus every language its suite's scripts are
+    /// written in.
+    ///
+    /// These are two different questions and only together do they answer "can
+    /// this runner grade this job?". The declaration says what Chickadee
+    /// GENERATES; the suite says what the runner will actually be asked to
+    /// execute, and a suite may legitimately mix — the runner classifies each
+    /// script independently (`classifyScriptInterpreter`) and stages every
+    /// language's `test_runtime.*` into the workspace, so a hand-written `.R`
+    /// helper inside a Python assignment runs under `Rscript` and always has.
+    ///
+    /// Asking only the declaration is how a `.R` helper in a Python assignment
+    /// could be claimed by an R-less runner and die at `exit 127` in front of a
+    /// student — the exact failure `RunnerLanguageGate` exists to prevent, for a
+    /// shape it could not see.
+    ///
+    /// Extensions that name no assignment language contribute nothing, which is
+    /// what keeps the original mode claimable by anyone: `.sh` carries no
+    /// language signal (deliberately — C++'s generated cases ARE `.sh`
+    /// wrappers), and neither do the other interpreters the runner can dispatch
+    /// but Chickadee cannot author in, like `.rb` or `.js`. A plain `.sh` suite
+    /// on an assignment declaring nothing therefore returns the empty set.
+    public static func languagesRequiredToGrade(manifest: TestProperties) -> Set<AssignmentLanguage> {
+        var required: Set<AssignmentLanguage> = []
+        if let declared = manifest.language { required.insert(declared) }
+        for entry in manifest.testSuites {
+            guard let found = languageByScriptExtension[scriptExtension(ofPath: entry.script)]
+            else { continue }
+            required.insert(found.language)
+        }
+        return required
+    }
+
     /// The language a notebook kernel name (`kernelspec.name` then
     /// `language_info.name`) declares, or nil when neither is recognised. The
     /// string-argument form of `fromNotebookMetadata`, matched against every

--- a/Tests/APITests/MixedLanguageSuiteTests.swift
+++ b/Tests/APITests/MixedLanguageSuiteTests.swift
@@ -1,0 +1,135 @@
+// Tests/APITests/MixedLanguageSuiteTests.swift
+//
+// A suite may hold scripts in languages other than the one the assignment
+// declares, and doing so must not change the assignment.
+//
+// This is not an edge case bolted on — it is how grading has always worked.
+// `scriptInvocation(for:)` takes only a URL and classifies each script
+// independently, and the runner stages EVERY language's `test_runtime.*` into
+// every job workspace. So a hand-written `.R` helper inside a Python assignment
+// runs under `Rscript`, and always did.
+//
+// What did not hold up was the authoring side. `resolveAuthoringLanguage` used
+// to scan the authored scripts and let a non-Python extension outrank the stored
+// declaration, so saving one `helper_test.R` into a Python assignment re-rendered
+// every generated script in R, deleted the `.py` ones, and wrote `.r` into the
+// manifest — a language migration nobody asked for, triggered by adding a
+// helper. These pin the corrected rule: the declaration governs what Chickadee
+// GENERATES; the suite's contents govern only what gets executed, and they do
+// not vote on the declaration.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MixedLanguageSuiteTests {
+
+    /// Authoring an off-language raw script leaves the declaration, the
+    /// generated scripts, and their extensions exactly as they were.
+    @Test func anOffLanguageHelperDoesNotMigrateTheAssignment() async throws {
+        try await withPatternFamilyFixture(declaredLanguage: .python) { fixture in
+            // A Python assignment with a generated family: the thing that would
+            // be re-rendered and deleted if content still voted.
+            let first = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfBMIFamily()], on: fixture.app.db)
+            #expect(first.writtenFiles.allSatisfy { $0.hasSuffix(".py") })
+            let generatedBefore = Set(
+                try pfDecodeManifest(fixture.setup.manifest)
+                    .testSuites.filter { $0.generatedBy != nil }.map(\.script))
+            #expect(!generatedBefore.isEmpty)
+
+            // Now the author adds a hand-written R helper beside it.
+            try updateScriptInZip(
+                zipPath: fixture.setup.zipPath,
+                filename: "helper_test.R",
+                content: "cat(\"ok\\n\")\n"
+            )
+            let props = try pfDecodeManifest(fixture.setup.manifest)
+            var authored: [AuthoredSuiteItem] = props.testSuites
+                .filter { $0.generatedBy == nil && $0.generatedByCheck == nil }
+                .map {
+                    .script(
+                        AuthoredRawScript(
+                            script: $0.script, tier: $0.tier, points: $0.points,
+                            displayName: nil, dependsOn: [], sectionID: nil))
+                }
+            authored.append(
+                .script(
+                    AuthoredRawScript(
+                        script: "helper_test.R", tier: .pub, points: 1,
+                        displayName: nil, dependsOn: [], sectionID: nil)))
+            authored.append(.family(id: "bmi_category", sectionID: nil))
+
+            let result = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfBMIFamily()], authoredItems: authored,
+                on: fixture.app.db)
+
+            let after = try pfDecodeManifest(fixture.setup.manifest)
+            #expect(
+                after.language == .python,
+                "a hand-written .R helper must not re-declare a Python assignment as R")
+            #expect(after.languageDeclared == true)
+
+            // The generated scripts are untouched — same names, still `.py`.
+            let generatedAfter = Set(
+                after.testSuites.filter { $0.generatedBy != nil }.map(\.script))
+            #expect(generatedAfter == generatedBefore)
+            #expect(
+                result.deletedFiles.isEmpty,
+                "nothing may be deleted: a migration would have removed the .py scripts")
+
+            // And the helper is in the suite, in its own language.
+            #expect(after.testSuites.contains { $0.script == "helper_test.R" })
+        }
+    }
+
+    /// The same in the other direction, which used to be the asymmetry: a `.py`
+    /// helper could never flip an R assignment, because Python was excluded by
+    /// name. Both directions are inert now, for the same reason.
+    @Test func aPythonHelperDoesNotMigrateAnRAssignment() async throws {
+        try await withPatternFamilyFixture(declaredLanguage: .r) { fixture in
+            try updateScriptInZip(
+                zipPath: fixture.setup.zipPath, filename: "helper_test.py",
+                content: "print('ok')\n")
+            let authored: [AuthoredSuiteItem] = [
+                .script(
+                    AuthoredRawScript(
+                        script: "helper_test.py", tier: .pub, points: 1,
+                        displayName: nil, dependsOn: [], sectionID: nil))
+            ]
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [], authoredItems: authored, on: fixture.app.db)
+
+            #expect(try pfDecodeManifest(fixture.setup.manifest).language == .r)
+        }
+    }
+
+    /// Generated scripts still render in the DECLARED language when an
+    /// off-language helper is present — the property that would break if the
+    /// scan were restored, and the reason this is not simply "the sniff was
+    /// redundant".
+    @Test func generatedScriptsFollowTheDeclarationNotTheSuite() async throws {
+        try await withPatternFamilyFixture(declaredLanguage: .python) { fixture in
+            try updateScriptInZip(
+                zipPath: fixture.setup.zipPath, filename: "helper_test.lua",
+                content: "print('ok')\n")
+            let authored: [AuthoredSuiteItem] = [
+                .script(
+                    AuthoredRawScript(
+                        script: "helper_test.lua", tier: .pub, points: 1,
+                        displayName: nil, dependsOn: [], sectionID: nil)),
+                .family(id: "bmi_category", sectionID: nil),
+            ]
+            let result = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfBMIFamily()], authoredItems: authored,
+                on: fixture.app.db)
+
+            #expect(result.writtenFiles.allSatisfy { $0.hasSuffix(".py") })
+            #expect(try pfDecodeManifest(fixture.setup.manifest).language == .python)
+        }
+    }
+}

--- a/Tests/APITests/RunnerLanguageGateTests.swift
+++ b/Tests/APITests/RunnerLanguageGateTests.swift
@@ -1,11 +1,12 @@
 // Tests/APITests/RunnerLanguageGateTests.swift
 //
 // Unit tests for the implicit assignment-language gate (RunnerLanguageGate):
-// the two fail-open short-circuits (no language, no runner profile), the
-// closed path when a profile is present without the language, token
-// normalization, and the allCases-driven pin that every language is gated —
-// including Python, which used to be unrepresentable here because resolution
-// could not tell "this is Python" from "we could not tell".
+// the two fail-open short-circuits (nothing requires an interpreter, no runner
+// profile), the closed path when a profile is present without a required
+// language, token normalization, the allCases-driven pin that every language is
+// gated — including Python, which used to be unrepresentable here because
+// resolution could not tell "this is Python" from "we could not tell" — and the
+// suite-implied requirements, which the declaration alone cannot see.
 
 import Core
 import Testing
@@ -13,6 +14,19 @@ import Testing
 @testable import APIServer
 
 @Suite struct RunnerLanguageGateTests {
+
+    /// A manifest that DECLARES `language` and whose suite holds `scripts`.
+    /// The two are separate inputs on purpose: the gate has to answer for both.
+    private func manifest(
+        language: AssignmentLanguage?, scripts: [String] = []
+    ) -> TestProperties {
+        TestProperties(
+            requiredFiles: [],
+            testSuites: scripts.map { TestSuiteEntry(tier: .pub, script: $0) },
+            timeLimitSeconds: 10,
+            language: language,
+            languageDeclared: true)
+    }
 
     private func profile(languages: [String]) -> RunnerCapabilityProfile {
         RunnerCapabilityProfile(
@@ -29,7 +43,7 @@ import Testing
     /// original mode and must stay claimable by any runner.
     @Test func anAssignmentWithNoLanguageIsClaimableByAnyone() {
         let result = RunnerLanguageGate.evaluate(
-            runnerProfile: profile(languages: []), language: nil)
+            runnerProfile: profile(languages: []), manifest: manifest(language: nil))
         #expect(result.isCompatible)
         #expect(result.reasons.isEmpty)
     }
@@ -40,7 +54,9 @@ import Testing
     @Test func aRunnerWithNoProfileIsNotBlocked() {
         for language in AssignmentLanguage.allCases {
             #expect(
-                RunnerLanguageGate.evaluate(runnerProfile: nil, language: language).isCompatible,
+                RunnerLanguageGate.evaluate(
+                    runnerProfile: nil, manifest: manifest(language: language)
+                ).isCompatible,
                 "a profile-less runner must not be blocked from \(language) work")
         }
     }
@@ -49,7 +65,7 @@ import Testing
 
     @Test func aProfileWithoutTheLanguageIsRefused() {
         let result = RunnerLanguageGate.evaluate(
-            runnerProfile: profile(languages: ["python"]), language: .octave)
+            runnerProfile: profile(languages: ["python"]), manifest: manifest(language: .octave))
         #expect(!result.isCompatible)
         #expect(result.reasons.count == 1)
         #expect(result.reasons.first?.contains("octave") == true)
@@ -58,7 +74,8 @@ import Testing
     @Test func aProfileWithTheLanguageIsAdmitted() {
         #expect(
             RunnerLanguageGate.evaluate(
-                runnerProfile: profile(languages: ["python", "octave"]), language: .octave
+                runnerProfile: profile(languages: ["python", "octave"]),
+                manifest: manifest(language: .octave)
             ).isCompatible)
     }
 
@@ -68,8 +85,14 @@ import Testing
     @Test func anOlderRunnerLeavesANewLanguagesJobAlone() {
         let old = profile(languages: ["python", "r"])
         let current = profile(languages: ["python", "r", "lua", "octave", "cpp"])
-        #expect(!RunnerLanguageGate.evaluate(runnerProfile: old, language: .octave).isCompatible)
-        #expect(RunnerLanguageGate.evaluate(runnerProfile: current, language: .octave).isCompatible)
+        #expect(
+            !RunnerLanguageGate.evaluate(
+                runnerProfile: old, manifest: manifest(language: .octave)
+            ).isCompatible)
+        #expect(
+            RunnerLanguageGate.evaluate(
+                runnerProfile: current, manifest: manifest(language: .octave)
+            ).isCompatible)
     }
 
     /// The case a `minimumRunnerVersion` gate cannot catch: the runner is new
@@ -77,8 +100,80 @@ import Testing
     @Test func aCurrentRunnerMissingTheInterpreterIsAlsoRefused() {
         #expect(
             !RunnerLanguageGate.evaluate(
-                runnerProfile: profile(languages: ["python", "r", "lua"]), language: .octave
+                runnerProfile: profile(languages: ["python", "r", "lua"]),
+                manifest: manifest(language: .octave)
             ).isCompatible)
+    }
+
+    // MARK: - What the suite needs, which the declaration cannot see
+
+    /// THE HOLE THIS CLOSES. A suite may legitimately mix languages — the runner
+    /// classifies each script independently and stages every language's
+    /// `test_runtime.*` — so a hand-written `.R` helper inside a Python
+    /// assignment runs under `Rscript`. The gate used to ask only the
+    /// declaration, so an R-less runner claimed the job and the `.R` test died
+    /// at `exit 127 / Rscript: not found` in front of a student: this gate's own
+    /// failure mode, in a shape it could not see.
+    @Test func aHandWrittenOffLanguageScriptIsRequiredToo() {
+        let mixed = manifest(language: .python, scripts: ["publictest_a.py", "helper_test.R"])
+
+        let pythonOnly = profile(languages: ["python"])
+        let result = RunnerLanguageGate.evaluate(runnerProfile: pythonOnly, manifest: mixed)
+        #expect(!result.isCompatible)
+        #expect(result.reasons.count == 1)
+        #expect(result.reasons.first?.contains("provide r ") == true)
+        // The reason distinguishes WHY it is needed, so an operator reading the
+        // compatibility log is not sent looking for an R assignment.
+        #expect(result.reasons.first?.contains("test script") == true)
+
+        #expect(
+            RunnerLanguageGate.evaluate(
+                runnerProfile: profile(languages: ["python", "r"]), manifest: mixed
+            ).isCompatible)
+    }
+
+    /// The declared language is still required even when no script in the suite
+    /// names it — which is C++'s ordinary shape, since its generated cases are
+    /// `.sh` wrappers.
+    @Test func theDeclaredLanguageIsRequiredEvenWhenNoScriptNamesIt() {
+        let cpp = manifest(language: .cpp, scripts: ["publictest_a.sh"])
+        #expect(
+            !RunnerLanguageGate.evaluate(
+                runnerProfile: profile(languages: ["python"]), manifest: cpp
+            ).isCompatible)
+        #expect(
+            RunnerLanguageGate.evaluate(
+                runnerProfile: profile(languages: ["cpp"]), manifest: cpp
+            ).isCompatible)
+    }
+
+    /// Extensions that name no assignment language contribute nothing, so the
+    /// original mode stays claimable by anyone. `.sh` is deliberately
+    /// signal-free, and the runner can dispatch interpreters Chickadee cannot
+    /// author in — a suite of those must not start requiring a capability token
+    /// that no runner advertises, which would queue the job forever.
+    @Test(arguments: [
+        ["publictest_a.sh"], ["a.sh", "b.bash"], ["helper.rb"], ["tool.js", "x.pl"],
+    ])
+    func aSuiteNamingNoAssignmentLanguageStaysClaimableByAnyone(_ scripts: [String]) {
+        let result = RunnerLanguageGate.evaluate(
+            runnerProfile: profile(languages: []),
+            manifest: manifest(language: nil, scripts: scripts))
+        #expect(result.isCompatible)
+        #expect(result.reasons.isEmpty)
+    }
+
+    /// Two missing languages are both named, in `allCases` order rather than a
+    /// Set's arbitrary one, so the compatibility log is stable.
+    @Test func everyMissingLanguageIsNamedInAStableOrder() {
+        let result = RunnerLanguageGate.evaluate(
+            runnerProfile: profile(languages: ["python"]),
+            manifest: manifest(
+                language: .python, scripts: ["a.py", "b.lua", "c.R"]))
+        #expect(!result.isCompatible)
+        #expect(result.reasons.count == 2)
+        #expect(result.reasons[0].contains("provide r "))
+        #expect(result.reasons[1].contains("provide lua "))
     }
 
     // MARK: - Normalization
@@ -86,7 +181,8 @@ import Testing
     @Test func languageTokensMatchCaseAndWhitespaceInsensitively() {
         #expect(
             RunnerLanguageGate.evaluate(
-                runnerProfile: profile(languages: ["  OCTAVE "]), language: .octave
+                runnerProfile: profile(languages: ["  OCTAVE "]),
+                manifest: manifest(language: .octave)
             ).isCompatible)
     }
 
@@ -100,7 +196,9 @@ import Testing
     func everyLanguageIsGatedBothWays(_ language: AssignmentLanguage) {
         let withIt = profile(languages: [language.capabilityName])
         #expect(
-            RunnerLanguageGate.evaluate(runnerProfile: withIt, language: language).isCompatible,
+            RunnerLanguageGate.evaluate(
+                runnerProfile: withIt, manifest: manifest(language: language)
+            ).isCompatible,
             "a runner advertising \(language.capabilityName) must be admitted for \(language)")
 
         let withoutIt = profile(
@@ -108,7 +206,9 @@ import Testing
                 .filter { $0 != language }
                 .map(\.capabilityName))
         #expect(
-            !RunnerLanguageGate.evaluate(runnerProfile: withoutIt, language: language).isCompatible,
+            !RunnerLanguageGate.evaluate(
+                runnerProfile: withoutIt, manifest: manifest(language: language)
+            ).isCompatible,
             "a runner advertising every language BUT \(language.capabilityName) must be refused")
     }
 }

--- a/Tests/CoreTests/AssignmentLanguageTests.swift
+++ b/Tests/CoreTests/AssignmentLanguageTests.swift
@@ -170,4 +170,65 @@ import Testing
                 "suite order \(rotated) must not change the resolved language")
         }
     }
+
+    // MARK: - What must be installed before this manifest can be graded
+
+    /// `languagesRequiredToGrade` answers a different question from resolution:
+    /// not "what is this assignment written in" (one answer) but "what
+    /// interpreters must exist" (a set). A suite may legitimately mix — the
+    /// runner classifies each script independently — so both the declaration
+    /// and the suite contribute.
+    private func manifest(language: AssignmentLanguage?, scripts: [String]) -> TestProperties {
+        TestProperties(
+            requiredFiles: [],
+            testSuites: scripts.map { TestSuiteEntry(tier: .pub, script: $0) },
+            timeLimitSeconds: 10,
+            language: language,
+            languageDeclared: true)
+    }
+
+    @Test func theDeclaredLanguageIsAlwaysRequired() {
+        // C++'s ordinary shape: generated cases are `.sh` wrappers, so nothing
+        // in the suite names the language and only the declaration can.
+        #expect(
+            AssignmentLanguage.languagesRequiredToGrade(
+                manifest: manifest(language: .cpp, scripts: ["publictest_a.sh"])) == [.cpp])
+    }
+
+    @Test func aHandWrittenOffLanguageScriptIsRequiredToo() {
+        #expect(
+            AssignmentLanguage.languagesRequiredToGrade(
+                manifest: manifest(language: .python, scripts: ["a.py", "helper.R"]))
+                == [.python, .r])
+    }
+
+    /// The empty set is what keeps the system's original mode claimable by any
+    /// runner. `.sh` is deliberately signal-free, and the interpreters the
+    /// runner can dispatch but Chickadee cannot author in have no capability
+    /// token at all — requiring one would queue such a job forever.
+    @Test(arguments: [
+        ["publictest_a.sh"], ["a.sh", "b.bash", "c.zsh"], ["helper.rb", "tool.js", "x.pl"], [],
+    ])
+    func aSuiteNamingNoAssignmentLanguageRequiresNothing(_ scripts: [String]) {
+        #expect(
+            AssignmentLanguage.languagesRequiredToGrade(
+                manifest: manifest(language: nil, scripts: scripts)
+            ).isEmpty)
+    }
+
+    /// Every language is reachable through the suite, not just through the
+    /// declaration — derived from `allCases`, so a seventh is covered the day
+    /// it exists. C++ is the one exception and it is stated rather than skipped:
+    /// its `.sh` generated extension must keep carrying no language signal.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func everyLanguageIsReachableFromItsOwnScript(_ language: AssignmentLanguage) {
+        let script = "publictest_x.\(language.generatedScriptExtension)"
+        let required = AssignmentLanguage.languagesRequiredToGrade(
+            manifest: manifest(language: nil, scripts: [script]))
+        if language == .cpp {
+            #expect(required.isEmpty, "a `.sh` script must name no language, C++ included")
+        } else {
+            #expect(required == [language])
+        }
+    }
 }

--- a/changelog.d/mixed-language-suites.md
+++ b/changelog.d/mixed-language-suites.md
@@ -1,0 +1,26 @@
+### Fixed
+
+- **Adding a hand-written test script in another language no longer migrates the
+  assignment.** Authoring one `helper_test.R` into an assignment declared as
+  Python re-rendered every generated test in R, deleted the `.py` ones, and
+  rewrote the manifest's language — a migration nobody asked for, triggered by
+  adding a helper, and asymmetric (a `.py` helper could never flip an R
+  assignment). It also went around the guard that refuses a language change once
+  generated tests exist. The declaration is now what decides, and changing it is
+  the language dropdown's job.
+- **A runner can no longer claim a job it can only partly grade.** The claim gate
+  required just the assignment's declared language, so a `.R` script inside a
+  Python assignment could be claimed by a runner with no R and die at
+  "Rscript: not found" in front of a student — the exact failure the gate exists
+  to prevent. It now requires every language the suite actually uses. A suite of
+  plain shell scripts still runs anywhere, as it always has.
+
+### Changed
+
+- **Written down: a declared language is not exclusive.** Shell is the substrate
+  every assignment sits on, and a suite may legitimately mix languages — the
+  runner classifies each script on its own and stages every language's test
+  runtime, so an `.R` helper in a Python assignment has always run under Rscript.
+  The declaration governs what Chickadee *generates*; the script's own extension
+  governs how it *runs*. `CLAUDE.md` and `docs/language-declaration.md` now say
+  so, along with why "None" is not a shell language case.

--- a/docs/language-declaration.md
+++ b/docs/language-declaration.md
@@ -250,12 +250,84 @@ Closed:
   refused *and* what must still be allowed).
 - Manifest rebuilds preserve `language` + `languageDeclared`.
 
+- The last content sniff on an authoring path is gone:
+  `resolveAuthoringLanguage` returns the stored declaration. See "A declared
+  language is not exclusive" below for why it was wrong rather than merely
+  redundant.
+- `RunnerLanguageGate` requires every language the suite actually needs, not
+  just the declared one.
+
 Deliberately open:
 
 - Group 3 stays as it is. Those defaults are correct, not debt.
-- `resolveAuthoringLanguage` still lets an authored non-Python raw script
-  outrank the stored declaration — the last content sniff on an authoring path.
-  It is harmless while it agrees with the declaration and wrong when it does
-  not (adding `test_extra.R` to a declared-Python assignment would re-render its
-  families as R), but removing it is a separate behaviour change with its own
-  reachability question, so it is named here rather than done quietly.
+
+---
+
+## A declared language is not exclusive
+
+The declaration governs what Chickadee **generates**. It does not restrict what
+the suite may hold, and never did.
+
+| | `ScriptInterpreter` (RunnerCore) | `AssignmentLanguage` (Core) |
+|---|---|---|
+| scope | one script | one assignment |
+| derived from | extension → shebang → content sniff | the author's declaration |
+| cases | 13, incl. `sh` `bash` `zsh` `ruby` `perl` `node` `php` | 6 |
+| answers | "how do I run this file?" | "what do generated artifacts render in?" |
+
+`scriptInvocation(for:)` takes only a URL — no `AssignmentLanguage` parameter
+exists and no caller passes one — and the runner stages *every* language's
+`test_runtime.*` into every job workspace. `TestSuiteEntry` carries no language
+field. No authoring surface refuses an off-language script; `KernelImportGuard`
+switches on the script's own extension. A hand-written `.R` helper inside a
+Python assignment runs under `Rscript`, and always has.
+
+This is the original design — "test suites are shell scripts; the runner
+executes them generically" — with per-language generation layered on top rather
+than replacing it. **Shell is the substrate all six languages sit on**, which
+is why "None" means "nothing is generated" and, in practice, "hand-written
+scripts only".
+
+### Two places that contradicted it
+
+**Content voted on the declaration.** `resolveAuthoringLanguage` scanned the
+authored scripts and let a non-Python extension outrank the stored language. It
+ran on *every* suite save, including reorders, so authoring one `helper_test.R`
+into a Python assignment re-rendered every generated script in R, **deleted** the
+`.py` ones (the deletion diff reads `previous`), and wrote `.r` into the
+manifest. It was asymmetric too — a `.py` helper could not flip an R assignment,
+because Python was excluded by name — so the same act had opposite consequences
+depending on which language you already had. It also went around the guard that
+refuses a language change once generated scripts exist. Now it returns the
+declaration; changing language is the dropdown's job and
+`set_assignment_language`'s.
+
+**The capability gate asked the wrong question.** It required exactly one token,
+the declared language, so a `.R` helper in a Python assignment was claimable by
+an R-less runner and died at `exit 127 / Rscript: not found` in front of a
+student — this gate's own failure mode, in a shape it could not see.
+`AssignmentLanguage.languagesRequiredToGrade(manifest:)` unions the declaration
+with every language the suite's extensions imply. An empty set still fails open,
+which is what keeps a plain `.sh` suite — and one written in an interpreter with
+no capability token, like `.rb` or `.js` — claimable by anyone.
+
+Both were the same root cause: using the declaration to answer a question about
+*the suite's contents*, which only the contents can answer.
+
+### Why "None" is not a `.shell` language
+
+Tempting, because it would delete the Optional and collapse the remaining
+fallbacks into the per-language capability tables. It does not work:
+`languageByScriptExtension` folds every language's `scriptExtensions`, so a
+`.shell` case claiming `["sh"]` would make every C++ assignment's generated `.sh`
+wrappers derive as shell — `generatedScriptExtension: "sh"` is C++'s, and
+`everyLanguageResolvesFromItsOwnGradedScript` carries an explicit C++ arm
+asserting a bare `.sh` suite derives nil. Giving `.shell` no `scriptExtensions`
+defuses that but breaks `update_solution`, which reads the same field to decide
+which solution filenames are acceptable — one field, two questions, opposite
+answers.
+
+A *genuine* shell assignment language — students submit `solution.sh`, tests
+source it and compare stdout, with a `test_runtime.sh` — is a defensible
+separate feature. It would not replace "None", since a `.sh` harness that
+compiles a student's C file is still an assignment with no generation language.


### PR DESCRIPTION
## What this is

A question — *is a declared language exclusive, or can any assignment use shell
scripts alongside its own?* — turned out to have a clear answer that two places
in the code contradicted, one of them in front of a student.

## The model, now written down

Two concepts do two jobs and had been quietly conflated:

| | `ScriptInterpreter` (RunnerCore) | `AssignmentLanguage` (Core) |
|---|---|---|
| scope | one script | one assignment |
| derived from | extension → shebang → content sniff | the author's declaration |
| cases | 13, incl. `sh` `bash` `zsh` `ruby` `perl` `node` `php` | 6 |
| answers | "how do I run this file?" | "what do generated artifacts render in?" |

**The declaration governs what Chickadee generates; the script's own extension
governs how it runs.** Grading already worked this way and always has:
`scriptInvocation(for:)` takes only a URL, `TestSuiteEntry` carries no language
field, and the runner stages *every* language's `test_runtime.*` into every job
workspace — so a hand-written `.R` helper inside a Python assignment runs under
`Rscript`. No authoring surface refuses an off-language script, and
`KernelImportGuard` switches on the file's own extension.

This is the original design — "test suites are shell scripts; the runner executes
them generically" — with per-language generation layered on top rather than
replacing it. **Shell is the substrate all six languages sit on**, which is why
"None" means "nothing is generated" and, in practice, "hand-written scripts only".

## Two places that contradicted it

**1. Content voted on the declaration.** `resolveAuthoringLanguage` scanned the
authored scripts and let a non-Python extension outrank the stored language, on
*every* suite save including reorders. Authoring one `helper_test.R` into a
Python assignment re-rendered every generated script in R, **deleted** the `.py`
ones, and wrote `.r` into the manifest — while going around the guard that
refuses a language change once generated scripts exist. It was asymmetric on top
of that: a `.py` helper could not flip an R assignment, because Python was
excluded by name, so the same act had opposite consequences depending on which
language you already had.

**2. The capability gate asked for one token.** Only the declared language — so
that same `.R` helper was claimable by an R-less runner and died at
`exit 127 / Rscript: not found` in front of a student, which is this gate's own
failure mode in a shape it could not see. `AssignmentLanguage.languagesRequiredToGrade(manifest:)`
now unions the declaration with every language the suite's extensions imply.

Both are the same root cause: using the declaration to answer a question about
the *suite's contents*, which only the contents can answer.

### The fail-open that matters

An empty required set still admits any runner. `.sh` is deliberately signal-free
(C++'s generated cases *are* `.sh` wrappers), and interpreters with no capability
token — `.rb`, `.js`, `.pl` — contribute nothing, so a suite of those keeps
failing open exactly as before. That is what keeps the system's original mode
claimable by anyone.

**Known trade:** the gate's worse failure direction is queuing a job when no
runner advertises a required language, and this widens that exposure — an
assignment carrying one stray `.R` test will now wait for an R-capable runner.
That is the correct outcome versus a student seeing exit 127, and it is the same
exposure the declared language already carried.

## Why "None" is not a `.shell` language

Considered and rejected, with the reasoning recorded in the doc:
`languageByScriptExtension` folds every language's `scriptExtensions`, so a
`.shell` case claiming `["sh"]` would make every C++ assignment's generated
wrappers derive as shell — and `everyLanguageResolvesFromItsOwnGradedScript`
carries an explicit C++ arm asserting a bare `.sh` suite derives nil. Giving
`.shell` no `scriptExtensions` defuses that but breaks `update_solution`, which
reads the same field to decide acceptable solution filenames: one field, two
questions, opposite answers.

(A *genuine* shell assignment language — students submit `solution.sh`, tests
source it and compare stdout — remains a defensible separate feature. It would
not replace "None".)

## Testing

- `MixedLanguageSuiteTests` (new, 3 tests): an off-language helper leaves the
  declaration, the generated filenames and their extensions untouched and deletes
  nothing; the same in the other direction; generated scripts still follow the
  declaration when an off-language helper is present.
- `RunnerLanguageGateTests` (+5): the mixed-suite requirement with a reason
  naming *why* each language is needed, the declared language still required when
  no script names it (C++), suites naming no assignment language staying
  claimable, and missing languages reported in stable `allCases` order.
- `AssignmentLanguageTests` (+4) for `languagesRequiredToGrade`, including an
  `allCases` pin with C++ stated as the deliberate exception.
- **Both new suites negative-tested** by restoring the old behaviour: the
  migration tests fail on the re-rendered `.R` filenames, the gate tests on the
  missing requirement.
- Full suite green locally: **3,444 tests in 414 suites**, plus `scripts/lint.sh`,
  `scripts/swiftlint.sh --strict` and `scripts/no-language-defaults.sh`.

## Not done

The "None" dropdown label already reads "None — plain shell scripts", so the
relabel I had planned was unnecessary.

---
_Generated by [Claude Code](https://claude.ai/code/session_0155K4qAeJKdQfdeBxC7Hcvb)_