### PR TITLE
fix: hold family parameter names to the assignment's language

### DIFF
--- a/Sources/APIServer/Utilities/IdentifierValidation.swift
+++ b/Sources/APIServer/Utilities/IdentifierValidation.swift
@@ -1,11 +1,23 @@
 // APIServer/Utilities/IdentifierValidation.swift
 //
-// Tiny shared helpers for validating Python-identifier safety of
+// Tiny shared helpers for validating the identifier safety of
 // instructor-authored manifest fields (pattern-family ids, case keys,
 // variable names, etc.).  Lifted out of `ManifestValidation.swift` in
 // v0.4.182 when that file was split into per-concern validators —
 // all three (`ManifestDependencyValidator`, `PatternFamilyValidator`,
 // `NotebookCheckValidator`) call these.
+//
+// Two questions live here and must not be collapsed into one:
+// `isValidIdentifier` asks whether a BARE NAME is legal (a variable, a
+// parameter), `isValidFunctionTarget` whether a CALL TARGET is. They disagree
+// on Java, whose target is a qualified `Solution.classify` that is not itself
+// an identifier, and on Lua, whose bare names are checked against Lua's grammar
+// while its targets still borrow Python's.
+//
+// The per-language arms are what makes them right: a check here that answers
+// with Python's rules on every assignment does not fail loudly, it simply
+// refuses a name the author's language considers ordinary, in a message naming
+// a language their assignment has nothing to do with.
 
 import Core
 import Foundation
@@ -53,6 +65,45 @@ func isValidRIdentifier(_ s: String) -> Bool {
         guard ch.isLetter || ch.isNumber || ch == "." || ch == "_" else { return false }
     }
     return true
+}
+
+/// Whether `s` is a valid *bare name* in `language` — a variable, a parameter,
+/// a module-level identifier.
+///
+/// Distinct from `isValidFunctionTarget`, and deliberately so: the two answer
+/// different questions and disagree on two languages. A Java call target is a
+/// qualified `Solution.classify`, which is not a Java identifier; a Lua bare
+/// name is checked against Lua's own grammar while a Lua call target still
+/// borrows Python's. Collapsing them would either let a dotted name through as
+/// a variable or refuse Java's only legal call target.
+///
+/// Lives here rather than beside its first caller because it has several: it
+/// was written for notebook checks, stayed `private` in that file, and the
+/// pattern-family validator went on applying Python's rules to every language's
+/// parameter and variable names as a result.
+func isValidIdentifier(_ value: String, language: AssignmentLanguage) -> Bool {
+    switch language {
+    case .python: return isValidPythonIdentifier(value)
+    case .r: return isValidRIdentifier(value)
+    case .lua: return isValidLuaIdentifier(value)
+    case .octave: return isValidOctaveIdentifier(value)
+    case .cpp: return isValidCppIdentifier(value)
+    case .racket: return isValidRacketIdentifier(value)
+    case .java: return isValidJavaIdentifier(value)
+    }
+}
+
+/// Human-readable name of the identifier grammar, for validation messages.
+func identifierKindName(_ language: AssignmentLanguage) -> String {
+    switch language {
+    case .python: return "Python identifier"
+    case .r: return "R name"
+    case .lua: return "Lua identifier"
+    case .octave: return "Octave identifier"
+    case .cpp: return "C++ identifier"
+    case .racket: return "Racket identifier"
+    case .java: return "Java identifier"
+    }
 }
 
 /// Whether `s` is a usable pattern-family function target in `language`.

--- a/Sources/APIServer/Utilities/NotebookCheckKindHandler.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckKindHandler.swift
@@ -87,34 +87,6 @@ private func validateRequiredIdentifier(
     return value
 }
 
