### PR TITLE
fix(grading): deliver the verdict when a compiled submission throws mid-capture

### DIFF
--- a/Tests/APITests/PatternFamilyRendererCppTests.swift
+++ b/Tests/APITests/PatternFamilyRendererCppTests.swift
@@ -254,6 +254,33 @@ import Testing
         #expect(bad.stdout.contains("wrong output"))
     }
 
+    /// A throw from the student's code during a stdout-capturing kind must
+    /// still deliver its verdict.
+    ///
+    /// The capture is fd-level, so unwinding past `finish()` used to leave fd 1
+    /// pointing at the capture file: `ck::failed` wrote its JSON in there, the
+    /// runner saw empty stdout, and the shell contract synthesized a bare
+    /// "failed" with no reason (#1344). Asserting on the MESSAGE rather than
+    /// the exit code is what makes this a regression test — the status was
+    /// always 1.
+    @Test func stdoutEqualityStillReportsWhenTheSubmissionThrows() throws {
+        guard Self.gppAvailable else { return }
+        let script = Self.render(
+            Self.family(.stdoutEquality, expected: .string("hello")))
+        let thrown = try Self.execute(
+            script: script,
+            submission: """
+                #include <stdexcept>
+                int f(int) { throw std::runtime_error("boom"); }
+                """)
+        #expect(thrown.code == 1, "a throwing submission did not fail: \(thrown.stdout)")
+        #expect(
+            thrown.stdout.contains(GeneratedMessage.unexpectedException),
+            "the verdict never reached stdout — the capture left fd 1 redirected: \(thrown.stdout)"
+        )
+        #expect(thrown.stdout.contains("boom"), "the failure did not carry the exception text")
+    }
+
     /// A throwing submission on a guarded kind is a graded FAIL with the
     /// shared first line, never a crash.
     @Test func anUnexpectedThrowIsAGradedFailure() throws {

--- a/Tests/APITests/PatternFamilyRendererJavaTests.swift
+++ b/Tests/APITests/PatternFamilyRendererJavaTests.swift
@@ -287,6 +287,33 @@ import Testing
         #expect(bad.code == 1, "mismatched output passed: \(bad.stdout)")
     }
 
