### PR TITLE
fix(runner): apply one dotfile rule to both file-extension scanners

### DIFF
--- a/Sources/RunnerCore/ScriptClassification.swift
+++ b/Sources/RunnerCore/ScriptClassification.swift
@@ -110,10 +110,25 @@ private func looksLikePythonContent(_ source: String) -> Bool {
 // colliding with the similarly-named helpers in NotebookExtraction.swift).
 
 /// Lowercased file extension, or "" when there's none (bare name or dotfile).
+///
+/// A base name beginning with `.` is a DOTFILE and has no extension, whatever
+/// follows it — so `.hidden.lua` and `..R` both answer "". This has to agree
+/// with `AssignmentLanguage.scriptExtension(ofPath:)`, which applies the same
+/// rule, because the two answer halves of one question: that one decides which
+/// interpreters a job REQUIRES (and so which runners may claim it), this one
+/// decides which interpreter a script is actually RUN with.
+///
+/// They disagreed. This guard rejected only a name whose *only* dot was
+/// leading, so `.hidden.lua` was classified `.lua` here while
+/// `languagesRequiredToGrade` did not count Lua — and `RunnerLanguageGate`
+/// then let a Lua-less runner claim the job, which died at `exit 127` in front
+/// of a student. That is the exact failure the gate exists to prevent, in a
+/// shape it could not see. `FilenameSafety` permits such names, so this was
+/// reachable rather than theoretical.
 private func fileExtensionLowercased(_ name: String) -> String {
     let baseStart = name.lastIndex(of: "/").map { name.index(after: $0) } ?? name.startIndex
     let base = name[baseStart...]
-    guard let dot = base.lastIndex(of: "."), dot != base.startIndex else { return "" }
+    guard base.first != ".", let dot = base.lastIndex(of: ".") else { return "" }
     return asciiLowercased(String(base[base.index(after: dot)...]))
 }
 

--- a/Tests/WorkerTests/DotfileScriptNameAgreementTests.swift
+++ b/Tests/WorkerTests/DotfileScriptNameAgreementTests.swift
@@ -1,0 +1,63 @@
+// Tests/WorkerTests/DotfileScriptNameAgreementTests.swift
+//
+// The two file-extension scanners must answer the same question the same way.
+//
+// `AssignmentLanguage.scriptExtension(ofPath:)` (Core) decides which
+// interpreters a job REQUIRES, and so which runners `RunnerLanguageGate` will
+// let claim it. `classifyScriptInterpreter` (RunnerCore) decides which
+// interpreter a script is actually RUN with. They are separate implementations
+// — RunnerCore cannot import Core — so nothing but a test holds them together,
+// and this is that test.
+//
+// They disagreed on dotfiles: Core applied the classic rule (a base name
+// beginning with `.` has no extension), RunnerCore rejected only a name whose
+// ONLY dot was leading. So `.hidden.lua` required no Lua of a runner and was
+// then dispatched to `lua` anyway — `exit 127` in front of a student, which is
+// the exact failure the gate exists to prevent.
+//
+// This lives in WorkerTests because it is the only target that can see both.
+
+import Core
+import RunnerCore
+import Testing
+
+@Suite struct DotfileScriptNameAgreementTests {
+
+    private static func manifest(script: String) -> TestProperties {
+        TestProperties(
+            testSuites: [TestSuiteEntry(tier: .pub, script: script)],
+            timeLimitSeconds: 10
+        )
+    }
+
+    /// A dotfile name carries no language to EITHER scanner.
+    ///
+    /// The pairing is the point: the first expectation is what the claim gate
+    /// sees, the second is what the runner does with the file it claimed. A fix
+    /// to one without the other reopens the gap.
+    @Test(arguments: [".hidden.lua", "..R", ".quiet.rkt", ".inner.m", ".x.java"])
+    func aDotfileNameIsLanguagelessToBothScanners(_ script: String) {
+        #expect(
+            AssignmentLanguage.languagesRequiredToGrade(manifest: Self.manifest(script: script))
+                .isEmpty,
+            "the capability gate thinks \(script) needs an interpreter")
+        #expect(
+            classifyScriptInterpreter(name: script, source: "") == .unknown,
+            "the dispatcher would run \(script) under a language interpreter the gate never required"
+        )
+    }
+
+    /// The ordinary case still works — this narrows dotfiles, it does not
+    /// disable extension classification.
+    @Test(arguments: [
+        ("t.lua", ScriptInterpreter.lua), ("t.R", .rscript), ("t.rkt", .racket),
+        ("t.m", .octave), ("t.java", .java), ("t.py", .python),
+    ])
+    func anOrdinaryNameStillClassifies(_ pair: (String, ScriptInterpreter)) {
+        #expect(classifyScriptInterpreter(name: pair.0, source: "") == pair.1)
+        #expect(
+            !AssignmentLanguage.languagesRequiredToGrade(manifest: Self.manifest(script: pair.0))
+                .isEmpty,
+            "\(pair.0) stopped requiring an interpreter of the runner that claims it")
+    }
+}

