### PR TITLE
perf(submissions): take the student submit writes off the cooperative pool

### DIFF
--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -96,7 +96,10 @@ struct BrowserResultRoutes: RouteCollection {
             instructorData = body.notebook
         }
         let notebookToSave = mergeNotebook(student: body.notebook, instructor: instructorData)
-        try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
+        // Offloaded to the NIO thread pool: a synchronous write pins a
+        // cooperative-pool thread for its duration, and these are the routes a
+        // whole lab section hits at once.
+        try await req.fileio.writeFile(.init(data: notebookToSave), at: nbPath)
 
         // Create the submission record as "complete" immediately — browser
         // results are authoritative and no native worker re-run is queued.
@@ -296,7 +299,10 @@ struct BrowserResultRoutes: RouteCollection {
             instructorData = body.notebook
         }
         let notebookToSave = mergeNotebook(student: body.notebook, instructor: instructorData)
-        try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
+        // Offloaded to the NIO thread pool: a synchronous write pins a
+        // cooperative-pool thread for its duration, and these are the routes a
+        // whole lab section hits at once.
+        try await req.fileio.writeFile(.init(data: notebookToSave), at: nbPath)
 
         let submittedFilename = normalizedNotebookFilename(body.filename)
         let submission = APISubmission(
@@ -417,7 +423,10 @@ struct BrowserResultRoutes: RouteCollection {
             instructorData = studentData
         }
         let notebookToSave = mergeNotebook(student: studentData, instructor: instructorData)
-        try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
+        // Offloaded to the NIO thread pool: a synchronous write pins a
+        // cooperative-pool thread for its duration, and these are the routes a
+        // whole lab section hits at once.
+        try await req.fileio.writeFile(.init(data: notebookToSave), at: nbPath)
 
         let submission = APISubmission(
             id: subID,

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -149,7 +149,11 @@ extension WebRoutes {
         }()
         let storedExt = isZip ? "zip" : ext
         let filePath = subsDir + "\(subID).\(storedExt)"
-        try fileData.write(to: URL(fileURLWithPath: filePath))
+        // Offloaded to the NIO thread pool, matching the API submission path: a
+        // synchronous write pins a cooperative-pool thread while the handler
+        // still holds the whole body in memory, and a deadline burst is exactly
+        // when this route is hot.
+        try await req.fileio.writeFile(.init(data: fileData), at: filePath)
         let fallbackFilename = isZip ? nil : (uploadFilename ?? "submission.\(storedExt)")
 
         // Attempt number is scoped to this student for this test setup,

--- a/changelog.d/1364-nonblocking-submit-writes.md
+++ b/changelog.d/1364-nonblocking-submit-writes.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Student submission uploads no longer block a cooperative-pool thread on
+  disk I/O.** The web upload form and all three notebook submit routes
+  (browser-graded result, runner-submit, browser-failover) wrote their file with
+  a synchronous `Data.write(to:)`. Vapor handlers run on the Swift cooperative
+  pool, which has roughly one thread per core and never grows, so each write
+  pinned a thread for its duration while the handler still held the whole body
+  in memory — during a deadline burst, which is exactly when these routes are
+  hot. They now use `req.fileio.writeFile`, matching the API submission path
+  that was already fixed.


### PR DESCRIPTION
Closes #1364. Fifth of six PRs from the August 2026 web-server scalability audit.

## What was wrong

Vapor route handlers run on the Swift cooperative pool — roughly one thread per core, and it never grows. A synchronous `Data.write(to:)` **pins** one of those threads for the duration of the write, while the handler is still holding the entire uploaded body in memory.

`SubmissionRoutes.swift:45` (the API path) was moved to `req.fileio.writeFile` for exactly this reason. The routes students actually use were left behind:

| Route | Site |
|---|---|
| Web upload form | `WebRoutes+Submission.swift:152` |
| Browser-graded result | `BrowserResultRoutes.swift:99` |
| `runner-submit` | `BrowserResultRoutes.swift:299` |
| `browser-failover` | `BrowserResultRoutes.swift:420` |

A deadline burst — a lab section submitting at once — is precisely when these are hot. This is the shape `BlockingWork.swift`'s own header warns about ("a burst of such requests … starves every other request"), and the same failure class as the #1233 cooperative-pool wedge, where blocking waits on pool threads became permanent and self-sustaining once pinned threads reached pool width.

## What changed

All four now use `req.fileio.writeFile`, which offloads to the NIO thread pool. No behavioural change — same bytes, same paths, same error propagation.

## Deliberately out of scope

The other synchronous writes under `Routes/` are authoring paths: test-setup upload, notebook save, draft writes, bundle import, validation enqueue. Those are one-instructor-at-a-time by nature rather than class-wide, so the same fix there buys much less and would broaden the diff well past what the issue describes. Noting them here so the next reader knows they were seen, not missed.

## Testing

Ran everything matching `BrowserResult|Submission` — **220 tests across 57 suites**, all passing, including `SubmissionRoutesTests`, `SubmissionQueryRoutesTests`, `BrowserResultSideEffectOrderTests`, `SubmissionModeRoutesTests` and `NotebookWebRoutesTests`. `scripts/lint.sh` and `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL)_