### PR TITLE
perf(dashboard): aggregate the student grade maps in SQL

### DIFF
--- a/Sources/APIServer/Helpers/BuiltInAchievements.swift
+++ b/Sources/APIServer/Helpers/BuiltInAchievements.swift
@@ -14,7 +14,6 @@
 // is exactly one place that defines what "Ace" or "Trailblazer" is.
 
 import Core
-import Fluent
 
 enum BuiltInAchievements {
 
@@ -138,16 +137,15 @@ enum BuiltInAchievements {
         var achievements: [Achievement] = []
     }
 
-    /// Batch `[setupID: SetupAchievementData]`; setups whose manifest can't be
-    /// decoded are absent (callers treat that as "registry defaults, nothing
-    /// disabled").
+    /// Batch `[setupID: SetupAchievementData]` over already-loaded setup rows;
+    /// setups whose manifest can't be decoded are absent (callers treat that
+    /// as "registry defaults, nothing disabled").  Takes the rows rather than
+    /// querying: the caller has already fetched the setups it is rendering,
+    /// and re-selecting them — manifest blobs included — doubled the
+    /// dashboard's setup reads on every render (#1382 item 2).
     static func achievementDataBySetup(
-        setupIDs: [String], on db: Database
-    ) async throws -> [String: SetupAchievementData] {
-        guard !setupIDs.isEmpty else { return [:] }
-        let setups = try await APITestSetup.query(on: db)
-            .filter(\.$id ~~ Set(setupIDs))
-            .all()
+        setups: [APITestSetup]
+    ) -> [String: SetupAchievementData] {
         var map: [String: SetupAchievementData] = [:]
         for setup in setups {
             guard let id = setup.id, let props = setup.decodedManifest() else { continue }

--- a/Sources/APIServer/Helpers/StudentSubmissionAggregates.swift
+++ b/Sources/APIServer/Helpers/StudentSubmissionAggregates.swift
@@ -1,0 +1,187 @@
+// APIServer/Helpers/StudentSubmissionAggregates.swift
+//
+// SQL-side aggregation for the student dashboard's per-setup maps (#1382
+// item 2). The dashboard used to load EVERY submission the student ever made
+// across the visible setups, then every result row for all of them, only to
+// fold both down to one latest pick, one count, and one best percent per
+// setup — two unbounded reads that grow monotonically all term. These
+// loaders push the folds into the database and return O(visible setups) rows.
+//
+// The grade fold mirrors `APIResult.gradePercentValue` (the #1085/#1111
+// "highest grade wins" policy, branch for branch): MAX is taken over the raw
+// per-row fraction and rounded ONCE in Swift with the same `.rounded()` the
+// accessor uses. Rounding is monotone, so max-then-round equals
+// round-then-max — the SQL never re-implements the rounding and the two
+// paths cannot disagree on a boundary like 87.5. Rows whose four grade
+// columns are all nil contribute NULL to the MAX, exactly as the
+// column-first accessor reports no grade for them.
+
+import Fluent
+import Foundation
+import SQLKit
+
+/// Per-setup submission summary for one student: the latest submission's id
+/// and the total attempt count, computed by the database rather than by
+/// materializing the full history.
+struct StudentSetupSubmissionSummary {
+    let latestSubmissionID: String
+    let submissionCount: Int
+}
+
+/// `[setupID: summary]` for the student's submissions across `setupIDs`.
+/// Latest means newest `submitted_at` (ties broken by attempt number), the
+/// same order the pre-aggregate loader sorted by.
+func studentSubmissionSummaryBySetup(
+    userID: UUID, setupIDs: [String], on db: Database
+) async throws -> [String: StudentSetupSubmissionSummary] {
+    guard !setupIDs.isEmpty else { return [:] }
+    guard let sql = db as? SQLDatabase else {
+        return try await studentSubmissionSummaryBySetupViaFluent(
+            userID: userID, setupIDs: setupIDs, on: db)
+    }
+    struct SummaryRow: Decodable {
+        let testSetupID: String
+        let id: String
+        let total: Int
+        enum CodingKeys: String, CodingKey {
+            case testSetupID = "test_setup_id"
+            case id
+            case total
+        }
+    }
+    let rows = try await sql.raw(
+        """
+        SELECT test_setup_id, id, total FROM (
+            SELECT test_setup_id, id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY test_setup_id
+                    ORDER BY submitted_at DESC, attempt_number DESC
+                ) AS rn,
+                COUNT(*) OVER (PARTITION BY test_setup_id) AS total
+            FROM \(unsafeRaw: APISubmission.schema)
+            WHERE user_id = \(bind: userID)
+              AND kind = \(bind: APISubmission.Kind.student)
+              AND test_setup_id IN (\(binds: setupIDs))
+        ) ranked
+        WHERE rn = 1
+        """
+    ).all(decoding: SummaryRow.self)
+    return rows.reduce(into: [:]) {
+        $0[$1.testSetupID] = StudentSetupSubmissionSummary(
+            latestSubmissionID: $1.id, submissionCount: $1.total)
+    }
+}
+
+/// The highest grade percent per setup across every result of every student
+/// submission — `bestGradePercent(of:)` pushed into SQL. Setups with no
+/// gradeable result are absent from the map, and so is a best of exactly 0:
+/// the fold this replaces only admitted a grade when it exceeded the 0
+/// sentinel, so an all-fail student shows no grade rather than "0%" — kept
+/// bit-for-bit so the rewrite is invisible.
+func studentBestGradePercentBySetup(
+    userID: UUID, setupIDs: [String], on db: Database
+) async throws -> [String: Int] {
+    guard !setupIDs.isEmpty else { return [:] }
+    guard let sql = db as? SQLDatabase else {
+        return try await studentBestGradePercentBySetupViaFluent(
+            userID: userID, setupIDs: setupIDs, on: db)
+    }
+    struct BestRow: Decodable {
+        let testSetupID: String
+        let bestFraction: Double?
+        enum CodingKeys: String, CodingKey {
+            case testSetupID = "test_setup_id"
+            case bestFraction = "best_fraction"
+        }
+    }
+    // CAST(... AS DOUBLE PRECISION) resolves to an 8-byte IEEE double on both
+    // dialects (SQLite's "DOUB" affinity rule), and the operand order matches
+    // the accessor's `Double(pass) / Double(total) * 100` exactly, so the SQL
+    // fraction is bit-identical to the Swift one.
+    let rows = try await sql.raw(
+        """
+        SELECT s.test_setup_id AS test_setup_id,
+            MAX(CASE
+                WHEN r.total_points > 0 AND r.earned_points IS NOT NULL
+                    THEN r.earned_points / r.total_points * 100
+                WHEN r.total_tests > 0 AND r.pass_count IS NOT NULL
+                    THEN CAST(r.pass_count AS DOUBLE PRECISION)
+                        / CAST(r.total_tests AS DOUBLE PRECISION) * 100
+            END) AS best_fraction
+        FROM \(unsafeRaw: APIResult.schema) r
+        INNER JOIN \(unsafeRaw: APISubmission.schema) s ON s.id = r.submission_id
+        WHERE s.user_id = \(bind: userID)
+          AND s.kind = \(bind: APISubmission.Kind.student)
+          AND s.test_setup_id IN (\(binds: setupIDs))
+        GROUP BY s.test_setup_id
+        """
+    ).all(decoding: BestRow.self)
+    var best: [String: Int] = [:]
+    for row in rows {
+        guard let fraction = row.bestFraction else { continue }
+        let percent = Int(fraction.rounded())
+        if percent > 0 { best[row.testSetupID] = percent }
+    }
+    return best
+}
+
+// MARK: - Non-SQL fallbacks
+//
+// Not hit by the sqlite/postgres drivers in use; they load the rows and run
+// the identical folds in Swift.
+
+private func studentSubmissionSummaryBySetupViaFluent(
+    userID: UUID, setupIDs: [String], on db: Database
+) async throws -> [String: StudentSetupSubmissionSummary] {
+    let rows = try await APISubmission.query(on: db)
+        .filter(\.$userID == userID)
+        .filter(\.$testSetupID ~~ setupIDs)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .sort(\.$submittedAt, .descending)
+        .sort(\.$attemptNumber, .descending)
+        .field(\.$id)
+        .field(\.$testSetupID)
+        .all()
+    var summary: [String: StudentSetupSubmissionSummary] = [:]
+    for row in rows {
+        guard let id = row.id else { continue }
+        if let existing = summary[row.testSetupID] {
+            summary[row.testSetupID] = StudentSetupSubmissionSummary(
+                latestSubmissionID: existing.latestSubmissionID,
+                submissionCount: existing.submissionCount + 1)
+        } else {
+            summary[row.testSetupID] = StudentSetupSubmissionSummary(
+                latestSubmissionID: id, submissionCount: 1)
+        }
+    }
+    return summary
+}
+
+private func studentBestGradePercentBySetupViaFluent(
+    userID: UUID, setupIDs: [String], on db: Database
+) async throws -> [String: Int] {
+    let submissions = try await APISubmission.query(on: db)
+        .filter(\.$userID == userID)
+        .filter(\.$testSetupID ~~ setupIDs)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .field(\.$id)
+        .field(\.$testSetupID)
+        .all()
+    var setupBySubmissionID: [String: String] = [:]
+    for submission in submissions {
+        guard let id = submission.id else { continue }
+        setupBySubmissionID[id] = submission.testSetupID
+    }
+    guard !setupBySubmissionID.isEmpty else { return [:] }
+    let results = try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ Array(setupBySubmissionID.keys))
+        .all()
+    var best: [String: Int] = [:]
+    for row in results {
+        guard let setupID = setupBySubmissionID[row.submissionID],
+            let pct = row.gradePercentValue
+        else { continue }
+        if pct > (best[setupID] ?? 0) { best[setupID] = pct }
+    }
+    return best
+}

--- a/Sources/APIServer/Routes/Web/WebRoutes+IndexRows.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+IndexRows.swift
@@ -71,9 +71,13 @@ struct IndexRowContext {
 
 extension WebRoutes {
 
-    /// Loads the viewer's grade/submission/badge maps for the dashboard —
-    /// overrides + submissions concurrently, then the result/achievement
-    /// phase (`applyResultDerivedData`).
+    /// Loads the viewer's grade/submission/badge maps for the dashboard.
+    /// The overrides, the per-setup submission summary (latest pick + count),
+    /// and the best-grade fold are independent reads and run concurrently;
+    /// the summary and the fold are SQL aggregates (#1382 item 2 — this used
+    /// to load every submission and every result the student ever made across
+    /// the visible setups and fold them in Swift, two unbounded reads that
+    /// grew all term).
     static func loadStudentDashboardGradeData(
         req: Request, user: APIUser, setups: [APITestSetup], fmt: DateFormatter
     ) async throws -> DashboardGradeData {
@@ -83,90 +87,82 @@ extension WebRoutes {
         guard !setupIDs.isEmpty else { return data }
 
         // Instructor grade overrides for this student take precedence over
-        // the runner-computed best grade.  The override and submission reads
-        // are independent and run concurrently.
+        // the runner-computed best grade.
         async let overridesFetch = loadGradeOverridePercents(setupIDs: setupIDs, on: req.db)
-        async let submissionsFetch = APISubmission.query(on: req.db)
-            .filter(\.$userID == userID)
-            .filter(\.$testSetupID ~~ setupIDs)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .sort(\.$submittedAt, .descending)
-            .all()
+        async let summaryFetch = studentSubmissionSummaryBySetup(
+            userID: userID, setupIDs: setupIDs, on: req.db)
+        async let bestGradeFetch = studentBestGradePercentBySetup(
+            userID: userID, setupIDs: setupIDs, on: req.db)
+
         let overrideMap = try await overridesFetch
         for setupID in setupIDs {
             if let pct = overrideMap[GradeOverrideKey(setupID: setupID, userID: userID)] {
                 data.overridePercentBySetupID[setupID] = pct
             }
         }
-        let submissions = try await submissionsFetch
+        let summaryBySetup = try await summaryFetch
+        data.bestGradePercentBySetupID = try await bestGradeFetch
 
-        var grouped: [String: [APISubmission]] = [:]
-        for submission in submissions {
-            grouped[submission.testSetupID, default: []].append(submission)
-        }
-        for (setupID, items) in grouped {
-            data.submissionCountBySetupID[setupID] = items.count
-            if let latest = items.first {
-                let when = latest.submittedAt.map { fmt.string(from: $0) } ?? "—"
-                data.latestSubmissionBySetupID[setupID] = LatestSubmissionItem(
-                    submissionID: latest.id ?? "",
-                    submittedAtText: when
-                )
-            }
+        // The latest submission per setup, refetched as O(setups) full rows
+        // for their timestamps and attempt numbers.
+        let latestIDs = summaryBySetup.values.map(\.latestSubmissionID)
+        let latestRows =
+            latestIDs.isEmpty
+            ? []
+            : try await APISubmission.query(on: req.db)
+                .filter(\.$id ~~ latestIDs)
+                .all()
+        let latestRowByID = Dictionary(
+            latestRows.compactMap { row in row.id.map { ($0, row) } },
+            uniquingKeysWith: { first, _ in first })
+        var latestRowBySetupID: [String: APISubmission] = [:]
+        for (setupID, summary) in summaryBySetup {
+            data.submissionCountBySetupID[setupID] = summary.submissionCount
+            guard let latest = latestRowByID[summary.latestSubmissionID] else { continue }
+            latestRowBySetupID[setupID] = latest
+            data.latestSubmissionBySetupID[setupID] = LatestSubmissionItem(
+                submissionID: summary.latestSubmissionID,
+                submittedAtText: latest.submittedAt.map { fmt.string(from: $0) } ?? "—"
+            )
         }
 
         try await applyResultDerivedData(
-            req: req, userID: userID, setupIDs: setupIDs,
-            submissions: submissions, grouped: grouped, data: &data)
+            req: req, userID: userID, setups: setups,
+            latestRowBySetupID: latestRowBySetupID, data: &data)
         return data
     }
 
-    /// The result-derived phase of the grade-data load: best grade per setup
-    /// ("highest grade wins", #1111), latest-submission badges, and the class
-    /// badges this user holds.  No-op when the student has no submissions.
+    /// The result-derived phase of the grade-data load: latest-submission
+    /// badges and the class badges this user holds.  Reads results only for
+    /// the latest submission per setup plus its prior attempt (the Rally
+    /// badge's grade-jump input) — never the full history (#1382 item 2).
+    /// No-op when the student has no submissions.
     private static func applyResultDerivedData(
-        req: Request, userID: UUID, setupIDs: [String],
-        submissions: [APISubmission], grouped: [String: [APISubmission]],
+        req: Request, userID: UUID, setups: [APITestSetup],
+        latestRowBySetupID: [String: APISubmission],
         data: inout DashboardGradeData
     ) async throws {
-        let submissionIDs = submissions.compactMap(\.id)
-        guard !submissionIDs.isEmpty else { return }
-        // Results plus the three achievement reads only share inputs computed
-        // by the caller, so all four run concurrently.
-        async let resultsFetch = APIResult.query(on: req.db)
-            .filter(\.$submissionID ~~ submissionIDs)
-            .sort(\.$receivedAt, .descending)
-            .all()
-        async let achievementFetch = BuiltInAchievements.achievementDataBySetup(
-            setupIDs: setupIDs, on: req.db)
-        // Class-wide badges this user currently holds across all setups.
+        guard !latestRowBySetupID.isEmpty else { return }
+        let setupIDs = setups.compactMap(\.id)
+        // Class-wide badges this user currently holds across all setups; runs
+        // concurrently with the prior-attempt and result fetches below.
         async let classAchievementsFetch = APIClassAchievement.query(on: req.db)
             .filter(\.$userID == userID)
             .filter(\.$testSetupID ~~ setupIDs)
             .all()
-        let resultRows = try await resultsFetch
+        let achievementBySetup = BuiltInAchievements.achievementDataBySetup(setups: setups)
+        let priorBySetupID = try await loadPriorAttemptRows(
+            req: req, userID: userID, latestRowBySetupID: latestRowBySetupID)
 
-        // Best grade percentage per submission across ALL result sources —
-        // the shared "highest grade wins" fold applied to the rows we
-        // already fetched (#1111).
-        var resultsBySubmissionID: [String: [APIResult]] = [:]
-        for row in resultRows {
-            resultsBySubmissionID[row.submissionID, default: []].append(row)
-        }
-        let bestPercentBySubmissionID =
-            resultsBySubmissionID
-            .compactMapValues { bestGradePercent(of: $0) }
+        // Results for the latest + prior submissions only, newest-first (the
+        // worker-first preference depends on that order).
+        var interestingIDs = latestRowBySetupID.values.compactMap(\.id)
+        interestingIDs.append(contentsOf: priorBySetupID.values.compactMap(\.id))
+        let resultRows = try await APIResult.query(on: req.db)
+            .filter(\.$submissionID ~~ interestingIDs)
+            .sort(\.$receivedAt, .descending)
+            .all()
         let preferredResultBySubmissionID = preferredResultsWorkerFirst(resultRows)
-
-        for submission in submissions {
-            guard let subID = submission.id,
-                let gradePercent = bestPercentBySubmissionID[subID]
-            else { continue }
-            let setupID = submission.testSetupID
-            if gradePercent > (data.bestGradePercentBySetupID[setupID] ?? 0) {
-                data.bestGradePercentBySetupID[setupID] = gradePercent
-            }
-        }
 
         // Badge evaluation needs the collection (executionTimeMs) for each
         // LATEST submission's preferred result only — batch-fetch just those
@@ -180,10 +176,11 @@ extension WebRoutes {
             collectionByResultID: latestBlobs.compactMapValues(decodedCollection(from:))
         )
 
-        let achievementBySetup = try await achievementFetch
         for (setupID, latest) in data.latestSubmissionBySetupID {
+            guard let latestRow = latestRowBySetupID[setupID] else { continue }
             if let badges = latestSubmissionBadges(
-                setupID: setupID, latest: latest, grouped: grouped,
+                latestRow: latestRow, latest: latest,
+                priorRow: priorBySetupID[setupID],
                 badgeResults: badgeResults,
                 perSubmission: achievementBySetup[setupID]?.perSubmission,
                 disabled: achievementBySetup[setupID]?.disabled ?? [])
@@ -202,6 +199,39 @@ extension WebRoutes {
                 data.latestBadgesBySetupID[ach.testSetupID, default: []].append(badge)
             }
         }
+    }
+
+    /// The newest submission at attempt (latest − 1) per setup — the Rally
+    /// badge's prior-grade input — fetched as one bounded OR-group query in
+    /// place of the full-history load it used to be picked from.
+    private static func loadPriorAttemptRows(
+        req: Request, userID: UUID,
+        latestRowBySetupID: [String: APISubmission]
+    ) async throws -> [String: APISubmission] {
+        let priorPairs: [(setupID: String, attempt: Int)] = latestRowBySetupID.compactMap { entry in
+            let latestAttempt = entry.value.attemptNumber ?? 1
+            guard latestAttempt >= 2 else { return nil }
+            return (entry.key, latestAttempt - 1)
+        }
+        guard !priorPairs.isEmpty else { return [:] }
+        let priorRows = try await APISubmission.query(on: req.db)
+            .filter(\.$userID == userID)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .group(.or) { or in
+                for pair in priorPairs {
+                    or.group(.and) { and in
+                        and.filter(\.$testSetupID == pair.setupID)
+                        and.filter(\.$attemptNumber == pair.attempt)
+                    }
+                }
+            }
+            .sort(\.$submittedAt, .descending)
+            .all()
+        var priorBySetupID: [String: APISubmission] = [:]
+        for row in priorRows where priorBySetupID[row.testSetupID] == nil {
+            priorBySetupID[row.testSetupID] = row
+        }
+        return priorBySetupID
     }
 
     /// One preferred result per submission, worker-first — the browser result
@@ -237,27 +267,25 @@ extension WebRoutes {
     /// The per-submission badges for one setup's latest submission, or nil
     /// when it has no decodable graded result.
     private static func latestSubmissionBadges(
-        setupID: String,
+        latestRow: APISubmission,
         latest: LatestSubmissionItem,
-        grouped: [String: [APISubmission]],
+        priorRow: APISubmission?,
         badgeResults: BadgeResultData,
         perSubmission: [Achievement]?,
         disabled: Set<String>
     ) -> [AchievementBadge]? {
         guard
-            let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
             let result = badgeResults.preferredResultBySubmissionID[latest.submissionID],
             let resultID = result.id,
             let collection = badgeResults.collectionByResultID[resultID],
             let gradePercent = gradePercent(from: collection)
         else { return nil }
-        let latestAttempt = latestSubmission.attemptNumber ?? 1
-        let priorSub = grouped[setupID]?.first(where: { $0.attemptNumber == latestAttempt - 1 })
-        let priorGradePercent: Int? = priorSub.flatMap { ps in
-            guard let psID = ps.id,
-                let pr = badgeResults.preferredResultBySubmissionID[psID]
+        let latestAttempt = latestRow.attemptNumber ?? 1
+        let priorGradePercent: Int? = priorRow.flatMap { prior in
+            guard let priorID = prior.id,
+                let priorResult = badgeResults.preferredResultBySubmissionID[priorID]
             else { return nil }
-            return pr.gradePercentValue
+            return priorResult.gradePercentValue
         }
         return AchievementBadge.forSubmission(
             BadgeContext(

--- a/Tests/APITests/StudentSubmissionAggregatesTests.swift
+++ b/Tests/APITests/StudentSubmissionAggregatesTests.swift
@@ -1,0 +1,193 @@
+// Tests/APITests/StudentSubmissionAggregatesTests.swift
+//
+// Direct tests for the dashboard's SQL-side aggregation (#1382 item 2):
+// latest-pick + count, the best-percent fold (both grade branches, the
+// half-away-from-zero boundary, the nil-columns row), and the scoping rules
+// (other users, validation runs, out-of-scope setups). These run the real
+// SQL on whichever driver the suite is configured for — SQLite in the
+// default lane, Postgres in api-tests-postgres.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct StudentSubmissionAggregatesTests {
+
+    @Test func summaryPicksLatestAndCountsPerSetup() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            _ = try await loginUser(
+                username: "student2", password: "pass", role: "student", on: app)
+            let other = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "student2").first())
+            let otherID = try other.requireID()
+
+            try await wrInsertSetup(id: "agg_a", on: app)
+            try await wrInsertSetup(id: "agg_b", on: app)
+            try await wrInsertSubmission(
+                id: "agg_a1", testSetupID: "agg_a", userID: userID, attemptNumber: 1, on: app)
+            try await wrInsertSubmission(
+                id: "agg_a2", testSetupID: "agg_a", userID: userID, attemptNumber: 2, on: app)
+            try await wrInsertSubmission(
+                id: "agg_b1", testSetupID: "agg_b", userID: userID, attemptNumber: 1, on: app)
+            // Noise the aggregate must ignore: another user's attempt, a
+            // validation run, and a setup outside the requested scope.
+            try await wrInsertSubmission(
+                id: "agg_other", testSetupID: "agg_a", userID: otherID, attemptNumber: 1, on: app)
+            let validation = APISubmission(
+                id: "agg_validation", testSetupID: "agg_a",
+                zipPath: app.submissionsDirectory + "agg_validation.py",
+                attemptNumber: 3, userID: userID, kind: APISubmission.Kind.validation)
+            try await validation.save(on: app.db)
+            try await wrInsertSetup(id: "agg_out", on: app)
+            try await wrInsertSubmission(
+                id: "agg_out1", testSetupID: "agg_out", userID: userID, attemptNumber: 1, on: app)
+
+            let summary = try await studentSubmissionSummaryBySetup(
+                userID: userID, setupIDs: ["agg_a", "agg_b"], on: app.db)
+
+            #expect(summary.count == 2)
+            #expect(summary["agg_a"]?.latestSubmissionID == "agg_a2")
+            #expect(summary["agg_a"]?.submissionCount == 2)
+            #expect(summary["agg_b"]?.latestSubmissionID == "agg_b1")
+            #expect(summary["agg_b"]?.submissionCount == 1)
+        }
+    }
+
+    @Test func summaryIsEmptyForNoSetupsOrNoSubmissions() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+
+            let empty = try await studentSubmissionSummaryBySetup(
+                userID: userID, setupIDs: [], on: app.db)
+            #expect(empty.isEmpty)
+
+            try await wrInsertSetup(id: "agg_none", on: app)
+            let none = try await studentSubmissionSummaryBySetup(
+                userID: userID, setupIDs: ["agg_none"], on: app.db)
+            #expect(none.isEmpty)
+        }
+    }
+
+    @Test func bestPercentTakesMaxAcrossAttemptsAndSources() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+
+            try await wrInsertSetup(id: "agg_best", on: app)
+            try await wrInsertSubmission(
+                id: "agg_best1", testSetupID: "agg_best", userID: userID, attemptNumber: 1, on: app)
+            // Browser result 3/4 = 75%, worker regrade 1/4 = 25%: best is 75.
+            try await wrInsertResult(
+                submissionID: "agg_best1",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .pass),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                ],
+                source: "browser", on: app)
+            try await wrInsertResult(
+                submissionID: "agg_best1",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .fail),
+                    wrMakeOutcome(name: "t3", status: .fail),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                ],
+                source: "worker", on: app)
+            // A second attempt at 2/4 = 50% must not displace attempt 1's 75.
+            try await wrInsertSubmission(
+                id: "agg_best2", testSetupID: "agg_best", userID: userID, attemptNumber: 2, on: app)
+            try await wrInsertResult(
+                submissionID: "agg_best2",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .fail),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                ], on: app)
+
+            let best = try await studentBestGradePercentBySetup(
+                userID: userID, setupIDs: ["agg_best"], on: app.db)
+            #expect(best == ["agg_best": 75])
+        }
+    }
+
+    @Test func bestPercentPrefersWeightedBranchAndRoundsHalfAwayFromZero() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+
+            try await wrInsertSetup(id: "agg_weighted", on: app)
+            try await wrInsertSubmission(
+                id: "agg_w1", testSetupID: "agg_weighted", userID: userID, attemptNumber: 1, on: app)
+            // Weighted 7/8 points = 87.5 → rounds to 88, and the weighted
+            // branch wins over the row's own 1/4 pass count (25%).
+            let weighted = APIResult(id: "agg_res_w", submissionID: "agg_w1", source: "worker")
+            try await weighted.saveWithCollection(
+                json: #"{"submissionID":"agg_w1","earnedPoints":7,"totalPoints":8,"passCount":1,"totalTests":4}"#,
+                on: app.db)
+
+            let best = try await studentBestGradePercentBySetup(
+                userID: userID, setupIDs: ["agg_weighted"], on: app.db)
+            #expect(best == ["agg_weighted": 88])
+        }
+    }
+
+    @Test func bestPercentOmitsAnAllFailZero() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+
+            try await wrInsertSetup(id: "agg_zero", on: app)
+            try await wrInsertSubmission(
+                id: "agg_z1", testSetupID: "agg_zero", userID: userID, attemptNumber: 1, on: app)
+            try await wrInsertResult(
+                submissionID: "agg_z1",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .fail),
+                    wrMakeOutcome(name: "t2", status: .fail),
+                ], on: app)
+
+            // A best of exactly 0 stays out of the map — the pre-aggregate
+            // fold only admitted a grade above its 0 sentinel, so an all-fail
+            // student shows no grade rather than "0%".
+            let best = try await studentBestGradePercentBySetup(
+                userID: userID, setupIDs: ["agg_zero"], on: app.db)
+            #expect(best.isEmpty)
+        }
+    }
+
+    @Test func bestPercentSkipsRowsWithNoGradeColumns() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+
+            try await wrInsertSetup(id: "agg_nograde", on: app)
+            try await wrInsertSubmission(
+                id: "agg_ng1", testSetupID: "agg_nograde", userID: userID, attemptNumber: 1, on: app)
+            // A result whose blob carries no parseable grade leaves all four
+            // columns nil; the fold reports no grade, matching
+            // `APIResult.gradePercentValue`.
+            let ungraded = APIResult(id: "agg_res_ng", submissionID: "agg_ng1", source: "worker")
+            try await ungraded.saveWithCollection(json: "not json", on: app.db)
+
+            let best = try await studentBestGradePercentBySetup(
+                userID: userID, setupIDs: ["agg_nograde"], on: app.db)
+            #expect(best.isEmpty)
+        }
+    }
+}

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -542,6 +542,240 @@ import VaporTesting
         }
     }
 
