### PR TITLE
fix(deploy): reconcile the nginx body cap, the run mode, and a false comment

### DIFF
--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -30,6 +30,12 @@ struct CourseBundleRoutes: RouteCollection {
             // A real bundle is testsetup zips + every submission for the
             // course; the 10 MB default made importing Chickadee's own
             // exports impossible (#1158).
+            //
+            // This is a backstop, not the effective limit. Behind a reverse
+            // proxy the proxy's own cap applies first and rejects the body
+            // before the app is reached — `client_max_body_size` in
+            // deploy/nginx.conf, deliberately set well below this. Raise that
+            // too when a deployment genuinely needs a larger import.
             body: .collect(maxSize: "2gb"),
             use: importCourse)
     }

--- a/changelog.d/1363-deploy-config-drift.md
+++ b/changelog.d/1363-deploy-config-drift.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **The nginx body cap no longer sits below the app's own upload limits.**
+  Both sample vhosts capped request bodies at 50 MB while the app declares 300
+  MB for test-setup zip upload, so a large test setup was rejected by nginx with
+  a bare 413 before the app saw it — and the app-side limit read as though it
+  were in force. Raised to 512 MB, including in the commented HTTPS block that
+  operators uncomment in production, which carried the same cap. Course-bundle
+  import's 2 GB backstop is deliberately not matched, and both sides now say so.
+- **The systemd unit runs the server in production mode.** It invoked
+  `chickadee-server serve` with no `--env`, so a bare-metal deploy took Vapor's
+  `development` default and ran with Leaf's template cache disabled, re-reading
+  and re-parsing every template on every page render. The Docker entrypoint
+  already passed `--env production`; the unit file now does too.
+- **Corrected the nginx compression comment.** It claimed Chickadee serves
+  pre-compressed `.br`/`.gz` variants for the largest assets. It does not —
+  there is no `gzip_static`, no build step producing them, and the only `.gz`
+  files shipped are conda kernel tarballs. The comment now describes what
+  actually happens, including that a cold multi-MB wasm fetch is gzipped on the
+  fly each time.

--- a/deploy/chickadee-server.service
+++ b/deploy/chickadee-server.service
@@ -6,7 +6,12 @@ After=network.target
 Type=simple
 User=chickadee
 WorkingDirectory=/opt/chickadee
-ExecStart=/opt/chickadee/.build/release/chickadee-server serve --hostname 127.0.0.1 --port 8080
+# --env production is load-bearing, not decoration: Vapor defaults to
+# `development`, which disables Leaf's template cache, so every page render
+# re-reads and re-parses the templates from disk. The Docker entrypoint already
+# passes it; this unit did not, so a bare-metal deploy silently ran a
+# development-mode server.
+ExecStart=/opt/chickadee/.build/release/chickadee-server serve --env production --hostname 127.0.0.1 --port 8080
 Restart=on-failure
 RestartSec=5
 EnvironmentFile=/opt/chickadee/.env

