### PR TITLE
fix: hold every authored name to the assignment's language

### DIFF
--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -38,6 +38,25 @@
 // point; the returned `{ getFamilies() }` exists for console debugging.
 
 (function (global) {
+
+    /// A `$name` reference cell, e.g. `$bmi_threshold` in an arg or Expected
+    /// cell.
+    ///
+    /// A PERMISSIVE TOKEN GRAB, not a grammar check, and one constant rather
+    /// than the ten hand-written copies this replaces. It used to be
+    /// `[A-Za-z_][A-Za-z0-9_]*` — the cross-language identifier subset — which
+    /// silently broke references on the languages that accept more: a Racket
+    /// author could declare `bmi-value` and `$bmi-value` then matched nothing
+    /// and fell through as a literal STRING, i.e. a wrong expected value in a
+    /// generated test with no error anywhere.
+    ///
+    /// Whether the captured name is legal is NOT decided here. The server
+    /// decides, per language, in `isValidSharedName`; this side only has to
+    /// resolve the token against the declared variable list, which fails
+    /// loudly on a name that does not exist. Excluding whitespace keeps a cell
+    /// of prose from reading as a reference.
+    var VAR_REF_RE = /^\$([^\s]+)$/;
+
     'use strict';
 
     function initPatternFamilyEditor(config) {
@@ -596,23 +615,27 @@
         /// Is `s` a name the SERVER will accept for a family variable or
         /// function?
         ///
-        /// Still Python's grammar, deliberately, because that is what the
-        /// server applies here: `PatternFamilyValidator` and the inputs
-        /// services call `isValidPythonIdentifier` for every language. Widening
-        /// the client alone would let a name through that the save then
-        /// rejects, which is worse than the wording bug this fixes.
+        /// A DELIBERATELY PERMISSIVE inline hint, not a grammar check. The
+        /// server is authoritative and answers per language
+        /// (`isValidSharedName`), so anything narrower here is a second,
+        /// hand-written copy of seven grammars that can only drift from it.
         ///
-        /// (The server DOES have a per-language identifier dispatch —
-        /// `isValidRIdentifier` and friends — but it is private to
-        /// `NotebookCheckKindHandler` and reaches notebook checks only.
-        /// Extending it to families is a real improvement and a real behaviour
-        /// change: `my.df` would become a legal R variable name, and `$name`
-        /// reference parsing has to be checked against a dot before that can
-        /// ship. It is not a wording fix and is not bundled with one.)
+        /// It used to be Python's grammar, which was correct only while the
+        /// server applied Python's grammar to every language. Now that the
+        /// server asks the assignment's own, a fixed rule here would refuse
+        /// names the save accepts — an R author's `my.df`, a Racket author's
+        /// `bmi-value` — and the author would have no way to tell that the
+        /// refusal came from the browser rather than from Chickadee.
+        ///
+        /// It cannot be made exact, either: Racket's grammar is a NEGATIVE rule
+        /// (anything but whitespace, reader delimiters, a leading `#`, or
+        /// something that parses as a number), which no character class
+        /// expresses. Rejecting whitespace catches the one mistake worth
+        /// catching inline; everything else is the server's to refuse, with a
+        /// message that names the language.
         function isValidServerIdentifier(s) {
             if (!s) return false;
-            if (PYTHON_KEYWORDS.has(s)) return false;
-            return /^[A-Za-z_][A-Za-z0-9_]*$/.test(s);
+            return !/\s/.test(s);
         }
 
         /// Shared with the Global/Section Inputs editors — see
@@ -828,7 +851,7 @@
 
         function refreshArgCellHighlight(cell, declaredNames) {
             var raw = (cell.value || '').trim();
-            var match = raw.match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+            var match = raw.match(VAR_REF_RE);
             cell.style.fontStyle = '';
             cell.style.color = '';
             cell.style.borderColor = '';
@@ -852,7 +875,7 @@
         /// when an unrelated keystroke triggers a bulk refresh.
         function refreshExpectedCellHighlight(cell, declaredNames) {
             var raw = (cell.value || '').trim();
-            var match = raw.match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+            var match = raw.match(VAR_REF_RE);
             if (!match) {
                 cell.style.fontStyle = '';
                 cell.style.borderColor = '';
@@ -1142,7 +1165,7 @@
                             continue;
                         }
                         // Variable reference: `$ident` (not `$"...$"` quoted).
-                        var varMatch = trimmed.match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+                        var varMatch = trimmed.match(VAR_REF_RE);
                         if (varMatch) {
                             var varName = varMatch[1];
                             if (!declaredVarNames.has(varName)) {
@@ -1172,7 +1195,7 @@
                     // Per-student expected: `$name` references a declared input
                     // (a global/section `=` expression), resolved per student at
                     // grading time — mirrors arg-cell refs.
-                    var expRefMatch = rawExp.trim().match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+                    var expRefMatch = rawExp.trim().match(VAR_REF_RE);
                     if (expRefMatch) {
                         var expRefName = expRefMatch[1];
                         if (!declaredVarNames.has(expRefName)) {
@@ -1229,7 +1252,7 @@
                             argVarRefs.push(null);
                             return;
                         }
-                        var varMatch = String(raw).trim().match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+                        var varMatch = String(raw).trim().match(VAR_REF_RE);
                         if (varMatch) {
                             args.push(null);
                             argsProvided.push(true);
@@ -1254,7 +1277,7 @@
                 var expected = null;
                 var expectedVarRef = null;
                 var rawExpTrim = rawExp.trim();
-                var expRefMatch = rawExpTrim.match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+                var expRefMatch = rawExpTrim.match(VAR_REF_RE);
                 if (expRefMatch) {
                     expectedVarRef = expRefMatch[1];
                 } else if (rawExpTrim !== '') {
@@ -2005,7 +2028,7 @@
                 var hasVarRef = Array.from(row.querySelectorAll('.pf-case-arg'))
                     .some(function (cell) {
                         var v = (cell.value || '').trim();
-                        return /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(v);
+                        return VAR_REF_RE.test(v);
                     });
                 if (!hasVarRef) return;
                 // Don't clobber the instructor's manual expected value.
@@ -2047,7 +2070,7 @@
             if (expectedEl.dataset.manual === '1' && expectedEl.value.trim() !== '') return;
             // A per-student `$name` Expected is resolved server-side per
             // student — never auto-compute/overwrite it.
-            if (/^\$[A-Za-z_][A-Za-z0-9_]*$/.test(expectedEl.value.trim())) return;
+            if (VAR_REF_RE.test(expectedEl.value.trim())) return;
 
             // Pull the latest variable values straight from the DOM so
             // `$name` refs in arg cells resolve to what the instructor
@@ -2084,7 +2107,7 @@
                     if (currentParamHasDefault && currentParamHasDefault[i]) continue;
                     return;
                 }
-                var varMatch = raw.trim().match(/^\$([A-Za-z_][A-Za-z0-9_]*)$/);
+                var varMatch = raw.trim().match(VAR_REF_RE);
                 if (varMatch) {
                     if (!(varMatch[1] in varsNow)) return; // unresolved ref — skip until valid
                     args.push(varsNow[varMatch[1]]);
@@ -2181,7 +2204,7 @@
                 // cell manual so auto-compute won't clobber an author value.
                 // Clearing the cell re-enables auto-compute.
                 refreshExpectedCellHighlight(t, collectDeclaredInputNames());
-                if (/^\$[A-Za-z_][A-Za-z0-9_]*$/.test(t.value.trim())) {
+                if (VAR_REF_RE.test(t.value.trim())) {
                     t.dataset.manual = '1';
                     delete t.dataset.autoComputed;
                 } else if (t.value.trim() === '') {

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -605,13 +605,6 @@
         var variablesEmpty = document.getElementById('family-variables-empty');
         var addVariableBtn = document.getElementById('add-family-variable-btn');
 
-        var PYTHON_KEYWORDS = new Set([
-            'False','None','True','and','as','assert','async','await','break',
-            'class','continue','def','del','elif','else','except','finally',
-            'for','from','global','if','import','in','is','lambda','nonlocal',
-            'not','or','pass','raise','return','try','while','with','yield'
-        ]);
-
         /// Is `s` a name the SERVER will accept for a family variable or
         /// function?
         ///

--- a/Sources/APIServer/Services/GlobalInputsService.swift
+++ b/Sources/APIServer/Services/GlobalInputsService.swift
@@ -83,7 +83,8 @@ enum GlobalInputsService {
 
         // 1. Per-row validation across variables + expressions.
         let seenNames = try validateNames(
-            variables: inputs.variables, expressions: inputs.expressions)
+            variables: inputs.variables, expressions: inputs.expressions,
+            language: AssignmentLanguage.resolve(manifest: manifest))
         // 2. Cross-list: no clash with any section variable name.
         try validateAgainstSections(seenNames: seenNames, manifest: manifest)
         // 3. Starter-notebook `{{undeclared}}` scan.
@@ -123,13 +124,15 @@ enum GlobalInputsService {
     /// duplicates across kinds are also rejected.
     static func validateNames(
         variables: [FamilyVariable],
-        expressions: [PersonalizationExpression]
+        expressions: [PersonalizationExpression],
+        language: AssignmentLanguage?
     ) throws -> Set<String> {
         var seenNames: Set<String> = []
         for v in variables {
-            guard isValidPythonIdentifier(v.name) else {
+            guard isValidSharedName(v.name, language: language) else {
                 throw WebAssignmentError.unprocessable(
-                    reason: "Global variable name '\(v.name)' is not a valid Python identifier.")
+                    reason: "Global variable name '\(v.name)' is not valid here — expected "
+                        + sharedNameExpectation(for: language) + ".")
             }
             guard !reservedNames.contains(v.name) else {
                 throw WebAssignmentError.unprocessable(
@@ -141,9 +144,10 @@ enum GlobalInputsService {
             }
         }
         for e in expressions {
-            guard isValidPythonIdentifier(e.name) else {
+            guard isValidSharedName(e.name, language: language) else {
                 throw WebAssignmentError.unprocessable(
-                    reason: "Global expression name '\(e.name)' is not a valid Python identifier.")
+                    reason: "Global expression name '\(e.name)' is not valid here — expected "
+                        + sharedNameExpectation(for: language) + ".")
             }
             guard !reservedNames.contains(e.name) else {
                 throw WebAssignmentError.unprocessable(

--- a/Sources/APIServer/Services/NotebookSubstitution.swift
+++ b/Sources/APIServer/Services/NotebookSubstitution.swift
@@ -26,9 +26,28 @@ enum NotebookSubstitution {
     /// `{{ciphertext}}` is tagged `chickadee_personalized: "ciphertext"`).
     static let fencedCellMetadataKey = "chickadee_personalized"
 
-    /// Regex that matches `{{identifier}}` — only valid Python identifier
-    /// characters between the braces, no spaces.  Mirrors the validator
-    /// used by the editor so the on-disk shape matches what the user typed.
+    /// Regex that matches `{{name}}` — any run of non-space, non-brace
+    /// characters between the braces.
+    ///
+    /// Deliberately a PERMISSIVE TOKEN GRAB, not a grammar check. It used to be
+    /// `[A-Za-z_][A-Za-z0-9_]*`, which is the cross-language identifier subset,
+    /// and that made a name an author could legally declare on an R or Racket
+    /// assignment (`my.df`, `bmi-value`) unreferenceable: `{{my.df}}` matched
+    /// nothing and survived into every student's notebook as literal text, with
+    /// no error raised anywhere.
+    ///
+    /// Parameterising this by the assignment's language was the obvious fix and
+    /// is the wrong one twice over. A placeholder is replaced by a literal
+    /// VALUE and never reaches a runtime, so no language rule applies to it —
+    /// and Racket's grammar is a NEGATIVE rule (anything but whitespace, reader
+    /// delimiters, a leading `#`, or something that parses as a number) which
+    /// no character-class regex expresses faithfully. So the parser's job is
+    /// only to grab a token; whether that name is legal is the validator's job,
+    /// and `isValidSharedName` already answers it per language.
+    ///
+    /// Excluding whitespace is what keeps this safe for existing content:
+    /// `{{ some prose }}` stays unmatched exactly as it does today, so only
+    /// brace-wrapped single tokens become newly visible.
     private static let placeholderRegex: NSRegularExpression = {
         // The pattern is a compile-time string literal that we know parses
         // successfully — there is no runtime input that could change it.
@@ -36,7 +55,7 @@ enum NotebookSubstitution {
         // through every call site of `apply(...)`, which would give
         // callers a failure case that can never actually fire.
         // swiftlint:disable:next force_try
-        try! NSRegularExpression(pattern: #"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}"#)
+        try! NSRegularExpression(pattern: #"\{\{([^\s{}]+)\}\}"#)
     }()
 
     /// Applies `substitutions` to the notebook in `notebookData`.

--- a/Sources/APIServer/Services/SectionInputsService.swift
+++ b/Sources/APIServer/Services/SectionInputsService.swift
@@ -68,7 +68,9 @@ enum SectionInputsService {
         }
 
         // 1. Per-row validation across this section's vars + expressions.
-        let seenNames = try validateNames(variables: inputs.variables, expressions: inputs.expressions)
+        let seenNames = try validateNames(
+            variables: inputs.variables, expressions: inputs.expressions,
+            language: AssignmentLanguage.resolve(manifest: manifest))
         // 2. Cross-section + global clash check.
         try validateAgainstOtherScopes(seenNames: seenNames, manifest: manifest, sectionID: sectionID)
         // 3. Save-time eval check against the acting account's own seed. The
@@ -83,17 +85,20 @@ enum SectionInputsService {
 
     // MARK: - Validation
 
-    /// Validates that every variable/expression name is a valid Python
-    /// identifier, not the reserved `seed`, and unique across both kinds.
+    /// Validates that every variable/expression name is a valid identifier in
+    /// the ASSIGNMENT'S language (the cross-language subset when it declares
+    /// none), not the reserved `seed`, and unique across both kinds.
     static func validateNames(
         variables: [FamilyVariable],
-        expressions: [PersonalizationExpression]
+        expressions: [PersonalizationExpression],
+        language: AssignmentLanguage?
     ) throws -> Set<String> {
         var seenNames: Set<String> = []
         for v in variables {
-            guard isValidPythonIdentifier(v.name) else {
+            guard isValidSharedName(v.name, language: language) else {
                 throw WebAssignmentError.unprocessable(
-                    reason: "Section input name '\(v.name)' is not a valid Python identifier.")
+                    reason: "Section input name '\(v.name)' is not valid here — expected "
+                        + sharedNameExpectation(for: language) + ".")
             }
             guard v.name != "seed" else {
                 throw WebAssignmentError.unprocessable(
@@ -105,9 +110,10 @@ enum SectionInputsService {
             }
         }
         for e in expressions {
-            guard isValidPythonIdentifier(e.name) else {
+            guard isValidSharedName(e.name, language: language) else {
                 throw WebAssignmentError.unprocessable(
-                    reason: "Section expression name '\(e.name)' is not a valid Python identifier.")
+                    reason: "Section expression name '\(e.name)' is not valid here — expected "
+                        + sharedNameExpectation(for: language) + ".")
             }
             guard e.name != "seed" else {
                 throw WebAssignmentError.unprocessable(

--- a/Sources/APIServer/Utilities/IdentifierValidation.swift
+++ b/Sources/APIServer/Utilities/IdentifierValidation.swift
@@ -67,6 +67,39 @@ func isValidRIdentifier(_ s: String) -> Bool {
     return true
 }
 
+/// The widest name EVERY language's generated code can carry as a bare
+/// identifier — `[A-Za-z_][A-Za-z0-9_]*`.
+///
+/// Implemented as Python's rule because they coincide, not because Python is
+/// privileged: R accepts more (and `rIdentifier` backticks the rest), Racket
+/// accepts far more, and C++/Java/Lua/Octave accept exactly this. It is the
+/// intersection, and it is what a name falls back to when the assignment
+/// declares no language at all — a plain `.sh` suite has no grammar to consult,
+/// and a name in this subset is safe whatever the suite's scripts turn out to
+/// be written in.
+func isValidCrossLanguageIdentifier(_ s: String) -> Bool {
+    isValidPythonIdentifier(s)
+}
+
+/// The grammar a shared name (a global/section input, a family variable) is
+/// held to on an assignment whose language may be undeclared.
+///
+/// A declared language is checked against its own grammar, so an R author may
+/// name an input `my.df` and a Racket author `bmi-value`. A declared-None
+/// assignment falls back to the cross-language subset rather than refusing:
+/// nil means the author said "no language", not that nobody has been asked, and
+/// refusing to name an input would make a plain `.sh` assignment unauthorable.
+func isValidSharedName(_ s: String, language: AssignmentLanguage?) -> Bool {
+    guard let language else { return isValidCrossLanguageIdentifier(s) }
+    return isValidIdentifier(s, language: language)
+}
+
+/// What a shared name may look like, for the save-time refusal.
+func sharedNameExpectation(for language: AssignmentLanguage?) -> String {
+    guard let language else { return "a letter or underscore followed by letters, digits or underscores" }
+    return "a valid \(identifierKindName(language))"
+}
+
 /// Whether `s` is a valid *bare name* in `language` — a variable, a parameter,
 /// a module-level identifier.
 ///

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -53,38 +53,32 @@ private func validatePatternCaseHeader(
 /// section.
 private func validateFamilyVariablesAndArgRefs(
     family: PatternFamily,
+    language: AssignmentLanguage,
     sectionVarNamesHere: Set<String>,
     globalVarNames: Set<String>,
     perStudentExpressionNames: Set<String>
 ) throws {
     var seenVarNames: Set<String> = []
     let paramNameSet = Set(family.paramNames)
-    // Deliberately the CROSS-LANGUAGE SUBSET, not the assignment's grammar —
-    // unlike `paramNames` and `.variableEquality`'s case variable, which this
-    // release did widen.
+    // Held to the assignment's own grammar, like `paramNames`.
     //
-    // `isValidPythonIdentifier` is the predicate, but Python is not the reason,
-    // and reading it that way points at the wrong fix. Two things pin it:
+    // This was briefly pinned to the cross-language subset for a real reason:
+    // the name is REFERENCED from an arg cell as `$name`, and the editor parsed
+    // that with a subset-shaped regex, so accepting a Racket `bmi-value` made
+    // `$bmi-value` match nothing and fall through as a literal STRING — a wrong
+    // expected value in a generated test, reported nowhere.
     //
-    //  1. A family variable is REFERENCED from an arg cell as `$name`, parsed
-    //     by `/^\$([A-Za-z_][A-Za-z0-9_]*)$/` in `pattern-family-editor.js`.
-    //     Accepting a Racket `bmi-value` makes `$bmi-value` match nothing and
-    //     fall through as a literal STRING — a wrong expected value in a
-    //     generated test, reported nowhere.
-    //  2. The name is EMITTED bare into the generated preamble. Every language
-    //     has an emitter that makes an arbitrary name safe (`rIdentifier`
-    //     backticks, `luaIdentifier`/`octaveIdentifier` mangle) EXCEPT Python,
-    //     whose preamble writes `name = _ck["name"]` directly — so a hyphen is
-    //     a syntax error. The subset is pinned by that weakest emitter.
-    //
-    // So the unlock is not "make this language-aware". It is: give Python an
-    // emitter like the other four have, then widen the `$name` parser with it.
-    // Same reasoning holds for global/section input names and `{{name}}`.
+    // That parser is now a permissive token grab (`VAR_REF_RE`), which is what
+    // lifts the constraint. A parser's job is to grab a token; deciding whether
+    // the name is legal is THIS check's job, per language. Once the two stopped
+    // duplicating each other, the subset had nothing left to protect.
     for v in family.variables {
-        guard isValidPythonIdentifier(v.name) else {
+        guard isValidIdentifier(v.name, language: language) else {
             throw Abort(
                 .unprocessableEntity,
-                reason: "Pattern family '\(family.id)': variable name '\(v.name)' is not a valid Python identifier")
+                reason:
+                    "Pattern family '\(family.id)': variable name '\(v.name)' is not a valid "
+                    + identifierKindName(language))
         }
         guard seenVarNames.insert(v.name).inserted else {
             throw Abort(
@@ -333,6 +327,7 @@ func validatePatternFamilies(
         // `paramNames`, stay on Python's grammar; see the helper.
         try validateFamilyVariablesAndArgRefs(
             family: family,
+            language: language,
             sectionVarNamesHere: sectionVarNames(forFamily: family.id),
             globalVarNames: globalVariableNames,
             perStudentExpressionNames: perStudentExpressionNames

--- a/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
+++ b/Tests/APITests/PatternFamilyIdentifierGrammarTests.swift
@@ -18,48 +18,24 @@
 // These assert the OUTCOME an author sees, not that a particular predicate ran
 // — the predicate was being called correctly the whole time it was wrong.
 //
-// TWO deliberate gaps, both the same shape: a name that is REFERENCED by
-// another parser cannot be widened on its own, because the result is not a
-// refusal but a silent misread.
+// The names that are REFERENCED elsewhere — family variables via `$name`, and
+// global/section inputs via `{{name}}` — are now checked per language too.
 //
-// Both parsers accept `[A-Za-z_][A-Za-z0-9_]*`, and it is worth being precise
-// about WHY, because "they use Python's rules" is wrong and points at the wrong
-// fix. Chickadee is not a Python system with other languages bolted on. That
-// character set is the CROSS-LANGUAGE SUBSET: the widest name every language's
-// generated code can carry as a bare identifier. It is pinned by the weakest
-// emitter, not by Python's semantics — R (`rIdentifier`) quotes an awkward name
-// in backticks and Lua/Octave (`luaIdentifier`/`octaveIdentifier`) mangle one,
-// but the Python preamble emits `name = _ck["name"]` with no emitter at all, so
-// a hyphen there is a syntax error. The subset happens to coincide with
-// Python's grammar; it is not derived from it.
+// They could not be while the reference PARSERS carried their own copy of a
+// grammar: both matched `[A-Za-z_][A-Za-z0-9_]*`, so a name an author could
+// legally declare on an R or Racket assignment was unreferenceable, and failed
+// as a SILENT MISREAD rather than a refusal (`$bmi-value` falling through as a
+// literal string; `{{my.df}}` surviving into a student's notebook as text).
 //
-// So widening these is NOT "make it language-aware" — a placeholder name is
-// replaced by a literal VALUE and never reaches any runtime, so a per-language
-// rule there would be meaningless. It is: give Python an emitter like the other
-// four have, after which the grammar is a free choice of Chickadee's own DSL.
+// The fix was not to teach those parsers the grammar — Racket's is a negative
+// rule that no character class expresses — but to stop them having one. A
+// parser grabs a token; deciding whether the token is a legal name belongs to
+// the validator, which already answers per language and is exhaustive over all
+// seven. Once the duplication went, the subset had nothing left to protect.
 //
-//   * Global and section INPUT names — referenced from starter notebooks as
-//     `{{name}}`, parsed by `NotebookSubstitution.placeholderRegex`, which
-//     hardcodes `[A-Za-z_][A-Za-z0-9_]*`. Widening the check alone lets an
-//     author save `bmi-value` and leaves `{{bmi-value}}` as literal text in
-//     every student's notebook.
-//   * Family `variables` — referenced from an arg cell as `$name`, parsed by
-//     the same shape in `pattern-family-editor.js`. Widening the check alone
-//     makes `$bmi-value` fall through as a literal STRING, i.e. a wrong
-//     expected value in a generated test, reported nowhere.
-//
-// `paramNames` and `.variableEquality`'s case variable have no such referencing
-// parser — they are rendered directly into generated source — which is exactly
-// why those two are widened here and the other two are not.
-//
-// The web editor needs no matching change, which is worth recording because it
-// is not obvious and was initially assumed backwards. `pattern-family-editor.js`
-// does have a Python-grammar check, `isValidServerIdentifier` — but it gates
-// only the family VARIABLES table, the names that correctly stayed on Python
-// here. A family's parameter list is a comma-separated text field that is split,
-// trimmed and sent unvalidated, so the server is its only authority and the
-// widening below is reachable from the browser as well as MCP and REST. Client
-// and server already agree on both halves; nothing to sync.
+// The editor's own check went permissive rather than learning the grammar, for
+// the same reason: the server answers per language, so any fixed rule in the
+// browser is a second copy that can only drift from it.
 
 import Core
 import Foundation
@@ -139,7 +115,7 @@ import Vapor
         }
     }
 
-    // MARK: - Family-scoped variables stay on Python's grammar, ON PURPOSE
+    // MARK: - Family-scoped variables
 
     /// A plain name still works everywhere.
     @Test(arguments: AssignmentLanguage.allCases)
@@ -151,26 +127,38 @@ import Vapor
             language)
     }
 
-    /// But an R or Racket spelling is REFUSED even on its own language — the
-    /// one place this change deliberately stops short, for two reasons that are
-    /// both about generated code and neither about Python.
-    ///
-    /// The name is REFERENCED from an arg cell as `$name`, parsed by
-    /// `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`, so `$threshold-value` would match
-    /// nothing and fall through as a literal string — a wrong expected value in
-    /// a generated test, reported nowhere. And it is EMITTED bare into the
-    /// preamble, where Python has no emitter to quote or mangle it the way
-    /// `rIdentifier` and `luaIdentifier` do for their languages.
-    ///
-    /// Widening the server alone converts a clear refusal into a silent
-    /// miscompare, which is strictly worse. Delete this test when Python gains
-    /// an emitter and the `$name` parser widens with it.
+    /// And each language's own spelling is accepted too, now that the editor's
+    /// `$name` parser is a permissive token grab rather than a second copy of
+    /// the grammar. While those two duplicated each other, this had to stay on
+    /// the cross-language subset: `$threshold-value` matched nothing and fell
+    /// through as a literal string, which is a wrong expected value in a
+    /// generated test rather than a refusal.
     @Test(
         arguments: [
             ("threshold.value", AssignmentLanguage.r),
             ("threshold-value", AssignmentLanguage.racket),
         ])
-    func familyVariableRefusesASpellingOutsideTheCrossLanguageSubset(
+    func familyVariableAcceptsItsOwnLanguagesSpelling(
+        name: String, language: AssignmentLanguage
+    ) throws {
+        try validate(
+            family(
+                function: validTarget(for: language),
+                variables: [FamilyVariable(name: name, value: .double(25))]),
+            language)
+    }
+
+    /// A reserved word is still refused, in the language that reserves it —
+    /// which the cross-language subset could not do. An input named `template`
+    /// on a C++ assignment used to pass (Python has no such keyword) and then
+    /// render `inline const auto template = …`, which does not compile.
+    @Test(
+        arguments: [
+            ("template", AssignmentLanguage.cpp),
+            ("class", AssignmentLanguage.java),
+            ("function", AssignmentLanguage.lua),
+        ])
+    func familyVariableRefusesAReservedWordInItsOwnLanguage(
         name: String, language: AssignmentLanguage
     ) {
         #expect(throws: (any Error).self) {

--- a/changelog.d/identifier-grammar-generalization.md
+++ b/changelog.d/identifier-grammar-generalization.md
@@ -1,0 +1,36 @@
+### Fixed
+
+- **Every author-supplied name is now held to the assignment's own language, not
+  a cross-language subset.** Global and section input names, family variables,
+  parameter names and `variable_equality` case variables all now use
+  `isValidIdentifier(_:language:)`, so an R author may name an input `my.df` and
+  a Racket author `bmi-value`.
+
+  Two of those could not be widened before, because the parsers that REFERENCE
+  them each carried their own copy of a grammar — `{{name}}` in
+  `NotebookSubstitution` and `$name` in `pattern-family-editor.js`, both matching
+  `[A-Za-z_][A-Za-z0-9_]*`. A name outside that set failed as a silent misread
+  rather than a refusal: `$bmi-value` fell through as a literal string (a wrong
+  expected value in a generated test) and `{{my.df}}` survived into every
+  student's notebook as text.
+
+  Rather than teach those parsers the grammar, they stopped having one. Both are
+  now permissive token grabs, and the ten hand-written copies of the `$name`
+  regex became a single constant. Deciding whether a token is a legal name is
+  the validator's job, and it already answers per language, exhaustively, with
+  the compiler enforcing that a new language cannot be missed. Racket settles
+  the point: its grammar is a negative rule — anything but whitespace, reader
+  delimiters, a leading `#`, or something that parses as a number — which no
+  character class expresses, so a per-language regex in the browser was never
+  going to be correct anyway.
+
+  The editor's inline check went permissive for the same reason: the server
+  answers per language, so a fixed rule in the browser can only drift from it.
+
+- **Reserved words are now refused in the language that reserves them.** A C++
+  assignment could take an input named `template` (Python has no such keyword)
+  and then render `inline const auto template = …`, which does not compile;
+  likewise `class` on a Java assignment, whose inputs become `public static
+  final` fields. The C++ renderer's comment already asserted these were "refused
+  by the cpp validator" — the inputs path was calling Python's, so that was an
+  intention rather than a fact. It is a fact now.


### PR DESCRIPTION
Follow-up to #1342 (merged). Rebased onto `main`, so this is now two standalone commits.

## What

#1342 made two name kinds language-aware and had to stop, because the other two are REFERENCED by parsers that carried their own copy of a grammar. This removes that obstacle and generalizes to all of them: global and section inputs, family variables, parameter names, and `variable_equality` case variables now all use `isValidIdentifier(_:language:)`.

An R author can name an input `my.df`; a Racket author `bmi-value`.

## The design question, and why the obvious answer was wrong

The two blocked names were blocked by `{{name}}` in `NotebookSubstitution` and `$name` in `pattern-family-editor.js`, both matching `[A-Za-z_][A-Za-z0-9_]*`. A name outside that set failed as a **silent misread** rather than a refusal — `$bmi-value` fell through as a literal string (a wrong expected value in a generated test) and `{{my.df}}` survived into every student's notebook as text.

The obvious fix is to teach those parsers each language's grammar, shipping it to the browser as a derived `AuthoringLanguageFacts` field. **Racket makes that unworkable**: its grammar is a *negative* rule — anything but whitespace, reader delimiters, a leading `#`, or something that parses as a number — which no character class expresses. A per-language regex in the browser was never going to be correct.

So the parsers stopped having a grammar instead. A parser's job is to grab a token; deciding whether the token is a legal name belongs to the validator, which already answers per language, exhaustively, with the compiler enforcing that a new language cannot be missed. Both are now permissive token grabs, and the **ten** hand-written copies of the `$name` regex collapsed into one constant — that duplication is what let them drift from the server in the first place.

The editor's own inline check went permissive for the same reason: the server answers per language, so any fixed rule in the browser can only drift from it. It still rejects whitespace, which is the one mistake worth catching inline.

A consequence worth stating, since it is the opposite of what the plan assumed: **the identifier emitters need no unification.** `rIdentifier` quotes, `luaIdentifier`/`octaveIdentifier` mangle, `racketArgumentName` poisons, `cppIdentifier` refuses, and Python/Java have none — five answers to one question, which looked like the thing to fix. Once each language validates by its own grammar, they are all unreachable: a name arriving at `luaIdentifier` has already passed `isValidLuaIdentifier`. They are backstops for a case that can no longer occur, so they are left alone.

## A latent defect the subset was hiding

C++ renders inputs as `inline const auto <name> = …` and Java as `public static final` fields — both bare identifiers. Under Python's grammar, an input named `template` on a C++ assignment passed validation and generated source that does not compile; likewise `class` on Java.

The C++ renderer's comment already asserted these were *"refused by the cpp validator (`isValidCppIdentifier`)"*. The inputs path was calling Python's, so that was an intention rather than a fact. It is a fact now, and there is a test per language.

## Declared-None assignments

Fall back to the cross-language subset rather than refusing. `nil` means the author said "no language", not that nobody has been asked, and a plain `.sh` assignment has no grammar to consult but must stay authorable.

## Compatibility note worth a reviewer's eye

Widening `{{name}}` means brace-wrapped tokens that previously matched nothing are now visible to the placeholder scan, so an undeclared one is reported at save where it used to be ignored. Excluding whitespace is what bounds this: `{{ some prose }}` stays unmatched exactly as today, so only single-token cases change. I believe that is the right trade — the alternative is a name you can declare but not reference — but it is the one behaviour change here that touches existing content.

## Testing

- 450 tests pass across `PatternFamily|Inputs|NotebookSubstitution|Personalization|Manifest`; 44 of the directly-affected suites re-run green after the rebase.
- 348 browser JS tests pass (317 pass, 31 skipped).
- New cases: each language's own spelling accepted for parameters and family variables; a foreign spelling still refused; the refusal naming the assignment's language; and reserved words refused per language (`template`/C++, `class`/Java, `function`/Lua).
- `format.sh`, `lint.sh`, `swiftlint.sh` (0 violations), `check-styles.sh`, `eslint.sh`, `no-language-defaults.sh` all clean.