### PR TITLE
fix(java): enable assertions, and keep non-ASCII in verdicts and source

### DIFF
--- a/Sources/APIServer/Services/JavaPersonalizationDriver.swift
+++ b/Sources/APIServer/Services/JavaPersonalizationDriver.swift
@@ -49,7 +49,7 @@ enum JavaPersonalizationDriver {
             cat > CkPersonalizeDriver.java <<'CHICKADEE_GENERATED_SOURCE'
             \(program)
             CHICKADEE_GENERATED_SOURCE
-            javac -d . \(sources) 1>&2 || exit 3
+            javac -encoding UTF-8 -d . \(sources) 1>&2 || exit 3
             exec java -cp . CkPersonalizeDriver
             """ + "\n"
     }

--- a/Sources/APIServer/Utilities/PatternFamilyRendererJava.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRendererJava.swift
@@ -203,7 +203,7 @@ private func javaShellWrapper(
         \(embeddedSource)
         \(generatedSourceHeredocDelimiter)
         \(compileStep)
-        ck_out=$(java -cp . \(className))
+        ck_out=$(java -ea -cp . \(className))
         ck_rc=$?
         # The sentinel check. Without it, a student's own System.exit(0)
         # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/approximate_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/approximate_equality/publictest_fam_01.sh
@@ -32,7 +32,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/boundary_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/boundary_equality/publictest_fam_01.sh
@@ -32,7 +32,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/differential/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/differential/publictest_fam_01.sh
@@ -41,7 +41,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/exception_expected/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/exception_expected/publictest_fam_01.sh
@@ -32,7 +32,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/performance_threshold/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/performance_threshold/publictest_fam_01.sh
@@ -33,7 +33,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/return_type_check/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/return_type_check/publictest_fam_01.sh
@@ -31,7 +31,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/stdout_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/stdout_equality/publictest_fam_01.sh
@@ -37,7 +37,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/unordered_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/unordered_equality/publictest_fam_01.sh
@@ -32,7 +32,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tests/Fixtures/generated-source/java/pattern/variable_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/java/pattern/variable_equality/publictest_fam_01.sh
@@ -24,7 +24,7 @@ if ! javac -encoding UTF-8 -cp . -d . CkTest_fam_01.java test_runtime.java 2>.ck
     cat .ck_build_log 1>&2
     exit 2
 fi
-ck_out=$(java -cp . CkTest_fam_01)
+ck_out=$(java -ea -cp . CkTest_fam_01)
 ck_rc=$?
 # The sentinel check. Without it, a student's own System.exit(0)
 # anywhere in their code exits the JVM with status 0 and this case —

--- a/Tools/runner-support/test_runtime.java
+++ b/Tools/runner-support/test_runtime.java
@@ -47,6 +47,30 @@ class ck {
     // in the generated test is deliberate: a renderer cannot forget it.
     private static final String SENTINEL = "CK_SENTINEL";
 
+    /// Real stdout, decoded as UTF-8 whatever the host locale says.
+    ///
+    /// `System.out` uses `stdout.encoding`, which follows `native.encoding` —
+    /// ASCII on a container with no `LANG`. A verdict quoting a student's
+    /// accented output therefore reached the runner with `?` in place of every
+    /// non-ASCII character. The COMPARISON was never affected (`beginCapture`
+    /// decodes UTF-8 explicitly, and equality runs in-JVM before anything is
+    /// printed) — only the message the student reads.
+    ///
+    /// Writing to `FileDescriptor.out` rather than to `System.out` also means a
+    /// verdict cannot land in an installed capture, which is the property
+    /// `restoreOut` exists to guarantee; the two agree rather than compete.
+    private static PrintStream ckOut = null;
+
+    private static PrintStream verdictStream() {
+        if (ckOut == null) {
+            ckOut = new PrintStream(
+                new java.io.FileOutputStream(java.io.FileDescriptor.out),
+                true,
+                java.nio.charset.StandardCharsets.UTF_8);
+        }
+        return ckOut;
+    }
+
     // ---- the shell contract's exit codes ----
     //
     // stdout carries one JSON object as the last non-empty line; stderr carries
@@ -54,17 +78,19 @@ class ck {
     // here.
     static void passed(String msg) {
         restoreOut();
-        System.out.println(SENTINEL);
-        System.out.println("{\"shortResult\": \"" + jsonEscape(msg) + "\"}");
-        System.out.flush();
+        PrintStream out = verdictStream();
+        out.println(SENTINEL);
+        out.println("{\"shortResult\": \"" + jsonEscape(msg) + "\"}");
+        out.flush();
         Runtime.getRuntime().halt(0);
     }
 
     static void failed(String msg) {
         restoreOut();
-        System.out.println(SENTINEL);
-        System.out.println("{\"shortResult\": \"" + jsonEscape(msg) + "\"}");
-        System.out.flush();
+        PrintStream out = verdictStream();
+        out.println(SENTINEL);
+        out.println("{\"shortResult\": \"" + jsonEscape(msg) + "\"}");
+        out.flush();
         Runtime.getRuntime().halt(1);
     }
 
@@ -74,7 +100,8 @@ class ck {
         // it the wrapper could not tell a genuine error from a student's
         // premature exit, and would report the less specific of the two —
         // hiding the message this call exists to deliver.
-        System.out.println(SENTINEL);
+        PrintStream out = verdictStream();
+        out.println(SENTINEL);
         // A shortResult footer, even though the exit code already says `error`.
         // The shell contract takes the LAST non-empty stdout line as the
         // summary, so without one a student's own final print became the
@@ -84,8 +111,8 @@ class ck {
         int ckNewline = msg == null ? -1 : msg.indexOf('\n');
         String ckSummary = msg == null ? "" : (ckNewline < 0 ? msg : msg.substring(0, ckNewline));
         if (ckSummary.isEmpty()) ckSummary = "error";
-        System.out.println("{\"shortResult\": \"" + jsonEscape(ckSummary) + "\"}");
-        System.out.flush();
+        out.println("{\"shortResult\": \"" + jsonEscape(ckSummary) + "\"}");
+        out.flush();
         System.err.println(msg);
         System.err.flush();
         Runtime.getRuntime().halt(2);

--- a/changelog.d/1348-java-assertions-and-encoding.md
+++ b/changelog.d/1348-java-assertions-and-encoding.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Java assertions now run in generated tests.** `javaGuarded` documents
+  catching a student's `assert`, but the JVM was launched without `-ea`, so
+  assertions were disabled and a submission proceeded with its precondition
+  unchecked — the opposite of what the comment promised.
+- **A Java verdict message keeps its non-ASCII characters.** `System.out` uses
+  the host's `native.encoding` (ASCII on a container with no `LANG`), so a
+  failure quoting a student's accented output reached the runner with `?` in
+  place of every non-ASCII character. Verdicts are written through an explicit
+  UTF-8 stream on the real stdout. Comparisons were never affected.
+- **`javac` is given `-encoding UTF-8`** in the personalization driver as well
+  as the test wrappers. Generated Java source is unconditionally non-ASCII, and
+  while javac defaults to UTF-8 on JDK 18+ regardless of locale, the repo
+  supports Java 11+, where it does not.


### PR DESCRIPTION
Closes #1348.

**1. `javaGuarded` promised to catch a student's `assert`; the JVM ran without `-ea`.** Java disables assertions by default, so the assertion never fired and the submission proceeded with its precondition unchecked — the opposite of what the comment said. Measured both ways:

```
--- default (as the wrapper ran it) ---
assert NOT enforced
--- with -ea ---
assert enforced: assertion fired
```

**2. A verdict quoting non-ASCII reached the runner mangled.** `System.out` encodes with `stdout.encoding`, which follows `native.encoding` — ASCII on a container with no `LANG`, which is what the runner image is — so a failure quoting a student's accented output arrived with `?` in place of every non-ASCII character. Verdicts now go through an explicit UTF-8 stream on the real stdout, which also cannot land in an installed capture, so it agrees with `restoreOut` rather than competing with it. The **comparison** was never affected: `beginCapture` decodes UTF-8 explicitly and equality runs in-JVM before anything is printed.

**3. `javac -encoding UTF-8`** now reaches the personalization driver too (the test wrappers picked it up with the build-log change in #1349).

## A correction to my own issue

The original #1348 claimed javac follows `native.encoding` on JDK 18+, so a runner without `LANG` would silently corrupt string literals. **That is wrong**, and I've rewritten the issue to say so. Measured on the CI image — `javac 21.0.10`, `native.encoding = ANSI_X3.4-1968`, no `LANG`:

- No `-encoding`: a source file with an em dash and `"café"` compiled cleanly and decoded correctly (`length=4`, `codepoint3=233`).
- Only an explicit `-encoding US-ASCII` errors.

JEP 400 made the default charset UTF-8 regardless of locale. So item 3 is **version-hardening** for the JDK 11/17 the repo still supports, not a live defect. Item 1 is confirmed as filed; item 2 was found while measuring item 3.

## Verification

```
✔ Test run with 44 tests in 3 suites passed after 27.636 seconds.
```

Goldens: nine Java kinds pick up `java -ea`. `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_