### PR TITLE
fix(grading): make the class-goal bonus visible — uncap it, and push it to LEARN at the deadline

### DIFF
--- a/Sources/APIServer/Helpers/ClassGoalBonus.swift
+++ b/Sources/APIServer/Helpers/ClassGoalBonus.swift
@@ -4,9 +4,16 @@
 // reward: when (at least the configured share of) the class reaches the
 // threshold, every student who submitted earns the same bonus, scaled by how
 // far the class got (`APIAchievementResult.progress`).  The bonus is applied as
-// **extra credit, capped at 100%** (the user-chosen semantic) at each
-// grade-of-record site — the submission page, the BrightSpace push, and the
-// grades CSV — so it never reduces anyone's grade and never exceeds full marks.
+// **true extra credit, uncapped** at each grade-of-record site — the submission
+// page, the BrightSpace push, and the grades CSV — so it never reduces anyone's
+// grade and a student already at full marks is credited above 100%.
+//
+// It used to be capped at 100%, which made the reward invisible to exactly the
+// students who earned it: a goal conditioned on "N% of the class reaches 100%"
+// puts most of the class at full marks, where the cap absorbed the whole bonus.
+// (HLTH 230 Lab 9: a +1 bonus worth 25% of a 4-point suite showed up as no
+// change at all for the majority.)  A class goal is a reward for collective
+// work, so it now reads as one.
 //
 // 0 when the assignment defines no points-rewarded class goals (the common
 // case), so this is a no-op for ordinary assignments.
@@ -38,12 +45,21 @@ func classGoalBonusPoints(
     }
 }
 
-/// Adds a class-goal bonus to an earned-points grade as extra credit, capped at
-/// the suite total so the percentage never exceeds 100%.  A 0 bonus or a
-/// non-positive total leaves the grade untouched.
+/// Adds a class-goal bonus to an earned-points grade as true extra credit: the
+/// result may exceed the suite total, so a student already at full marks is
+/// credited above 100%.  A 0 bonus leaves the grade untouched.
+///
+/// `total` no longer bounds the result, but it still gates the operation: the
+/// bonus is denominated in suite points, so it means nothing against a suite
+/// whose total is unknown or zero, and adding it there would put the grade on a
+/// scale nothing else shares.
+///
+/// The single place the bonus semantic lives — all three grade-of-record sites
+/// call this rather than re-deriving it, which is how the grades CSV came to
+/// carry its own copy of the old cap.
 func earnedWithClassGoalBonus(earned: Double, total: Double, bonus: Double) -> Double {
     guard total > 0, bonus > 0 else { return earned }
-    return min(total, earned + bonus)
+    return earned + bonus
 }
 
 /// The suite's total possible points (sum of test-suite item weights) from a

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+GradesCSV.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+GradesCSV.swift
@@ -88,9 +88,10 @@ extension InstructorDashboardRoutes {
             overrideKeys.insert(mapKey)
         }
 
