### PR TITLE
fix(diagnostics): prune client_diagnostics and index the session reaper sweep

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
@@ -277,6 +277,16 @@ extension OperationalDiagnosticsService {
             try await APISubmissionDiagnostics.query(on: db)
                 .filter(\.$finishedAt < jobCutoff)
                 .delete()
+            // Browser-side telemetry: one row per JS error, kernel boot failure
+            // and grading failover, each carrying a message and a stack. It was
+            // the only diagnostics table with no retention at all, while being
+            // the highest-volume endpoint the server takes — and it grows
+            // fastest during exactly the incident that makes someone read it.
+            // Same window as the rest; `idx_client_diagnostics_created_at`
+            // already covers the predicate (#1365).
+            try await APIClientDiagnostic.query(on: db)
+                .filter(\.$createdAt < jobCutoff)
+                .delete()
 
             await maintenance.markPruned(at: now)
             logger.info(

--- a/Sources/APIServer/Migrations/CreateSessionReaperIndex.swift
+++ b/Sources/APIServer/Migrations/CreateSessionReaperIndex.swift
@@ -1,0 +1,26 @@
+import Fluent
+import SQLKit
+
+/// Index for the hourly session reaper's sweep column.
+///
+/// `AddSessionsCreatedAt` gave `_fluent_sessions` a `created_at` column so
+/// `SessionReaperService` could expire sessions, but left it unindexed. That
+/// sweep runs every hour as `DELETE … WHERE created_at < cutoff` against the
+/// table with the highest read volume in the schema — every authenticated
+/// request resolves its session through it — so the reaper was scanning and
+/// locking the hottest table on the server once an hour (#1365).
+struct CreateSessionReaperIndex: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw(
+            "CREATE INDEX IF NOT EXISTS idx_fluent_sessions_created_at ON _fluent_sessions(created_at)"
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw("DROP INDEX IF EXISTS idx_fluent_sessions_created_at").run()
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -413,6 +413,10 @@ func registerMigrations(on app: Application) {
     // of. Index-only; `submissions` is created far above.
     app.migrations.add(CreateClaimPriorityIndex())
 
+    // Session reaper sweep column (#1365). Index-only, but it must follow
+    // `AddSessionsCreatedAt` above, which is what creates the column.
+    app.migrations.add(CreateSessionReaperIndex())
+
     // Data backfill, registered LAST on purpose: it full-queries `APITestSetup`,
     // which is only safe once every migration that adds a column to
     // `test_setups` has already run (the #1077 boot-order hazard, inverted —

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -486,6 +486,29 @@ import VaporTesting
         }
     }
 
+    /// `client_diagnostics` is the highest-volume endpoint the server takes and
+    /// was the one diagnostics table with no retention at all — every other one
+    /// goes through this same prune. Rows carry a message and a full JS stack,
+    /// and they arrive fastest during the incident that makes someone want to
+    /// read them, so "grows forever" and "grows fastest when it matters" were
+    /// the same table (#1365).
+    @Test func prunePassRemovesExpiredClientDiagnostics() async throws {
+        try await withApp(app) { _ in
+            let retentionDays = app.diagnostics.configuration.jobMetricRetentionDays
+            let expired = Date().addingTimeInterval(-Double(retentionDays + 5) * 86400)
+
+            let staleID = try await makeClientDiagnostic(kind: "js_error", createdAt: expired)
+            let freshID = try await makeClientDiagnostic(kind: "js_error", createdAt: Date())
+
+            await app.diagnostics.pruneNow(on: app.db, logger: app.logger)
+
+            let stale = try await APIClientDiagnostic.find(staleID, on: app.db)
+            let fresh = try await APIClientDiagnostic.find(freshID, on: app.db)
+            #expect(stale == nil)
+            #expect(fresh != nil)
+        }
+    }
+
     /// Regression test for the admin runner page showing `Total < Queue
     /// Wait`. Models the production failure mode: the runner's wall clock
     /// is offset relative to the server, so the runner-reported
@@ -665,6 +688,27 @@ import VaporTesting
         )
         try await submission.save(on: app.db)
         return (setup, submission)
+    }
+
+    /// `createdAt` is a `.create` timestamp, so it is stamped on save and then
+    /// backdated with an update — which `.create` leaves alone. `user_id`
+    /// carries a foreign key, so the row needs a real user behind it.
+    private func makeClientDiagnostic(kind: String, createdAt: Date) async throws -> UUID {
+        let user = APIUser(username: "obs-diag-\(UUID().uuidString)", passwordHash: "x", role: "user")
+        try await user.save(on: app.db)
+        let row = APIClientDiagnostic(
+            userID: try user.requireID(),
+            testSetupID: nil,
+            kind: kind,
+            failedChecks: nil,
+            userAgent: nil,
+            message: "boom",
+            stack: "at <anonymous>"
+        )
+        try await row.save(on: app.db)
+        row.createdAt = createdAt
+        try await row.update(on: app.db)
+        return try row.requireID()
     }
 
     @discardableResult

