### PR TITLE
ci(docker): boot the image and probe /health before pushing it

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -191,6 +191,14 @@ jobs:
       # sqlite, no worker secret (one is generated), no MCP — which is enough to
       # prove the binary starts, migrations apply, and the HTTP server serves.
       #
+      # `ENABLE_NON_SSO_AUTH_MODES=true` must accompany it. `AUTH_MODE` alone is
+      # SILENTLY IGNORED — the default mode is SSO and `AuthConfig` only honours
+      # a local/dual request when this second flag is set, logging "AUTH_MODE=
+      # local ignored ... using sso" and then trapping on the missing
+      # OIDC_CLIENT_ID. The first version of this step set only AUTH_MODE and
+      # died exactly that way, which is worth knowing: the two variables are a
+      # pair, and setting one of them looks like it worked right up until boot.
+      #
       # The budget MIRRORS PRODUCTION deliberately: `wait_healthy` in
       # scripts/bluegreen-deploy.sh gives a new color 90s
       # (CHICKADEE_HEALTH_TIMEOUT). Matching it means this step fails whenever
@@ -203,6 +211,7 @@ jobs:
           echo "Booting $IMAGE ..."
           docker run -d --name chickadee-smoke \
             -e AUTH_MODE=local \
+            -e ENABLE_NON_SSO_AUTH_MODES=true \
             -p 18080:8080 \
             "$IMAGE"
 
@@ -214,24 +223,32 @@ jobs:
           # which is precisely the ambiguity that made v0.5.65 hard to diagnose
           # from off-host. Here we can tell them apart, so we do.
           ok=0
+          exited=0
           last_code=000
           for i in $(seq 1 90); do
+            # `-w '%{http_code}'` already prints 000 when the connection fails,
+            # so curl's own non-zero exit is swallowed rather than appended —
+            # an `|| echo 000` here concatenates into "000000" and defeats the
+            # branch below.
             last_code="$(curl -s -o /tmp/health.body -w '%{http_code}' \
-              http://127.0.0.1:18080/health 2>/dev/null || echo 000)"
+              http://127.0.0.1:18080/health 2>/dev/null)" || true
+            [ -n "$last_code" ] || last_code=000
             if [ "$last_code" = "200" ]; then
               echo "Healthy after ${i}s."
               ok=1
               break
             fi
             if [ "$(docker inspect -f '{{.State.Running}}' chickadee-smoke 2>/dev/null)" != "true" ]; then
-              echo "::error::Container exited before answering /health."
+              exited=1
               break
             fi
             sleep 1
           done
 
           if [ "$ok" -ne 1 ]; then
-            if [ "$last_code" = "000" ]; then
+            if [ "$exited" -eq 1 ]; then
+              echo "::error::The container EXITED before answering /health — the server process died at startup."
+            elif [ "$last_code" = "000" ]; then
               echo "::error::No HTTP response from /health within 90s — the server never began serving."
             else
               echo "::error::/health answered ${last_code}, not 200 — the server is up but degraded (503 means its database check failed)."

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -173,6 +173,85 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # THE STEP THAT WOULD HAVE CAUGHT v0.5.65.
+      #
+      # Until now nothing in this pipeline ever STARTED the image: checkout →
+      # build → scan → push. A build can therefore be green, publish `:latest`,
+      # and produce a container that never answers `/health` — which is exactly
+      # what happened on v0.5.65, where the blue-green deployer aborted four
+      # consecutive swaps and the defect was only visible on the production
+      # host. A green build is not evidence the image runs.
+      #
+      # The image is already `load: true`d above for Trivy, so this costs one
+      # container start and no extra pull.
+      #
+      # `AUTH_MODE=local` is required, not cosmetic: the server refuses to boot
+      # under any other mode without OIDC credentials, and a smoke test is not
+      # the place to hold real ones. Everything else runs at its default —
+      # sqlite, no worker secret (one is generated), no MCP — which is enough to
+      # prove the binary starts, migrations apply, and the HTTP server serves.
+      #
+      # The budget MIRRORS PRODUCTION deliberately: `wait_healthy` in
+      # scripts/bluegreen-deploy.sh gives a new color 90s
+      # (CHICKADEE_HEALTH_TIMEOUT). Matching it means this step fails whenever
+      # the deployer would abort, rather than passing on a slower-but-tolerated
+      # boot and letting the difference reach the host.
+      - name: Smoke-test the image (boot it and probe /health)
+        run: |
+          set -euo pipefail
+          IMAGE='${{ fromJSON(steps.meta.outputs.json).tags[0] }}'
+          echo "Booting $IMAGE ..."
+          docker run -d --name chickadee-smoke \
+            -e AUTH_MODE=local \
+            -p 18080:8080 \
+            "$IMAGE"
+
+          # The probe records the HTTP CODE, not just success. `curl -sf` — what
+          # the deployer's wait_healthy uses — fails identically on "no
+          # response" and on "503", and /health answers 503 whenever its
+          # database check fails. That makes a broken image and a healthy image
+          # that cannot reach its database look the same to the deploy gate,
+          # which is precisely the ambiguity that made v0.5.65 hard to diagnose
+          # from off-host. Here we can tell them apart, so we do.
+          ok=0
+          last_code=000
+          for i in $(seq 1 90); do
+            last_code="$(curl -s -o /tmp/health.body -w '%{http_code}' \
+              http://127.0.0.1:18080/health 2>/dev/null || echo 000)"
+            if [ "$last_code" = "200" ]; then
+              echo "Healthy after ${i}s."
+              ok=1
+              break
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' chickadee-smoke 2>/dev/null)" != "true" ]; then
+              echo "::error::Container exited before answering /health."
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$ok" -ne 1 ]; then
+            if [ "$last_code" = "000" ]; then
+              echo "::error::No HTTP response from /health within 90s — the server never began serving."
+            else
+              echo "::error::/health answered ${last_code}, not 200 — the server is up but degraded (503 means its database check failed)."
+              echo "----- /health body -----"
+              cat /tmp/health.body 2>/dev/null || true
+              echo
+            fi
+            echo "::error::The blue-green deployer would abort this release."
+            echo "----- docker inspect -----"
+            docker inspect -f 'State: {{.State.Status}}  ExitCode: {{.State.ExitCode}}  OOMKilled: {{.State.OOMKilled}}  Error: {{.State.Error}}' chickadee-smoke || true
+            echo "----- container logs (tail 200) -----"
+            docker logs --tail 200 chickadee-smoke 2>&1 || true
+            docker rm -f chickadee-smoke >/dev/null 2>&1 || true
+            exit 1
+          fi
+
+          echo "----- container logs (tail 40, for the record) -----"
+          docker logs --tail 40 chickadee-smoke 2>&1 || true
+          docker rm -f chickadee-smoke >/dev/null 2>&1 || true
+
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
         with:


### PR DESCRIPTION
Follow-up to #1337. **v0.5.65 built clean, pushed both tags, and then failed four consecutive blue-green swaps on the production host** with "new color unhealthy". Prod auto-rolled-back and is stable on 0.5.64.

This PR does not fix that yet — it makes CI capable of *reproducing* it, which is the blocker to fixing it from off-host.

## Why CI could not have caught it

`build-and-push` was checkout → build → Trivy → push. **No step ever started the image.** A build can therefore be green, publish `:latest`, and produce a container that never answers `/health`. The image even carries its own `HEALTHCHECK`, which nothing exercised.

The smoke step slots in after the existing `load: true` build (so it costs one container start and no extra pull) and before the push, so a bad image cannot become `:latest`.

## Two deliberate details

- **`AUTH_MODE=local` is required, not cosmetic.** The server refuses to boot in any other mode without OIDC credentials — I hit exactly this while trying to reproduce locally. Everything else runs at defaults (sqlite, generated worker secret), which is enough to prove the binary starts, migrations apply, and the HTTP server serves.
- **The 90 s budget mirrors production.** `wait_healthy` in `scripts/bluegreen-deploy.sh` gives a new color 90 s (`CHICKADEE_HEALTH_TIMEOUT`). Matching it means this fails exactly when the deployer would abort, rather than passing on a slower-but-tolerated boot and letting the difference reach the host.

## The probe records the HTTP code, not just success

This is the part that matters for diagnosis. `curl -sf` — what the deployer uses — fails **identically** on "no response" and on "503", and `/health` answers 503 whenever its database check fails. So a broken image and a healthy image that cannot reach its database are indistinguishable to the deploy gate. That ambiguity is most of why v0.5.65 has been hard to diagnose remotely.

On failure this reports which of the two it is, plus the response body, `docker inspect` (status, exit code, **OOMKilled**), and 200 lines of container log.

## What this PR should tell us

The `pull_request` trigger for this workflow includes `.github/workflows/docker-build.yml` in its paths, and this branch is based on post-merge `main` — so **this PR builds an image containing Java and the JDK and runs the new smoke step against it.**

- **If the smoke step fails here**, the image itself is broken, we get the container log in CI, and we fix forward.
- **If it passes**, the image boots fine standalone and the production failure is environmental — host disk, memory, or database reachability from the new color — which narrows the next step to the host.

Either outcome is progress; right now we cannot tell those apart.

## Status

Prod is healthy on 0.5.64. `:latest` is currently the v0.5.65 image that fails to come up, so the deployer will keep retrying and failing until this is resolved or the merge is reverted. Reverting #1337 remains available and is the safe option if we want a known-good `:latest` before tomorrow.

---
_Generated by [Claude Code](https://claude.ai/code/session_017F7GgWKR5xb3Yj7cw5iZJS)_