### PR TITLE
perf(editor): derive the asset fast-path kernel list from the language table

### DIFF
--- a/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
+++ b/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
@@ -38,34 +38,52 @@
 // request falls through to the normal chain unchanged, so worst case is
 // exactly today's behaviour.
 
+import Core
 import Vapor
 
 struct EditorAssetFastPathMiddleware: AsyncMiddleware {
     /// Vendored-only trees. Never list a prefix that can contain
     /// user-generated or access-controlled files.
-    static let fastPathPrefixes = [
-        "/jupyterlite/build/",
-        "/jupyterlite/extensions/",
-        // The vendored kernel PACKAGES — the bulk of the ~230 MB xeus tree, and
-        // the reason this middleware matters most: a kernel boot fetches every
-        // package in its environment (up to 48 for Python, 51 for R), and each
-        // one used to ride the full chain and pay a Fluent session lookup it
-        // never needed. That is exactly the class-wide-rush cost the fast path
-        // exists to remove.
-        //
-        // Deliberately the `kernel_packages/` subtree and NOT `/jupyterlite/xeus/`
-        // wholesale. The wider prefix also captures `kernels.json` and each
-        // `<env>/<kernel>/kernel.json`, which the editor fetches during app
-        // STARTUP — before any kernel exists — and short-circuiting those skips
-        // BundleAssetCacheMiddleware and the isolation middlewares for the
-        // requests that bring the app up. Keeping startup JSON on the normal
-        // chain costs a handful of requests per boot and leaves the app's own
-        // bring-up exactly as it was; the tarballs, which are the volume, still
-        // take the fast path.
-        "/jupyterlite/xeus/chickadee-python/kernel_packages/",
-        "/jupyterlite/xeus/chickadee-r/kernel_packages/",
-        "/vendor/",
-    ]
+    static let fastPathPrefixes: [String] =
+        [
+            "/jupyterlite/build/",
+            "/jupyterlite/extensions/",
+        ] + vendoredKernelPackagePrefixes + [
+            "/vendor/"
+        ]
+
+    /// One `kernel_packages/` prefix per language that ships a vendored kernel.
+    ///
+    /// These are the bulk of the ~310 MB xeus tree and the reason this
+    /// middleware matters most: a kernel boot fetches every package in its
+    /// environment (up to 48 for Python, 51 for R), and each one otherwise
+    /// rides the full chain and pays a Fluent session lookup it never needed.
+    /// That is exactly the class-wide-rush cost the fast path exists to remove.
+    ///
+    /// Derived from `AssignmentLanguage.allCases` rather than typed out. The
+    /// hand-written list named Python and R only, so Lua (19 MB) and Octave
+    /// (142 MB, the largest env we ship) booted on the slow path — the failure
+    /// mode of a hand-maintained language list in a language-generic place, and
+    /// one that fails open, so nothing broke and no test noticed. Asking each
+    /// language whether it has a kernel means a seventh needs no edit here.
+    ///
+    /// Deliberately the `kernel_packages/` subtree and NOT `/jupyterlite/xeus/`
+    /// wholesale. The wider prefix also captures `kernels.json` and each
+    /// `<env>/<kernel>/kernel.json`, which the editor fetches during app
+    /// STARTUP — before any kernel exists — and short-circuiting those skips
+    /// BundleAssetCacheMiddleware and the isolation middlewares for the
+    /// requests that bring the app up. Keeping startup JSON on the normal chain
+    /// costs a handful of requests per boot and leaves the app's own bring-up
+    /// exactly as it was; the tarballs, which are the volume, still take the
+    /// fast path.
+    static let vendoredKernelPackagePrefixes: [String] =
+        AssignmentLanguage.allCases
+        .filter { language in
+            if case .notebookKernel = language.editorSupport { return true }
+            return false
+        }
+        .map { "/jupyterlite/xeus/\(KernelEnvironment.environmentName(for: $0))/kernel_packages/" }
+        .sorted()
 
     private let publicDirectory: String
 

--- a/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
+++ b/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
@@ -1,7 +1,9 @@
+import Foundation
 import Testing
 import VaporTesting
 
 @testable import APIServer
+@testable import Core
 
 /// Exercises EditorAssetFastPathMiddleware in the production ordering:
 /// fast path → UserFileNamespaceMiddleware → FileMiddleware.  The suite
@@ -252,5 +254,75 @@ import VaporTesting
     ])
     func contentHashDetection(path: String, expected: Bool) {
         #expect(EditorAssetFastPathMiddleware.isContentHashedBundleAsset(path: path) == expected)
+    }
+
+    private static var repoRoot: URL {
+        var url = URL(fileURLWithPath: #filePath)  // .../Tests/APITests/<thisFile>
+        for _ in 0..<3 { url.deleteLastPathComponent() }
+        return url
+    }
+
+    /// Reads the SHIPPED bytes, not the language table, and requires every
+    /// vendored kernel to be on the fast path.
+    ///
+    /// The hand-written list this replaced named Python and R only, so Lua and
+    /// Octave — the largest env we ship — booted on the slow path, each of ~50
+    /// package tarballs paying a session lookup it never needed. It fails open,
+    /// which is why it went unnoticed: nothing breaks, the boot is just
+    /// expensive. Deriving the list fixes today's gap; checking it against disk
+    /// is what stops the next one, since a vendored kernel whose language
+    /// forgot to declare a kernel would be invisible to a check that only read
+    /// `allCases`.
+    @Test func everyVendoredKernelPackageTreeTakesTheFastPath() throws {
+        let xeusDir = Self.repoRoot.appendingPathComponent("Public/jupyterlite/xeus")
+        let vendored = try FileManager.default.contentsOfDirectory(atPath: xeusDir.path)
+            .filter { $0.hasPrefix("chickadee-") }
+            .filter { environment in
+                var isDirectory: ObjCBool = false
+                let packages = xeusDir.appendingPathComponent("\(environment)/kernel_packages").path
+                let exists = FileManager.default.fileExists(
+                    atPath: packages, isDirectory: &isDirectory)
+                return exists && isDirectory.boolValue
+            }
+            .sorted()
+
+        // A derivation that silently produced nothing looks identical to a
+        // correct one, so assert the check found something before trusting it.
+        #expect(
+            !vendored.isEmpty,
+            "No vendored kernel_packages trees found under \(xeusDir.path) — this check read the wrong path"
+        )
+
+        for environment in vendored {
+            let prefix = "/jupyterlite/xeus/\(environment)/kernel_packages/"
+            #expect(
+                EditorAssetFastPathMiddleware.fastPathPrefixes.contains(prefix),
+                """
+                \(environment) ships kernel_packages but is not on the editor asset fast path, so \
+                every tarball of its boot rides the full session/auth chain. The prefix list is \
+                derived from AssignmentLanguage.allCases — check that language's editorSupport.
+                """
+            )
+        }
+    }
+
+    /// One prefix per kernel language, and none for an upload-only one: those
+    /// envs are never vendored, so a prefix for them would be a dead string
+    /// tested against every request path.
+    @Test func kernelPrefixesTrackEditorSupportExactly() {
+        let kernelLanguages = AssignmentLanguage.allCases.filter { language in
+            if case .notebookKernel = language.editorSupport { return true }
+            return false
+        }
+        #expect(!kernelLanguages.isEmpty)
+        #expect(
+            EditorAssetFastPathMiddleware.vendoredKernelPackagePrefixes.count
+                == kernelLanguages.count)
+
+        for language in AssignmentLanguage.allCases where language.editorSupport == .uploadOnly {
+            let prefix =
+                "/jupyterlite/xeus/\(KernelEnvironment.environmentName(for: language))/kernel_packages/"
+            #expect(!EditorAssetFastPathMiddleware.fastPathPrefixes.contains(prefix))
+        }
     }
 }

