### PR TITLE
fix(cpp): match an exception's type, and grade a non-std throw instead of crashing

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyRendererCpp.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRendererCpp.swift
@@ -335,6 +335,15 @@ private func cppReferenceBlock(_ family: PatternFamily) -> String {
 /// Wraps a body in the shared unexpected-exception handler: a throw from
 /// the student's code is a graded FAIL with the same first line every other
 /// language uses, never a std::terminate.
+///
+/// BOTH arms are required. `catch (const std::exception&)` alone left
+/// `throw "negative input";` and `throw -1;` — the shapes an intro course
+/// teaches before `<stdexcept>` — to escape `main`, where `std::terminate`
+/// aborts the process (measured: SIGABRT, exit 134, which the worker maps to
+/// status `error` with a raw "terminate called after throwing" on stderr).
+/// The equivalent Java submission has always been a clean `fail`, because
+/// `javaGuarded` catches `Throwable`. `expect_throw` already had the
+/// `catch (...)` arm, so the omission was inconsistent inside one feature.
 func cppGuarded(_ inner: String, inputLine: String) -> String {
     """
     try {
@@ -343,6 +352,10 @@ func cppGuarded(_ inner: String, inputLine: String) -> String {
         ck::failed(std::string("\(GeneratedMessage.unexpectedException)\\n")
             + \(inputLine)
             + "\(GeneratedMessage.error)" + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("\(GeneratedMessage.unexpectedException)\\n")
+            + \(inputLine)
+            + "\(GeneratedMessage.error)(a non-std exception)");
     }
     """
 }

--- a/Tests/APITests/PatternFamilyRendererCppTests.swift
+++ b/Tests/APITests/PatternFamilyRendererCppTests.swift
@@ -254,6 +254,62 @@ import Testing
         #expect(bad.stdout.contains("wrong output"))
     }
 
+    /// The save-time validator tells authors to name the exception CLASS, and
+    /// C++ matched the message only — so a student correctly throwing
+    /// `std::invalid_argument("n must be positive")` against an authored
+    /// `invalid_argument` was marked "wrong error raised" (#1347). Java and
+    /// Python both match the type; this is C++ catching up.
+    @Test func exceptionExpectedMatchesTheExceptionType() throws {
+        guard Self.gppAvailable else { return }
+        let byType = Self.render(
+            Self.family(.exceptionExpected, expected: .string("invalid_argument")))
+        let good = try Self.execute(
+            script: byType,
+            submission: """
+                #include <stdexcept>
+                int f(int) { throw std::invalid_argument("n must be positive"); }
+                """)
+        #expect(
+            good.code == 0,
+            "an authored exception TYPE did not match: \(good.stdout) \(good.stderr)")
+
+        // The message form keeps working — this widens the match, it does not
+        // move it.
+        let byMessage = Self.render(
+            Self.family(.exceptionExpected, expected: .string("must be positive")))
+        let stillGood = try Self.execute(
+            script: byMessage,
+            submission: """
+                #include <stdexcept>
+                int f(int) { throw std::invalid_argument("n must be positive"); }
+                """)
+        #expect(stillGood.code == 0, "an authored MESSAGE stopped matching: \(stillGood.stdout)")
+
+        // And a genuinely wrong type is still a fail.
+        let wrong = try Self.execute(
+            script: byType,
+            submission: """
+                #include <stdexcept>
+                int f(int) { throw std::out_of_range("nope"); }
+                """)
+        #expect(wrong.code == 1, "the wrong exception type passed: \(wrong.stdout)")
+    }
+
+    /// `throw "text";` and `throw -1;` are what an intro course teaches before
+    /// `<stdexcept>`. With only a `std::exception` handler they escaped `main`
+    /// and aborted the process (SIGABRT → status `error`), where the same
+    /// submission in Java has always been a graded fail (#1347).
+    @Test func aNonStdThrowIsAGradedFailureNotACrash() throws {
+        guard Self.gppAvailable else { return }
+        let script = Self.render(Self.family(.boundaryEquality, expected: .int(9)))
+        let thrown = try Self.execute(
+            script: script, submission: #"int f(int) { throw "negative input"; }"#)
+        #expect(
+            thrown.code == 1,
+            "a non-std throw was not a graded fail (134 = SIGABRT): \(thrown.code)")
+        #expect(thrown.stdout.contains(GeneratedMessage.unexpectedException))
+    }
+
     /// A `void` function is an ordinary thing to time (`render_board(int)`).
     /// The renderer bound the call with `auto result = …`, which on a void call
     /// is "deduced type 'void' for 'result' is incomplete" — so every case in