-        // Class-goal bonus: extra credit (capped at 100%) for every graded
-        // submission on a setup with class goals.  Overrides are authoritative,
-        // so a key an override already set is left untouched.
+        // Class-goal bonus: true extra credit for every graded submission on a
+        // setup with class goals — it may take a student above the suite total.
+        // Overrides are authoritative, so a key an override already set is left
+        // untouched.
         for setupID in setupIDs {
             guard let setup = setupByID[setupID] else { continue }
             let props = setup.decodedManifest()
@@ -101,7 +102,8 @@ extension InstructorDashboardRoutes {
             let suffix = "::\(setupID)"
             for (mapKey, points) in bestPointsByUserAndSetup
             where mapKey.hasSuffix(suffix) && !overrideKeys.contains(mapKey) {
-                bestPointsByUserAndSetup[mapKey] = min(total, points + bonus)
+                bestPointsByUserAndSetup[mapKey] = earnedWithClassGoalBonus(
+                    earned: points, total: total, bonus: bonus)
             }
         }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -385,8 +385,9 @@ extension WebRoutes {
 
     // MARK: - submissionPage helpers
 
-    /// Class-goal bonus: extra credit on the autograded grade, capped at 100%
-    /// (no-op unless the assignment has a points-rewarded class goal).
+    /// Class-goal bonus: true extra credit on the autograded grade, so a
+    /// student already at full marks reads above 100% (no-op unless the
+    /// assignment has a points-rewarded class goal).
     private func applyClassGoalBonus(
         to processed: inout ProcessedCollection,
         setupProps: TestProperties?,

--- a/Sources/APIServer/Services/AchievementEvaluationService.swift
+++ b/Sources/APIServer/Services/AchievementEvaluationService.swift
@@ -99,49 +99,30 @@ func evaluateClassGoalAchievements(
         let bestByStudent = try await bestAssignmentGradeByStudent(testSetupID: setupID, on: db)
             .filter { enrolledStudents.contains($0.key) }
 
-        for goal in goals {
-            if rowByAchievement[goal.id]?.locked == true { continue }  // frozen at the deadline
-
-            // Authoring rejects goal shapes the sweep can't evaluate (a single
-            // "grade ≥ X" condition at most), but a hand-authored manifest can
-            // still carry one — skip it loudly rather than silently mis-grade
-            // the bonus as grade-only (audit A4).
-            guard goal.isSweepEvaluableClassGoal else {
-                logger.warning(
-                    """
-                    Class goal '\(goal.id)' on setup \(setupID) has conditions the sweep \
-                    cannot evaluate (only a single 'grade atLeast' condition is supported); skipping.
-                    """
-                )
-                continue
-            }
-
-            let threshold = goal.gradeThresholdFraction ?? 1
-            let studentsMeeting = bestByStudent.values.filter { $0 >= threshold }.count
-            let progress = classGoalProgress(
-                studentsMeeting: studentsMeeting,
+        let outcome = try await writeClassGoalSnapshots(
+            goals: goals,
+            rowByAchievement: rowByAchievement,
+            evaluation: ClassGoalEvaluation(
+                setupID: setupID,
+                bestByStudent: bestByStudent,
                 denominator: denominator,
-                classFraction: goal.classFraction ?? 1)
+                locked: locked,
+                now: now),
+            on: db,
+            logger: logger)
+        written += outcome.written
 
-            if let row = rowByAchievement[goal.id] {
-                row.studentsMeeting = studentsMeeting
-                row.denominator = denominator
-                row.progress = progress
-                row.locked = locked
-                row.evaluatedAt = now
-                try await row.save(on: db)
-            } else {
-                try await APIAchievementResult(
-                    testSetupID: setupID,
-                    achievementID: goal.id,
-                    studentsMeeting: studentsMeeting,
-                    denominator: denominator,
-                    progress: progress,
-                    locked: locked,
-                    evaluatedAt: now
-                ).save(on: db)
-            }
-            written += 1
+        // The bonus a points-rewarded goal awards scales with live class
+        // progress, so every grade already pushed to LEARN carries whatever
+        // progress happened to be when THAT student's submission was graded.
+        // Freezing at the deadline is the moment the final bonus exists — and
+        // nothing else re-queues a push, because a push is only ever triggered
+        // by a new result, an override, or the manual "Push all". Without this,
+        // an assignment whose class goal completed late lands in LEARN with
+        // every early submitter's bonus permanently under-counted.
+        if outcome.bonusFroze {
+            try await requeueFrozenClassGoalBonusPushes(
+                assignment: assignment, testSetupID: setupID, on: db, logger: logger)
         }
     }
 
@@ -149,6 +130,150 @@ func evaluateClassGoalAchievements(
         logger.debug("Class-goal achievement sweep wrote \(written) snapshot(s)")
     }
     return written
+}
+
+// MARK: - Snapshot writing
+
+/// What one setup's snapshot write produced: how many rows were written, and
+/// whether a **points-rewarded** goal crossed from live to frozen in this pass.
+private struct ClassGoalWriteOutcome {
+    var written: Int
+    var bonusFroze: Bool
+}
+
+/// Everything one setup's goals are evaluated against in a single sweep pass:
+/// which setup, the per-student grades over the enrolled roster, the roster
+/// size, whether the deadline has passed, and the sweep's clock.
+private struct ClassGoalEvaluation {
+    let setupID: String
+    let bestByStudent: [UUID: Double]
+    let denominator: Int
+    let locked: Bool
+    let now: Date
+}
+
+/// Upserts one snapshot per evaluable goal on a setup and reports whether a
+/// points-rewarded goal just froze — the transition that finalizes the bonus
+/// every student's grade of record carries.
+///
+/// A goal that is *already* locked is skipped, so the freeze is reported exactly
+/// once in an assignment's life: the sweep never re-opens a locked row (the
+/// caller skips a setup whose goals are all locked), so a later due-date change
+/// cannot re-trigger the re-push.
+private func writeClassGoalSnapshots(
+    goals: [Achievement],
+    rowByAchievement: [String: APIAchievementResult],
+    evaluation: ClassGoalEvaluation,
+    on db: Database,
+    logger: Logger
+) async throws -> ClassGoalWriteOutcome {
+    var outcome = ClassGoalWriteOutcome(written: 0, bonusFroze: false)
+    let setupID = evaluation.setupID
+    let denominator = evaluation.denominator
+    let locked = evaluation.locked
+    let now = evaluation.now
+
+    for goal in goals {
+        if rowByAchievement[goal.id]?.locked == true { continue }  // frozen at the deadline
+
+        // Authoring rejects goal shapes the sweep can't evaluate (a single
+        // "grade ≥ X" condition at most), but a hand-authored manifest can
+        // still carry one — skip it loudly rather than silently mis-grade
+        // the bonus as grade-only (audit A4).
+        guard goal.isSweepEvaluableClassGoal else {
+            logger.warning(
+                """
+                Class goal '\(goal.id)' on setup \(setupID) has conditions the sweep \
+                cannot evaluate (only a single 'grade atLeast' condition is supported); skipping.
+                """
+            )
+            continue
+        }
+
+        let threshold = goal.gradeThresholdFraction ?? 1
+        let studentsMeeting = evaluation.bestByStudent.values.filter { $0 >= threshold }.count
+        let progress = classGoalProgress(
+            studentsMeeting: studentsMeeting,
+            denominator: denominator,
+            classFraction: goal.classFraction ?? 1)
+
+        if let row = rowByAchievement[goal.id] {
+            row.studentsMeeting = studentsMeeting
+            row.denominator = denominator
+            row.progress = progress
+            row.locked = locked
+            row.evaluatedAt = now
+            try await row.save(on: db)
+        } else {
+            try await APIAchievementResult(
+                testSetupID: setupID,
+                achievementID: goal.id,
+                studentsMeeting: studentsMeeting,
+                denominator: denominator,
+                progress: progress,
+                locked: locked,
+                evaluatedAt: now
+            ).save(on: db)
+        }
+        outcome.written += 1
+        // A goal awarding no points moves no grade, so its freeze is not a
+        // reason to re-push the class.
+        if locked, (goal.reward.points ?? 0) > 0 { outcome.bonusFroze = true }
+    }
+
+    return outcome
+}
+
+// MARK: - Re-push at the freeze
+
+/// Re-queues every student's grade for a setup whose class-goal bonus just
+/// froze, so LEARN carries the final bonus rather than the value in effect when
+/// each student's own submission happened to be graded.
+///
+/// Gated on the assignment actually being wired to a LEARN grade item (and not
+/// explicitly excluded from sync), mirroring `flagResultForBrightSpaceSync`: on
+/// a deployment with no BrightSpace binding this touches nothing. Runs at most
+/// once per assignment, at the deadline, so it costs one push per student in
+/// total — not the per-sweep churn that re-pushing on every progress *change*
+/// would cost while the assignment is still live.
+///
+/// An assignment with no due date never freezes and so is never re-pushed here;
+/// its bonus stays live-but-stale in LEARN, and "Push all" remains the way to
+/// settle it.
+private func requeueFrozenClassGoalBonusPushes(
+    assignment: APIAssignment,
+    testSetupID: String,
+    on db: Database,
+    logger: Logger
+) async throws {
+    guard assignment.brightspaceSyncExcluded != true,
+        let gradeObjectID = assignment.brightspaceGradeObjectID,
+        !gradeObjectID.isEmpty,
+        let course = try await APICourse.find(assignment.courseID, on: db),
+        let orgUnitID = course.brightspaceOrgUnitID,
+        !orgUnitID.isEmpty
+    else { return }
+
+    let submissionIDs = try await APISubmission.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .all()
+        .compactMap(\.id)
+    guard !submissionIDs.isEmpty else { return }
+
+    var results: [APIResult] = []
+    for chunk in chunkedForInFilter(submissionIDs) {
+        results += try await APIResult.query(on: db).filter(\.$submissionID ~~ chunk).all()
+    }
+    guard !results.isEmpty else { return }
+
+    try await requeueForImmediateSync(results, on: db)
+    logger.info(
+        """
+        Class-goal bonus froze for '\(assignment.title)' — re-queued \(results.count) \
+        grade push(es) so LEARN carries the final bonus.
+        """
+    )
 }
 
 /// Per-student best whole-assignment grade (`0...1`) for a setup, from

--- a/Sources/APIServer/Services/BrightSpaceGradeSelection.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSelection.swift
@@ -102,10 +102,20 @@ func bestGradeForStudent(
     } else {
         basePoints = earned
     }
-    // Class-goal bonus: extra credit, capped at the suite total (100%).
+    // Class-goal bonus: true extra credit, which may exceed the suite total.
     let bonus = try await classGoalBonusPoints(testSetupID: testSetupID, props: setupProps, on: db)
-    let points = bonus > 0 ? min(total, basePoints + bonus) : basePoints
+    let points = earnedWithClassGoalBonus(earned: basePoints, total: total, bonus: bonus)
     return StudentGrade(points: points, total: total)
+}
+
+/// One resolved grade push: the points to send, the item they target, a
+/// `refusal` when the item can't be synced to at all, and a `warning` recorded
+/// alongside a push that goes through but may not land as sent.
+struct ScaledGradePush {
+    let pushPoints: Double
+    let gradeObject: BrightSpaceGradeObject?
+    let refusal: String?
+    let warning: String?
 }
 
 /// The points to push and the grade item they target, or a `refusal` message
@@ -119,7 +129,7 @@ func scaledGradePush(
     client: any BrightSpaceGrading,
     gradeObjectCache: GradeObjectInfoCache,
     application: Application
-) async -> (pushPoints: Double, gradeObject: BrightSpaceGradeObject?, refusal: String?) {
+) async -> ScaledGradePush {
     var gradeObject: BrightSpaceGradeObject?
     do {
         gradeObject = try await gradeObjectCache.info(
@@ -136,7 +146,8 @@ func scaledGradePush(
         let message =
             "Grade item '\(gradeObject?.name ?? gradeObjectID)' is type \(type); "
             + "Chickadee can only sync to Numeric grade items."
-        return (grade.points, gradeObject, message)
+        return ScaledGradePush(
+            pushPoints: grade.points, gradeObject: gradeObject, refusal: message, warning: nil)
     }
 
     // Scale Chickadee's grade onto the D2L item's own max when both totals are
@@ -144,10 +155,36 @@ func scaledGradePush(
     // unknown or already equals the suite total, this is the identity, so the
     // pushed value is unchanged. The result is rounded to 2 decimals so the
     // gradebook shows a clean value (8.57) rather than 8.571428571…
+    var pushPoints = roundedGradePoints(grade.points)
     if let total = grade.total, total > 0, let maxPoints = gradeObject?.maxPoints, maxPoints > 0 {
-        return (roundedGradePoints(grade.points / total * maxPoints), gradeObject, nil)
+        pushPoints = roundedGradePoints(grade.points / total * maxPoints)
     }
-    return (roundedGradePoints(grade.points), gradeObject, nil)
+    return ScaledGradePush(
+        pushPoints: pushPoints, gradeObject: gradeObject, refusal: nil,
+        warning: aboveMaxWarning(pushPoints: pushPoints, gradeObject: gradeObject))
+}
+
+/// Flags a push that exceeds the item's maximum on an item D2L says cannot
+/// exceed it. A class-goal bonus is true extra credit, so this is now reachable
+/// by design — and it is the one way the bonus can be computed correctly and
+/// still not appear in LEARN, since D2L may clamp or reject the value. Recorded
+/// on the successful sync-log row rather than refused: a clamped grade is worth
+/// more to the student than no grade, and the instructor's fix (tick "Can
+/// Exceed" on the item) needs the observation, not a blocked push.
+///
+/// `canExceed` nil means D2L didn't tell us — say nothing rather than warn on
+/// every push to an item whose flag we never captured.
+private func aboveMaxWarning(pushPoints: Double, gradeObject: BrightSpaceGradeObject?) -> String? {
+    guard let gradeObject,
+        let maxPoints = gradeObject.maxPoints, maxPoints > 0,
+        pushPoints > maxPoints,
+        gradeObject.canExceed == false
+    else { return nil }
+    return """
+        Pushed \(pushPoints) to '\(gradeObject.name)', above its maximum of \(maxPoints). \
+        The item is not set to allow grades above the maximum, so LEARN may clamp or reject \
+        the extra credit — tick "Can Exceed" on the grade item to keep it.
+        """
 }
 
 /// Rounds a grade value to 2 decimal places for the LEARN gradebook.

--- a/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
+++ b/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
@@ -343,7 +343,11 @@ extension GradeSyncSweep {
             try await row.save(on: db)
         }
 
-        await appendSyncLog(.success, points: pushPoints, detail: nil)
+        // `warning` is nil on an ordinary push; when set, the push went through
+        // but LEARN may not keep all of it (extra credit above a grade item that
+        // is not "Can Exceed"). It rides the success row so it's visible in the
+        // sync-activity log without inventing a fourth status.
+        await appendSyncLog(.success, points: pushPoints, detail: scaled.warning)
 
         application.logger.info(
             "BrightSpace grade synced: user \(userID) assignment '\(assignment.title)' → \(pushPoints) pts")

--- a/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
+++ b/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
@@ -584,7 +584,9 @@ extension GradeSyncSweep {
     }
 }
 
-private func chunkedForInFilter<T>(_ items: [T]) -> [[T]] {
+/// Splits an `~~` (SQL IN) filter's operand into driver-safe chunks. Shared with
+/// the class-goal freeze re-push, which builds the same shape of query.
+func chunkedForInFilter<T>(_ items: [T]) -> [[T]] {
     guard items.count > gradeSyncInFilterChunkSize else {
         return items.isEmpty ? [] : [items]
     }

--- a/Tests/APITests/AchievementBonusSyncTests.swift
+++ b/Tests/APITests/AchievementBonusSyncTests.swift
@@ -1,0 +1,207 @@
+// Tests/APITests/AchievementBonusSyncTests.swift
+//
+// The class-goal bonus is scaled by LIVE class progress, but a BrightSpace push
+// only ever happens when a new result, an override, or the manual "Push all"
+// flags a row.  So a grade pushed while the class was still short of the goal
+// carried whatever progress was in effect at that moment, and nothing ever
+// corrected it: the class goal completing (or partly completing) moved every
+// student's grade of record on Chickadee while LEARN kept the stale value.
+//
+// The freeze at the deadline is the moment the bonus becomes final.  These
+// tests pin that transition re-queueing every student's grade for one push, and
+// pin the three cases that must NOT re-queue.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct AchievementBonusSyncTests {
+
+    // MARK: - Fixture
+
+    private func classGoalManifest(id: String, points: Int) throws -> String {
+        let props = TestProperties(
+            testSuites: try JSONDecoder().decode(
+                [TestSuiteEntry].self,
+                from: Data(#"[{"tier":"public","script":"t.sh","points":4}]"#.utf8)),
+            achievements: [
+                Achievement(
+                    id: id, name: "Class Goal", scope: .classWide,
+                    conditions: [
+                        AchievementCondition(signal: .grade, comparator: .atLeast, value: 100)
+                    ],
+                    reward: AchievementReward(type: .points, label: "Class Goal Met", points: points),
+                    classFraction: 0.8)
+            ])
+        return try #require(String(bytes: try JSONEncoder().encode(props), encoding: .utf8))
+    }
+
+    /// One enrolled student with one already-synced result on a class-goal
+    /// assignment.  `dueAt` in the past is what makes the sweep freeze the goal;
+    /// `wiredToLEARN` controls whether the assignment has a grade item bound.
+    @discardableResult
+    private func seedClassGoalAssignment(
+        prefix: String,
+        dueAt: Date?,
+        points: Int = 5,
+        wiredToLEARN: Bool = true,
+        on app: Application
+    ) async throws -> APIResult {
+        let courseID = try await app.testCourseID(enrollmentMode: .auto)
+        if wiredToLEARN, let course = try await APICourse.find(courseID, on: app.db) {
+            course.brightspaceOrgUnitID = "1265792"
+            try await course.save(on: app.db)
+        }
+
+        let setup = APITestSetup(
+            id: "\(prefix)_setup",
+            manifest: try classGoalManifest(id: "\(prefix)_goal", points: points),
+            zipPath: app.testSetupsDirectory + "\(prefix)_setup.zip",
+            courseID: courseID)
+        try await setup.save(on: app.db)
+
+        let assignment = try await arInsertAssignment(
+            testSetupID: "\(prefix)_setup", title: "\(prefix) Lab", isOpen: true, dueAt: dueAt,
+            on: app)
+        if wiredToLEARN {
+            assignment.brightspaceGradeObjectID = "9001"
+            try await assignment.save(on: app.db)
+        }
+
+        let student = try await arInsertStudent(username: "\(prefix)_student", on: app)
+        try await arEnrollStudentInTestCourse(student, on: app)
+        _ = try await arInsertSubmission(
+            id: "\(prefix)_sub", testSetupID: "\(prefix)_setup", userID: try student.requireID(),
+            on: app)
+
+        let result = APIResult(id: "\(prefix)_res", submissionID: "\(prefix)_sub")
+        try await result.saveWithCollection(
+            json: #"{"earnedPoints":4,"totalPoints":4}"#, on: app.db)
+        // Already pushed to LEARN, at whatever bonus was live back then.
+        result.brightspaceSyncPending = false
+        result.brightspacePendingSince = nil
+        result.brightspaceSyncedAt = Date()
+        try await result.save(on: app.db)
+        return result
+    }
+
+    private func reloadResult(_ id: String, on app: Application) async throws -> APIResult {
+        try #require(try await APIResult.find(id, on: app.db))
+    }
+
+    // MARK: - The freeze re-pushes
+
+    @Test func freezingAPointsGoalRequeuesEveryGradePush() async throws {
+        try await withAssignmentRoutesApp { app in
+            try await seedClassGoalAssignment(
+                prefix: "bfz", dueAt: Date().addingTimeInterval(-3600), on: app)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+
+            let snapshot = try #require(
+                try await APIAchievementResult.query(on: app.db)
+                    .filter(\.$testSetupID == "bfz_setup").first())
+            #expect(snapshot.locked, "a past deadline freezes the goal")
+
+            let result = try await reloadResult("bfz_res", on: app)
+            #expect(
+                result.brightspaceSyncPending == true,
+                "the frozen bonus must be pushed to LEARN, not left at the progress in effect when this student's own submission was graded"
+            )
+            // `Date.distantPast` is the "retry immediately" sentinel — the next
+            // sweep must not wait out the debounce window.
+            #expect(result.brightspacePendingSince == Date.distantPast)
+            #expect(result.brightspaceSyncError == nil)
+        }
+    }
+
+    /// The sweep never re-opens a locked snapshot, so the re-push fires exactly
+    /// once in an assignment's life — not on every 5-minute sweep forever.
+    @Test func theFreezeRequeuesOnlyOnce() async throws {
+        try await withAssignmentRoutesApp { app in
+            try await seedClassGoalAssignment(
+                prefix: "bonce", dueAt: Date().addingTimeInterval(-3600), on: app)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+            #expect(try await reloadResult("bonce_res", on: app).brightspaceSyncPending == true)
+
+            // Simulate the BrightSpace sweep having pushed it.
+            let pushed = try await reloadResult("bonce_res", on: app)
+            pushed.brightspaceSyncPending = false
+            pushed.brightspacePendingSince = nil
+            pushed.brightspaceSyncedAt = Date()
+            try await pushed.save(on: app.db)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+            #expect(
+                try await reloadResult("bonce_res", on: app).brightspaceSyncPending != true,
+                "a locked goal must not re-queue the class on every later sweep")
+        }
+    }
+
+    // MARK: - What must NOT re-queue
+
+    @Test func aLiveGoalDoesNotRequeue() async throws {
+        try await withAssignmentRoutesApp { app in
+            // No deadline → never locked → the bonus is still moving.
+            try await seedClassGoalAssignment(prefix: "blive", dueAt: nil, on: app)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+
+            let snapshot = try #require(
+                try await APIAchievementResult.query(on: app.db)
+                    .filter(\.$testSetupID == "blive_setup").first())
+            #expect(snapshot.locked == false)
+            #expect(
+                try await reloadResult("blive_res", on: app).brightspaceSyncPending != true,
+                "re-pushing on every progress change would push the whole class every sweep")
+        }
+    }
+
+    @Test func anAssignmentWithNoGradeItemDoesNotRequeue() async throws {
+        try await withAssignmentRoutesApp { app in
+            try await seedClassGoalAssignment(
+                prefix: "bnol", dueAt: Date().addingTimeInterval(-3600), wiredToLEARN: false,
+                on: app)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+
+            #expect(try await reloadResult("bnol_res", on: app).brightspaceSyncPending != true)
+        }
+    }
+
+    @Test func aGoalAwardingNoPointsDoesNotRequeue() async throws {
+        try await withAssignmentRoutesApp { app in
+            try await seedClassGoalAssignment(
+                prefix: "bzero", dueAt: Date().addingTimeInterval(-3600), points: 0, on: app)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+
+            #expect(
+                try await reloadResult("bzero_res", on: app).brightspaceSyncPending != true,
+                "a goal that moves no grade is no reason to re-push the class")
+        }
+    }
+
+    @Test func anExcludedAssignmentDoesNotRequeue() async throws {
+        try await withAssignmentRoutesApp { app in
+            try await seedClassGoalAssignment(
+                prefix: "bexc", dueAt: Date().addingTimeInterval(-3600), on: app)
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db)
+                    .filter(\.$testSetupID == "bexc_setup").first())
+            assignment.brightspaceSyncExcluded = true
+            try await assignment.save(on: app.db)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+
+            #expect(
+                try await reloadResult("bexc_res", on: app).brightspaceSyncPending != true,
+                "'Do not sync' is a deliberate choice the freeze must not override")
+        }
+    }
+}