--- a/changelog.d/1365-retention-and-index-hygiene.md
+++ b/changelog.d/1365-retention-and-index-hygiene.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`client_diagnostics` is now pruned like every other diagnostics table.** It
+  takes a row per browser error, kernel boot failure and grading failover, each
+  carrying a message and a full JS stack, from what is the highest-volume
+  endpoint the server serves — and nothing ever deleted them. Every neighbouring
+  table (`job_execution_metrics`, `runner_snapshots`, `request_metrics`,
+  `submission_diagnostics`) already went through the 24-hour observability
+  prune; `client_diagnostics` now does too, on the same retention window, using
+  the index already present on `created_at`.
+- **Indexed the session reaper's sweep column.** The hourly reaper runs
+  `DELETE FROM _fluent_sessions WHERE created_at < cutoff`, but the migration
+  that added `created_at` added no index — so once an hour the reaper scanned
+  and locked the table with the highest read volume in the schema. Added
+  `idx_fluent_sessions_created_at`.


### PR DESCRIPTION
Closes #1365. Last of six PRs from the August 2026 web-server scalability audit.

Two tables that take writes on hot paths and had no retention story.

## 1. `client_diagnostics` grew forever

It takes a row per browser error, kernel boot failure and grading failover (`ClientDiagnosticsRoutes.swift:147`, `BrowserResultRoutes.swift:448-457`), each carrying a message and a full JS stack. `POST /api/v1/client-diagnostics` is **the highest-volume endpoint in production** — 40,447 calls in the last 30 days, roughly half of all measured requests.

Every neighbouring diagnostics table already goes through the 24-hour observability prune: `job_execution_metrics`, `runner_snapshots`, `request_metrics`, `submission_diagnostics`. Grepping for any delete of `APIClientDiagnostic` returned nothing — it was the one left out, and it grows fastest during exactly the incident that makes someone want to read it.

Now pruned on the same retention window, using `idx_client_diagnostics_created_at` which already exists.

## 2. The hourly session reaper scanned an unindexed column

`SessionReaperService.swift:73-75` runs `DELETE FROM _fluent_sessions WHERE created_at < cutoff` every hour. `AddSessionsCreatedAt.swift:19-21` added the column and no index — so once an hour the reaper scanned and locked the table with the highest read volume in the schema, since every authenticated request resolves its session through it.

Adds `idx_fluent_sessions_created_at`, registered after the migration that creates the column.

## Notes

- **No new configuration.** The prune reuses the existing retention window rather than adding a knob, per the standing no-new-env-vars rule.
- The other unbounded growers the audit found — submissions, results, result blobs, and per-student notebook working copies — are deliberately **not** touched here. Those hold student work, and reclaiming them is a retention-policy decision (`SubmissionRetentionService` already stages it behind course archival plus an explicit admin action), not a hygiene fix to slip into a perf PR.

## Testing

- New `prunePassRemovesExpiredClientDiagnostics` asserts an expired row is deleted and a fresh one survives. It fails on the pre-fix prune, since nothing removed the stale row.
- `ObservabilityTests`, `SessionReaperServiceTests`, `ClientDiagnosticsRoutesTests` — 38 tests, all passing. `scripts/lint.sh` and `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzT8bxgKwsSFbLCiAWz8KL)_