--- a/Tests/Fixtures/generated-source/cpp/pattern/approximate_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/approximate_equality/publictest_fam_01.sh
@@ -43,6 +43,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tests/Fixtures/generated-source/cpp/pattern/boundary_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/boundary_equality/publictest_fam_01.sh
@@ -43,6 +43,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tests/Fixtures/generated-source/cpp/pattern/differential/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/differential/publictest_fam_01.sh
@@ -52,6 +52,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tests/Fixtures/generated-source/cpp/pattern/performance_threshold/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/performance_threshold/publictest_fam_01.sh
@@ -45,6 +45,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tests/Fixtures/generated-source/cpp/pattern/return_type_check/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/return_type_check/publictest_fam_01.sh
@@ -42,6 +42,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tests/Fixtures/generated-source/cpp/pattern/stdout_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/stdout_equality/publictest_fam_01.sh
@@ -53,6 +53,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tests/Fixtures/generated-source/cpp/pattern/unordered_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/unordered_equality/publictest_fam_01.sh
@@ -43,6 +43,10 @@ int main() {
         ck::failed(std::string("unexpected exception\n")
             + "  input:    " + "x=" + ck::format(x) + "\n"
             + "  error:    " + ck_e.what());
+    } catch (...) {
+        ck::failed(std::string("unexpected exception\n")
+            + "  input:    " + "x=" + ck::format(x) + "\n"
+            + "  error:    (a non-std exception)");
     }
 }
 CHICKADEE_GENERATED_SOURCE

--- a/Tools/runner-support/test_runtime.hpp
+++ b/Tools/runner-support/test_runtime.hpp
@@ -24,6 +24,11 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+// The Itanium ABI demangler, for naming a caught exception's TYPE in
+// `expect_throw`. Provided by both toolchains the runner grades on (libstdc++
+// and libc++); there is no portable standard equivalent, and `typeid(e).name()`
+// alone is a mangled string no author would write.
+#include <cxxabi.h>
 #include <fcntl.h>
 #include <fstream>
 #include <iostream>
@@ -35,6 +40,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unistd.h>
+#include <typeinfo>
 #include <utility>
 #include <vector>
 
@@ -272,6 +278,28 @@ class CaptureStdout {
 };
 
 // ---- exceptionExpected's trichotomy ----