--- a/changelog.d/1351-dotfile-script-name-capability-gate.md
+++ b/changelog.d/1351-dotfile-script-name-capability-gate.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A dotfile script name no longer slips past the runner capability gate.**
+  `AssignmentLanguage` treats a base name beginning with `.` as extensionless,
+  but the runner's own classifier rejected only a name whose *only* dot was
+  leading — so a suite entry like `.hidden.lua` required no Lua of the runner
+  that claimed the job, and was then dispatched to `lua` anyway, dying at
+  `exit 127` in front of a student. The two scanners now apply the same rule,
+  held together by a differential test.


### PR DESCRIPTION
Closes #1351.

## The defect

Two separate implementations answer halves of one question, and they disagreed.

- `AssignmentLanguage.scriptExtension(ofPath:)` (Core) decides which interpreters a job **requires**, and so which runners `RunnerLanguageGate` will let claim it.
- `classifyScriptInterpreter` (RunnerCore) decides which interpreter a script is actually **run** with.

RunnerCore cannot import Core, so nothing but agreement holds them together — and Core applied the classic dotfile rule while RunnerCore rejected only a name whose *only* dot was leading:

| name | Core (the gate) | RunnerCore (the dispatcher) |
|---|---|---|
| `.gitignore` | no extension | no extension |
| `.hidden.lua` | **no extension** | **`.lua`** |
| `..R` | **no extension** | **`.rscript`** |

So a suite entry named `.hidden.lua` required no Lua of the runner that claimed the job, and was then dispatched to `lua` anyway — `exit 127` in front of a student. That is the exact failure `RunnerLanguageGate` exists to prevent, in a shape it could not see. `FilenameSafety` permits such names, so this was reachable rather than theoretical.

## The fix

RunnerCore adopts Core's rule. The direction is deliberate: `nil` means *"no language-specific machinery applies"*, which is a supported state (a plain `.sh` suite), whereas widening Core would have to invent a language for a hidden file.

The new differential test lives in `WorkerTests` because that is the only target that can see both scanners, and it **pairs the two expectations in one test on purpose** — fixing one side without the other reopens the gap. A second test pins that ordinary names still classify, so this narrows dotfiles rather than disabling extension classification.

## Browser half

RunnerCore is also the wasm the browser grader runs. `runner-wasm-vendor.yml` re-vendors it automatically on pushes to main (gated by `scripts/runnercore-source-hash.sh`), so the browser path picks this up on the next release — no manual re-vendor needed.

## Verification

```
✔ Test aDotfileNameIsLanguagelessToBothScanners(_:) with 5 test cases passed
✔ Test anOrdinaryNameStillClassifies(_:) with 6 test cases passed
✔ Test workerDispatchMatchesSharedContract() passed
✔ Test run with 9 tests in 4 suites passed
```

The existing dispatch-contract and classification suites pass unchanged; `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_