### PR TITLE
perf(diagnostics): stop queue bookkeeping from scaling with backlog depth

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
@@ -84,26 +84,47 @@ extension OperationalDiagnosticsService {
         return SubmissionDiagnosticsContext(courseID: courseID, assignmentID: assignmentID)
     }
 
+    /// Pending jobs the native worker fleet is on the hook for: every pending
+    /// validation, plus pending student work whose assignment is not
+    /// browser-graded.
+    ///
+    /// Cost scales with the number of *distinct assignments* holding pending
+    /// work, never with queue depth. This used to load every pending student
+    /// row into memory to produce one log field, which made each claim and each
+    /// submission-accept slower exactly as the backlog grew — the wrong
+    /// direction under pressure, and unbounded after a retest fan-out flips
+    /// tens of thousands of rows back to pending (#1361).
     func pendingQueueDepth(on db: Database) async throws -> Int {
         let pendingValidation = try await APISubmission.query(on: db)
             .filter(\.$status == SubmissionStatus.pending.rawValue)
             .filter(\.$kind == APISubmission.Kind.validation)
             .count()
 
-        let pendingStudents = try await APISubmission.query(on: db)
-            .filter(\.$status == SubmissionStatus.pending.rawValue)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .all()
+        let distinctSetupIDs = Set(
+            try await APISubmission.query(on: db)
+                .filter(\.$status == SubmissionStatus.pending.rawValue)
+                .filter(\.$kind == APISubmission.Kind.student)
+                .unique()
+                .all(\.$testSetupID)
+        )
+        guard !distinctSetupIDs.isEmpty else { return pendingValidation }
 
         let workerModeSetupIDs = try await workerModeTestSetupIDs(
-            for: pendingStudents.map(\.testSetupID),
+            for: Array(distinctSetupIDs),
             on: db
         )
-        let pendingWorkerStudents = pendingStudents.reduce(into: 0) { count, submission in
-            if workerModeSetupIDs.contains(submission.testSetupID) {
-                count += 1
-            }
+        guard !workerModeSetupIDs.isEmpty else { return pendingValidation }
+
+        var studentQuery = APISubmission.query(on: db)
+            .filter(\.$status == SubmissionStatus.pending.rawValue)
+            .filter(\.$kind == APISubmission.Kind.student)
+        // When every pending assignment is worker-graded — the common case —
+        // the `IN` list would select exactly the rows already matched, so skip
+        // binding it.
+        if workerModeSetupIDs.count < distinctSetupIDs.count {
+            studentQuery = studentQuery.filter(\.$testSetupID ~~ Array(workerModeSetupIDs))
         }
+        let pendingWorkerStudents = try await studentQuery.count()
 
         return pendingValidation + pendingWorkerStudents
     }

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
@@ -256,19 +256,29 @@ final class OperationalDiagnosticsService: @unchecked Sendable {
 }
 
 extension OperationalDiagnosticsService {
-    // Returns the set of test setup IDs from the given list that exist in the database.
-    // Previously restricted to worker-mode setups; now includes browser-mode because
-    // the worker serves as a backstop for pending browser submissions.
+    /// Returns the subset of the given test setup IDs that exist and are graded
+    /// by the native worker fleet.
+    ///
+    /// Resolved in one query rather than a find-per-ID: the callers pass the
+    /// distinct setups behind a pending queue, and issuing a round trip each
+    /// put the queue-depth metric's cost on the wrong axis (#1361).
     func workerModeTestSetupIDs(for testSetupIDs: [String], on db: Database) async throws -> Set<String> {
+        let uniqueIDs = Set(testSetupIDs)
+        guard !uniqueIDs.isEmpty else { return [] }
+
+        let setups = try await APITestSetup.query(on: db)
+            .filter(\.$id ~~ Array(uniqueIDs))
+            .all()
+
         var result: Set<String> = []
-        for testSetupID in Set(testSetupIDs) {
-            guard let setup = try await APITestSetup.find(testSetupID, on: db) else { continue }
+        for setup in setups {
+            guard let setupID = setup.id else { continue }
             let manifest = try? JSONDecoder().decode(
                 TestProperties.self, from: Data(setup.manifest.utf8))
-            // Browser-graded setups are processed by the in-browser Pyodide runner,
-            // not the native worker. Exclude them from the worker queue depth metric.
+            // Browser-graded setups are graded by the in-browser runner, not the
+            // native worker. Exclude them from the worker queue depth metric.
             guard manifest?.effectiveGradingMode != .browser else { continue }
-            result.insert(testSetupID)
+            result.insert(setupID)
         }
         return result
     }

--- a/Sources/APIServer/Migrations/CreateClaimPriorityIndex.swift
+++ b/Sources/APIServer/Migrations/CreateClaimPriorityIndex.swift
@@ -1,0 +1,31 @@
+import Fluent
+import SQLKit
+
+/// Covering index for the worker claim query's fresh-work-first split.
+///
+/// `collectClaimCandidates` asks for pending student work in two passes —
+/// `retested_at IS NULL` first, then the retests — so a manifest-revision sweep
+/// cannot starve students who are actively submitting (#427). The pre-existing
+/// `idx_submissions_status_kind_submitted_at` stops at `submitted_at`, so the
+/// `retested_at` predicate was left to a filter step: when the queue is
+/// retest-dominated (exactly what #427 exists to handle) the planner had to walk
+/// the whole pending range to prove that fewer than 50 fresh rows existed, on
+/// every poll from every runner slot.
+///
+/// Column order matches the query: the two equality predicates, then the
+/// nullability split, then the sort key (#1361).
+struct CreateClaimPriorityIndex: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw(
+            "CREATE INDEX IF NOT EXISTS idx_submissions_claim_priority ON submissions(status, kind, retested_at, submitted_at)"
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw("DROP INDEX IF EXISTS idx_submissions_claim_priority").run()
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -408,6 +408,11 @@ func registerMigrations(on app: Application) {
     // all created above, so no additional ordering constraint.
     app.migrations.add(CreateSlipDaySpends())
 
+    // Worker claim priority (#1361): covers the fresh-work-first split's
+    // `retested_at` predicate, which the older submissions index stopped short
+    // of. Index-only; `submissions` is created far above.
+    app.migrations.add(CreateClaimPriorityIndex())
+
     // Data backfill, registered LAST on purpose: it full-queries `APITestSetup`,
     // which is only safe once every migration that adds a column to
     // `test_setups` has already run (the #1077 boot-order hazard, inverted —

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -431,6 +431,61 @@ import VaporTesting
         }
     }
 
+    /// Queue depth is now two SQL aggregates plus one grading-mode lookup per
+    /// *distinct* assignment, instead of a load of every pending row (#1361).
+    /// Several pending rows behind one assignment, and a mix of worker- and
+    /// browser-graded assignments, are what that rewrite has to keep right —
+    /// the old shape counted rows it had already materialized, so neither case
+    /// could regress independently of correctness.
+    @Test func queueDepthCountsEveryPendingRowBehindEachAssignment() async throws {
+        try await withApp(app) { _ in
+            let workerSetup = try await makeSetup(id: "setup_depth_worker", gradingMode: "worker")
+            let browserSetup = try await makeSetup(id: "setup_depth_browser", gradingMode: "browser")
+
+            for index in 0..<3 {
+                try await makePendingSubmission(
+                    id: "sub_depth_worker_\(index)",
+                    setup: workerSetup,
+                    kind: APISubmission.Kind.student
+                )
+            }
+            for index in 0..<2 {
+                try await makePendingSubmission(
+                    id: "sub_depth_browser_\(index)",
+                    setup: browserSetup,
+                    kind: APISubmission.Kind.student
+                )
+            }
+            // Validations count whatever the assignment's grading mode is:
+            // instructors validate through the native worker.
+            try await makePendingSubmission(
+                id: "sub_depth_validation",
+                setup: browserSetup,
+                kind: APISubmission.Kind.validation
+            )
+
+            let depth = try await app.diagnostics.pendingQueueDepth(on: app.db)
+            #expect(depth == 4)
+        }
+    }
+
+    /// With no browser-graded assignment in the pending set, the depth query
+    /// skips binding an `IN` list — the common-case branch. It must still count
+    /// every row.
+    @Test func queueDepthCountsAllPendingWhenNoAssignmentIsBrowserGraded() async throws {
+        try await withApp(app) { _ in
+            let first = try await makeSetup(id: "setup_depth_all_worker_a", gradingMode: "worker")
+            let second = try await makeSetup(id: "setup_depth_all_worker_b", gradingMode: "worker")
+
+            try await makePendingSubmission(id: "sub_all_a1", setup: first, kind: APISubmission.Kind.student)
+            try await makePendingSubmission(id: "sub_all_a2", setup: first, kind: APISubmission.Kind.student)
+            try await makePendingSubmission(id: "sub_all_b1", setup: second, kind: APISubmission.Kind.student)
+
+            let depth = try await app.diagnostics.pendingQueueDepth(on: app.db)
+            #expect(depth == 3)
+        }
+    }
+
     /// Regression test for the admin runner page showing `Total < Queue
     /// Wait`. Models the production failure mode: the runner's wall clock
     /// is offset relative to the server, so the runner-reported
@@ -610,6 +665,24 @@ import VaporTesting
         )
         try await submission.save(on: app.db)
         return (setup, submission)
+    }
+
+    @discardableResult
+    private func makePendingSubmission(
+        id: String,
+        setup: APITestSetup,
+        kind: String
+    ) async throws -> APISubmission {
+        let submission = APISubmission(
+            id: id,
+            testSetupID: try setup.requireID(),
+            zipPath: "/tmp/\(id).zip",
+            attemptNumber: 1,
+            status: "pending",
+            kind: kind
+        )
+        try await submission.save(on: app.db)
+        return submission
     }
 
     private func makeSetup(

--- a/changelog.d/1361-queue-depth-scaling.md
+++ b/changelog.d/1361-queue-depth-scaling.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Queue bookkeeping no longer gets slower as the backlog deepens.** The
+  `queue_depth` diagnostic loaded every pending student submission into memory
+  on every job claim and every accepted submission, then issued one test-setup
+  lookup and manifest decode per distinct assignment — so a deep queue, or a
+  retest fan-out flipping tens of thousands of rows back to pending, made each
+  claim and each intake progressively more expensive. It is now two SQL
+  aggregates plus one batched grading-mode lookup, costing what the number of
+  distinct pending assignments costs rather than what the queue depth costs.
+  The reported number is unchanged.
+- **Indexed the worker claim query's fresh-work-first split.** Claims ask for
+  pending student work with `retested_at IS NULL` before falling back to
+  retests (#427), but the existing submissions index stopped at `submitted_at`.
+  A retest-dominated queue — precisely the case that split exists to handle —
+  made every poll walk the whole pending range. Added
+  `idx_submissions_claim_priority` covering `(status, kind, retested_at,
+  submitted_at)`.


### PR DESCRIPTION
Closes #1361. First of six PRs from the August 2026 web-server scalability audit.

## What was wrong

`pendingQueueDepth` produced one log field — `queue_depth` — by loading **every pending student submission row into memory**, then issuing one `APITestSetup.find` plus a full manifest JSON decode **per distinct assignment**.

It runs on every job claim (`OperationalDiagnostics+Recording.swift:329`), every accepted submission (`:39`), and the admin `get_queue_state` tool. So at depth D with C claims/sec the server did `D × C` Fluent model decodes per second for a metric. That is the one path in the grading pipeline that got *slower as pressure rose* — and it is unbounded after a retest fan-out, which flips every student submission for an assignment back to pending in a single `UPDATE`.

Production sat at a 259-deep backlog for about two weeks in July 2026, so this is not hypothetical; it just never got deep enough to hurt.

## What changed

**`pendingQueueDepth` now costs what the number of distinct pending assignments costs**, not what the queue depth costs:

1. `COUNT` pending validations (unchanged)
2. `SELECT DISTINCT test_setup_id` for pending student work — bounded by assignment count
3. one batched grading-mode lookup for those setups
4. `COUNT` pending student rows, with an `IN` filter only when some assignment is browser-graded

The reported number is identical, including the browser-mode exclusion that `queueDepthExcludesBrowserModePendingJobs` pins.

**`workerModeTestSetupIDs` resolves in one query** instead of a find-per-ID.

**New index `idx_submissions_claim_priority`** on `submissions(status, kind, retested_at, submitted_at)`. `collectClaimCandidates` asks for fresh student work (`retested_at IS NULL`) before retests so a manifest sweep cannot starve active submitters (#427), but the existing index stopped at `submitted_at`. A retest-dominated queue — exactly what that split exists to handle — made every poll from every runner slot walk the whole pending range to prove fewer than 50 fresh rows existed.

**Corrected a stale doc comment.** `workerModeTestSetupIDs` claimed it now included browser-mode setups; the code and its test have always excluded them.

## Testing

- Two new tests in `ObservabilityTests` cover what the rewrite actually changed: several pending rows behind one assignment mixed with a browser-graded assignment (exercises the `IN` branch), and the all-worker-graded case (exercises the skip-the-`IN` branch). The old shape counted rows it had already materialized, so neither case could regress independently of correctness.
- Full `ObservabilityTests` suite passes locally (12 tests), including the existing browser-exclusion test.
- `scripts/lint.sh` and `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL)_