### PR TITLE
fix(worker): make SubmissionPolicy govern Python too, and log its exemptions

### DIFF
--- a/Sources/Worker/NotebookExtractor.swift
+++ b/Sources/Worker/NotebookExtractor.swift
@@ -9,17 +9,18 @@ struct NotebookExtraction {
 }
 
 struct NotebookExtractor {
+    /// Parses and shape-checks a file that claims to be a notebook.
+    ///
+    /// Delegates to `SubmissionValidation`, which is the point:
+    /// `SubmissionPolicy` says it is "the shared implementation of the notebook
+    /// guarantees, so both the Python normalizer and the generic extractor
+    /// enforce one standard rather than two" — and that was false. Python went
+    /// through a private second implementation here, so the exemption table
+    /// governed six languages and Python answered to nothing. The two agreed by
+    /// coincidence; a tightening of one would have silently skipped the other.
     func notebookJSONObject(from data: Data, filename: String) throws -> [String: Any] {
-        let rawObject: Any
-        do {
-            rawObject = try JSONSerialization.jsonObject(with: data)
-        } catch {
-            throw SubmissionNormalizationError.invalidNotebookJSON(filename)
-        }
-        guard let object = rawObject as? [String: Any] else {
-            throw SubmissionNormalizationError.invalidNotebookJSON(filename)
-        }
-        return object
+        try SubmissionValidation.validatedNotebook(
+            data: data, filename: filename, language: .python)
     }
 
     func isNotebookJSONObject(_ notebook: [String: Any]) -> Bool {
@@ -47,9 +48,10 @@ struct NotebookExtractor {
         }
         let extracted = extractPython(cells: inputCells, filename: filename)
 
-        guard extracted.codeCellCount > 0 else {
-            throw SubmissionNormalizationError.notebookHasNoCodeCells(filename)
-        }
+        // Through the policy, not a private `> 0` — same reason as
+        // `notebookJSONObject` above.
+        try SubmissionValidation.requireCodeCells(
+            extracted.codeCellCount, filename: filename, language: .python)
 
         return NotebookExtraction(
             source: extracted.executableModule,

--- a/Sources/Worker/SubmissionNormalizer.swift
+++ b/Sources/Worker/SubmissionNormalizer.swift
@@ -330,6 +330,21 @@ struct SubmissionNormalizer {
             progress.producedPythonFiles.count == 1,
             let sourceURL = progress.producedPythonFiles.first
         else { return }
+        // The source has to actually be Python. `classify` accepts ANY `text/*`
+        // as a Python script, so a student who uploaded `solution.lua` to a
+        // Python assignment — wrong assignment, or a mis-set language on a
+        // course clone — had it copied to `solution.py` and was then shown
+        // Python syntax errors against Lua source, under a warning saying
+        // Chickadee had made a copy "from the single detected Python source
+        // file". Extensionless is allowed: a notebook extracts to `.py`, and a
+        // bare script is genuinely ambiguous rather than wrong.
+        let sourceExtension = sourceURL.pathExtension.lowercased()
+        guard sourceExtension.isEmpty || sourceExtension == "py" else {
+            progress.warnings.append(
+                "Expected file \(expectedFilename) was not present, and \(sourceURL.lastPathComponent) "
+                    + "is not a Python file, so no compatibility copy was made.")
+            return
+        }
 
         let compatibilityURL = workspaceDirectory.appendingPathComponent(expectedFilename)
         try FileManager.default.createDirectory(

--- a/Sources/Worker/SubmissionPolicy.swift
+++ b/Sources/Worker/SubmissionPolicy.swift
@@ -107,6 +107,27 @@ func submissionGuaranteeApplies(
     submissionGuaranteeExemption(guarantee, for: language) == nil
 }
 
+/// Emits the structured log line this file's own doc promises for a skipped
+/// guarantee.
+///
+/// The promise — "it appears in the conformance test's output AND in the
+/// runner's structured log when a guarantee is skipped" — was half true: the
+/// conformance test reports exemptions, nothing logged them. So an operator
+/// asked why a student's empty notebook produced no error could grep the job's
+/// log, find nothing, and conclude the guarantee had run.
+func reportSkippedGuarantee(
+    _ guarantee: SubmissionGuarantee, language: AssignmentLanguage, filename: String
+) {
+    writeStructuredRunnerLog(
+        event: "submission_guarantee_skipped",
+        fields: [
+            "guarantee": guarantee.rawValue,
+            "language": language.rawValue,
+            "file": filename,
+            "reason": submissionGuaranteeExemption(guarantee, for: language) ?? "",
+        ])
+}
+
 // MARK: - The checks themselves
 
 /// The shared implementation of the notebook guarantees, so both the Python
@@ -126,6 +147,7 @@ enum SubmissionValidation {
     ) throws -> [String: Any] {
         guard submissionGuaranteeApplies(.validNotebookJSON, to: language) else {
             // Exempt: parse leniently and let the caller skip on failure.
+            reportSkippedGuarantee(.validNotebookJSON, language: language, filename: filename)
             return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
         }
         guard let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
@@ -152,7 +174,10 @@ enum SubmissionValidation {
         filename: String,
         language: AssignmentLanguage
     ) throws {
-        guard submissionGuaranteeApplies(.notebookHasCodeCells, to: language) else { return }
+        guard submissionGuaranteeApplies(.notebookHasCodeCells, to: language) else {
+            reportSkippedGuarantee(.notebookHasCodeCells, language: language, filename: filename)
+            return
+        }
         guard count > 0 else {
             throw SubmissionNormalizationError.notebookHasNoCodeCells(filename)
         }

--- a/changelog.d/1354-submission-policy-wiring.md
+++ b/changelog.d/1354-submission-policy-wiring.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **The Python submission path now goes through `SubmissionPolicy` like every
+  other language.** The policy file says it is "the shared implementation of the
+  notebook guarantees, so both the Python normalizer and the generic extractor
+  enforce one standard rather than two" — but Python used a private second
+  implementation, so the exemption table governed six languages and Python
+  answered to nothing. The two agreed only by coincidence.
+- **A skipped guarantee is logged.** The policy documented that an exemption
+  "appears in the runner's structured log"; nothing logged it, so an operator
+  diagnosing a missing error could find no trace and conclude the check had run.
+  Skipping now emits `submission_guarantee_skipped` with the guarantee, the
+  language and the stated reason.
+- **The Python compatibility copy refuses a non-Python source.** Any `text/*`
+  upload classifies as a Python script, so a student who submitted
+  `solution.lua` to a Python assignment had it copied to `solution.py` and was
+  shown Python syntax errors against Lua source — under a warning claiming a
+  copy had been made "from the single detected Python source file".


### PR DESCRIPTION
Closes #1354.

`SubmissionPolicy` opens by arguing that a protocol would be the wrong shape because *"an empty method body, or an inherited default, is indistinguishable from a decision nobody made"*. The file then reproduced that failure one layer up.

**1. Python never went through the policy.** `SubmissionValidation` had two call sites, both on the generic path, while the Python normalizer enforced the same two guarantees through a private second implementation (`notebookJSONObject` / `isNotebookJSONObject`, and a bare `codeCellCount > 0`). So the exemption table governed six languages and Python answered to nothing — even though the doc says it is *"the shared implementation … so both the Python normalizer and the generic extractor enforce one standard rather than two."*

The two agreed today, which is why nothing failed. They would not have kept agreeing: a tightening of `validatedNotebook` would have reached every language but the one most submissions use, and nothing in either file said so.

**2. Exemptions were never logged.** The doc promised a skipped guarantee *"appears in the conformance test's output and in the runner's structured log"*; only the first half was true. An operator asked why an R student's empty notebook produced no error could grep the job log, find nothing, and conclude the check had run. Skipping now emits `submission_guarantee_skipped` with the guarantee, the language and the stated reason.

**3. The Python compatibility copy could promote a non-Python file.** `classify` accepts **any** `text/*` as a Python script, so a student who uploaded `solution.lua` to a Python assignment — wrong assignment, or a mis-set language on a course clone — had it copied to `solution.py` and was then shown Python syntax errors against Lua source, under a warning saying Chickadee had made the copy *"from the single detected Python source file"*.

Extensionless is still allowed: a notebook extracts to `.py`, and a bare script is genuinely ambiguous rather than wrong.

## Verification

```
✔ Test run with 73 tests in 5 suites passed
```

The existing normalizer, policy and extractor suites pass unchanged — this routes Python through the same checks it already satisfied. `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_