+    // MARK: - Grade-data fold pins (#1382 item 2)
+    //
+    // These pin the VALUES the dashboard derives from submissions + results —
+    // best-across-attempts, best-across-sources, the latest-submission pick,
+    // the history count, the weighted-grade rounding, and the prior-attempt
+    // badge input — so a rewrite of `loadStudentDashboardGradeData` cannot
+    // change a fold's meaning without a test noticing.
+
+    @Test func indexShowsBestGradeAcrossAttemptsWithLatestLinkAndCount() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_multi", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_multi", title: "Multi Attempt", isOpen: true, on: app)
+            // Attempt 1: 3/5 = 60%.  Attempt 2 (the best): 4/5 = 80%.
+            // Attempt 3 (the latest): 1/5 = 20%.
+            try await wrInsertSubmission(
+                id: "sub_ma1", testSetupID: "setup_multi", userID: userID, attemptNumber: 1, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_ma1",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .pass),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                    wrMakeOutcome(name: "t5", status: .fail),
+                ], on: app)
+            try await wrInsertSubmission(
+                id: "sub_ma2", testSetupID: "setup_multi", userID: userID, attemptNumber: 2, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_ma2",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .pass),
+                    wrMakeOutcome(name: "t4", status: .pass),
+                    wrMakeOutcome(name: "t5", status: .fail),
+                ], on: app)
+            try await wrInsertSubmission(
+                id: "sub_ma3", testSetupID: "setup_multi", userID: userID, attemptNumber: 3, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_ma3",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .fail),
+                    wrMakeOutcome(name: "t3", status: .fail),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                    wrMakeOutcome(name: "t5", status: .fail),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains("<strong>80%</strong>"),
+                        "Best grade is the max across ALL attempts, not the latest one")
+                    #expect(
+                        !html.contains("<strong>20%</strong>"),
+                        "The latest attempt's lower grade must not displace the best")
+                    #expect(
+                        html.contains(#"/submissions/sub_ma3" class="submission-history-latest""#),
+                        "The latest-submission link points at the newest attempt")
+                    #expect(
+                        html.contains("+2 more"),
+                        "The history link counts every prior attempt")
+                })
+        }
+    }
+
+    @Test func indexShowsBestGradeAcrossSourcesWithinOneSubmission() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_sources", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_sources", title: "Sourced", isOpen: true, on: app)
+            try await wrInsertSubmission(
+                id: "sub_src", testSetupID: "setup_sources", userID: userID, on: app)
+            // Worker regrade at 50% must not displace the browser 75% —
+            // "highest grade wins" across every result source (#1111).
+            try await wrInsertResult(
+                submissionID: "sub_src",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .pass),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                ],
+                source: "browser", on: app)
+            try await wrInsertResult(
+                submissionID: "sub_src",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .fail),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                ],
+                source: "worker", on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.body.string.contains("<strong>75%</strong>"),
+                        "A browser result's higher grade survives a lower worker regrade")
+                })
+        }
+    }
+
+    @Test func indexShowsWeightedGradeRoundedHalfAwayFromZero() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_weighted", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_weighted", title: "Weighted", isOpen: true, on: app)
+            try await wrInsertSubmission(
+                id: "sub_w1", testSetupID: "setup_weighted", userID: userID, on: app)
+            // Weighted branch, on a rounding boundary: 7/8 points = 87.5 → 88%.
+            let result = APIResult(id: "res_weighted", submissionID: "sub_w1", source: "worker")
+            try await result.saveWithCollection(
+                json: #"{"submissionID":"sub_w1","earnedPoints":7,"totalPoints":8}"#, on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.body.string.contains("<strong>88%</strong>"),
+                        "Weighted grades round half away from zero: 87.5 → 88")
+                })
+        }
+    }
+
+    @Test func indexShowsNoGradeForAllFailSubmission() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_zero", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_zero", title: "Zero Lab", isOpen: true, on: app)
+            try await wrInsertSubmission(
+                id: "sub_zero", testSetupID: "setup_zero", userID: userID, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_zero",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .fail),
+                    wrMakeOutcome(name: "t2", status: .fail),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        !res.body.string.contains("<strong>0%</strong>"),
+                        "A best grade of exactly 0 renders no grade, not \"0%\" — the fold only admits a grade above the 0 sentinel"
+                    )
+                })
+        }
+    }
+
+    @Test func indexShowsRallyBadgeForGradeJumpOverPriorAttempt() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_rally", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_rally", title: "Rally Lab", isOpen: true, on: app)
+            // Attempt 1 at 40%, attempt 2 at 100%: a 60-point jump earns Rally,
+            // which reads the PRIOR attempt's preferred result.
+            try await wrInsertSubmission(
+                id: "sub_rally1", testSetupID: "setup_rally", userID: userID, attemptNumber: 1, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_rally1",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .fail),
+                    wrMakeOutcome(name: "t4", status: .fail),
+                    wrMakeOutcome(name: "t5", status: .fail),
+                ], on: app)
+            try await wrInsertSubmission(
+                id: "sub_rally2", testSetupID: "setup_rally", userID: userID, attemptNumber: 2, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_rally2",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .pass),
+                    wrMakeOutcome(name: "t2", status: .pass),
+                    wrMakeOutcome(name: "t3", status: .pass),
+                    wrMakeOutcome(name: "t4", status: .pass),
+                    wrMakeOutcome(name: "t5", status: .pass),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.body.string.contains("Rally"),
+                        "A ≥50-point jump over the prior attempt earns the Rally badge")
+                })
+        }
+    }
+
     // MARK: - Unenrolled admin scoping
 
     /// An admin who is not enrolled in any course is an *administrator*, not a

