### PR TITLE
fix(docker): pin the application UID to 999 — the cause of every failed deploy since v0.5.65

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -222,6 +222,14 @@ jobs:
       # whose descriptions and schemas derive from AssignmentLanguage.allCases
       # — the last startup path CI was not exercising.
       #
+      # `MCP_ALLOW_OPEN_GUARDS=true` clears the SECOND gate. PUBLIC_BASE_URL
+      # alone only got as far as "Refusing to mount /mcp: MCP_ALLOWED_HOSTS and
+      # MCP_ALLOWED_ORIGINS unset in production" — the DNS-rebinding guards.
+      # Production pins Host/Origin at its reverse proxy; the smoke has no
+      # proxy and makes no cross-origin request, so opening the guards here is
+      # the honest equivalent. Note /health does NOT assert that /mcp mounted,
+      # so this is checked by reading the boot log, not by the probe.
+      #
       # `ENABLE_NON_SSO_AUTH_MODES=true` must accompany AUTH_MODE. `AUTH_MODE` alone is
       # SILENTLY IGNORED — the default mode is SSO and `AuthConfig` only honours
       # a local/dual request when this second flag is set, logging "AUTH_MODE=
@@ -250,6 +258,7 @@ jobs:
               -e ENABLE_NON_SSO_AUTH_MODES=true \
               -e MCP_MODE=read_write \
               -e PUBLIC_BASE_URL=http://127.0.0.1:8080 \
+              -e MCP_ALLOW_OPEN_GUARDS=true \
               -e DATABASE_BACKEND=postgres \
               -e DATABASE_HOST=127.0.0.1 \
               -e DATABASE_PORT=5432 \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -323,6 +323,23 @@ jobs:
           docker image inspect "$IMAGE" --format '{{.Size}}' \
             | awk '{ printf "size: %.2f GB\n", $1/1e9 }' || true
 
+          # THE ASSERTION THAT WOULD HAVE CAUGHT v0.5.65. The application user
+          # is created with `useradd --system`, which allocates the highest FREE
+          # system ID counting down from 999 — so installing a package that
+          # creates its own system users silently moves it. `default-jdk` moved
+          # it 999 -> 997, and every deploy onto the real data volume (owned by
+          # 999, with .mcp-signing-key at mode 0600) crash-looped at boot while
+          # every test here stayed green, because a FRESH volume takes whatever
+          # UID writes it first. Nothing downstream of the image can see this;
+          # it has to be asserted on the image itself.
+          echo "----- application user -----"
+          image_uid="$(docker run --rm --entrypoint id "$IMAGE" -u)"
+          echo "uid: $image_uid"
+          if [ "$image_uid" != "999" ]; then
+            echo "::error::Application user UID is $image_uid, expected 999. An existing deployment's data volume is owned by 999; a different UID cannot read its own 0600 signing key and will crash-loop at boot on every host that already has data. Pin the UID in the Dockerfile rather than relaxing this check."
+            exit 1
+          fi
+
           echo "Phase 1: cold boot against empty postgres (applies migrations) ..."
           run_server
           probe 240 || dump_and_fail

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -213,7 +213,16 @@ jobs:
       # sqlite, no worker secret (one is generated), no MCP — which is enough to
       # prove the binary starts, migrations apply, and the HTTP server serves.
       #
-      # `ENABLE_NON_SSO_AUTH_MODES=true` must accompany it. `AUTH_MODE` alone is
+      # `PUBLIC_BASE_URL` is what actually MOUNTS the MCP surfaces. Setting
+      # `MCP_MODE` alone is not enough — without an issuer/resource the server
+      # logs "MCP_MODE=read_write but no issuer/resource could be resolved;
+      # /mcp not mounted" and carries on, so the first version of this proved
+      # only that the server boots with the variable set. Production has a
+      # PUBLIC_BASE_URL and therefore builds the MCP tool catalog at boot,
+      # whose descriptions and schemas derive from AssignmentLanguage.allCases
+      # — the last startup path CI was not exercising.
+      #
+      # `ENABLE_NON_SSO_AUTH_MODES=true` must accompany AUTH_MODE. `AUTH_MODE` alone is
       # SILENTLY IGNORED — the default mode is SSO and `AuthConfig` only honours
       # a local/dual request when this second flag is set, logging "AUTH_MODE=
       # local ignored ... using sso" and then trapping on the missing
