### PR TITLE
fix(worker): stop a submission overwriting the tests it is graded by

### DIFF
--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -627,7 +627,13 @@ extension WorkerDaemon {
                 return (normalization.warnings, normalization.preferredStudentModule)
 
             case .extractToSource(let forcedLanguage):
-                try mergeDirectoryContents(from: paths.submissionDir, into: testSetupDir)
+                // The student's upload must not be able to replace the tests it
+                // is about to be graded by (#1357). Skipped files are warned
+                // about rather than dropped silently.
+                let refused = try mergeDirectoryContents(
+                    from: paths.submissionDir,
+                    into: testSetupDir,
+                    protected: protectedWorkspaceFilenames(manifest: manifest))
                 // A suite owned by a non-default language extracts every notebook
                 // to THAT source, regardless of the submission's kernelspec (the
                 // in-browser editor can rewrite it) — so the student-module hint
@@ -643,7 +649,7 @@ extension WorkerDaemon {
                         URL(fileURLWithPath: $0).lastPathComponent
                     })
                 return (
-                    warnings,
+                    refused.map(protectedFileSkippedWarning) + warnings,
                     preferredStudentModuleFilename(
                         submissionFilename: job.submissionFilename,
                         // nil means the extractor trusted the notebook's own

--- a/Sources/Worker/SubmissionNormalizer.swift
+++ b/Sources/Worker/SubmissionNormalizer.swift
@@ -66,6 +66,10 @@ struct SubmissionNormalizer {
     ) throws -> NormalizationResult {
         let submissionFiles = regularFiles(in: submissionDirectory)
         var progress = NormalizationProgress()
+        // The student's own files must not be able to replace the tests they
+        // are about to be graded by (#1357). Same guard the generic merge path
+        // applies, because this path writes into the same workspace.
+        let protected = protectedWorkspaceFilenames(manifest: manifest)
 
         writeStructuredRunnerLog(
             event: "submission_normalization_start",
@@ -77,6 +81,17 @@ struct SubmissionNormalizer {
             ])
 
         for fileURL in submissionFiles {
+            let fileRelativePath = relativePath(of: fileURL, under: submissionDirectory)
+            guard !protected.contains(fileRelativePath) else {
+                progress.warnings.append(protectedFileSkippedWarning(fileRelativePath))
+                writeStructuredRunnerLog(
+                    event: "submission_file_refused",
+                    fields: [
+                        "file": fileRelativePath,
+                        "reason": "belongs_to_test_setup",
+                    ])
+                continue
+            }
             try processSubmissionFile(
                 fileURL: fileURL,
                 submissionDirectory: submissionDirectory,

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -53,7 +53,45 @@ func directorySizeBytes(at directory: URL) -> Int? {
     return total
 }
 
-func mergeDirectoryContents(from sourceDirectory: URL, into destinationDirectory: URL) throws {
+/// Workspace paths a student's upload must never be allowed to write over.
+///
+/// The runner executes `manifest.testSuites[].script` out of the same directory
+/// the submission is merged into, and the merge wrote every student file by its
+/// own name over whatever was already there. So an upload containing
+/// `publictest_bmi_01.py` REPLACED the instructor's generated test and was then
+/// graded against itself — self-grade-inflation reachable from the ordinary
+/// submit form, which accepts `.zip` (#1357). Generated names are deterministic
+/// and public-tier ones are visible to students, so the name is guessable.
+///
+/// `requiredFiles` is deliberately NOT protected: those name the files the
+/// student is required to SUPPLY, so protecting them would reject every correct
+/// submission.
+///
+/// The runtime helpers and `_ck_inputs.*` are included even though the prepare
+/// phase rewrites them after the merge. That ordering is what currently makes
+/// them safe, and it is not a property this function should have to depend on.
+func protectedWorkspaceFilenames(manifest: TestProperties) -> Set<String> {
+    var names = Set(manifest.testSuites.map(\.script))
+    names.formUnion(allRuntimeHelperFiles().keys)
+    names.formUnion(AssignmentLanguage.allCases.map(\.inputsFileName))
+    names.insert(".chickadee_student_module")
+    names.insert(".chickadee_student_source")
+    return names
+}
+
+/// Copies `sourceDirectory`'s regular files into `destinationDirectory`,
+/// skipping any whose destination path is `protected`.
+///
+/// Returns the relative paths that were skipped, so the caller can warn the
+/// student by name. Skipping silently would leave a student who collided by
+/// accident — a helper they happened to call `test_runtime.py` — with a
+/// missing file and no explanation.
+@discardableResult
+func mergeDirectoryContents(
+    from sourceDirectory: URL,
+    into destinationDirectory: URL,
+    protected: Set<String> = []
+) throws -> [String] {
     // Resolve symlinks once on the source root so that the prefix comparison
     // below works even when callers pass paths through `/var` vs `/private/var`
     // (macOS) or otherwise-aliased mounts.
@@ -67,9 +105,10 @@ func mergeDirectoryContents(from sourceDirectory: URL, into destinationDirectory
             options: [.skipsHiddenFiles]
         )
     else {
-        return
+        return []
     }
 
+    var skipped: [String] = []
     for case let sourceURL as URL in enumerator {
         let values = try sourceURL.resourceValues(forKeys: [.isRegularFileKey])
         guard values.isRegularFile == true else { continue }
@@ -85,6 +124,15 @@ func mergeDirectoryContents(from sourceDirectory: URL, into destinationDirectory
         }
         let relativeComponents = Array(entryComponents.dropFirst(sourceRootComponents.count))
 
+        // Matched on the RELATIVE PATH, not the bare filename: the collision
+        // that matters is one that lands on the workspace path the runner will
+        // execute, and a student's own `sub/test_runtime.py` is not that.
+        let relativePath = relativeComponents.joined(separator: "/")
+        guard !protected.contains(relativePath) else {
+            skipped.append(relativePath)
+            continue
+        }
+
         var destinationURL = destinationDirectory
         for component in relativeComponents {
             destinationURL.appendPathComponent(component)
@@ -96,6 +144,15 @@ func mergeDirectoryContents(from sourceDirectory: URL, into destinationDirectory
         try? FileManager.default.removeItem(at: destinationURL)
         try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
     }
+    return skipped
+}
+
+/// The warning a student sees when one of their files was refused because it
+/// would have replaced part of the test setup. Shared by both normalization
+/// paths so the wording cannot drift.
+func protectedFileSkippedWarning(_ relativePath: String) -> String {
+    "Ignoring \(relativePath) from your submission: that filename belongs to the "
+        + "assignment's test setup, so it was not copied into the grading workspace."
 }
 
 /// Filename the extracted submission will have in the grading workspace, written

--- a/Tests/WorkerTests/ProtectedWorkspaceFilenameTests.swift
+++ b/Tests/WorkerTests/ProtectedWorkspaceFilenameTests.swift
@@ -1,0 +1,124 @@
+// Tests/WorkerTests/ProtectedWorkspaceFilenameTests.swift
+//
+// A student's upload must not be able to replace the tests it is graded by.
+//
+// The runner executes `manifest.testSuites[].script` out of the same directory
+// the submission is merged into, and the merge wrote every student file by its
+// own name over whatever was there. Generated names are deterministic
+// (`{tier}test_{familyID}_{caseKey}.{ext}`) and public-tier ones are visible to
+// students, so a zip carrying `publictest_bmi_01.py` replaced the instructor's
+// test and was graded against itself. The submit form accepts `.zip`, so this
+// was reachable from the ordinary student path (#1357).
+
+import Core
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite struct ProtectedWorkspaceFilenameTests {
+
+    private static func manifest(
+        scripts: [String], requiredFiles: [String] = []
+    )
+        -> TestProperties
+    {
+        TestProperties(
+            requiredFiles: requiredFiles,
+            testSuites: scripts.map { TestSuiteEntry(tier: .pub, script: $0) },
+            timeLimitSeconds: 10
+        )
+    }
+
+    private static func directory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-protected-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test func theSuitesScriptsAndRuntimeHelpersAreProtected() {
+        let names = protectedWorkspaceFilenames(
+            manifest: Self.manifest(scripts: ["publictest_bmi_01.py", "test_manual.sh"]))
+        #expect(names.contains("publictest_bmi_01.py"))
+        #expect(names.contains("test_manual.sh"))
+        #expect(names.contains("test_runtime.py"), "the runtime helpers are not protected")
+        #expect(names.contains("sitecustomize.py"))
+        #expect(names.contains("_ck_inputs.py"))
+        #expect(names.contains(".chickadee_student_module"))
+    }
+
+    /// `requiredFiles` names what the student must SUPPLY. Protecting those
+    /// would refuse every correct submission, so the guard must not.
+    @Test func requiredFilesAreNotProtected() {
+        let names = protectedWorkspaceFilenames(
+            manifest: Self.manifest(scripts: ["publictest_a.py"], requiredFiles: ["warmup.py"]))
+        #expect(!names.contains("warmup.py"), "a file the student must submit was refused")
+    }
+
+    /// The merge is the exploit path: a zip carrying a graded script's name.
+    @Test func aStudentFileCannotOverwriteAGradedScript() throws {
+        let source = try Self.directory()
+        let destination = try Self.directory()
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: destination)
+        }
+
+        try "INSTRUCTOR TEST".write(
+            to: destination.appendingPathComponent("publictest_bmi_01.py"),
+            atomically: true, encoding: .utf8)
+        try "print('always passes')".write(
+            to: source.appendingPathComponent("publictest_bmi_01.py"),
+            atomically: true, encoding: .utf8)
+        try "def classify_bmi(x): return 'ok'".write(
+            to: source.appendingPathComponent("solution.py"), atomically: true, encoding: .utf8)
+
+        let refused = try mergeDirectoryContents(
+            from: source,
+            into: destination,
+            protected: protectedWorkspaceFilenames(
+                manifest: Self.manifest(scripts: ["publictest_bmi_01.py"])))
+
+        #expect(refused == ["publictest_bmi_01.py"], "the collision was not reported")
+        let surviving = try String(
+            contentsOf: destination.appendingPathComponent("publictest_bmi_01.py"),
+            encoding: .utf8)
+        #expect(
+            surviving == "INSTRUCTOR TEST",
+            "the student's file replaced the instructor's test")
+        #expect(
+            FileManager.default.fileExists(
+                atPath: destination.appendingPathComponent("solution.py").path),
+            "the student's legitimate file was dropped along with the refused one")
+    }
+
+    /// The collision that matters is the one landing on a path the runner
+    /// executes. A student's own file in a subdirectory is not that, and
+    /// refusing it would be over-blocking.
+    @Test func aNestedFileOfTheSameNameIsStillCopied() throws {
+        let source = try Self.directory()
+        let destination = try Self.directory()
+        defer {
+            try? FileManager.default.removeItem(at: source)
+            try? FileManager.default.removeItem(at: destination)
+        }
+
+        let nested = source.appendingPathComponent("helpers", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "mine".write(
+            to: nested.appendingPathComponent("publictest_bmi_01.py"),
+            atomically: true, encoding: .utf8)
+
+        let refused = try mergeDirectoryContents(
+            from: source,
+            into: destination,
+            protected: protectedWorkspaceFilenames(
+                manifest: Self.manifest(scripts: ["publictest_bmi_01.py"])))
+
+        #expect(refused.isEmpty, "a nested file was refused: \(refused)")
+        #expect(
+            FileManager.default.fileExists(
+                atPath: destination.appendingPathComponent("helpers/publictest_bmi_01.py").path))
+    }
+}

--- a/changelog.d/1357-protect-test-setup-from-submission.md
+++ b/changelog.d/1357-protect-test-setup-from-submission.md
@@ -1,0 +1,14 @@
+### Security
+
+- **A student's upload can no longer replace the tests it is graded by.** The
+  runner executes the suite's scripts out of the same directory the submission
+  is merged into, and the merge wrote every student file by its own name over
+  whatever was already there — so a zip containing `publictest_bmi_01.py`
+  overwrote the instructor's generated test and was graded against itself.
+  Generated filenames are deterministic and public-tier names are visible to
+  students, and the submit form accepts `.zip`, so this was reachable from the
+  ordinary student path. Both normalization paths now refuse a file whose
+  workspace path belongs to the test setup (the suite's scripts, the runtime
+  helpers, the per-student inputs file and the student-module hints) and warn
+  the student by name rather than dropping it silently. `requiredFiles` are
+  deliberately not protected — those name what the student must supply.


### PR DESCRIPTION
Closes #1357.

## The defect

The runner executes `manifest.testSuites[].script` out of the same directory the submission is merged into, and the merge wrote every student file **by its own name over whatever was already there**. So an upload containing `publictest_bmi_01.py` replaced the instructor's generated test, and the job was then graded against the student's own version.

**This is reachable from the ordinary student path**, not just the API — which is what the issue originally could not confirm:

- `WebRoutes+Submission.swift:48` accepts `["zip", "ipynb"]` and detects an archive by PK magic bytes.
- Generated filenames are deterministic (`{tier}test_{familyID}_{caseKey}.{ext}`).
- Public-tier names are visible to the student who wants to guess one.

Both paths were affected: the generic merge (`SubmissionStaging.swift:96-97`) and the Python normalizer (`SubmissionNormalizer.swift:166-172`).

**Scope:** the blast radius is the cheating student's own scratch copy — each job copies the cached setup fresh — so this is self-grade-inflation, not cross-student contamination or a route to anyone else's data.

## The fix

Both normalization paths refuse a file whose workspace path belongs to the test setup. The protected set is the suite's scripts, every language's runtime helpers and `_ck_inputs.*`, and the student-module hints.

Three decisions worth reviewing:

- **`requiredFiles` is deliberately NOT protected.** Those name what the student must *supply*; protecting them would refuse every correct submission.
- **Matching is on the relative path, not the bare filename.** The collision that matters is one landing on a path the runner will execute; a student's own `helpers/publictest_bmi_01.py` is not that, and refusing it would be over-blocking. There is a test for exactly this.
- **A refusal produces a warning naming the file**, rather than a silent drop — so a student who collides by accident is told instead of losing a file with no explanation.

The runtime helpers and inputs file are included even though `prepareJobWorkspace` rewrites them *after* the merge. That ordering is what currently makes them safe, and it is not a property this guard should have to depend on.

## Verification

```
✔ Test theSuitesScriptsAndRuntimeHelpersAreProtected() passed
✔ Test requiredFilesAreNotProtected() passed
✔ Test aStudentFileCannotOverwriteAGradedScript() passed
✔ Test aNestedFileOfTheSameNameIsStillCopied() passed
```

Full `WorkerTests` target green (16 `WorkerDaemonTests` + the normalizer suites); `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_