--- a/changelog.d/dashboard-sql-aggregates.md
+++ b/changelog.d/dashboard-sql-aggregates.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **The student dashboard no longer loads the full submission history to render.**
+  The per-setup grade/submission maps are now computed by the database — a
+  window-function pick for the latest submission + attempt count, and a
+  `MAX` over the same grade fraction `gradePercentValue` reads for the best
+  grade — instead of materializing every submission and every result the
+  student ever made and folding them in Swift, two reads that grew all term
+  (#1382 item 2). Badge evaluation now fetches results only for the latest
+  and prior attempt per assignment, and the achievements helper reuses the
+  setup rows the dashboard already loaded rather than re-selecting them,
+  manifest blobs included.


### PR DESCRIPTION
Item 2 of the #1382 scalability-audit handover — the first of the suggested-order picks (items 2, 3, 5).

## What was wrong

`loadStudentDashboardGradeData` loaded **every submission the student ever made** across the visible setups (`WebRoutes+IndexRows.swift:89`), then **every result row for all of those submissions** (`:136`) — both unbounded, both growing monotonically all term, on the most-hit authenticated page. `BuiltInAchievements.achievementDataBySetup` then re-`SELECT`ed the same `test_setups` rows (manifest blobs included) the dashboard had already loaded, on every render.

## What changed

- **New `StudentSubmissionAggregates.swift`**: two SQL aggregates returning O(visible setups) rows.
  - Latest submission + attempt count per setup via `ROW_NUMBER()` / `COUNT(*) OVER (PARTITION BY test_setup_id)`, using the existing `idx_submissions_setup_user_kind_submitted_at` index.
  - Best grade per setup via a JOIN + `MAX` over a CASE that mirrors `APIResult.gradePercentValue` branch for branch. The MAX is taken over the **raw fraction** and rounded once in Swift with the accessor's own `.rounded()` — rounding is monotone, so max-then-round equals round-then-max and the SQL never re-implements the rounding policy (no drift on boundaries like 87.5).
  - A best of exactly **0 stays absent** from the map: the old fold only admitted a grade above its `?? 0` sentinel, so an all-fail student shows no grade rather than "0%". Kept bit-for-bit and pinned by tests.
  - Portable SQL (`CAST(… AS DOUBLE PRECISION)` hits SQLite's `DOUB` affinity rule), so both the sqlite lane and `api-tests-postgres` exercise the real queries; Fluent fallbacks cover the (unused) non-SQL driver, matching the repo pattern.
- **Badge evaluation is bounded**: results are fetched only for the latest submission per setup plus its prior attempt (the Rally badge's grade-jump input), via one OR-group query — never the full history. The worker-first preference fold is unchanged code over the restricted set.
- **`achievementDataBySetup(setups:)`** now takes the already-loaded setup rows instead of querying; the async DB variant is gone (it had exactly one caller).

## How it's verified

Per the handover's warning ("add assertions for the grade/attempt values before refactoring"), the fold semantics were pinned **first** and the pins verified green against the pre-aggregate loader, then re-run against this change:

- Dashboard render pins: best-across-attempts (80% survives a later 20%), best-across-sources (#1111 — browser 75% survives a worker 50% regrade), the latest-submission link, the "+2 more" history count, weighted 87.5 → 88 rounding, the Rally prior-attempt input, and the 0%-renders-nothing sentinel.
- Direct loader tests (`StudentSubmissionAggregatesTests`): latest pick + counts with noise rows (other users, validation runs, out-of-scope setups), max across attempts and sources, the weighted-branch preference, the 87.5 boundary, nil-grade-column rows, and the 0 omission.

50 tests across the dashboard/grade suites pass locally; `format.sh` / `lint.sh` / `swiftlint.sh --strict` are clean. One fragment added under `changelog.d/`.

Closes nothing on its own — #1382 stays open for the remaining items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZvhhypNNTqMGV55BKEEhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZvhhypNNTqMGV55BKEEhH)_