@@ -240,6 +249,7 @@ jobs:
               -e AUTH_MODE=local \
               -e ENABLE_NON_SSO_AUTH_MODES=true \
               -e MCP_MODE=read_write \
+              -e PUBLIC_BASE_URL=http://127.0.0.1:8080 \
               -e DATABASE_BACKEND=postgres \
               -e DATABASE_HOST=127.0.0.1 \
               -e DATABASE_PORT=5432 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,27 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Non-root user for the application processes.
+#
+# The UID and GID are PINNED to 999 and must stay there, and this must stay
+# ABOVE the package installs below. `useradd --system` allocates the highest
+# free system ID counting DOWN from 999, so the number it lands on is a
+# property of how many system users the installed packages happened to create
+# — not of the useradd line. Adding `default-jdk` in v0.5.65 claimed two of
+# them, the application user silently became 997, and every blue-green deploy
+# then crash-looped at boot on `/data/.mcp-signing-key`: the persistent data
+# volume is owned by 999, that key is mode 0600, and a 997 process cannot read
+# its own signing key. The server exited fatally, `--restart unless-stopped`
+# restarted it, /health never answered, and the deploy aborted at the health
+# gate having deleted the container that would have explained why.
+#
+# No test could catch it downstream of here: a FRESH volume takes whatever UID
+# creates it, so the image smoke-tests green on any UID. Only a volume written
+# by an older image fails. The guard is therefore the pin itself plus the
+# uid=999 assertion in the docker-build smoke step.
+RUN groupadd --system --gid 999 chickadee \
+    && useradd --system --uid 999 --gid 999 --create-home chickadee
+
 # System dependencies:
 #   - C runtime libs (Swift stdlib is statically linked)
 #   - zip / unzip: the server and worker shell out to /usr/bin/{zip,unzip}
@@ -146,9 +167,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 # ft_text_renderer — either way every figureCount notebook check errors at
 # validation. Measured, not assumed; the wasm kernel side needs nothing (its
 # plotly toolkit is built in).
-
-# Non-root user for the application processes.
-RUN useradd --system --user-group --create-home chickadee
 
 WORKDIR /app
 

--- a/changelog.d/1341-pin-application-uid.md
+++ b/changelog.d/1341-pin-application-uid.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **Every deploy since v0.5.65 crash-looped at boot, and the cause was a user
+  ID.** The image creates its application user with `useradd --system`, which
+  allocates the highest free system ID counting DOWN from 999 — so the ID it
+  lands on depends on how many system users the packages installed above it
+  happened to create. Adding `default-jdk` for Java claimed two of them and
+  moved the application user from **999 to 997**. The production data volume is
+  owned by 999 and `.mcp-signing-key` is mode 0600, so the new container could
+  not read its own MCP signing key: the server exited fatally before serving a
+  request, `--restart unless-stopped` restarted it, `/health` never answered,
+  and the blue-green gate correctly aborted every attempt for hours while the
+  previous version kept serving. The UID and GID are now pinned to 999 and
+  created before any package install can claim them, and the image smoke test
+  asserts the UID so this cannot drift again.
+
+  No test downstream of the image could have caught it: a fresh volume takes
+  whatever UID writes it first, so the same image is healthy in seconds in CI
+  and fatal on a host that already has data. The check has to be on the image
+  itself, which is where it now is.
+
+- **A failed blue-green deploy no longer deletes the evidence.** When the health
+  gate failed, `bluegreen-deploy.sh` force-removed the container before anything
+  read its logs — the only record of why the boot failed. Its output is now
+  captured to the deploy state directory and echoed into the journal before the
+  cleanup runs. The free-space line printed on every deploy was also broken by a
+  quoting bug (`awk: backslash not last character on line`) and had never shown
+  a value.