--- a/Tests/APITests/AchievementBonusTests.swift
+++ b/Tests/APITests/AchievementBonusTests.swift
@@ -1,9 +1,14 @@
 // Tests/APITests/AchievementBonusTests.swift
 //
-// Phase 3b: the class-goal grade bonus — extra credit, capped at 100% — applied
-// at the grade-of-record sites. The pure cap is unit-tested; the grades CSV
+// Phase 3b: the class-goal grade bonus — true extra credit, uncapped — applied
+// at the grade-of-record sites. The pure fold is unit-tested; the grades CSV
 // (an official export) is exercised end-to-end. The submission page and the
 // BrightSpace push apply the same `classGoalBonusPoints` + `earnedWithClassGoalBonus`.
+//
+// Uncapped is deliberate and was a reversal: capping at the suite total made the
+// reward invisible to exactly the students who earned it, since a goal
+// conditioned on "N% of the class reaches 100%" leaves most of the class at full
+// marks, where the cap absorbed the whole bonus.
 
 import Core
 import Fluent
@@ -15,11 +20,16 @@ import VaporTesting
 
 @Suite struct AchievementBonusTests {
 
-    @Test func earnedWithClassGoalBonusCapsAtTotal() {
-        #expect(earnedWithClassGoalBonus(earned: 18, total: 20, bonus: 5) == 20)  // capped at 100%
-        #expect(earnedWithClassGoalBonus(earned: 10, total: 20, bonus: 5) == 15)  // under the cap
+    @Test func earnedWithClassGoalBonusIsUncappedExtraCredit() {
+        #expect(earnedWithClassGoalBonus(earned: 10, total: 20, bonus: 5) == 15)  // ordinary case
+        // Above the suite total: the student who was already at full marks is
+        // the one a class goal most needs to visibly reward.
+        #expect(earnedWithClassGoalBonus(earned: 18, total: 20, bonus: 5) == 23)
+        #expect(earnedWithClassGoalBonus(earned: 20, total: 20, bonus: 5) == 25)  // 125%
         #expect(earnedWithClassGoalBonus(earned: 18, total: 20, bonus: 0) == 18)  // no bonus
-        #expect(earnedWithClassGoalBonus(earned: 18, total: 0, bonus: 5) == 18)  // no total → untouched
+        // The bonus is denominated in suite points, so an unknown total is not a
+        // scale it can be added to.
+        #expect(earnedWithClassGoalBonus(earned: 18, total: 0, bonus: 5) == 18)
     }
 
     @Test func gradesCSVIncludesCappedClassGoalBonus() async throws {
@@ -72,8 +82,11 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let body = res.body.string
-                    #expect(body.contains("20.0"), "18/20 + 5 bonus capped at 20 must export as 20.0")
-                    #expect(!body.contains("18.0"), "Raw 18 must be replaced by the bonused 20")
+                    #expect(
+                        body.contains("23.0"),
+                        "18/20 + 5 bonus must export as 23.0 — the export carries the extra credit, uncapped"
+                    )
+                    #expect(!body.contains("18.0"), "Raw 18 must be replaced by the bonused 23")
                 })
         }
     }

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -800,6 +800,112 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
+    // MARK: Class-goal bonus (true extra credit, so a push may exceed the max)
+
+    /// A suite worth `total` points carrying one fully-met class goal awarding
+    /// `bonusPoints`, plus the snapshot that makes the bonus live.
+    private func seedClassGoalBonus(
+        setupID: String, total: Int, bonusPoints: Int, progress: Double = 1.0
+    ) async throws {
+        let props = TestProperties(
+            testSuites: try JSONDecoder().decode(
+                [TestSuiteEntry].self,
+                from: Data(#"[{"tier":"public","script":"t1.sh","points":\#(total)}]"#.utf8)),
+            achievements: [
+                Achievement(
+                    id: "cg", name: "Class Goal", scope: .classWide,
+                    conditions: [
+                        AchievementCondition(signal: .grade, comparator: .atLeast, value: 100)
+                    ],
+                    reward: AchievementReward(type: .points, label: "Met", points: bonusPoints),
+                    classFraction: 0.8)
+            ])
+        let setup = try #require(try await APITestSetup.find(setupID, on: app.db))
+        setup.manifest = try #require(
+            String(bytes: try JSONEncoder().encode(props), encoding: .utf8))
+        try await setup.save(on: app.db)
+
+        try await APIAchievementResult(
+            testSetupID: setupID, achievementID: "cg",
+            studentsMeeting: 8, denominator: 10, progress: progress, locked: true,
+            evaluatedAt: Date()
+        ).save(on: app.db)
+    }
+
+    @Test func aMetClassGoalPushesAboveTheGradeItemMaximum() async throws {
+        // 4/4 of a 4-point suite + a fully-met +1 class goal = 5/4, which onto a
+        // /10 item is 12.5. A student at full marks is exactly who a class goal
+        // needs to visibly reward, so the cap that used to hold this at 10 is gone.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-cg")
+            try await seedClassGoalBonus(setupID: scenario.setupID, total: 4, bonusPoints: 1)
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 4, total: 4),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                gradeObject: BrightSpaceGradeObject(
+                    id: "go-456", name: "Lab", maxPoints: 10, gradeType: "Numeric", canExceed: true))
+
+            #expect(try await sweep(client: fake) == 1)
+
+            let pushed = try #require(await fake.pushes.first?.earnedPoints)
+            #expect(abs(pushed - 12.5) < 0.0001)
+        }
+    }
+
+    @Test func anAboveMaxPushOnANonExceedingItemIsWarnedInTheSyncLog() async throws {
+        // The one way the bonus can be computed correctly and still not appear in
+        // LEARN: D2L may clamp or reject a value above an item that isn't set to
+        // exceed its maximum. The push still goes out — a clamped grade beats no
+        // grade — but the success row has to say so, or the instructor is back to
+        // "the bonus isn't counting" with nothing to look at.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-cgx")
+            try await seedClassGoalBonus(setupID: scenario.setupID, total: 4, bonusPoints: 1)
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 4, total: 4),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                gradeObject: BrightSpaceGradeObject(
+                    id: "go-456", name: "Lab", maxPoints: 10, gradeType: "Numeric", canExceed: false))
+
+            #expect(try await sweep(client: fake) == 1)
+            #expect(await fake.pushes.count == 1, "the push still goes out")
+
+            let logs = try await APIBrightSpaceSyncLog.query(on: app.db).all()
+            let row = try #require(logs.first(where: { $0.status == APIBrightSpaceSyncLog.Status.success.rawValue }))
+            let detail = try #require(row.detail)
+            #expect(detail.contains("above its maximum"))
+            #expect(detail.contains("Can Exceed"))
+        }
+    }
+
+    @Test func anAtMaxPushCarriesNoWarning() async throws {
+        // The warning must be specific to exceeding the max, not fire on every
+        // push to an item that happens to be flagged non-exceeding.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-cgn")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 4, total: 4),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                gradeObject: BrightSpaceGradeObject(
+                    id: "go-456", name: "Lab", maxPoints: 10, gradeType: "Numeric", canExceed: false))
+
+            #expect(try await sweep(client: fake) == 1)
+
+            let logs = try await APIBrightSpaceSyncLog.query(on: app.db).all()
+            let row = try #require(logs.first(where: { $0.status == APIBrightSpaceSyncLog.Status.success.rawValue }))
+            #expect(row.detail == nil)
+        }
+    }
+
     @Test func scaledGradeIsRoundedToTwoDecimals() async throws {
         // 6/7 of a /7 suite onto a /10 item = 8.571428…, which must land as 8.57.
         try await withApp(app) { _ in

--- a/changelog.d/class-goal-bonus-freeze-sync.md
+++ b/changelog.d/class-goal-bonus-freeze-sync.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **A class-goal bonus now reaches LEARN.** The bonus a class goal awards scales
+  with live class progress, but a BrightSpace push only ever happened when a new
+  result, an instructor override, or the manual "Push all" flagged a row — the
+  class goal's progress moving flagged nothing. So each student's LEARN grade
+  froze at whatever share of the class had reached the goal *at the moment their
+  own submission was graded*, and the students who submitted earliest were
+  under-credited permanently, while Chickadee's own submission page and grades
+  CSV (which compute the bonus live) showed the full amount. The class-goal
+  sweep now re-queues every student's grade for one push when a points-rewarded
+  goal **freezes at the deadline** — the moment the final bonus exists. It fires
+  once per assignment, is gated on the assignment actually being bound to a LEARN
+  grade item and not excluded from sync, and leaves the live window alone (a goal
+  still moving would otherwise re-push the whole class every sweep). An
+  assignment with no due date never freezes, so "Push all" remains the way to
+  settle its bonus.

--- a/changelog.d/class-goal-bonus-freeze-sync.md
+++ b/changelog.d/class-goal-bonus-freeze-sync.md
@@ -1,17 +1,36 @@
+### Changed
+
+- **A class-goal bonus is now true extra credit, uncapped.** It used to be capped
+  at 100% of the suite total, which made the reward invisible to exactly the
+  students who earned it: a goal conditioned on "N% of the class reaches 100%"
+  leaves most of the class at full marks, where the cap absorbed the whole bonus.
+  (HLTH 230 Lab 9: a +1 bonus worth 25% of a 4-point suite showed up as no change
+  at all for the majority.) A student at full marks now reads above 100% on the
+  submission page, in the grades CSV, and in LEARN. The grades CSV had grown its
+  own copy of the cap inline; all three grade-of-record sites now call the single
+  shared helper.
+
 ### Fixed
 
-- **A class-goal bonus now reaches LEARN.** The bonus a class goal awards scales
-  with live class progress, but a BrightSpace push only ever happened when a new
-  result, an instructor override, or the manual "Push all" flagged a row — the
-  class goal's progress moving flagged nothing. So each student's LEARN grade
-  froze at whatever share of the class had reached the goal *at the moment their
-  own submission was graded*, and the students who submitted earliest were
-  under-credited permanently, while Chickadee's own submission page and grades
-  CSV (which compute the bonus live) showed the full amount. The class-goal
-  sweep now re-queues every student's grade for one push when a points-rewarded
-  goal **freezes at the deadline** — the moment the final bonus exists. It fires
-  once per assignment, is gated on the assignment actually being bound to a LEARN
-  grade item and not excluded from sync, and leaves the live window alone (a goal
-  still moving would otherwise re-push the whole class every sweep). An
+- **A class-goal bonus now reaches LEARN at all.** The bonus scales with live
+  class progress, but a BrightSpace push is only ever queued by an event on a row
+  — a new result, an instructor override, or the manual "Push all" — and class
+  progress moving queued nothing. So each student's LEARN grade froze at whatever
+  share of the class had reached the goal *at the moment their own submission was
+  graded*, leaving the earliest submitters under-credited permanently, while
+  Chickadee's own pages (which compute the bonus live) showed the full amount.
+  The class-goal sweep now re-queues every student's grade for one push when a
+  points-rewarded goal **freezes at the deadline** — the moment the final bonus
+  exists. It fires once per assignment, is gated on the assignment being bound to
+  a LEARN grade item and not excluded from sync, and leaves the live window alone
+  (a goal still moving would otherwise re-push the whole class every sweep). An
   assignment with no due date never freezes, so "Push all" remains the way to
   settle its bonus.
+
+- **A grade push above a LEARN item's maximum is now reported.** D2L's
+  `CanExceed` flag was decoded onto `BrightSpaceGradeObject` but never consulted.
+  Uncapped extra credit makes an above-max push reachable by design, and it is
+  the one way the bonus can be computed correctly and still not appear in LEARN,
+  since D2L may clamp or reject the value. The push still goes out — a clamped
+  grade beats no grade — and the sync-activity log's success row now names the
+  item, its maximum, and the fix (tick "Can Exceed" on the grade item).

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -288,6 +288,21 @@ in the LEARN classlist and no usable student number).
 4. Watch the **sync-activity log** on the tab (success / failure / skipped),
    and use **"Retry failed"** / per-assignment **"Push all"** as needed.
 
+### What triggers a push
+
+A push is queued by an *event on a row*, never by a periodic re-derivation of
+the grade: a new or re-graded result, an instructor override (or its removal),
+the manual "Sync now" / "Push all", and — for an assignment carrying a
+points-rewarded **class goal** — the goal freezing at the deadline.
+
+That last one exists because the class-goal bonus is not a property of the
+student's submission: it scales with how far the *class* got, so it keeps moving
+after a grade has already been pushed. Freezing at the deadline is the moment the
+final bonus exists, so the class-goal sweep re-queues every student's grade for
+one push then. Nothing re-pushes while the goal is still live — the bonus in
+LEARN is a lower bound until the deadline — and an assignment with **no due
+date** never freezes at all, so its bonus only reaches LEARN via "Push all".
+
 For ops-level diagnosis, the admin diagnostic MCP surface exposes
 `get_brightspace_sync_status` (counts by status + recent D2L error detail,
 student-free).

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -303,6 +303,22 @@ one push then. Nothing re-pushes while the goal is still live — the bonus in
 LEARN is a lower bound until the deadline — and an assignment with **no due
 date** never freezes at all, so its bonus only reaches LEARN via "Push all".
 
+### Grades above the item maximum
+
+A class-goal bonus is **true extra credit and is not capped**, so a student
+already at full marks pushes above 100%: a 4-point suite with a met +1 bonus
+sends 5/4, which onto a /10 LEARN item is **12.5**. This is deliberate — capping
+it at 100% made the reward invisible to precisely the students who earned it,
+since a goal like "80% of the class reaches 100%" leaves most of the class at
+full marks.
+
+D2L decides whether it keeps that value. A numeric grade item carries a
+**"Can Exceed"** flag, and an item without it may clamp or reject an above-max
+grade. Chickadee pushes the true value either way — a clamped grade is worth more
+to the student than no grade — and records a warning on the **success** row of
+the sync-activity log naming the item, its maximum, and the fix. If an assignment
+carries a points-rewarded class goal, tick **Can Exceed** on its LEARN grade item.
+
 For ops-level diagnosis, the admin diagnostic MCP surface exposes
 `get_brightspace_sync_status` (counts by status + recent D2L error detail,
 student-free).


### PR DESCRIPTION
Found while investigating why HLTH 230 Lab 9's class-wide bonus never showed up in LEARN. Two independent defects, both of which had to be fixed for the bonus to be visible at all.

## 1. The bonus never reached LEARN

A class goal's bonus is `reward.points × current class progress` — it scales with how far the *class* has got, so it keeps moving after a student's own submission is long since graded. All three grade-of-record sites compute it live at read time.

But a BrightSpace push is only ever *queued* by an event on a row: a new/re-graded result, an instructor override, or the manual "Sync now" / "Push all". **Class-goal progress moving queues nothing.** So each student's LEARN grade froze at whatever share of the class had reached the goal at the moment their own submission happened to be graded — while Chickadee's own pages showed the current amount. The earliest submitters were under-credited, permanently. On Lab 9 every sync-log entry lands on 2026-07-29, the day before the deadline; nothing pushed after.

**Fix:** the class-goal sweep already freezes a goal at the deadline, which is exactly when the final bonus exists. It now re-queues every student's grade for one push at that transition — once per assignment (the sweep never re-opens a locked snapshot), gated on the assignment being bound to a grade item and not excluded from sync. The live window is deliberately untouched: re-pushing on every progress *change* would push the whole class every sweep. An assignment with no due date never freezes, so "Push all" remains the way to settle it — stated in the runbook rather than papered over.

## 2. …and when it did, it was capped to invisibility

The bonus was applied as extra credit **capped at 100%** of the suite total. A class goal is typically conditioned on "N% of the class reaches 100%", which leaves most of the class at full marks — precisely where the cap absorbed the entire bonus. On Lab 9 a +1 bonus worth **25% of a 4-point suite** showed up as no change at all for the majority, while the students it did move were the ones furthest from earning it.

**Fix:** true extra credit, uncapped. A student at full marks now reads above 100% on the submission page, in the grades CSV, and in LEARN (4/4 + 1 on a /10 item → 12.5). The grades CSV had grown its own inline copy of the cap; all three sites now call the one shared helper.

## 3. Which surfaced a third gap

Uncapping makes an above-max push reachable by design — and D2L's **`CanExceed`** flag turned out to be decoded onto `BrightSpaceGradeObject` and never consulted anywhere. It is the one remaining way the bonus can be computed correctly and still not appear in LEARN, since D2L may clamp or reject the value.

The push still goes out (a clamped grade beats no grade, and refusing would block the whole grade over the extra credit), and the sync-activity log's **success** row now names the item, its maximum, and the fix — tick "Can Exceed". A nil flag stays silent rather than warning on every push to an item D2L never described.

## Changes

- `AchievementEvaluationService.swift` — freeze detection and the re-queue. The per-setup goal loop is extracted into `writeClassGoalSnapshots` (returning whether a points-bearing goal froze) to stay under the body-length threshold; inputs grouped into `ClassGoalEvaluation`.
- `ClassGoalBonus.swift` — `earnedWithClassGoalBonus` drops the cap. `total` still gates the operation (the bonus is denominated in suite points) but no longer bounds it.
- `BrightSpaceGradeSelection.swift` — the push uses the shared helper; `scaledGradePush` returns a `ScaledGradePush` struct carrying the new `warning` alongside the existing `refusal`.
- `InstructorDashboardRoutes+GradesCSV.swift` — the duplicated inline cap replaced by the shared helper.
- `BrightSpaceSyncSweep.swift` — the warning rides the success log row; `chunkedForInFilter` made internal so the new query reuses it.
- Tests — `AchievementBonusSyncTests` (6: the freeze re-queues with the `distantPast` sentinel, fires only once, and the four cases that must not); `BrightSpaceGradeSyncTests` (3: an above-max push, its warning, and no warning at max); `AchievementBonusTests` updated from cap to uncapped, including the CSV export.
- `docs/brightspace-setup.md` — "What triggers a push" and "Grades above the item maximum".

## Testing

Full `APITests` target, plus `scripts/format.sh` / `lint.sh` / `swiftlint.sh --strict` clean.

## Note for the affected course

This only helps assignments that freeze *after* it deploys. Lab 9 has already frozen, so its correction is **"Push all"** on `/instructor/brightspace` once this is live — the frozen progress is already the correct final value. Its LEARN grade item needs **Can Exceed** ticked, or D2L may clamp the students who are now above 10.