### PR TITLE
ci(docker): smoke-test the image against postgres, in two phases

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -239,6 +239,7 @@ jobs:
             docker run -d --name chickadee-smoke --network host \
               -e AUTH_MODE=local \
               -e ENABLE_NON_SSO_AUTH_MODES=true \
+              -e MCP_MODE=read_write \
               -e DATABASE_BACKEND=postgres \
               -e DATABASE_HOST=127.0.0.1 \
               -e DATABASE_PORT=5432 \
@@ -291,7 +292,19 @@ jobs:
           # PHASE 1 — cold boot against an EMPTY postgres. This applies every
           # migration, so it gets a generous budget: prod's database is already
           # migrated and never pays this cost at boot.
-          echo "Phase 1: cold boot against empty postgres (applies migrations) ..."
+          # THE NUMBER THE DEPLOY HOST CARES ABOUT. Every blue-green swap
+          # pulls this image while the live color still holds the previous one,
+          # so the host needs room for BOTH plus the rollback target. The Java
+          # arc added a JDK to the runtime layer (+387 MB by apt's own
+          # accounting), and buildx never prints a final size anywhere — so it
+          # has never been visible in CI at all. Printed unconditionally, on
+          # every build, so the trend is greppable rather than archaeological.
+          echo "----- image size -----"
+          docker image inspect "$IMAGE" --format 'size: {{.Size}} bytes ({{.Size}} / 1e9 GB)' || true
+          docker image inspect "$IMAGE" --format '{{.Size}}' \
+            | awk '{ printf "size: %.2f GB\n", $1/1e9 }' || true
+
+          echo "Phase 1: cold boot against empty postgres (applies migrations) ...
           run_server
           probe 240 || dump_and_fail
 
@@ -304,8 +317,11 @@ jobs:
           run_server
           probe 90 || dump_and_fail
 
-          echo "----- container logs (tail 40, for the record) -----"
-          docker logs --tail 40 chickadee-smoke 2>&1 || true
+          # Printed on SUCCESS too, and generously: the boot sequence of a
+          # known-good image is the baseline a future failure gets diffed
+          # against, and it costs nothing to keep it in the log.
+          echo "----- container logs (tail 80, for the record) -----"
+          docker logs --tail 80 chickadee-smoke 2>&1 || true
           docker rm -f chickadee-smoke >/dev/null 2>&1 || true
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -105,6 +105,28 @@ jobs:
       contents: read
       packages: write
 
+    # Postgres for the smoke test below. Production runs postgres, and the
+    # server's /health answers 503 whenever its database check fails — so a
+    # smoke test on the sqlite default proves the binary starts and nothing
+    # about the path the deploy gate actually keys on.
+    services:
+      postgres:
+        image: ghcr.io/jimwallace/chickadee/postgres:16
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          POSTGRES_DB: chickadee_smoke
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d chickadee_smoke"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v6
 
@@ -208,67 +230,83 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE='${{ fromJSON(steps.meta.outputs.json).tags[0] }}'
-          echo "Booting $IMAGE ..."
-          docker run -d --name chickadee-smoke \
-            -e AUTH_MODE=local \
-            -e ENABLE_NON_SSO_AUTH_MODES=true \
-            -p 18080:8080 \
-            "$IMAGE"
 
