### PR TITLE
fix(ci): repair the vendored-kernel guard and run it on pull requests

### DIFF
--- a/.github/workflows/jupyterlite.yml
+++ b/.github/workflows/jupyterlite.yml
@@ -21,50 +21,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Skip the expensive toolchain + build on PRs that touch nothing
-      # JupyterLite/Pyodide-related. The job itself still runs and reports
-      # success — so it stays safe to mark as a required check (a skipped
-      # required workflow would block merges forever); only the heavy steps
-      # are gated. Fail-safe like editor-smoke's `changes` job: non-PR
-      # events, a missing base, or an empty diff run everything.
-      - name: Detect JupyterLite-relevant changes
-        id: detect
-        env:
-          EVENT: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -uo pipefail
-          if [ "$EVENT" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::non-PR event ($EVENT) — running the JupyterLite build."
-            exit 0
-          fi
-          git fetch --no-tags --quiet origin "$BASE_REF" || true
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::base sha unavailable — running the build (fail-safe)."
-            exit 0
-          fi
-          changed="$(git diff --name-only "$BASE_SHA" HEAD)"
-          if [ -z "$changed" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::no diff computed — running the build (fail-safe)."
-            exit 0
-          fi
-          pattern='^(Public/jupyterlite/|Public/vendor/|Tools/jupyterlite/|Tools/vendor/|scripts/setup-jupyterlite\.sh|scripts/build-jupyterlite\.sh|scripts/setup-vendor\.sh|scripts/verify-jupyterlite\.sh|scripts/check-xeus-vendored\.sh|scripts/check-env-vendored-sync\.sh|scripts/derive-kernel-modules\.py|\.github/workflows/jupyterlite\.yml)'
-          # Here-string, not a pipe — see editor-smoke.yml for the SIGPIPE
-          # trap that silently misclassifies large diffs.
-          if grep -qE "$pattern" <<< "$changed"; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::JupyterLite-relevant files changed — running the build."
-          else
-            echo "relevant=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::no JupyterLite-relevant changes — skipping the build steps."
-          fi
-
+      # EVERY step below runs on EVERY event, deliberately.
+      #
+      # There used to be a path filter here that skipped these steps on a PR
+      # touching nothing JupyterLite-related, while still reporting the job
+      # green so it stayed safe as a required check. Two things made that a bad
+      # trade. It was written to skip "the expensive toolchain + build", and
+      # that build no longer exists — CI cannot rebuild the kernels from
+      # emscripten-forge, so the committed bytes are authoritative and all this
+      # job does is verify them. The guards below take well under a second; the
+      # filter's entire saving was one Python setup.
+      #
+      # What it cost was the merge-time signal. `push` to main always counted as
+      # relevant, so the guards effectively ran ONLY on main: a PR touching no
+      # JupyterLite path was reported green without them, and main went red
+      # seconds after the merge. That is exactly how the broken kernel
+      # derivation in check-xeus-vendored.sh survived five releases — every PR
+      # was green, every push to main was red, and the two were never the same
+      # check. A guard whose answer depends on the event it runs under is not a
+      # guard, so this one now runs everywhere.
       - name: Set up Python
-        if: steps.detect.outputs.relevant == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -77,7 +53,6 @@ jobs:
       # emscripten-forge are reachable, or via the re-vendor workflow. See
       # docs/xeus-r-kernel-spike.md.
       - name: Verify the committed JupyterLite bundle is coherent
-        if: steps.detect.outputs.relevant == 'true'
         # No Pyodide may return, the diagnostics collector tag, and the xeus
         # parselmouth-fetch stub — the internal invariants a rebuild used to
         # guarantee, asserted on the committed bytes. (The waitAsync blob-worker
@@ -96,7 +71,6 @@ jobs:
       # nothing a kernel imports at boot is missing from the vendored bytes.
 
       - name: Verify the vendored xeus-r kernel is intact
-        if: steps.detect.outputs.relevant == 'true'
         # The xeus-r WASM kernel is manually vendored (CI can't rebuild it from
         # emscripten-forge). Assert it is present + internally coherent so a
         # botched or partial re-vendor fails here, not in front of a student.
@@ -107,5 +81,4 @@ jobs:
       # vendored tree against itself, which is how an env file could list scipy
       # while the kernel had none — see the script's header.
       - name: Environment files match the vendored kernels
-        if: steps.detect.outputs.relevant == 'true'
         run: scripts/check-env-vendored-sync.sh

--- a/changelog.d/jupyterlite-guard-derivation.md
+++ b/changelog.d/jupyterlite-guard-derivation.md
@@ -1,0 +1,27 @@
+### Fixed
+
+- **The vendored-kernel guard stopped reading the language descriptors, and CI
+  had been red on `main` for five releases.** `check-xeus-vendored.sh` derives
+  which kernels to expect from `LanguageDescriptor`, but it paired them by line
+  PROXIMITY — the nearest preceding `case .X:` owned the next `kernelName:`.
+  When #1330 hoisted each descriptor into its own `static let`, the six
+  consecutive `case .X: return Self.XDescriptor` lines left `.racket` current,
+  the first kernel name found (`xpython`) was attributed to it, and `xr`, `xlua`
+  and `xoctave` were discarded — so the guard reported three of the four
+  vendored kernels as claimed by no language, and mapped the fourth to the wrong
+  one. The vendored tree was healthy throughout; only the parse was wrong. It
+  now reads the language set from the exhaustive `descriptor` switch and each
+  language's own descriptor literal, and refuses to proceed on a descriptor it
+  cannot classify — a partial derivation was previously indistinguishable from a
+  complete one, which is the same fails-open shape the guard exists to catch.
+
+- **The JupyterLite guards now run on pull requests, not only on `main`.** Their
+  path filter skipped them for any PR touching no JupyterLite file while still
+  reporting the job green, and `push` to `main` always counted as relevant — so
+  the guards effectively ran only after merge. That is why the broken derivation
+  above was invisible: every PR was green, every push to `main` was red, and the
+  two were never running the same check. The filter was written to skip an
+  expensive rebuild that no longer exists (CI cannot rebuild the kernels; the
+  committed bytes are authoritative), so it was saving one Python setup and
+  costing the merge-time signal. All three guards run unconditionally now; they
+  take well under a second.

--- a/scripts/check-xeus-vendored.sh
+++ b/scripts/check-xeus-vendored.sh
@@ -56,26 +56,67 @@ if not ext.is_dir():
 #    That makes the guard follow the language set by construction: a seventh
 #    language with a kernel is checked the day its descriptor names one, and an
 #    upload-only language contributes nothing because it declares no kernel.
+#    Read the language set out of the ONE switch the compiler forces to be
+#    exhaustive, then read each language's own descriptor literal. What this
+#    deliberately does NOT do is infer the pairing from line PROXIMITY, which is
+#    how it broke: the previous parse treated the nearest preceding `case .X:`
+#    as the owner of the next `kernelName:`, so when #1330 hoisted each
+#    descriptor into its own `static let`, the six consecutive `case .X: return
+#    Self.XDescriptor` lines left `.racket` current, the first kernelName found
+#    (`xpython`) was attributed to it, and the other three were discarded
+#    entirely. The guard then failed on every push to main for five releases
+#    while reporting the one kernel it did find against the wrong language.
 def derive_expected_kernels():
-    source = (root / "Sources" / "Core" / "LanguageDescriptor.swift").read_text()
+    path = root / "Sources" / "Core" / "LanguageDescriptor.swift"
+    source = path.read_text()
+
+    descriptor_of = dict(re.findall(r"case \.(\w+):\s*return Self\.(\w+Descriptor)", source))
+    if not descriptor_of:
+        fail(
+            f"could not read the AssignmentLanguage → descriptor switch out of {path.name} — "
+            "the vendored kernels would go completely unchecked"
+        )
+
+    # Each descriptor's literal runs from its own `static let` to the next one.
+    starts = [
+        (m.group(1), m.start())
+        for m in re.finditer(r"static let (\w+) = LanguageDescriptor\(", source)
+    ]
+    blocks = {
+        name: source[start : (starts[i + 1][1] if i + 1 < len(starts) else len(source))]
+        for i, (name, start) in enumerate(starts)
+    }
+
     expected = {}
-    language = None
-    for line in source.splitlines():
-        case_match = re.search(r"case \.([A-Za-z]+):", line)
-        if case_match:
-            language = case_match.group(1)
-            continue
-        name_match = re.search(r'kernelName:\s*"([^"]+)"', line)
-        if name_match and language is not None:
-            expected[name_match.group(1)] = language
-            language = None
+    for language, descriptor_name in sorted(descriptor_of.items()):
+        block = blocks.get(descriptor_name)
+        if block is None:
+            fail(f"{language} resolves to {descriptor_name}, which {path.name} does not define")
+        support = re.search(r"editorSupport:\s*\.(\w+)", block)
+        if support is None:
+            fail(
+                f"{descriptor_name} declares no editorSupport — cannot tell whether "
+                f"{language} claims a vendored kernel"
+            )
+        kind = support.group(1)
+        if kind == "uploadOnly":
+            continue  # no kernel vendored for this language, deliberately
+        if kind != "notebookKernel":
+            fail(
+                f"{descriptor_name} declares editorSupport .{kind}, which this guard does not "
+                "understand — teach it that case rather than letting the kernel go unchecked"
+            )
+        name_match = re.search(r'kernelName:\s*"([^"]+)"', block[support.start() :])
+        if name_match is None:
+            fail(f"{descriptor_name} claims .notebookKernel but names no kernelName")
+        expected[name_match.group(1)] = language
     return expected
 
 
 expected_language = derive_expected_kernels()
 if not expected_language:
     fail(
-        "could not read any kernelName out of Sources/Core/LanguageDescriptor.swift — "
+        "no AssignmentLanguage claims a vendored kernel, yet kernels are vendored — "
         "the vendored kernels would go completely unchecked"
     )
 


### PR DESCRIPTION
`main` has been red on the JupyterLite workflow since **v0.5.58** (Aug 11, 02:58) — five releases. Last green was v0.5.57. The vendored kernels were fine the whole time; the guard that checks them was broken, and the reason nobody noticed is a second, separate defect.

## The broken derivation

`check-xeus-vendored.sh` derives which kernels to expect from `LanguageDescriptor` rather than listing them — the right design, and the script's header explains at length why. But it paired language to kernel by **line proximity**: the nearest preceding `case .X:` owned the next `kernelName:` it saw.

#1330 hoisted each descriptor into its own `static let`. The switch became six consecutive lines:

```swift
case .python: return Self.pythonDescriptor
…
case .racket: return Self.racketDescriptor
```

with the `kernelName:` literals hundreds of lines below. The parser burned through all six cases, landed on `racket`, attached the first kernel name it found (`xpython`) to it, reset to `None`, and discarded the rest. Running the old function against `main`:

```
derived expected_language = {'xpython': 'racket'}
```

One kernel, mapped to the wrong language — so `xr`, `xlua` and `xoctave` were reported as claimed by nobody, and the job died before reaching the kernelspec/env/package/loader checks below it.

**Fix:** read the language set from the exhaustive `descriptor` switch (`case .X: return Self.XDescriptor`), then read each language's own descriptor literal for `editorSupport` — `.uploadOnly` contributes nothing, `.notebookKernel` contributes its `kernelName`. No proximity assumption, so a descriptor moving cannot silently re-pair it.

It also now **refuses to proceed on a descriptor it cannot classify** (no `editorSupport`, no `kernelName`, or an `EditorSupport` case it doesn't know). Previously a *partial* derivation was indistinguishable from a complete one — only an entirely empty one failed. That is precisely the fails-open shape this guard exists to catch, in the guard itself.

Verified both directions:

| input | result |
|---|---|
| real source | `{'xlua': 'lua', 'xoctave': 'octave', 'xpython': 'python', 'xr': 'r'}` |
| a `kernelName:` removed | fails loudly |
| an `editorSupport:` removed | fails loudly |
| an unknown `EditorSupport` case | fails loudly |

With the parse repaired the script reaches and passes every downstream check for all four kernels — envs, package counts, loaders, module indexes, the pyodide-http patch — confirming the vendored tree was healthy throughout.

## Why it survived five releases

The workflow's path filter skipped these steps for any PR touching no JupyterLite file, while still reporting the job **green** (deliberate, so a required check can't block merges). But `push` to `main` always counted as relevant. So the guards effectively ran **only on `main`**: every PR was green, every push to `main` was red, and the two were never running the same check.

The filter was written to skip "the expensive toolchain + build" — which no longer exists. CI cannot rebuild the kernels from emscripten-forge; the committed bytes are authoritative and this job only verifies them. Its entire saving was one Python setup, against the cost of the merge-time signal.

All three guards now run unconditionally. Measured locally: `verify-jupyterlite.sh`, `check-xeus-vendored.sh` and `check-env-vendored-sync.sh` together complete in well under a second.

## Testing

All three guards run clean against the real vendored tree locally, plus the four-case derivation table above. `scripts/format.sh` / `lint.sh` / `check-styles.sh` clean; workflow YAML parses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mtk6k1mVAkB62vLtdD823L)_