### PR TITLE
perf(server): stop rewriting unchanged sessions and metering the result poll

### DIFF
--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -64,7 +64,14 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
 
     // MARK: - Sessions (Fluent-backed; persisted in the database)
 
-    app.sessions.use(.fluent)
+    // The Fluent driver, wrapped so an untouched session is not rewritten.
+    // Vapor's SessionsMiddleware has no dirty flag and calls updateSession on
+    // every request carrying a cookie, which made a plain page view a row
+    // write on the busiest table in the schema. See
+    // UnchangedSessionSkippingDriver for why skipping is behaviour-preserving.
+    app.sessions.use { application in
+        UnchangedSessionSkippingDriver(base: application.fluent.sessions.driver())
+    }
     var sessionConfig = app.sessions.configuration
     sessionConfig.cookieFactory = { sessionID in
         chickadeeSessionCookie(

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
@@ -174,7 +174,13 @@ extension OperationalDiagnosticsService {
         logger: Logger
     ) async {
         guard configuration.enabled else { return }
-        guard shouldCaptureRequest(path: metric.path, statusCode: metric.statusCode) else { return }
+        guard
+            shouldCaptureRequest(
+                method: metric.method,
+                path: metric.path,
+                statusCode: metric.statusCode
+            )
+        else { return }
 
         do {
             try await metric.save(on: db)
@@ -201,7 +207,7 @@ extension OperationalDiagnosticsService {
             ])
     }
 
-    private func shouldCaptureRequest(path: String, statusCode: Int) -> Bool {
+    private func shouldCaptureRequest(method: String, path: String, statusCode: Int) -> Bool {
         if configuration.verboseRequestTiming { return true }
         // Runner check-in noise: an idle poll (204, no job) and a healthy
         // heartbeat arrive at up-to-1/s per runner. Persisting a metric row
@@ -209,7 +215,26 @@ extension OperationalDiagnosticsService {
         // the 2026-07 audit flagged on this exact path. Real dispatches
         // (200), result writebacks, and any error status still record.
         if isIdleWorkerCheckIn(path: path, statusCode: statusCode) { return false }
+        if isSubmissionStatusPoll(method: method, path: path, statusCode: statusCode) { return false }
         return shouldAlwaysLogRequest(path: path)
+    }
+
+    /// The student result view polls `GET /api/v1/submissions/<id>` every two
+    /// seconds for as long as its submission is pending (`Public/app.js`).
+    /// During a deadline that is the highest-frequency request the server
+    /// takes, and persisting a row for each turns a cheap read into a write at
+    /// the moment the database is busiest — the same amplification already
+    /// excluded for idle runner check-ins, arriving from the other side.
+    ///
+    /// Scoped to the bare status route: `/results`, `/download` and the
+    /// collection route keep recording. Errors record too, so a poll that
+    /// starts failing or slowing into 5xx stays visible.
+    private func isSubmissionStatusPoll(method: String, path: String, statusCode: Int) -> Bool {
+        guard method == "GET", statusCode < 400 else { return false }
+        let prefix = "/api/v1/submissions/"
+        guard path.hasPrefix(prefix) else { return false }
+        let remainder = path.dropFirst(prefix.count)
+        return !remainder.isEmpty && !remainder.contains("/")
     }
 
     private func isIdleWorkerCheckIn(path: String, statusCode: Int) -> Bool {

--- a/Sources/APIServer/Utilities/UnchangedSessionSkippingDriver.swift
+++ b/Sources/APIServer/Utilities/UnchangedSessionSkippingDriver.swift
@@ -1,0 +1,63 @@
+import Fluent
+import Vapor
+
+/// Wraps a session driver so a session that nothing touched is not rewritten.
+///
+/// Vapor's `SessionsMiddleware` calls `updateSession` on the way out of every
+/// request that arrived with a session cookie, whether or not anything in the
+/// session changed — it has no dirty flag to consult. With the Fluent driver
+/// that is an `UPDATE` on `_fluent_sessions`: a row write plus WAL, on the one
+/// table every authenticated request already reads.
+///
+/// Almost nothing writes session data. It changes at login, during the OIDC
+/// handshake, when the active course switches, and when a draft form stashes
+/// state — a handful of requests per session. Every other request was paying a
+/// write to store back the bytes it had just read, including static assets that
+/// miss the editor fast path and the two-second poll a student's result page
+/// runs while a submission is pending.
+///
+/// Skipping is behaviour-preserving because `updateSession` sets the data
+/// column and nothing else: no expiry, no touched-at. Session lifetime comes
+/// from `created_at`, stamped once at create and reaped by
+/// `SessionReaperService`; the idle timeout is enforced against the user row by
+/// `SessionIdleTimeoutMiddleware`, not against this one. So a session that is
+/// read and not modified is, on disk, already exactly what the write would
+/// have produced.
+struct UnchangedSessionSkippingDriver: SessionDriver {
+    /// The payload `readSession` handed back for this request, so the write
+    /// side can tell an untouched session from a modified one. Request storage
+    /// is the right scope: it lives exactly as long as the comparison is valid.
+    private struct LoadedSessionDataKey: StorageKey {
+        typealias Value = SessionData
+    }
+
+    let base: any SessionDriver
+
+    func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
+        base.createSession(data, for: request)
+    }
+
+    func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<SessionData?> {
+        base.readSession(sessionID, for: request).map { data in
+            if let data {
+                request.storage[LoadedSessionDataKey.self] = data
+            }
+            return data
+        }
+    }
+
+    func updateSession(
+        _ sessionID: SessionID,
+        to data: SessionData,
+        for request: Request
+    ) -> EventLoopFuture<SessionID> {
+        if let loaded = request.storage[LoadedSessionDataKey.self], loaded == data {
+            return request.eventLoop.makeSucceededFuture(sessionID)
+        }
+        return base.updateSession(sessionID, to: data, for: request)
+    }
+
+    func deleteSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<Void> {
+        base.deleteSession(sessionID, for: request)
+    }
+}

--- a/Tests/APITests/RequestTimingMiddlewareTests.swift
+++ b/Tests/APITests/RequestTimingMiddlewareTests.swift
@@ -33,10 +33,10 @@ import VaporTesting
             .count()
     }
 
-    private func recordMetric(path: String, statusCode: Int) async {
+    private func recordMetric(method: String = "POST", path: String, statusCode: Int) async {
         await app.diagnostics.recordRequestMetric(
             APIRequestMetric(
-                method: "POST",
+                method: method,
                 path: path,
                 requestKind: "job_dispatch",
                 statusCode: statusCode,
@@ -92,6 +92,50 @@ import VaporTesting
             await recordMetric(path: "/api/v1/worker/heartbeat", statusCode: 500)
             let failedHeartbeatRows = try await metricCount(path: "/api/v1/worker/heartbeat")
             #expect(failedHeartbeatRows == 1)
+        }
+    }
+
+    /// The student result view polls the bare submission-status route every two
+    /// seconds while a submission is pending, so during a deadline it is the
+    /// highest-frequency request the server takes. Recording each one turns a
+    /// read into a write exactly when the database is busiest — the idle-runner
+    /// exclusion above, arriving from the client side.
+    @Test func submissionStatusPollIsNotPersisted() async throws {
+        try await withApp(app) { _ in
+            await recordMetric(method: "GET", path: "/api/v1/submissions/sub_abc123", statusCode: 200)
+            let pollRows = try await metricCount(path: "/api/v1/submissions/sub_abc123")
+            #expect(pollRows == 0)
+        }
+    }
+
+    /// A poll that starts failing has to stay visible — the exclusion is for
+    /// volume, not for hiding a broken route.
+    @Test func failingSubmissionStatusPollIsPersisted() async throws {
+        try await withApp(app) { _ in
+            await recordMetric(method: "GET", path: "/api/v1/submissions/sub_err", statusCode: 500)
+            let errorRows = try await metricCount(path: "/api/v1/submissions/sub_err")
+            #expect(errorRows == 1)
+        }
+    }
+
+    /// The exclusion is scoped to the bare status route. Its sub-routes are
+    /// real work — `/results` reads and decodes the outcome blob — and a
+    /// non-GET against the same path is not a poll at all.
+    @Test func submissionSubroutesAndWritesStillPersist() async throws {
+        try await withApp(app) { _ in
+            await recordMetric(
+                method: "GET", path: "/api/v1/submissions/sub_abc123/results", statusCode: 200)
+            let resultRows = try await metricCount(path: "/api/v1/submissions/sub_abc123/results")
+            #expect(resultRows == 1)
+
+            await recordMetric(
+                method: "GET", path: "/api/v1/submissions/sub_abc123/download", statusCode: 200)
+            let downloadRows = try await metricCount(path: "/api/v1/submissions/sub_abc123/download")
+            #expect(downloadRows == 1)
+
+            await recordMetric(method: "DELETE", path: "/api/v1/submissions/sub_abc123", statusCode: 200)
+            let deleteRows = try await metricCount(path: "/api/v1/submissions/sub_abc123")
+            #expect(deleteRows == 1)
         }
     }
 }

--- a/Tests/APITests/UnchangedSessionSkippingDriverTests.swift
+++ b/Tests/APITests/UnchangedSessionSkippingDriverTests.swift
@@ -1,0 +1,146 @@
+// Tests/APITests/UnchangedSessionSkippingDriverTests.swift
+//
+// Vapor's SessionsMiddleware has no dirty flag: it calls updateSession on the
+// way out of every request that arrived with a session cookie. With the Fluent
+// driver that made a plain page view an UPDATE on `_fluent_sessions`, the table
+// every authenticated request already reads. These tests pin that an untouched
+// session skips the write and a modified one still takes it.
+
+import Foundation
+import NIOConcurrencyHelpers
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+/// A stand-in for the Fluent driver that counts what actually reaches it.
+private struct RecordingSessionDriver: SessionDriver {
+    let stored: SessionData?
+    let updateCount = NIOLockedValueBox(0)
+    let createCount = NIOLockedValueBox(0)
+
+    func createSession(_ data: SessionData, for request: Request) -> EventLoopFuture<SessionID> {
+        createCount.withLockedValue { $0 += 1 }
+        return request.eventLoop.makeSucceededFuture(SessionID(string: "created"))
+    }
+
+    func readSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<SessionData?> {
+        request.eventLoop.makeSucceededFuture(stored)
+    }
+
+    func updateSession(
+        _ sessionID: SessionID,
+        to data: SessionData,
+        for request: Request
+    ) -> EventLoopFuture<SessionID> {
+        updateCount.withLockedValue { $0 += 1 }
+        return request.eventLoop.makeSucceededFuture(sessionID)
+    }
+
+    func deleteSession(_ sessionID: SessionID, for request: Request) -> EventLoopFuture<Void> {
+        request.eventLoop.makeSucceededFuture(())
+    }
+}
+
+@Suite(.serialized) final class UnchangedSessionSkippingDriverTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-session-driver")
+    }
+
+    private func makeRequest() -> Request {
+        Request(application: app, on: app.eventLoopGroup.next())
+    }
+
+    /// The common case by a wide margin: a request reads its session, changes
+    /// nothing, and would have written the same bytes back.
+    @Test func unchangedSessionSkipsTheWrite() async throws {
+        try await withApp(app) { _ in
+            let data: SessionData = ["user": "abc", "active_course": "CS136"]
+            let base = RecordingSessionDriver(stored: data)
+            let driver = UnchangedSessionSkippingDriver(base: base)
+            let request = makeRequest()
+            let sessionID = SessionID(string: "sid")
+
+            let loaded = try await driver.readSession(sessionID, for: request).get()
+            #expect(loaded == data)
+
+            let returned = try await driver.updateSession(sessionID, to: data, for: request).get()
+            #expect(returned == sessionID)
+            #expect(base.updateCount.withLockedValue { $0 } == 0)
+        }
+    }
+
+    /// A login, an OIDC handshake, or an active-course switch must still land.
+    @Test func modifiedSessionStillWrites() async throws {
+        try await withApp(app) { _ in
+            let data: SessionData = ["user": "abc"]
+            let base = RecordingSessionDriver(stored: data)
+            let driver = UnchangedSessionSkippingDriver(base: base)
+            let request = makeRequest()
+            let sessionID = SessionID(string: "sid")
+
+            _ = try await driver.readSession(sessionID, for: request).get()
+
+            var changed = data
+            changed["active_course"] = "CS135"
+            _ = try await driver.updateSession(sessionID, to: changed, for: request).get()
+            #expect(base.updateCount.withLockedValue { $0 } == 1)
+        }
+    }
+
+    /// Removing a key is a change too — comparing only added keys would leave a
+    /// logged-out session on disk.
+    @Test func clearingAKeyStillWrites() async throws {
+        try await withApp(app) { _ in
+            let data: SessionData = ["user": "abc", "oidc_state": "xyz"]
+            let base = RecordingSessionDriver(stored: data)
+            let driver = UnchangedSessionSkippingDriver(base: base)
+            let request = makeRequest()
+            let sessionID = SessionID(string: "sid")
+
+            _ = try await driver.readSession(sessionID, for: request).get()
+
+            var cleared = data
+            cleared["oidc_state"] = nil
+            _ = try await driver.updateSession(sessionID, to: cleared, for: request).get()
+            #expect(base.updateCount.withLockedValue { $0 } == 1)
+        }
+    }
+
+    /// With nothing read for this request there is no baseline to compare
+    /// against, so the write must go through rather than be assumed redundant.
+    @Test func updateWithoutAPriorReadAlwaysWrites() async throws {
+        try await withApp(app) { _ in
+            let base = RecordingSessionDriver(stored: nil)
+            let driver = UnchangedSessionSkippingDriver(base: base)
+            let request = makeRequest()
+
+            _ = try await driver.updateSession(
+                SessionID(string: "sid"), to: ["user": "abc"], for: request
+            ).get()
+            #expect(base.updateCount.withLockedValue { $0 } == 1)
+        }
+    }
+
+    /// A session id that no longer resolves reads back nil, and the middleware
+    /// then creates a fresh session — nothing is cached that could make the
+    /// create look redundant.
+    @Test func missingSessionCreatesRatherThanSkips() async throws {
+        try await withApp(app) { _ in
+            let base = RecordingSessionDriver(stored: nil)
+            let driver = UnchangedSessionSkippingDriver(base: base)
+            let request = makeRequest()
+
+            let loaded = try await driver.readSession(SessionID(string: "gone"), for: request).get()
+            #expect(loaded == nil)
+
+            _ = try await driver.createSession(["user": "abc"], for: request).get()
+            #expect(base.createCount.withLockedValue { $0 } == 1)
+            #expect(base.updateCount.withLockedValue { $0 } == 0)
+        }
+    }
+}

--- a/changelog.d/1362-per-request-write-tax.md
+++ b/changelog.d/1362-per-request-write-tax.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A page view no longer rewrites its own session row.** Vapor's session
+  middleware has no dirty flag, so it called `updateSession` on the way out of
+  every request that arrived with a cookie — an `UPDATE` on `_fluent_sessions`,
+  the table every authenticated request already reads, to store back the bytes
+  it had just read. The Fluent driver is now wrapped so an untouched session
+  skips the write. Sessions still write on the requests that actually change
+  them (login, the OIDC handshake, an active-course switch, a stashed draft
+  form), and lifetime is unaffected: the driver only ever set the data column,
+  with expiry coming from `created_at` and the idle timeout enforced against
+  the user row.
+- **The two-second submission poll no longer writes a metrics row per poll.**
+  A student's result view polls the submission-status route every two seconds
+  while grading is pending, which during a deadline makes it the
+  highest-frequency request the server takes — and each one persisted an
+  `api_request_metrics` INSERT on the response path. It is now excluded the
+  same way idle runner check-ins already were. Errors still record, and
+  `/results`, `/download` and the collection route are untouched.


### PR DESCRIPTION
Closes #1362. Second of six PRs from the August 2026 web-server scalability audit.

Two DB **writes** rode on requests that should have been reads, and both concentrate in the deadline hour.

## 1. Every request rewrote its own session row

Vapor's `SessionsMiddleware` has no dirty flag — it calls `updateSession` on the way out of every request that arrived with a session cookie, changed or not. With the Fluent driver that is an `UPDATE` on `_fluent_sessions`, a row write plus WAL on the one table every authenticated request already reads, to store back the bytes it had just read.

Session data changes on a handful of requests per session: login, the OIDC handshake, an active-course switch, a stashed draft form. Everything else — including static assets that miss the editor fast path, and the two-second poll below — was paying a write for nothing.

The driver is now wrapped (`UnchangedSessionSkippingDriver`) so an untouched session skips the write.

**This is behaviour-preserving, not a trade-off.** `updateSession` sets the data column and nothing else — no expiry, no touched-at. Session lifetime comes from `created_at`, stamped once at create and reaped by `SessionReaperService`; the idle timeout is enforced against the *user* row by `SessionIdleTimeoutMiddleware`. A session that was read and not modified is already, on disk, exactly what the write would have produced.

## 2. The two-second result poll wrote a metrics row per poll

`Public/app.js` polls `GET /api/v1/submissions/:id` every two seconds while a submission is pending. During a deadline that is the highest-frequency request the server takes, and each one persisted an `api_request_metrics` INSERT inline on the response path.

Idle runner check-ins were already excluded for exactly this reason; this is the same amplification arriving from the client side. Now excluded too, with the established carve-outs preserved:

- errors still record (`statusCode >= 400`), so a poll that starts failing stays visible
- scoped to the **bare** status route — `/results`, `/download` and the collection route are untouched
- a non-GET against the same path is not a poll and still records

## Testing

- New `UnchangedSessionSkippingDriverTests`: unchanged session skips the write; a modified session writes; **clearing** a key writes (comparing only added keys would leave a logged-out session on disk); an update with no prior read always writes; a missing session creates rather than skips.
- Extended `RequestTimingMiddlewareTests` with the poll exclusion, the failing-poll case, and the sub-route/non-GET cases.
- Ran `RequestTimingMiddlewareTests`, `UnchangedSessionSkippingDriverTests`, `SessionReaperServiceTests`, `SessionIdleTimeoutMiddlewareTests`, `AuthRoutesTests`, `SSOAuthFlowTests` — 58 tests, all passing.
- `scripts/lint.sh` and `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL)_