--- a/changelog.d/1366-fastpath-all-kernels.md
+++ b/changelog.d/1366-fastpath-all-kernels.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Lua and Octave kernel boots now take the editor asset fast path.** The
+  fast path's allowlist was a hand-written list naming Python and R, so a Lua
+  (19 MB) or Octave (142 MB, the largest env shipped) kernel boot sent every one
+  of its ~50 package tarballs through the full middleware chain — session
+  lookup, user lookup, activity middleware — that the fast path exists to skip.
+  It failed open, so nothing broke and no test noticed; the boot was just
+  needlessly expensive. The prefixes are now derived from
+  `AssignmentLanguage.allCases`, so a seventh language needs no edit here, and a
+  new test reads the vendored tree on disk and fails if any shipped kernel is
+  missing from the list.


### PR DESCRIPTION
Closes #1366. Third of six PRs from the August 2026 web-server scalability audit.

## What was wrong

`EditorAssetFastPathMiddleware` short-circuits the session lookup, user lookup, activity middleware and request metering for the vendored editor asset trees — it exists precisely to keep a kernel boot's ~50-tarball fetch storm off the database.

Its allowlist was a hand-written list naming two kernels:

```
/jupyterlite/xeus/chickadee-python/kernel_packages/
/jupyterlite/xeus/chickadee-r/kernel_packages/
```

We ship **four**. `chickadee-lua` (19 MB) and `chickadee-octave` (142 MB, the largest env here) were absent, so every package tarball of a Lua or Octave kernel boot rode the full middleware chain.

It fails open, which is why it survived two language additions: nothing breaks, the boot is just needlessly expensive, and no test looked at it.

## What changed

The prefixes derive from `AssignmentLanguage.allCases`, filtered to languages whose `editorSupport` declares a vendored kernel and mapped through `KernelEnvironment.environmentName(for:)` — the switch the compiler already forces to be exhaustive. **A seventh language needs no edit here.**

This is the same shape as the MCP language-list defect fixed twice before (#1288, #1290): a hand-maintained list of languages in a place whose types are language-generic, failing open.

The `kernel_packages/`-not-`/jupyterlite/xeus/` scoping and its reasoning are preserved verbatim — the wider prefix would capture the startup JSON the editor fetches before any kernel exists.

## Testing

Deriving the list fixes today's gap; the new test is what stops the next one.

- `everyVendoredKernelPackageTreeTakesTheFastPath` reads the **shipped bytes** under `Public/jupyterlite/xeus/` rather than the language table, so a kernel that ships without its language declaring one is still caught. It asserts it found something before trusting the result — a derivation that silently produced nothing would otherwise look identical to a correct one (the #1330 lesson).
- `kernelPrefixesTrackEditorSupportExactly` pins one prefix per kernel language and none for an upload-only one, so no dead prefix gets tested against every request path.
- This test fails on the pre-fix list (2 of 4 kernels covered).
- Full `EditorAssetFastPathMiddlewareTests` suite passes locally (14 tests). `scripts/lint.sh` and `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL)_