### PR TITLE
docs(xeus): correct the runbook step that predates the derived kernel guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,12 +790,25 @@ same marker-emitting RunnerCore extractor R uses — vendoring a kernel puts it
 in the editor's picker, so a language that can be authored must be one that
 can be graded.
 
-**Two places enumerate the kernels rather than discovering them, and both fail
-open for one they have never heard of:** the `chickadee-*` glob in
-`build-jupyterlite.sh` (which decides who gets a module index) and
-`expected_language` in `check-xeus-vendored.sh` (which decides who gets a
-vendoring guard). Neither errors — you simply get a kernel nothing checks.
-`docs/adding-a-xeus-kernel.md` is the runbook.
+**One place still enumerates the kernels rather than discovering them, and it
+fails open for one it has never heard of:** the `chickadee-*` glob in
+`build-jupyterlite.sh`, which decides who gets a module index. It does not error
+— you simply get a kernel nothing checks. Its twin is closed: `expected_language`
+in `check-xeus-vendored.sh` derives the expected set from each language's
+`editorSupport.notebookKernel(kernelName:)`, so a kernel is guarded the day its
+descriptor names it.
+
+**Deriving it did not make it safe.** That derivation reads Swift with a regex
+and paired language to kernel by line PROXIMITY, so when #1330 hoisted the
+descriptors into their own `static let`s it went silently partial — one kernel,
+mapped to the wrong language — and `main` was red for five releases while every
+PR showed green, because the workflow's path filter reported the job green when
+it skipped it and only `push` counted as relevant. Three rules came out of it: a
+derivation must assert its own **completeness** (only an empty one used to fail,
+and a partial one is indistinguishable from a correct one); read the mapping the
+compiler already forces to be exhaustive rather than inferring one from
+proximity; and **a guard whose answer depends on the event it runs under is not
+a guard**. `docs/adding-a-xeus-kernel.md` is the runbook.
 
 The channel is **`emscripten-forge-4x`**. The older `emscripten-forge-dev` alias
 serves the 3x (emscripten 3.x ABI) channel, which stopped receiving builds of

--- a/changelog.d/xeus-runbook-guard-derivation.md
+++ b/changelog.d/xeus-runbook-guard-derivation.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **The add-a-kernel runbook no longer tells you to register your kernel with a
+  map that does not exist.** Step 4 still described `check-xeus-vendored.sh` as
+  carrying a literal `expected_language` and instructed you to add an entry to
+  it — a step that predates the guard being derived from
+  `editorSupport.notebookKernel(kernelName:)`, and one the same document's
+  parity checklist already listed as free. It now says there is nothing to
+  register, and gives the check that matters instead: confirm the derivation
+  actually lists your kernel, since a derivation over source can go partial
+  without going loud. The two rules that fall out of it going partial — assert a
+  derivation's completeness, and read the mapping the compiler already forces to
+  be exhaustive rather than inferring one from line proximity — are recorded
+  alongside the existing enumerated-not-discovered traps, together with the
+  reason it stayed invisible: a guard whose answer depends on the event it runs
+  under is not a guard.

--- a/docs/adding-a-xeus-kernel.md
+++ b/docs/adding-a-xeus-kernel.md
@@ -181,13 +181,27 @@ from the YAML would accept imports the shipped kernel cannot serve.
 If the language has no package ecosystem, emit an empty `moduleOwners`. On-demand
 loading then correctly does nothing.
 
-### 4. Register it with the vendoring guard
+### 4. Confirm the vendoring guard picked your kernel up
 
-`scripts/check-xeus-vendored.sh` carries
-`expected_language = {"xpython": "python", "xr": "r"}` and iterates **that map**,
-not `kernels.json`. A third kernel that is not in it ships completely unguarded:
-a partial or botched re-vendor of your kernel passes CI. Add the entry when you
-add the env.
+There is nothing to register. This step used to say `check-xeus-vendored.sh`
+carried a literal `expected_language` map you had to add your kernel to, and
+that was true once; it now derives the expected set from each language's
+`editorSupport: .notebookKernel(kernelName:)`. **Your kernel is guarded the day
+your descriptor names it**, which is why the parity checklist below lists the
+vendoring guard as free.
+
+What you do owe is a check that the derivation actually sees you, because it
+reads Swift source with a regex and a derivation can go *partial* without going
+loud. After vendoring:
+
+```
+scripts/check-xeus-vendored.sh
+```
+
+Confirm the first OK line lists your kernel alongside the others — e.g.
+`kernels ['xlua', 'xoctave', 'xpython', 'xr']`. A kernel missing from that list
+is unguarded even though nothing failed. If yours is absent, the derivation is
+what to fix, not your env; see the trap below.
 
 ### 5. Write the language module
 