--- a/scripts/bluegreen-deploy.sh
+++ b/scripts/bluegreen-deploy.sh
@@ -250,6 +250,22 @@ cmd_deploy() {
 
   if ! wait_healthy "$idle_port"; then
     warn "New container failed health check. Aborting — active (:$active_port) is untouched."
+    # Capture the container's own output BEFORE the cleanup below removes it.
+    # That output is the ONLY record of why the boot failed, and `docker rm -f`
+    # destroys it — so a deploy that fails repeatedly used to leave nothing at
+    # all to diagnose from, on the host or through the admin MCP surface.
+    if (( ! DRY_RUN )); then
+      mkdir -p "$STATE_DIR" 2>/dev/null || true
+      local failed_log="${STATE_DIR}/failed-${idle_name}-$(date -u +%Y%m%dT%H%M%SZ).log"
+      if docker logs --tail 400 "$idle_name" >"$failed_log" 2>&1; then
+        warn "Captured failed container output -> $failed_log"
+      else
+        rm -f "$failed_log" 2>/dev/null || true
+        warn "Could not capture container output (container may never have started)."
+      fi
+      warn "Last lines from the failed container:"
+      docker logs --tail 40 "$idle_name" 2>&1 | sed 's/^/    | /' || true
+    fi
     run "docker rm -f '$idle_name' >/dev/null 2>&1 || true"
     die "deploy aborted; no traffic was moved."
   fi

--- a/scripts/bluegreen-deploy.sh
+++ b/scripts/bluegreen-deploy.sh
@@ -222,7 +222,7 @@ cmd_deploy() {
   # still reference their own images, so the rollback target is never pruned.
   log "Reclaiming disk from images orphaned by past swaps (before pull)..."
   run "docker image prune -f || true"
-  log "Free space on $(df -P / | awk 'NR==2{print $4\" KiB on \"$6}')"
+  log "Free space on $(df -P / | awk 'NR==2{print $4 " KiB on " $6}')"
 
   run "docker pull '$IMAGE'"
 


### PR DESCRIPTION
Root cause found and fixed, confirmed against the production host.

## What was happening

Every blue-green deploy since v0.5.65 aborted at the health gate, ~12 times over several hours. The container started, never answered `/health` for the full 90 s, and was destroyed. The server was taking a **fatal error at boot**:

```
Fatal error: Error raised at top level: NSCocoaErrorDomain Code=513
"You don't have permission." NSFilePath=/data/.mcp-signing-key
NSPOSIXErrorDomain Code=13 "Permission denied"
```

`--restart unless-stopped` restarted it, it crashed again, and the loop ran until the gate gave up.

## Why

The runtime stage created its user with `useradd --system`, which allocates the highest **free** system ID counting down from 999. That makes the resulting ID a property of how many system users the packages installed *above* it happen to create — not of the `useradd` line. `default-jdk`, added for Java in v0.5.65, claimed two:

| | UID |
|---|---|
| blue, v0.5.64, still serving | **999** |
| new image, v0.5.65+ | **997** |
| every entry on the data volume | **999** |
| `/data/.mcp-signing-key` | `-rw-------` 999 999 |

A 997 process cannot read a 0600 file owned by 999. The MCP signing key was unreadable, and the failure was fatal rather than degraded.

## The fix

Create the group and user with explicit `--gid 999 --uid 999`, **above** the package installs so nothing can take the ID first. It cannot be pinned in its old position — 999 and 998 are occupied there now, which is exactly how it drifted.

The smoke test asserts `uid=999` on the built image and fails the build otherwise.

## Why no test caught it, and why the assertion has to be on the image

A **fresh** volume takes whatever UID writes it first. The identical image boots healthy in ~2 s against a clean postgres in CI and is fatal on any host that already has data. Every green check during the outage was honest — the condition simply does not exist downstream of the image, so the check has to be on the image itself.

## Also in this PR

- **A failed deploy no longer deletes its own evidence.** `bluegreen-deploy.sh` force-removed the failed container before anything read its logs — the only record of why the boot failed. Output is now captured to the deploy state dir and echoed to the journal first. This turned a multi-hour hunt into one glance at `docker logs`, and would have shown the fatal error immediately.
- **The free-space line printed on every deploy was broken** by a quoting bug (`awk: backslash not last character on line`) and had never shown a value — the one diagnostic that speaks directly to a disk question.
- The image smoke test now boots against a **real postgres** in two phases (cold boot with migrations, then a restart against the migrated DB mirroring a swap), reports image size (4.02 GB), and mounts both MCP surfaces. Those were added while diagnosing; all pass, and none of them could have caught this.

## Deploying it

Once merged and released, the deployer picks it up on its next poll. Nothing is needed on the host: the pin restores 999, so the existing volume works untouched — no `chown`, no migration. Blue keeps serving until the new color passes its health gate.