+//
+// THE EXPECTATION MATCHES THE TYPE AS WELL AS THE MESSAGE, and it has to: the
+// save-time validator tells authors to write "a non-empty string naming the
+// exception class (e.g. \"ValueError\")", and matching `what()` alone meant an
+// author who did exactly that never matched. A student correctly throwing
+// `std::invalid_argument("n must be positive")` against an authored
+// `invalid_argument` was reported "wrong error raised" — a wrong mark on a
+// correct submission, on every case in the family.
+//
+// Java's runtime already tests the type name (`getSimpleName`/`getName`) beside
+// the message, and Python walks `__mro__`; this is C++ catching up, done by
+// folding the type into `what` so ONE substring search covers both. That also
+// makes the reported "got:" line name the type, which is what a student needs
+// in order to see why their exception did not match.
+inline std::string exception_type_name(const std::type_info& info) {
+    int status = 0;
+    char* raw = abi::__cxa_demangle(info.name(), nullptr, nullptr, &status);
+    std::string out = (status == 0 && raw != nullptr) ? std::string(raw) : std::string(info.name());
+    std::free(raw);  // free(nullptr) is well-defined, so this needs no guard
+    return out;
+}
+
 enum class ThrowOutcome { threwMatching, threwOther, returned };
 template <typename F>
 ThrowOutcome expect_throw(F&& f, std::string_view messageSubstring, std::string& what) {
@@ -279,7 +307,7 @@ ThrowOutcome expect_throw(F&& f, std::string_view messageSubstring, std::string&
         f();
         return ThrowOutcome::returned;
     } catch (const std::exception& e) {
-        what = e.what();
+        what = exception_type_name(typeid(e)) + ": " + e.what();
         return what.find(messageSubstring) != std::string::npos ? ThrowOutcome::threwMatching
                                                                 : ThrowOutcome::threwOther;
     } catch (...) {

--- a/changelog.d/1347-cpp-exception-type-and-nonstd-throw.md
+++ b/changelog.d/1347-cpp-exception-type-and-nonstd-throw.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **A C++ `exceptionExpected` case now matches the exception's type, not only
+  its message.** The save-time validator asks authors to name the exception
+  class, and C++ compared the authored text against `what()` alone — so a
+  student correctly throwing `std::invalid_argument("n must be positive")`
+  against an authored `invalid_argument` was marked "wrong error raised". The
+  type name is folded into the reported text, so the "got:" line now names it
+  too. Java and Python already matched on type.
+- **A C++ submission that throws something other than a `std::exception` is a
+  graded failure instead of a crash.** `throw "text";` and `throw -1;` — what an
+  intro course teaches before `<stdexcept>` — escaped the generated handler and
+  aborted the process, which the runner reported as `error` with a raw
+  `terminate called after throwing` on stderr. The same submission in Java has
+  always been a clean fail.


### PR DESCRIPTION
Closes #1347.

Two C++ exception defects, both producing a **wrong outcome on a submission the student got right**.

## 1. `exceptionExpected` could only match the message, never the type

The save-time validator tells authors to write *"a non-empty string naming the exception class (e.g. `ValueError`)"* — and doing exactly that never matched, because `ck::expect_throw` searched `what()` alone.

A student correctly throwing `std::invalid_argument("n must be positive")` against an authored `invalid_argument` was reported **"wrong error raised"**, on every case in the family.

Java's runtime already tests the type name beside the message, and Python walks `__mro__`. C++ now folds the demangled type into `what`, so one substring search covers both — which also makes the reported `got:` line name the type, the thing a student needs in order to see *why* it did not match:

```
what = std::invalid_argument: n must be positive
```

Measured against the real runtime: type match ✓, message match still ✓, wrong type still fails ✓.

## 2. A non-`std` throw aborted the process

`cppGuarded` caught only `const std::exception&`, so `throw "negative input";` and `throw -1;` — what an intro course teaches before `<stdexcept>` — escaped `main` and hit `std::terminate`. Measured: **SIGABRT, exit 134**, which the worker maps to status `error` with a raw `terminate called after throwing an instance of 'char const*'` on stderr.

The same submission in Java has always been a clean `fail` (`javaGuarded` catches `Throwable`), and `ck::expect_throw` already had its own `catch (...)` — so the omission was inconsistent *inside one feature*.

## Goldens

The seven guarded C++ kinds each gain the `catch (...)` arm (4 lines apiece). `exception_expected` is untouched — it does not route through `cppGuarded`.

## Verification

Both defects reproduced standalone against real `g++` first (`byType=1`, `wrongType=1`, and exit 134 respectively), then fixed and re-measured. Two new execution tests; the type test also asserts the message form still matches and a wrong type still fails, so it pins the widening rather than a swap.

```
✔ Test run with 18 tests in 1 suite passed after 9.030 seconds.
```

Goldens regenerated and diff read; `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_