+    /// A throw from the student's code during a stdout-capturing kind must
+    /// still deliver its verdict.
+    ///
+    /// `beginCapture` swaps `System.out` for a buffer that `endCapture`
+    /// restores, and a throw unwinds past `endCapture` — so the catch handler's
+    /// `ck.failed` printed the SENTINEL into the discarded buffer, the wrapper
+    /// found no sentinel, and an ordinary exception was reported as exit 2
+    /// "Does the submission call System.exit?" (#1344). The exit code is the
+    /// regression: it must be 1 (a graded fail), not 2.
+    @Test func stdoutEqualityStillReportsWhenTheSubmissionThrows() throws {
+        guard Self.javacAvailable else { return }
+        let script = Self.render(Self.family(.stdoutEquality, expected: .string("hello")))
+        let thrown = try Self.execute(
+            script: script,
+            submission: Self.solution(
+                "static void f(int x) { throw new IllegalStateException(\"boom\"); }"))
+        #expect(
+            thrown.code == 1,
+            "a throwing submission was not a graded fail: \(thrown.stdout) \(thrown.stderr)")
+        #expect(
+            !thrown.stderr.contains("System.exit"),
+            "an ordinary exception was blamed on System.exit: \(thrown.stderr)")
+        #expect(
+            thrown.stdout.contains(GeneratedMessage.unexpectedException),
+            "the verdict never reached stdout — the capture was still installed: \(thrown.stdout)")
+    }
+
     // MARK: - variableEquality
 
     @Test func variableEqualityReadsAStaticField() throws {

--- a/Tools/runner-support/test_runtime.hpp
+++ b/Tools/runner-support/test_runtime.hpp
@@ -216,7 +216,7 @@ std::string format(const T&) {
 // rdbuf-swapping misses printf, and a course cannot control which one a
 // student reaches for.
 class CaptureStdout {
-    int saved_;
+    int saved_ = -1;
     static constexpr const char* path_ = ".ck_stdout_capture";
 
   public:
@@ -225,19 +225,49 @@ class CaptureStdout {
         std::cout.flush();
         saved_ = dup(1);
         int tmp = open(path_, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+        // A capture we cannot set up must not read as "the student printed
+        // nothing": that fails a correct submission for a harness problem.
+        // Un-checked, a failed open made this `dup2(-1, 1)` and every
+        // comparison ran against an empty string.
+        if (saved_ < 0 || tmp < 0) {
+            if (tmp >= 0) ::close(tmp);
+            errored("Could not capture stdout for this test.");
+        }
         dup2(tmp, 1);
         // Qualified: inside namespace ck, a bare `close` is ck::close (the
         // tolerance comparison), not POSIX close(2).
         ::close(tmp);
     }
-    std::string finish() {
+
+    /// Puts the real stdout back, if it is still redirected. Idempotent.
+    ///
+    /// THE DESTRUCTOR IS THE POINT. A throw from the student's code unwinds
+    /// past `finish()`, and the enclosing catch handler then reports its
+    /// verdict — which, with fd 1 still pointing at the capture file, was
+    /// written into that file and never reached the runner. stdout came back
+    /// empty, so the shell contract synthesized a bare "failed" with no
+    /// reason for what was an ordinary exception.
+    void restore() {
+        if (saved_ < 0) return;
         std::fflush(stdout);
         std::cout.flush();
         dup2(saved_, 1);
         ::close(saved_);
+        saved_ = -1;
+    }
+
+    ~CaptureStdout() { restore(); }
+
+    std::string finish() {
+        restore();
         std::ifstream in(path_);
-        return std::string(
+        std::string captured(
             (std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        in.close();
+        // The capture file is an implementation detail of this class, not an
+        // artefact the next test should be able to see.
+        std::remove(path_);
+        return captured;
     }
 };
 

--- a/Tools/runner-support/test_runtime.java
+++ b/Tools/runner-support/test_runtime.java
@@ -53,6 +53,7 @@ class ck {
     // detail. Exit 0 pass, 1 fail, 2 error — identical to every other runtime
     // here.
     static void passed(String msg) {
+        restoreOut();
         System.out.println(SENTINEL);
         System.out.println("{\"shortResult\": \"" + jsonEscape(msg) + "\"}");
         System.out.flush();
@@ -60,6 +61,7 @@ class ck {
     }
 
     static void failed(String msg) {
+        restoreOut();
         System.out.println(SENTINEL);
         System.out.println("{\"shortResult\": \"" + jsonEscape(msg) + "\"}");
         System.out.flush();
@@ -67,6 +69,7 @@ class ck {
     }
 
     static void errored(String msg) {
+        restoreOut();
         // The sentinel goes out here too, even though no JSON follows. Without
         // it the wrapper could not tell a genuine error from a student's
         // premature exit, and would report the less specific of the two —
@@ -245,9 +248,28 @@ class ck {
     static String endCapture() {
         System.out.flush();
         String captured = captureBuffer.toString(java.nio.charset.StandardCharsets.UTF_8);
-        System.setOut(savedOut);
-        captureBuffer = null;
+        restoreOut();
         return captured;
+    }
+
+    /// Puts the real stdout back, if a capture is still installed. Idempotent.
+    ///
+    /// EVERY VERDICT CALLS THIS FIRST, and that is the point. A throw from the
+    /// student's code unwinds past `endCapture()`, so the enclosing catch
+    /// handler reported its verdict — the sentinel included — into the capture
+    /// buffer, which is then discarded. The wrapper saw no sentinel and
+    /// reported "The test did not run to completion. Does the submission call
+    /// System.exit?" for what was an ordinary exception, losing the failure
+    /// message the test had already produced.
+    ///
+    /// Restoring here rather than in the generated test is deliberate, for the
+    /// same reason the sentinel is printed here: a renderer cannot forget it.
+    private static void restoreOut() {
+        if (savedOut == null) return;
+        System.out.flush();
+        System.setOut(savedOut);
+        savedOut = null;
+        captureBuffer = null;
     }
 
     // ---- exceptionExpected's trichotomy ----

--- a/changelog.d/1344-compiled-stdout-capture-restore.md
+++ b/changelog.d/1344-compiled-stdout-capture-restore.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **A C++ or Java submission that throws during a `stdoutEquality` test now
+  reports its real failure.** Both runtimes install a stdout capture that was
+  only undone on the success path, so an exception unwound past the restore and
+  the verdict was written into the capture instead of to the runner. C++ students
+  saw a bare "failed" with no reason; Java students saw an `error` blaming a
+  `System.exit` they never called. `ck::CaptureStdout` now restores in its
+  destructor and `ck.passed`/`failed`/`errored` restore before printing, so a
+  verdict always reaches the runner.


### PR DESCRIPTION
Closes #1344.

## The defect

Both compiled runtimes install a stdout capture that is undone only on the success path, so a throw from the student's code unwinds past the restore and the enclosing `catch` reports its verdict into the still-installed capture.

- **C++** capture is fd-level (`dup2`), so `ck::failed` wrote its JSON into `.ck_stdout_capture`. stdout came back empty and the shell contract synthesized a bare **`failed` with no reason**.
- **Java** swaps `System.out`, so the verdict — the sentinel included — landed in the discarded buffer. The wrapper found no sentinel and reported **exit 2, "Does the submission call `System.exit`?"** for what was an ordinary exception, losing the failure message the test had already produced.

Both are ordinary student mistakes (a throw during a `stdoutEquality` case) and both were mis-reported.

## The fix

`ck::CaptureStdout` gains a `restore()` that its **destructor** calls, so unwinding puts fd 1 back before the catch handler runs; `finish()` shares it and additionally removes the capture file. The three Java verdict methods call a `restoreOut()` first.

Putting the restore in the runtimes rather than in the renderers is the same argument the sentinel already makes in `test_runtime.java`: **a renderer cannot forget it.**

Also fixes an unchecked `dup`/`open` in the C++ constructor — a failed `open` made this `dup2(-1, 1)`, so every comparison ran against an empty string and a *correct* submission failed. It now reports an error rather than blaming the student.

## Verification

Both fixes were validated standalone against real `g++`/`javac` before wiring the tests, including confirming the pre-fix behaviour (C++ produced **empty stdout**).

New regression tests in both execution suites, asserting on the **message** (C++) and the **exit code** (Java) rather than only status, since C++'s status was already 1:

```
✔ Test run with 30 tests in 2 suites passed after 21.304 seconds.
```

`scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh` all clean (0 violations in 999 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_