-/// Identifier grammar for `language`. Keeps name fields (`variable`, function
-/// names) held to the right language's rules, so an R name like `my.df` passes
-/// on an R assignment while Python assignments are unchanged.
-private func isValidIdentifier(_ value: String, language: AssignmentLanguage) -> Bool {
-    switch language {
-    case .python: return isValidPythonIdentifier(value)
-    case .r: return isValidRIdentifier(value)
-    case .lua: return isValidLuaIdentifier(value)
-    case .octave: return isValidOctaveIdentifier(value)
-    case .cpp: return isValidCppIdentifier(value)
-    case .racket: return isValidRacketIdentifier(value)
-    case .java: return isValidJavaIdentifier(value)
-    }
-}
-
-/// Human-readable name of the identifier grammar, for validation messages.
-private func identifierKindName(_ language: AssignmentLanguage) -> String {
-    switch language {
-    case .python: return "Python identifier"
-    case .r: return "R name"
-    case .lua: return "Lua identifier"
-    case .octave: return "Octave identifier"
-    case .cpp: return "C++ identifier"
-    case .racket: return "Racket identifier"
-    case .java: return "Java identifier"
-    }
-}
-
 /// rtol / atol bounds check shared by the float-comparison kinds.
 private func validateTolerances(_ check: NotebookCheck, kindLabel: String) throws {
     if let rtol = check.rtol, !rtol.isFinite || rtol < 0 {

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -59,19 +59,27 @@ private func validateFamilyVariablesAndArgRefs(
 ) throws {
     var seenVarNames: Set<String> = []
     let paramNameSet = Set(family.paramNames)
-    // Deliberately Python's grammar, NOT the assignment's — unlike `paramNames`
-    // and `.variableEquality`'s case variable, which this release did widen.
+    // Deliberately the CROSS-LANGUAGE SUBSET, not the assignment's grammar —
+    // unlike `paramNames` and `.variableEquality`'s case variable, which this
+    // release did widen.
     //
-    // A family variable is referenced from an arg cell as `$name`, and the web
-    // editor parses that with `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`. Accepting a
-    // Racket `bmi-value` here would make `$bmi-value` match nothing and fall
-    // through as a literal STRING — a wrong expected value in a generated test,
-    // with no error anywhere. Exactly the `{{name}}` hazard that keeps global
-    // and section inputs on Python's grammar too.
+    // `isValidPythonIdentifier` is the predicate, but Python is not the reason,
+    // and reading it that way points at the wrong fix. Two things pin it:
     //
-    // The two are one coupled change: widen this only together with the
-    // editor's `$name` parser, via a grammar fact on `AuthoringLanguageFacts`
-    // rather than a second hand-written rule in JavaScript.
+    //  1. A family variable is REFERENCED from an arg cell as `$name`, parsed
+    //     by `/^\$([A-Za-z_][A-Za-z0-9_]*)$/` in `pattern-family-editor.js`.
+    //     Accepting a Racket `bmi-value` makes `$bmi-value` match nothing and
+    //     fall through as a literal STRING — a wrong expected value in a
+    //     generated test, reported nowhere.
+    //  2. The name is EMITTED bare into the generated preamble. Every language
+    //     has an emitter that makes an arbitrary name safe (`rIdentifier`
+    //     backticks, `luaIdentifier`/`octaveIdentifier` mangle) EXCEPT Python,
+    //     whose preamble writes `name = _ck["name"]` directly — so a hyphen is
+    //     a syntax error. The subset is pinned by that weakest emitter.
+    //
+    // So the unlock is not "make this language-aware". It is: give Python an
+    // emitter like the other four have, then widen the `$name` parser with it.
+    // Same reasoning holds for global/section input names and `{{name}}`.
     for v in family.variables {
         guard isValidPythonIdentifier(v.name) else {
             throw Abort(

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -53,20 +53,30 @@ private func validatePatternCaseHeader(
 /// section.
 private func validateFamilyVariablesAndArgRefs(
     family: PatternFamily,
-    language: AssignmentLanguage,
     sectionVarNamesHere: Set<String>,
     globalVarNames: Set<String>,
     perStudentExpressionNames: Set<String>
 ) throws {
     var seenVarNames: Set<String> = []
     let paramNameSet = Set(family.paramNames)
+    // Deliberately Python's grammar, NOT the assignment's — unlike `paramNames`
+    // and `.variableEquality`'s case variable, which this release did widen.
+    //
+    // A family variable is referenced from an arg cell as `$name`, and the web
+    // editor parses that with `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`. Accepting a
+    // Racket `bmi-value` here would make `$bmi-value` match nothing and fall
+    // through as a literal STRING — a wrong expected value in a generated test,
+    // with no error anywhere. Exactly the `{{name}}` hazard that keeps global
+    // and section inputs on Python's grammar too.
+    //
+    // The two are one coupled change: widen this only together with the
+    // editor's `$name` parser, via a grammar fact on `AuthoringLanguageFacts`
+    // rather than a second hand-written rule in JavaScript.
     for v in family.variables {
-        guard isValidIdentifier(v.name, language: language) else {
+        guard isValidPythonIdentifier(v.name) else {
             throw Abort(
                 .unprocessableEntity,
-                reason:
-                    "Pattern family '\(family.id)': variable name '\(v.name)' is not a valid "
-                    + identifierKindName(language))
+                reason: "Pattern family '\(family.id)': variable name '\(v.name)' is not a valid Python identifier")
         }
         guard seenVarNames.insert(v.name).inserted else {
             throw Abort(
@@ -308,13 +318,13 @@ func validatePatternFamilies(
         try handler.validateFamily(family)
 
         // v0.4.94: family-scoped variables.  Each name must be a valid
-        // identifier in the ASSIGNMENT'S language, unique within the family,
-        // and not collide with a parameter name (the renderer would shadow it
-        // at call time, silently breaking the test).  Any `$name` reference in
-        // a case arg cell must resolve to a declared variable.
+        // identifier, unique within the family, and not collide with a
+        // parameter name (the renderer would shadow it at call time, silently
+        // breaking the test).  Any `$name` reference in a case arg cell must
+        // resolve to a declared variable — which is why these names, unlike
+        // `paramNames`, stay on Python's grammar; see the helper.
         try validateFamilyVariablesAndArgRefs(
             family: family,
-            language: language,
             sectionVarNamesHere: sectionVarNames(forFamily: family.id),
             globalVarNames: globalVariableNames,
             perStudentExpressionNames: perStudentExpressionNames

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -53,6 +53,7 @@ private func validatePatternCaseHeader(
 /// section.
 private func validateFamilyVariablesAndArgRefs(
     family: PatternFamily,
+    language: AssignmentLanguage,
     sectionVarNamesHere: Set<String>,
     globalVarNames: Set<String>,
     perStudentExpressionNames: Set<String>
@@ -60,10 +61,12 @@ private func validateFamilyVariablesAndArgRefs(
     var seenVarNames: Set<String> = []
     let paramNameSet = Set(family.paramNames)
     for v in family.variables {
-        guard isValidPythonIdentifier(v.name) else {
+        guard isValidIdentifier(v.name, language: language) else {
             throw Abort(
                 .unprocessableEntity,
-                reason: "Pattern family '\(family.id)': variable name '\(v.name)' is not a valid Python identifier")
+                reason:
+                    "Pattern family '\(family.id)': variable name '\(v.name)' is not a valid "
+                    + identifierKindName(language))
         }
         guard seenVarNames.insert(v.name).inserted else {
             throw Abort(
@@ -216,10 +219,12 @@ private func validatePatternFamilyHeader(
     }
     var seenParams: Set<String> = []
     for param in family.paramNames {
-        guard isValidPythonIdentifier(param) else {
+        guard isValidIdentifier(param, language: language) else {
             throw Abort(
                 .unprocessableEntity,
-                reason: "Pattern family '\(family.id)': parameter name '\(param)' is not a valid Python identifier")
+                reason:
+                    "Pattern family '\(family.id)': parameter name '\(param)' is not a valid "
+                    + identifierKindName(language))
         }
         guard seenParams.insert(param).inserted else {
             throw Abort(
@@ -295,7 +300,7 @@ func validatePatternFamilies(
         var seenCaseKeys: Set<String> = []
         for c in family.cases {
             try validatePatternCaseHeader(family: family, c: c, seenCaseKeys: &seenCaseKeys)
-            try handler.validateCase(family: family, case: c)
+            try handler.validateCase(family: family, case: c, language: language)
         }
 
         // Family-level, kind-specific rules (e.g. approximateEquality's
@@ -303,12 +308,13 @@ func validatePatternFamilies(
         try handler.validateFamily(family)
 
         // v0.4.94: family-scoped variables.  Each name must be a valid
-        // Python identifier, unique within the family, and not collide
-        // with a parameter name (the renderer would shadow it at call
-        // time, silently breaking the test).  Any `$name` reference in
+        // identifier in the ASSIGNMENT'S language, unique within the family,
+        // and not collide with a parameter name (the renderer would shadow it
+        // at call time, silently breaking the test).  Any `$name` reference in
         // a case arg cell must resolve to a declared variable.
         try validateFamilyVariablesAndArgRefs(
             family: family,
+            language: language,
             sectionVarNamesHere: sectionVarNames(forFamily: family.id),
             globalVarNames: globalVariableNames,
             perStudentExpressionNames: perStudentExpressionNames

--- a/Sources/APIServer/Utilities/PatternKindHandler.swift
+++ b/Sources/APIServer/Utilities/PatternKindHandler.swift
@@ -23,8 +23,9 @@ import Vapor
 /// family/case is validated before it is applied to a test setup.
 protocol PatternKindHandler: Sendable {
     /// Whether this kind requires `PatternFamily.functionName` to be a valid
-    /// Python identifier.  `false` for kinds that inspect module-level state
-    /// rather than calling a function (`.variableEquality`).
+    /// call target in the assignment's language (`isValidFunctionTarget`).
+    /// `false` for kinds that inspect module-level state rather than calling a
+    /// function (`.variableEquality`).
     var requiresFunctionName: Bool { get }
 
     /// Renders one enabled case to Python source.  Delegates to the matching
@@ -39,8 +40,11 @@ protocol PatternKindHandler: Sendable {
     func validateFamily(_ family: PatternFamily) throws
 
     /// Validates the `args` / `expected` shape of a single case against this
-    /// kind's contract.
-    func validateCase(family: PatternFamily, case c: PatternCase) throws
+    /// kind's contract.  `language` is the assignment's declared language:
+    /// `.variableEquality` holds its case's variable name to that language's
+    /// identifier grammar, so an R `my.df` or a Racket `total-count` is
+    /// accepted where Python's rules would have refused it.
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws
 }
 
 extension PatternKindHandler {
@@ -111,7 +115,7 @@ struct DifferentialKind: PatternKindHandler {
         }
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: "differential")
     }
 }
@@ -147,7 +151,7 @@ struct BoundaryEqualityKind: PatternKindHandler {
             specHash: specHash, perStudentNames: perStudentNames)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: nil)
     }
 }
@@ -173,7 +177,7 @@ struct ApproximateEqualityKind: PatternKindHandler {
         }
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: nil)
     }
 }
@@ -193,7 +197,7 @@ struct VariableEqualityKind: PatternKindHandler {
             perStudentNames: perStudentNames)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         // Exactly one arg, which must be a non-empty string naming
         // the module-level variable to check.  `paramNames` is
         // ignored — for this kind it's purely a UI hint (column
@@ -215,11 +219,12 @@ struct VariableEqualityKind: PatternKindHandler {
                     "Pattern family '\(family.id)' (variable_equality): case '\(c.key)' arg must be a non-empty string (the variable name)"
             )
         }
-        guard isValidPythonIdentifier(varName) else {
+        guard isValidIdentifier(varName, language: language) else {
             throw Abort(
                 .unprocessableEntity,
                 reason:
-                    "Pattern family '\(family.id)' (variable_equality): case '\(c.key)' variable name '\(varName)' is not a valid Python identifier"
+                    "Pattern family '\(family.id)' (variable_equality): case '\(c.key)' variable name "
+                    + "'\(varName)' is not a valid \(identifierKindName(language))"
             )
         }
     }
@@ -236,7 +241,7 @@ struct ReturnTypeCheckKind: PatternKindHandler {
         renderReturnTypeCheck(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: "return_type_check")
         guard case .string(let expectedType) = c.expected,
             !expectedType.trimmingCharacters(in: .whitespaces).isEmpty
@@ -261,7 +266,7 @@ struct ExceptionExpectedKind: PatternKindHandler {
         renderExceptionExpected(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: "exception_expected")
         guard case .string(let exceptionType) = c.expected,
             !exceptionType.trimmingCharacters(in: .whitespaces).isEmpty
@@ -286,7 +291,7 @@ struct PerformanceThresholdKind: PatternKindHandler {
         renderPerformanceThreshold(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: "performance_threshold")
         let threshold: Double? = {
             switch c.expected {
@@ -316,7 +321,7 @@ struct StdoutEqualityKind: PatternKindHandler {
         renderStdoutEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: "stdout_equality")
         // Empty string is intentionally allowed — it means "this
         // function should print nothing", a legitimate case for
@@ -345,7 +350,7 @@ struct UnorderedEqualityKind: PatternKindHandler {
             specHash: specHash, perStudentNames: perStudentNames)
     }
 
-    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+    func validateCase(family: PatternFamily, case c: PatternCase, language: AssignmentLanguage) throws {
         try validatePatternArgCount(family: family, case: c, kindLabel: "unordered_equality")
         // Expected must be a list (the elements to match, in any order) — except
         // when it's per-student (expectedVarRef), where the list arrives at

--- a/Sources/Core/Models/PatternFamily.swift
+++ b/Sources/Core/Models/PatternFamily.swift
@@ -245,8 +245,10 @@ public struct PatternCase: Codable, Equatable, Sendable {
 /// useful we can promote this struct onto `TestProperties` without a
 /// breaking change to the per-family spec.
 public struct FamilyVariable: Codable, Equatable, Sendable {
-    /// Python identifier.  Validated against keywords + identifier syntax
-    /// in `ManifestValidation`.  Must be unique within the family.
+    /// An identifier in the ASSIGNMENT'S language — validated against that
+    /// language's keywords + identifier syntax by `PatternFamilyValidator`,
+    /// not against Python's on every assignment.  Must be unique within the
+    /// family.
     public let name: String
     /// The value bound to `name` in the generated test.  Any JSON-expressible
     /// Python literal (scalar, list, dict) works; nesting is free.

--- a/Sources/Core/Models/PatternFamily.swift
+++ b/Sources/Core/Models/PatternFamily.swift
@@ -245,12 +245,13 @@ public struct PatternCase: Codable, Equatable, Sendable {
 /// useful we can promote this struct onto `TestProperties` without a
 /// breaking change to the per-family spec.
 public struct FamilyVariable: Codable, Equatable, Sendable {
-    /// Python identifier, on EVERY assignment — unlike a family's `paramNames`,
-    /// which `PatternFamilyValidator` holds to the assignment's own language.
-    /// The difference is the `$name` reference syntax: this name is referenced
-    /// from an arg cell as `$name`, and the editor's parser for that is
-    /// Python-shaped, so a Racket `bmi-value` would silently read as a literal
-    /// string rather than a reference.  Must be unique within the family.
+    /// Held to the cross-language subset `[A-Za-z_][A-Za-z0-9_]*` on EVERY
+    /// assignment — unlike a family's `paramNames`, which
+    /// `PatternFamilyValidator` holds to the assignment's own language.  Not a
+    /// Python rule despite the predicate's name: this name is both referenced
+    /// as `$name` by a parser of that shape and emitted bare into the generated
+    /// preamble, where Python alone has no quoting or mangling emitter.  Must
+    /// be unique within the family.
     public let name: String
     /// The value bound to `name` in the generated test.  Any JSON-expressible
     /// Python literal (scalar, list, dict) works; nesting is free.

--- a/Sources/Core/Models/PatternFamily.swift
+++ b/Sources/Core/Models/PatternFamily.swift
@@ -245,10 +245,12 @@ public struct PatternCase: Codable, Equatable, Sendable {
 /// useful we can promote this struct onto `TestProperties` without a
 /// breaking change to the per-family spec.
 public struct FamilyVariable: Codable, Equatable, Sendable {
-    /// An identifier in the ASSIGNMENT'S language — validated against that
-    /// language's keywords + identifier syntax by `PatternFamilyValidator`,
-    /// not against Python's on every assignment.  Must be unique within the
-    /// family.
+    /// Python identifier, on EVERY assignment — unlike a family's `paramNames`,
+    /// which `PatternFamilyValidator` holds to the assignment's own language.
+    /// The difference is the `$name` reference syntax: this name is referenced
+    /// from an arg cell as `$name`, and the editor's parser for that is
+    /// Python-shaped, so a Racket `bmi-value` would silently read as a literal
+    /// string rather than a reference.  Must be unique within the family.
     public let name: String
     /// The value bound to `name` in the generated test.  Any JSON-expressible
     /// Python literal (scalar, list, dict) works; nesting is free.

--- a/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
+++ b/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
@@ -18,9 +18,25 @@
 // These assert the OUTCOME an author sees, not that a particular predicate ran
 // — the predicate was being called correctly the whole time it was wrong.
 //
-// TWO deliberate gaps, both the same shape: a name that is REFERENCED by a
-// Python-shaped parser elsewhere cannot be widened on its own, because the
-// result is not a refusal but a silent misread.
+// TWO deliberate gaps, both the same shape: a name that is REFERENCED by
+// another parser cannot be widened on its own, because the result is not a
+// refusal but a silent misread.
+//
+// Both parsers accept `[A-Za-z_][A-Za-z0-9_]*`, and it is worth being precise
+// about WHY, because "they use Python's rules" is wrong and points at the wrong
+// fix. Chickadee is not a Python system with other languages bolted on. That
+// character set is the CROSS-LANGUAGE SUBSET: the widest name every language's
+// generated code can carry as a bare identifier. It is pinned by the weakest
+// emitter, not by Python's semantics — R (`rIdentifier`) quotes an awkward name
+// in backticks and Lua/Octave (`luaIdentifier`/`octaveIdentifier`) mangle one,
+// but the Python preamble emits `name = _ck["name"]` with no emitter at all, so
+// a hyphen there is a syntax error. The subset happens to coincide with
+// Python's grammar; it is not derived from it.
+//
+// So widening these is NOT "make it language-aware" — a placeholder name is
+// replaced by a literal VALUE and never reaches any runtime, so a per-language
+// rule there would be meaningless. It is: give Python an emitter like the other
+// four have, after which the grammar is a free choice of Chickadee's own DSL.
 //
 //   * Global and section INPUT names — referenced from starter notebooks as
 //     `{{name}}`, parsed by `NotebookSubstitution.placeholderRegex`, which
@@ -136,23 +152,25 @@ import Vapor
     }
 
     /// But an R or Racket spelling is REFUSED even on its own language — the
-    /// one place this change deliberately stops short.
+    /// one place this change deliberately stops short, for two reasons that are
+    /// both about generated code and neither about Python.
     ///
-    /// A family variable is referenced from an arg cell as `$name`, and the web
-    /// editor parses that with `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`. Accepting
-    /// `threshold-value` here would make `$threshold-value` match nothing and
-    /// fall through as a literal string — a wrong expected value in a generated
-    /// test, reported nowhere. Widening the server alone converts a clear
-    /// refusal into a silent miscompare, which is strictly worse.
+    /// The name is REFERENCED from an arg cell as `$name`, parsed by
+    /// `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`, so `$threshold-value` would match
+    /// nothing and fall through as a literal string — a wrong expected value in
+    /// a generated test, reported nowhere. And it is EMITTED bare into the
+    /// preamble, where Python has no emitter to quote or mangle it the way
+    /// `rIdentifier` and `luaIdentifier` do for their languages.
     ///
-    /// When the editor's `$name` parser learns the language's grammar, delete
-    /// this test and fold these names into the accepting one above.
+    /// Widening the server alone converts a clear refusal into a silent
+    /// miscompare, which is strictly worse. Delete this test when Python gains
+    /// an emitter and the `$name` parser widens with it.
     @Test(
         arguments: [
             ("threshold.value", AssignmentLanguage.r),
             ("threshold-value", AssignmentLanguage.racket),
         ])
-    func familyVariableRefusesANonPythonSpellingPendingTheRefParser(
+    func familyVariableRefusesASpellingOutsideTheCrossLanguageSubset(
         name: String, language: AssignmentLanguage
     ) {
         #expect(throws: (any Error).self) {

--- a/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
+++ b/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
@@ -1,0 +1,154 @@
+// Regression guard for the SIBLINGS of the language-blind `functionName` check.
+//
+// #1341 made a family's `functionName` language-aware and stopped there. The
+// same file went on validating three other author-supplied names against
+// Python's rules on every assignment:
+//
+//   * `paramNames` — a family's parameter list.
+//   * `variables` — family-scoped literals referenced from arg cells.
+//   * `.variableEquality`'s per-case variable name — a module-level name in
+//     the student's own submission.
+//
+// So a Racket author could finally save `bmi-category` as the target and was
+// then refused on the parameter `bmi-value`, with a message naming Python. The
+// fix points all three at `isValidIdentifier(_:language:)` — which already
+// existed, `private`, in `NotebookCheckKindHandler.swift`, written for notebook
+// checks and never shared. Nothing was missing; it was out of reach.
+//
+// These assert the OUTCOME an author sees, not that a particular predicate ran
+// — the predicate was being called correctly the whole time it was wrong.
+//
+// NOTE the deliberate gap: global and section INPUT names are still held to
+// Python's grammar, and that is not an oversight. They are referenced from
+// starter notebooks as `{{name}}`, and `NotebookSubstitution.placeholderRegex`
+// hardcodes `[A-Za-z_][A-Za-z0-9_]*`. Widening the name check alone would let
+// an author save `bmi-value` and then silently leave `{{bmi-value}}` as literal
+// text in every student's notebook. The two must move together.
+
+import Core
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct PatternFamilyIdentifierGrammarTests {
+
+    private func family(
+        function: String = "f",
+        paramNames: [String] = ["x"],
+        variables: [FamilyVariable] = []
+    ) -> PatternFamily {
+        PatternFamily(
+            id: "fam",
+            name: "Family",
+            kind: .boundaryEquality,
+            functionName: function,
+            paramNames: paramNames,
+            cases: [
+                PatternCase(
+                    key: "01", label: "A case",
+                    args: [.double(1)], expected: .string("ok"))
+            ],
+            variables: variables
+        )
+    }
+
+    private func validate(_ f: PatternFamily, _ language: AssignmentLanguage) throws {
+        try validatePatternFamilies([f], testSuites: [], language: language)
+    }
+
+    /// A call target that language accepts, so a test about PARAMETER names is
+    /// not failed by the `functionName` check standing in front of it. Java is
+    /// the one that matters: its target must be qualified, so the bare `f`
+    /// every other language takes is refused there.
+    private func validTarget(for language: AssignmentLanguage) -> String {
+        language == .java ? "Solution.f" : "f"
+    }
+
+    // MARK: - Parameter names
+
+    /// The parameter spellings each language's authors actually write. Every
+    /// one must save; the last two are what #1341 left broken.
+    @Test(
+        arguments: [
+            ("bmi_value", AssignmentLanguage.python),
+            ("bmi.value", AssignmentLanguage.r),
+            ("bmiValue", AssignmentLanguage.java),
+            ("bmi-value", AssignmentLanguage.racket),
+        ])
+    func parameterNameAcceptedInItsOwnLanguage(name: String, language: AssignmentLanguage) throws {
+        try validate(
+            family(function: validTarget(for: language), paramNames: [name]), language)
+    }
+
+    /// An R name is still refused on a Python assignment — widening the grammar
+    /// per language must not widen it everywhere.
+    @Test func parameterNameRefusedInAForeignLanguage() {
+        #expect(throws: (any Error).self) {
+            try validate(family(paramNames: ["bmi-value"]), .python)
+        }
+    }
+
+    /// The refusal names the assignment's language, not Python. This is the
+    /// half an author actually reads, and naming Python on a Racket assignment
+    /// is what made the original defect unactionable.
+    @Test func parameterRefusalNamesTheAssignmentsLanguage() throws {
+        do {
+            try validate(family(paramNames: ["has space"]), .racket)
+            Issue.record("expected a refusal for an invalid Racket parameter name")
+        } catch let error as Abort {
+            #expect(error.reason.contains("Racket"))
+            #expect(!error.reason.contains("Python"))
+        }
+    }
+
+    // MARK: - Family-scoped variables
+
+    @Test(
+        arguments: [
+            ("threshold_value", AssignmentLanguage.python),
+            ("threshold.value", AssignmentLanguage.r),
+            ("threshold-value", AssignmentLanguage.racket),
+        ])
+    func familyVariableAcceptedInItsOwnLanguage(name: String, language: AssignmentLanguage) throws {
+        try validate(family(variables: [FamilyVariable(name: name, value: .double(25))]), language)
+    }
+
+    @Test func familyVariableRefusedInAForeignLanguage() {
+        #expect(throws: (any Error).self) {
+            try validate(
+                family(variables: [FamilyVariable(name: "threshold-value", value: .double(25))]),
+                .python)
+        }
+    }
+
+    // MARK: - variableEquality's per-case variable name
+
+    /// This one names a variable in the STUDENT'S submission, so Python's rules
+    /// were refusing authors the right to test an idiomatic name in their own
+    /// language.
+    @Test(
+        arguments: [
+            ("total_count", AssignmentLanguage.python),
+            ("total.count", AssignmentLanguage.r),
+            ("total-count", AssignmentLanguage.racket),
+        ])
+    func variableEqualityNameAcceptedInItsOwnLanguage(
+        name: String, language: AssignmentLanguage
+    ) throws {
+        let f = PatternFamily(
+            id: "vars",
+            name: "Module variables",
+            kind: .variableEquality,
+            functionName: "",
+            paramNames: [],
+            cases: [
+                PatternCase(
+                    key: "01", label: "The count",
+                    args: [.string(name)], expected: .double(3))
+            ]
+        )
+        try validate(f, language)
+    }
+}

--- a/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
+++ b/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
@@ -18,12 +18,28 @@
 // These assert the OUTCOME an author sees, not that a particular predicate ran
 // — the predicate was being called correctly the whole time it was wrong.
 //
-// NOTE the deliberate gap: global and section INPUT names are still held to
-// Python's grammar, and that is not an oversight. They are referenced from
-// starter notebooks as `{{name}}`, and `NotebookSubstitution.placeholderRegex`
-// hardcodes `[A-Za-z_][A-Za-z0-9_]*`. Widening the name check alone would let
-// an author save `bmi-value` and then silently leave `{{bmi-value}}` as literal
-// text in every student's notebook. The two must move together.
+// TWO deliberate gaps, both the same shape: a name that is REFERENCED by a
+// Python-shaped parser elsewhere cannot be widened on its own, because the
+// result is not a refusal but a silent misread.
+//
+//   * Global and section INPUT names — referenced from starter notebooks as
+//     `{{name}}`, parsed by `NotebookSubstitution.placeholderRegex`, which
+//     hardcodes `[A-Za-z_][A-Za-z0-9_]*`. Widening the check alone lets an
+//     author save `bmi-value` and leaves `{{bmi-value}}` as literal text in
+//     every student's notebook.
+//   * Family `variables` — referenced from an arg cell as `$name`, parsed by
+//     the same shape in `pattern-family-editor.js`. Widening the check alone
+//     makes `$bmi-value` fall through as a literal STRING, i.e. a wrong
+//     expected value in a generated test, reported nowhere.
+//
+// `paramNames` and `.variableEquality`'s case variable have no such referencing
+// parser — they are rendered directly into generated source — which is exactly
+// why those two are widened here and the other two are not.
+//
+// Separately: the web editor's own `isValidServerIdentifier` is still Python's
+// grammar, so until it learns the language, these names are reachable through
+// MCP and REST but refused client-side in the browser. That is a narrowing bug
+// in the UI, not a correctness one in the save path.
 
 import Core
 import Foundation
@@ -103,23 +119,44 @@ import Vapor
         }
     }
 
-    // MARK: - Family-scoped variables
+    // MARK: - Family-scoped variables stay on Python's grammar, ON PURPOSE
 
+    /// A plain name still works everywhere.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func familyVariableAcceptsAPlainNameInEveryLanguage(language: AssignmentLanguage) throws {
+        try validate(
+            family(
+                function: validTarget(for: language),
+                variables: [FamilyVariable(name: "threshold_value", value: .double(25))]),
+            language)
+    }
+
+    /// But an R or Racket spelling is REFUSED even on its own language — the
+    /// one place this change deliberately stops short.
+    ///
+    /// A family variable is referenced from an arg cell as `$name`, and the web
+    /// editor parses that with `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`. Accepting
+    /// `threshold-value` here would make `$threshold-value` match nothing and
+    /// fall through as a literal string — a wrong expected value in a generated
+    /// test, reported nowhere. Widening the server alone converts a clear
+    /// refusal into a silent miscompare, which is strictly worse.
+    ///
+    /// When the editor's `$name` parser learns the language's grammar, delete
+    /// this test and fold these names into the accepting one above.
     @Test(
         arguments: [
-            ("threshold_value", AssignmentLanguage.python),
             ("threshold.value", AssignmentLanguage.r),
             ("threshold-value", AssignmentLanguage.racket),
         ])
-    func familyVariableAcceptedInItsOwnLanguage(name: String, language: AssignmentLanguage) throws {
-        try validate(family(variables: [FamilyVariable(name: name, value: .double(25))]), language)
-    }
-
-    @Test func familyVariableRefusedInAForeignLanguage() {
+    func familyVariableRefusesANonPythonSpellingPendingTheRefParser(
+        name: String, language: AssignmentLanguage
+    ) {
         #expect(throws: (any Error).self) {
             try validate(
-                family(variables: [FamilyVariable(name: "threshold-value", value: .double(25))]),
-                .python)
+                family(
+                    function: validTarget(for: language),
+                    variables: [FamilyVariable(name: name, value: .double(25))]),
+                language)
         }
     }
 

--- a/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
+++ b/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
@@ -36,10 +36,14 @@
 // parser — they are rendered directly into generated source — which is exactly
 // why those two are widened here and the other two are not.
 //
-// Separately: the web editor's own `isValidServerIdentifier` is still Python's
-// grammar, so until it learns the language, these names are reachable through
-// MCP and REST but refused client-side in the browser. That is a narrowing bug
-// in the UI, not a correctness one in the save path.
+// The web editor needs no matching change, which is worth recording because it
+// is not obvious and was initially assumed backwards. `pattern-family-editor.js`
+// does have a Python-grammar check, `isValidServerIdentifier` — but it gates
+// only the family VARIABLES table, the names that correctly stayed on Python
+// here. A family's parameter list is a comma-separated text field that is split,
+// trimmed and sent unvalidated, so the server is its only authority and the
+// widening below is reachable from the browser as well as MCP and REST. Client
+// and server already agree on both halves; nothing to sync.
 
 import Core
 import Foundation

--- a/changelog.d/language-blind-identifier-siblings.md
+++ b/changelog.d/language-blind-identifier-siblings.md
@@ -12,11 +12,14 @@
   shared, so nothing was missing, it was out of reach. The refusal names the
   assignment's language.
 
-  Two name kinds are deliberately left on Python's grammar, because each is
-  REFERENCED by a Python-shaped parser and widening one alone converts a clear
-  refusal into a silent misread: global/section **input** names, referenced from
-  starter notebooks as `{{name}}`, and family **variables**, referenced from an
-  arg cell as `$name`. In both cases the reference would stop matching and fall
-  through as literal text — a wrong expected value in a generated test, or an
-  unsubstituted placeholder in every student's notebook, reported nowhere. Each
-  is one coupled change with its parser, not a validation tweak.
+  Two name kinds keep the `[A-Za-z_][A-Za-z0-9_]*` rule, and the comments around
+  them now say why in terms that are not Python's: global/section **input**
+  names, referenced from a notebook as `{{name}}`, and family **variables**,
+  referenced from an arg cell as `$name`. That character set is the
+  cross-language subset, pinned by the weakest emitter rather than by Python's
+  semantics — R backticks an awkward name and Lua/Octave mangle one, but the
+  Python preamble writes `name = _ck["name"]` with no emitter, so a hyphen is a
+  syntax error. Widening them is therefore not "make it language-aware" (a
+  placeholder is replaced by a literal value and reaches no runtime); it is
+  giving Python an emitter like the other four have, then widening the two
+  reference parsers with it.

--- a/changelog.d/language-blind-identifier-siblings.md
+++ b/changelog.d/language-blind-identifier-siblings.md
@@ -1,20 +1,22 @@
 ### Fixed
 
-- **Pattern-family parameter, variable and `variable_equality` names are now
-  checked against the assignment's language, not Python's.** The previous
+- **Pattern-family parameter names and `variable_equality` case variables are
+  now checked against the assignment's language, not Python's.** The previous
   release made a family's `functionName` language-aware and stopped there,
-  leaving three sibling names in the same file still validated with
+  leaving sibling names in the same file still validated with
   `isValidPythonIdentifier` on every assignment. A Racket author could finally
   save `bmi-category` as the target and was then refused on the parameter
-  `bmi-value`, with a message naming Python. All three now use
+  `bmi-value`, with a message naming Python. Both now use
   `isValidIdentifier(_:language:)` — which already existed, `private`, in
   `NotebookCheckKindHandler.swift`: it was written for notebook checks and never
   shared, so nothing was missing, it was out of reach. The refusal names the
   assignment's language.
 
-  Global and section **input** names are deliberately unchanged and remain on
-  Python's grammar. They are referenced from starter notebooks as `{{name}}`,
-  and `NotebookSubstitution.placeholderRegex` hardcodes `[A-Za-z_][A-Za-z0-9_]*`
-  — widening the name check alone would let an author save `bmi-value` and then
-  silently leave `{{bmi-value}}` as literal text in every student's notebook.
-  The two have to move together.
+  Two name kinds are deliberately left on Python's grammar, because each is
+  REFERENCED by a Python-shaped parser and widening one alone converts a clear
+  refusal into a silent misread: global/section **input** names, referenced from
+  starter notebooks as `{{name}}`, and family **variables**, referenced from an
+  arg cell as `$name`. In both cases the reference would stop matching and fall
+  through as literal text — a wrong expected value in a generated test, or an
+  unsubstituted placeholder in every student's notebook, reported nowhere. Each
+  is one coupled change with its parser, not a validation tweak.

--- a/changelog.d/language-blind-identifier-siblings.md
+++ b/changelog.d/language-blind-identifier-siblings.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **Pattern-family parameter, variable and `variable_equality` names are now
+  checked against the assignment's language, not Python's.** The previous
+  release made a family's `functionName` language-aware and stopped there,
+  leaving three sibling names in the same file still validated with
+  `isValidPythonIdentifier` on every assignment. A Racket author could finally
+  save `bmi-category` as the target and was then refused on the parameter
+  `bmi-value`, with a message naming Python. All three now use
+  `isValidIdentifier(_:language:)` — which already existed, `private`, in
+  `NotebookCheckKindHandler.swift`: it was written for notebook checks and never
+  shared, so nothing was missing, it was out of reach. The refusal names the
+  assignment's language.
+
+  Global and section **input** names are deliberately unchanged and remain on
+  Python's grammar. They are referenced from starter notebooks as `{{name}}`,
+  and `NotebookSubstitution.placeholderRegex` hardcodes `[A-Za-z_][A-Za-z0-9_]*`
+  — widening the name check alone would let an author save `bmi-value` and then
+  silently leave `{{bmi-value}}` as literal text in every student's notebook.
+  The two have to move together.


### PR DESCRIPTION
## What

#1341 made a pattern family's `functionName` language-aware and stopped there. Sibling names **in the same file** were still validated with `isValidPythonIdentifier` on every assignment, so a Racket author could finally save `bmi-category` as the target and was then refused on the parameter `bmi-value`, in a message naming Python. Same defect, one field over.

## The rule that decides which names could actually be widened

Not every Python-gated name is safe to widen. The deciding question is whether the name is **referenced by a separate parser**:

| Name | How it is consumed | Widened? |
|---|---|---|
| `paramNames` | rendered directly into generated source | **yes** |
| `.variableEquality` case variable | rendered directly into generated source | **yes** |
| family `variables` | referenced from an arg cell as `$name` | no |
| global / section **input** names | referenced from a notebook as `{{name}}` | no |

For the bottom two, widening the server *alone* does not produce a working reference — it produces a silent misread. `pattern-family-editor.js` parses `$name` with `/^\$([A-Za-z_][A-Za-z0-9_]*)$/` and `NotebookSubstitution.swift:39` parses `{{name}}` with the same shape. A saved `bmi-value` would leave `$bmi-value` falling through as a literal **string** (a wrong expected value in a generated test) or `{{bmi-value}}` surviving as literal text in every student's notebook. Reported nowhere. That is strictly worse than the refusal it would replace, so each is one coupled change with its parser, not a validation tweak.

The second commit here is a **self-correction**: the first widened family `variables` too, having identified that exact hazard for `{{name}}` inputs and then walked into it one field over. Caught before merge by reading the authoring JS the change has to agree with.

## The fix needed no new abstraction

`isValidIdentifier(_:language:)` already existed and was already exhaustive over all seven languages — `private` in `NotebookCheckKindHandler.swift`, written for notebook checks and never shared. Nothing was missing; it was out of reach.

Hoisted to `IdentifierValidation.swift` beside `isValidFunctionTarget`, with a comment on why the two must **not** be collapsed: they disagree on Java, whose call target is a qualified `Solution.classify` that is not itself an identifier, and on Lua. A bare name and a call target are different questions.

`validateCase` gains a `language` parameter so `.variableEquality` can reach it. The compiler enforced all nine conformers.

## No JavaScript change is needed

An earlier revision of this description claimed the browser would now be stricter than the server, and that was wrong — the third commit corrects it. `pattern-family-editor.js` does carry a Python-grammar check, but `isValidServerIdentifier` gates only the family **variables** table, i.e. exactly the names that stayed on Python. A family's parameter list is a comma-separated text field that is split, trimmed and sent unvalidated, so the server is its only authority.

Client and server already agree on both halves, and specifically this needs no second hand-written copy of each language's grammar in JavaScript — the recurring failure shape `AuthoringLanguageFacts` exists to prevent.

## Verified against the real thing

The deployed predecessor (#1341, live in v0.5.67) was exercised end to end while this was in review: the first Java pattern family, target `Solution.bmiCategory`, five boundary cases, graded on the native worker (runner `Starling`, v0.5.67). 6/6 pass, `buildStatus: passed` — the `.sh` wrapper compiled and `javac` resolved both `Solution` and `test_runtime.java` from the sourcepath.

## Testing

- New `PatternFamilyIdentifierGrammarTests` — asserts the **outcome an author sees** (does the save succeed?), not that a particular predicate ran, which is what was true the whole time it was broken. Covers each language's idiomatic parameter spelling accepted, a foreign spelling still refused, the refusal naming the assignment's language, and the two deliberate gaps asserted as refusals with a note on what deleting them requires.
- 255 tests across `PatternFamily|ManifestValidation|Validator` pass.
- `format.sh`, `lint.sh`, `swiftlint.sh` (0 violations), `no-language-defaults.sh` all clean.