-          # The probe records the HTTP CODE, not just success. `curl -sf` — what
-          # the deployer's wait_healthy uses — fails identically on "no
-          # response" and on "503", and /health answers 503 whenever its
-          # database check fails. That makes a broken image and a healthy image
-          # that cannot reach its database look the same to the deploy gate,
-          # which is precisely the ambiguity that made v0.5.65 hard to diagnose
-          # from off-host. Here we can tell them apart, so we do.
-          ok=0
-          exited=0
-          last_code=000
-          for i in $(seq 1 90); do
-            # `-w '%{http_code}'` already prints 000 when the connection fails,
-            # so curl's own non-zero exit is swallowed rather than appended —
-            # an `|| echo 000` here concatenates into "000000" and defeats the
-            # branch below.
-            last_code="$(curl -s -o /tmp/health.body -w '%{http_code}' \
-              http://127.0.0.1:18080/health 2>/dev/null)" || true
-            [ -n "$last_code" ] || last_code=000
-            if [ "$last_code" = "200" ]; then
-              echo "Healthy after ${i}s."
-              ok=1
-              break
-            fi
-            if [ "$(docker inspect -f '{{.State.Running}}' chickadee-smoke 2>/dev/null)" != "true" ]; then
-              exited=1
-              break
-            fi
-            sleep 1
-          done
+          # `--network host`: the container must reach the postgres SERVICE,
+          # which Actions maps onto the runner's own localhost. Host networking
+          # also means the server's 8080 is reachable directly, so no -p.
+          run_server () {
+            docker rm -f chickadee-smoke >/dev/null 2>&1 || true
+            docker run -d --name chickadee-smoke --network host \
+              -e AUTH_MODE=local \
+              -e ENABLE_NON_SSO_AUTH_MODES=true \
+              -e DATABASE_BACKEND=postgres \
+              -e DATABASE_HOST=127.0.0.1 \
+              -e DATABASE_PORT=5432 \
+              -e DATABASE_NAME=chickadee_smoke \
+              -e DATABASE_USER=postgres \
+              -e DATABASE_PASSWORD=postgres \
+              "$IMAGE" >/dev/null
+          }
 
-          if [ "$ok" -ne 1 ]; then
-            if [ "$exited" -eq 1 ]; then
-              echo "::error::The container EXITED before answering /health — the server process died at startup."
-            elif [ "$last_code" = "000" ]; then
-              echo "::error::No HTTP response from /health within 90s — the server never began serving."
+          # Probes /health for $1 seconds. Records the HTTP CODE rather than
+          # using `curl -sf`: the deployer's gate cannot tell "no response" from
+          # "503", and /health answers 503 whenever its database check fails, so
+          # a broken image and a healthy image that cannot reach its database
+          # look identical from off-host. That ambiguity is most of why v0.5.65
+          # was hard to diagnose remotely.
+          probe () {
+            local budget="$1" i last_code=000
+            for i in $(seq 1 "$budget"); do
+              last_code="$(curl -s -o /tmp/health.body -w '%{http_code}' \
+                http://127.0.0.1:8080/health 2>/dev/null)" || true
+              [ -n "$last_code" ] || last_code=000
+              if [ "$last_code" = "200" ]; then
+                echo "  healthy after ~${i}s (HTTP 200)"
+                return 0
+              fi
+              if [ "$(docker inspect -f '{{.State.Running}}' chickadee-smoke 2>/dev/null)" != "true" ]; then
+                echo "::error::The container EXITED before answering /health — the server process died at startup."
+                return 1
+              fi
+              sleep 1
+            done
+            if [ "$last_code" = "000" ]; then
+              echo "::error::No HTTP response from /health within ${budget}s — the server never began serving."
             else
               echo "::error::/health answered ${last_code}, not 200 — the server is up but degraded (503 means its database check failed)."
-              echo "----- /health body -----"
-              cat /tmp/health.body 2>/dev/null || true
-              echo
+              echo "----- /health body -----"; cat /tmp/health.body 2>/dev/null || true; echo
             fi
-            echo "::error::The blue-green deployer would abort this release."
+            return 1
+          }
+
+          dump_and_fail () {
             echo "----- docker inspect -----"
             docker inspect -f 'State: {{.State.Status}}  ExitCode: {{.State.ExitCode}}  OOMKilled: {{.State.OOMKilled}}  Error: {{.State.Error}}' chickadee-smoke || true
             echo "----- container logs (tail 200) -----"
             docker logs --tail 200 chickadee-smoke 2>&1 || true
             docker rm -f chickadee-smoke >/dev/null 2>&1 || true
             exit 1
-          fi
+          }
+
+          # PHASE 1 — cold boot against an EMPTY postgres. This applies every
+          # migration, so it gets a generous budget: prod's database is already
+          # migrated and never pays this cost at boot.
+          echo "Phase 1: cold boot against empty postgres (applies migrations) ..."
+          run_server
+          probe 240 || dump_and_fail
+
+          # PHASE 2 — the production mirror. Restart against the NOW-MIGRATED
+          # database and hold it to the same 90s `wait_healthy` budget
+          # scripts/bluegreen-deploy.sh gives a new color
+          # (CHICKADEE_HEALTH_TIMEOUT). This is the shape of a real deploy: an
+          # existing database, no migrations to apply, 90 seconds to answer.
+          echo "Phase 2: restart against the migrated database (mirrors a production swap) ..."
+          run_server
+          probe 90 || dump_and_fail
 
           echo "----- container logs (tail 40, for the record) -----"
           docker logs --tail 40 chickadee-smoke 2>&1 || true
           docker rm -f chickadee-smoke >/dev/null 2>&1 || true