--- a/deploy/nginx-docker.conf
+++ b/deploy/nginx-docker.conf
@@ -15,13 +15,22 @@ server {
     listen 80;
     server_name _;   # replace _ with your domain name in production
 
-    client_max_body_size 50m;
+    # Must clear the largest per-route limit the app declares and expects to
+    # work — test-setup zip upload, capped at 300 MB in TestSetupRoutes. nginx
+    # 413s an oversized body before the app sees it, so this is the real
+    # ceiling. Course-bundle import declares 2gb as a backstop and is
+    # deliberately not matched: see deploy/nginx.conf for the reasoning.
+    client_max_body_size 512m;
 
     # Compress text assets, INCLUDING application/wasm — nginx's default
-    # gzip_types omits it, which left Pyodide's ~8.6 MB core wasm uncompressed
-    # on every cold/incognito kernel boot. (Chickadee also serves pre-compressed
-    # .br/.gz for the largest assets; nginx passes those through untouched, so
-    # this covers everything else — JS/JSON/CSS and any un-pre-compressed wasm.)
+    # gzip_types omits it, which left the multi-MB kernel wasm uncompressed on
+    # every cold/incognito boot.
+    #
+    # Everything is compressed on the fly, per request. Chickadee ships no
+    # pre-compressed .br/.gz variants and there is no gzip_static here, so a
+    # cold fetch of xpython.wasm (~15.7 MB) pays a level-5 gzip each time. The
+    # app also compresses compressible types itself, so for proxied responses
+    # this mostly passes an already-gzipped body through.
     gzip on;
     gzip_proxied any;
     gzip_vary on;
@@ -107,7 +116,7 @@ server {
 #     include             /etc/letsencrypt/options-ssl-nginx.conf;
 #     ssl_dhparam         /etc/letsencrypt/ssl-dhparams.pem;
 #
-#     client_max_body_size 50m;
+#     client_max_body_size 512m;
 #
 #     error_page 502 503 504 /chickadee-maintenance.html;
 #     location = /chickadee-maintenance.html {

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -8,8 +8,21 @@ server {
     listen 80;
     server_name your-vm.example.com;
 
-    # Increase body size limit to allow test-setup zip uploads (default 1m is too small).
-    client_max_body_size 50m;
+    # Body size limit. nginx rejects an oversized body with its own 413 before
+    # the app sees the request, so this value — not the app's per-route limit —
+    # is the real ceiling on every upload path. It must therefore clear the
+    # largest route the app actually declares: test-setup zip upload, capped at
+    # 300 MB in TestSetupRoutes. At the previous 50m an instructor uploading a
+    # large test setup got a bare nginx 413 while the app's own limit read as
+    # though it were in force.
+    #
+    # Course-bundle import declares 2gb (a "do not block me" backstop, since a
+    # real bundle is test-setup zips plus every submission for the course). That
+    # is deliberately NOT matched here: buffering a 2 GB body through the app is
+    # not something to make reachable from the internet by default. Bundle
+    # import through this vhost is capped at the value below — raise it on a
+    # host that genuinely needs a larger one.
+    client_max_body_size 512m;
 
     # Chickadee-themed page shown when the server is unreachable (e.g. during a
     # restart or update) instead of the default nginx 502. nginx generates
@@ -23,10 +36,14 @@ server {
     }
 
     # Compress text assets, INCLUDING application/wasm — nginx's default
-    # gzip_types omits it, which left Pyodide's ~8.6 MB core wasm uncompressed
-    # on every cold/incognito kernel boot. (Chickadee also serves pre-compressed
-    # .br/.gz for the largest assets; nginx passes those through untouched, so
-    # this covers everything else — JS/JSON/CSS and any un-pre-compressed wasm.)
+    # gzip_types omits it, which left the multi-MB kernel wasm uncompressed on
+    # every cold/incognito boot.
+    #
+    # Everything is compressed on the fly, per request. Chickadee ships no
+    # pre-compressed .br/.gz variants and there is no gzip_static here, so a
+    # cold fetch of xpython.wasm (~15.7 MB) pays a level-5 gzip each time. The
+    # app also compresses compressible types itself, so for proxied responses
+    # this mostly passes an already-gzipped body through.
     gzip on;
     gzip_proxied any;
     gzip_vary on;


### PR DESCRIPTION
Closes #1363. Fourth of six PRs from the August 2026 web-server scalability audit.

Three independent inconsistencies in `deploy/`, none of which any test or guard could see. Config-only apart from one clarifying code comment.

## 1. The nginx body cap sat below the app's own upload limits

`deploy/nginx.conf` and `deploy/nginx-docker.conf` set `client_max_body_size 50m`. The app declares **300 MB** for test-setup zip upload (`TestSetupRoutes.swift:42`) and 60 MB for content items. nginx rejects an oversized body with its own 413 **before the app is reached**, so the proxy was the real ceiling on every upload path while the app-side limit read as though it were in force.

Raised to **512 MB** — comfortably above the largest route the app expects to work.

The commented-out HTTPS `server` block carried the same 50m. That is the block operators uncomment for production, so leaving it would have quietly reintroduced the cap the moment TLS was enabled. Fixed too.

Course-bundle import's `2gb` is deliberately **not** matched: buffering a body that size through the app is not something to make reachable from the internet by default. Both sides now state the relationship — the app comment says the proxy cap applies first, the nginx comment says why the backstop isn't mirrored.

## 2. The systemd unit ran the server in development mode

`deploy/chickadee-server.service` invoked `chickadee-server serve` with no `--env`, so a bare-metal deploy took Vapor's `development` default — which disables Leaf's template cache, re-reading and re-parsing all 49 templates from disk on **every page render**.

`deploy/docker-entrypoint.sh:65` already passes `--env production`, which is why production is unaffected and this survived unnoticed. The unit now passes it too.

## 3. The gzip comment described behaviour that does not exist

The config claimed Chickadee "also serves pre-compressed .br/.gz for the largest assets; nginx passes those through untouched." It does not: no `gzip_static` directive, no build step producing them, no `.br` files under `Public/`, and the only `.gz` files are conda kernel tarballs.

Every asset is compressed on the fly, so a cold fetch of the ~15.7 MB `xpython.wasm` pays a level-5 gzip each time. The comment now says so — the difference between a known cost and an invisible one, and it stops the next reader from "confirming" pre-compression that was never there.

## Testing

No behavioural code change (the only Swift edit is a comment), so this rides the existing suite. Build, `scripts/lint.sh` and `scripts/swiftlint.sh` clean locally.

Worth noting these files are not exercised by CI at all — they are operator-facing samples — which is precisely how all three drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL)_