@@ -299,6 +313,35 @@ an uncaught error with its message on stderr, and — if the language has packag
   `editorSupport.notebookKernel(kernelName:)`, so **your kernel is guarded the
   day your descriptor names it**, and a vendored kernel no language claims is an
   error rather than dead weight in a 100 MB payload.
+
+  **Deriving it did not make it safe, and learning that cost five red releases
+  on `main`.** The derivation reads `LanguageDescriptor.swift` with a regex, and
+  it paired language to kernel by line PROXIMITY: the nearest preceding
+  `case .X:` owned the next `kernelName:`. When #1330 hoisted each descriptor
+  into its own `static let`, the six consecutive `case .X: return
+  Self.XDescriptor` lines left `.racket` current, the first kernel name found
+  (`xpython`) was attributed to it, and `xr`/`xlua`/`xoctave` were dropped —
+  three of four kernels unguarded, the fourth checked against the wrong
+  language. Only an *entirely empty* derivation failed loudly, so a partial one
+  was indistinguishable from a complete one. Two rules fall out, and they
+  generalise past this script:
+
+  - **A derivation must assert its own completeness.** Deriving four of seven
+    silently is the same fail-open you replaced the hand-written list to escape,
+    wearing better clothes. Refuse on anything you cannot classify.
+  - **Do not infer structure from proximity.** Read the mapping the compiler
+    already forces to be exhaustive — here the `descriptor` switch — rather than
+    whichever `case` line happens to sit nearest. Proximity survives exactly
+    until someone moves the code, and moving code is not a change anyone expects
+    to break a guard.
+
+  It stayed invisible for a second reason worth its own rule: `jupyterlite.yml`
+  gated these guards behind a path filter that reported the job green when it
+  skipped them, while `push` to `main` always counted as relevant — so the guard
+  ran only after merge. Every PR was green, every push to `main` was red, and
+  the two were never the same check. **A guard whose answer depends on the event
+  it runs under is not a guard.** All three JupyterLite guards now run
+  unconditionally; they cost well under a second.
 - **Do not add a `default:` arm to a language switch.** The compiler producing
   the worklist is the entire reason the count of touched files is acceptable.
   See `docs/language-handling-review.md` §4.
@@ -1220,6 +1263,11 @@ where predicted: `expected_language` in `check-xeus-vendored.sh` and the
 `XEUS_ENVS` array in `build-jupyterlite.sh`. Neither errors on a kernel it has
 never heard of. The `chickadee-*` naming rule is what made the module-index step
 pick the new env up for free.
+
+(Point-in-time, as postmortems here are: `expected_language` was a literal map
+when Lua was added. It has since been derived from the language descriptors, so
+that half of the trap no longer applies to a seventh language — see the traps
+section above, including what deriving it did *not* fix.)
 
 ### What did not hold — R's two expensive lessons do not generalise
 


### PR DESCRIPTION
Follow-up to #1335. Fixing the guard left the runbook describing the version of it that broke.

## The contradiction

`docs/adding-a-xeus-kernel.md` said three different things about the same guard:

| where | says | correct? |
|---|---|---|
| step 4 | "carries `expected_language = {…}` … **Add the entry** when you add the env" | ❌ that map no longer exists |
| traps section | "Its twin is closed … It now derives the expected set" | ✅ |
| parity checklist | "the vendoring guard — derived from your descriptor's `kernelName`" | ✅ free |

Step 4 is the stale one, and it is the one someone adding a seventh language actually follows — a numbered step sending them to edit something that isn't there, in a document whose own checklist says the work is unnecessary. It now says there is nothing to register, and gives the check that matters instead: run the guard and confirm your kernel appears in its OK line, because the derivation reads Swift with a regex and can go partial without going loud.

## The lesson, recorded where the next person will hit it

#1335 fixed the breakage but left it as a closed CI incident. It belongs with the existing enumerated-not-discovered traps, because two of its rules generalise past this script:

- **A derivation must assert its own completeness.** Only an *entirely empty* derivation failed loudly, so deriving four kernels of seven looked exactly like deriving all seven — the same fail-open the literal map was replaced to escape.
- **Do not infer structure from proximity.** Read the mapping the compiler already forces to be exhaustive (the `descriptor` switch) rather than whichever `case` line sits nearest. Proximity survives exactly until someone moves the code, and moving code is not a change anyone expects to break a guard.

And a third explains the five-release delay: the path filter reported the job green when it skipped the guards while `push` to `main` always ran them, so **a guard whose answer depends on the event it runs under is not a guard**.

## Also

- `CLAUDE.md` still claimed *two* places enumerate the kernels and fail open. One does — the `chickadee-*` glob. Updated, with the derivation caveat.
- The Lua postmortem's mention of `expected_language` is left intact: it was a literal map when Lua was added, and postmortems here are point-in-time. Added a parenthetical so it doesn't read as current state.

## Testing

Documentation only — no code, no scripts, no workflows. `scripts/check-styles.sh` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mtk6k1mVAkB62vLtdD823L)_