-
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -304,7 +304,7 @@ jobs:
           docker image inspect "$IMAGE" --format '{{.Size}}' \
             | awk '{ printf "size: %.2f GB\n", $1/1e9 }' || true
 
-          echo "Phase 1: cold boot against empty postgres (applies migrations) ...
+          echo "Phase 1: cold boot against empty postgres (applies migrations) ..."
           run_server
           probe 240 || dump_and_fail
 


### PR DESCRIPTION
Diagnostic follow-up to #1337 / #1338. **Seven consecutive blue-green swaps have now aborted** with "new color unhealthy" against an image that boots clean in CI in 1.2 s. This PR closes the gap between those two facts.

## Why the first smoke test couldn't see it

It booted the image on the **sqlite default**. That proved the binary starts and serves HTTP — and nothing about the path production fails on. Prod runs postgres, and `/health` answers **503** whenever its database check fails. The sqlite smoke could never reach that ground.

## Two phases, answering different questions

- **Phase 1 — cold boot against an empty database, 240 s budget.** Applies every migration. Production never pays that cost at boot (its database is already migrated), so holding this phase to the deploy gate's budget would only manufacture false failures.
- **Phase 2 — restart against the now-migrated database, 90 s budget.** That is the same `wait_healthy` budget `scripts/bluegreen-deploy.sh` gives a new color, and the shape of a real swap: existing database, no migrations, ninety seconds to answer. **If the image can't do that here, it can't do it on the host.**

`--network host` because the container must reach the postgres service, which Actions maps onto the runner's own localhost.

The probe still records the HTTP **code** rather than using `curl -sf`, and that matters more now: with a real database in the picture, "no response" and "503 from a failed database check" are both reachable, and the deployer's gate cannot tell them apart. This can, and says which one it saw.

## What we know so far

| Evidence | Reading |
|---|---|
| Swap at 21:37:07 succeeded, `detail: running=0.5.64` — pulled `:latest` ~10 s before the Java image was pushed | The blue-green machinery works on that host |
| Seven aborts since, across **two distinct** Java-containing images | The image is implicated, not the machinery |
| Deploy script `docker pull`s `:latest` fresh every attempt (verified in `bluegreen-deploy.sh`) | The later aborts really did use the new image |
| Both Java images boot in ~1.2 s in CI | …but with no database, no migrations, and none of the host's disk/memory pressure |
| apt log: `default-jdk` purely additive — zero removals, zero downgrades, every pre-existing package at an identical version | The JDK didn't displace anything |
| That layer grew 1897 MB → 2284 MB installed | Disk on the host remains a live hypothesis |
| Runner fleet still on 0.5.64; `refresh_runner` only runs after a healthy swap | **No container from the Java image has ever run on that host** |

Prod is stable on 0.5.64, queue empty, three runners healthy — no student impact.

## If this passes

Then the image boots fine against a real postgres too, and the remaining candidates are host-local: disk (that +387 MB), memory pressure with two colors plus postgres plus runners, or the new color's database reachability specifically. That's the shortlist for the container log.

---
_Generated by [Claude Code](https://claude.ai/code/session_017F7GgWKR5xb3Yj7cw5iZJS)_