### PR TITLE
fix(runner): ask the language for its exec-probe program, and test the probe

### DIFF
--- a/Sources/APIServer/Utilities/TestScriptTemplates.swift
+++ b/Sources/APIServer/Utilities/TestScriptTemplates.swift
@@ -201,10 +201,21 @@ func shellTestScript(type: ShellTestTemplateType, language: AssignmentLanguage?)
 /// The shell lines that run the submission and leave its output in `$ACTUAL`.
 ///
 /// Three shapes. The two language ones are chosen by
-/// `capabilityRequiresExecutableOutput` — the fact that already means "grading
-/// this language builds something before running it". Asking it here rather
-/// than switching on `.cpp` keeps the one judgement in one place; a seventh
-/// compiled language gets the compile form for free.
+/// `capabilityRequiresExecutableOutput`, which is asked here rather than
+/// switching on `.cpp` — but note what that fact actually means, because the
+/// comment here used to overstate it. It means "grading EXECS a file it just
+/// produced", which is true of C++ alone: Java is compiled too, and answers
+/// `false`, because its `.class` files are READ by the JVM and `noexec` cannot
+/// bite them. So Java takes the interpreted branch, where `java solution.java`
+/// works only by single-file source mode and breaks the moment a submission
+/// needs a second file.
+///
+/// A future compiled language therefore does NOT "get the compile form for
+/// free" — it gets whichever branch its exec answer happens to select. Making
+/// this correct needs a fact meaning "grading builds before running", which is
+/// a different question from the one `capabilityRequiresExecutableOutput`
+/// exists to answer (see #1352); it is left as one fact rather than guessed
+/// at here.
 ///
 /// The third is for an assignment that declares no language, where there is no
 /// interpreter to name and guessing `python3` would be a guess the author has
@@ -235,7 +246,7 @@ private func runSubmissionShellFragment(
         return #"ACTUAL=$(\#(interpreter) \#(solutionFile) 2>&1)"#
     }
     return """
-        \(interpreter) -O2 -o ./ck_solution \(solutionFile) || { echo "Compilation failed" >&2; exit 2; }
+        \(interpreter) -std=c++20 -O2 -o ./ck_solution \(solutionFile) || { echo "Compilation failed" >&2; exit 2; }
         ACTUAL=$(./ck_solution 2>&1)
         """
 }

--- a/Sources/Worker/RunnerProfileDetector.swift
+++ b/Sources/Worker/RunnerProfileDetector.swift
@@ -46,7 +46,8 @@ struct RunnerProfileDetector {
                     // runner that can genuinely grade it, which is what the
                     // gate is for.
                     if language.descriptor.capabilityRequiresExecutableOutput,
-                        await !canExecuteCompiledOutput(compiler: probe.command)
+                        await !canExecuteCompiledOutput(
+                            language: language, compiler: probe.command)
                     {
                         return nil
                     }
@@ -125,16 +126,49 @@ struct RunnerProfileDetector {
         return firstNumericVersion(in: output)
     }
 
-    /// Compiles a trivial program into the runner's work root and runs it,
-    /// mirroring what a generated C++ wrapper does (compile into the working
-    /// directory, then `exec` the binary).
+    /// The trivial program whose compilation proves this language can produce a
+    /// runnable binary here, or nil when the language never produces one.
+    ///
+    /// EXHAUSTIVE, so an eighth language that sets
+    /// `capabilityRequiresExecutableOutput` cannot reach the probe without
+    /// supplying a program. The probe used to hardcode `probe.cpp` and
+    /// `int main(void)` — correct while C++ was the only such language, and a
+    /// silent failure for the next one: the C++ source would be handed to a
+    /// different compiler, fail, and the language would never be advertised,
+    /// so its jobs would queue forever with no error. That is the WORSE
+    /// direction of the capability gate.
+    static func execProbeProgram(
+        for language: AssignmentLanguage
+    ) -> (
+        filename: String, source: String
+    )? {
+        switch language {
+        case .cpp: return ("probe.cpp", "int main(void) { return 0; }\n")
+        case .python, .r, .lua, .octave, .racket, .java:
+            // Interpreted, or (Java) producing class files the JVM READS rather
+            // than anything handed to the kernel as an executable — so `noexec`
+            // cannot bite and there is nothing to prove.
+            return nil
+        }
+    }
+
+    /// Compiles this language's probe program into the runner's work root and
+    /// runs it, mirroring what a generated C++ wrapper does (compile into the
+    /// working directory, then `exec` the binary).
     ///
     /// Returns false when either step fails, including the case this exists
     /// for: the work root is mounted `noexec`, so the compile succeeds, the
     /// binary is `-rwxr-xr-x`, and `exec` still fails with EACCES. Failing
     /// closed here is deliberate — an unusable capability is worse than an
     /// absent one, because the gate trusts what a runner advertises.
-    private func canExecuteCompiledOutput(compiler: String) async -> Bool {
+    ///
+    /// True for a language with no probe program: there is nothing to prove,
+    /// and withholding the capability would be the fail-closed answer to a
+    /// question that was never asked.
+    private func canExecuteCompiledOutput(
+        language: AssignmentLanguage, compiler: String
+    ) async -> Bool {
+        guard let program = Self.execProbeProgram(for: language) else { return true }
         let probeDir = workRoot.appendingPathComponent(
             "chickadee_exec_probe_\(UUID().uuidString)", isDirectory: true)
         let fileManager = FileManager.default
@@ -144,9 +178,9 @@ struct RunnerProfileDetector {
         else { return false }
         defer { try? fileManager.removeItem(at: probeDir) }
 
-        let source = probeDir.appendingPathComponent("probe.cpp")
+        let source = probeDir.appendingPathComponent(program.filename)
         let binary = probeDir.appendingPathComponent("probe")
-        guard (try? "int main(void) { return 0; }\n".write(to: source, atomically: true, encoding: .utf8)) != nil
+        guard (try? program.source.write(to: source, atomically: true, encoding: .utf8)) != nil
         else { return false }
 
         guard

--- a/Tests/WorkerTests/RunnerProfileDetectorTests.swift
+++ b/Tests/WorkerTests/RunnerProfileDetectorTests.swift
@@ -119,3 +119,70 @@ import Testing
         }
     }
 }
+
+/// The compile-and-exec capability probe.
+///
+/// It gates whether a runner advertises C++ at all, and `docs/cpp-support.md`
+/// records it catching a real production case (a `noexec` work root at
+/// v0.5.33) — and nothing tested it. Both directions matter: failing open
+/// advertises a capability the host does not have and every C++ job dies at
+/// `exec`; failing closed advertises nothing and every C++ job queues forever.
+@Suite struct RunnerExecProbeTests {
+
+    /// The probe program is answered per language, exhaustively — the guard
+    /// against an eighth compiled language reaching the probe with C++'s source.
+    @Test func onlyCppSuppliesAnExecProbeProgram() {
+        for language in AssignmentLanguage.allCases {
+            let program = RunnerProfileDetector.execProbeProgram(for: language)
+            #expect(
+                (program != nil) == language.descriptor.capabilityRequiresExecutableOutput,
+                """
+                \(language) disagrees with its descriptor: capabilityRequiresExecutableOutput \
+                is \(language.descriptor.capabilityRequiresExecutableOutput) but the probe \
+                program is \(program == nil ? "absent" : "present").
+                """)
+        }
+    }
+
+    /// A work root that permits exec advertises C++; the same probe against a
+    /// directory it cannot write to does not.
+    @Test func theProbeAdvertisesCppOnlyWhenTheWorkRootCanRunABinary() async throws {
+        guard gppIsAvailable() else { return }
+
+        let usable = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-execprobe-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: usable, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: usable) }
+
+        let good = await RunnerProfileDetector(discoveryEnabled: true, workRoot: usable).detect()
+        let goodProfile = try #require(good)
+        #expect(
+            goodProfile.languageVersions.contains { $0.language == "cpp" },
+            "a usable work root did not advertise cpp: \(goodProfile.languageVersions)")
+
+        // An unwritable work root cannot hold the probe, so the capability is
+        // withheld — the fail-closed direction the gate depends on.
+        let unusable = URL(fileURLWithPath: "/proc/chickadee-nonexistent-probe-root")
+        let denied = await RunnerProfileDetector(discoveryEnabled: true, workRoot: unusable)
+            .detect()
+        let deniedProfile = try #require(denied)
+        #expect(
+            !deniedProfile.languageVersions.contains { $0.language == "cpp" },
+            "cpp was advertised from a work root the probe could not use")
+        // Everything else survives: the probe withholds one capability, not all.
+        #expect(
+            deniedProfile.languageVersions.contains { $0.language == "python" },
+            "an unusable work root withheld python too, which needs no exec probe")
+    }
+
+    private func gppIsAvailable() -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["g++", "--version"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do { try process.run() } catch { return false }
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    }
+}

--- a/changelog.d/1352-exec-probe-generalization.md
+++ b/changelog.d/1352-exec-probe-generalization.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The runner's compile-and-exec capability probe asks the language for its
+  probe program** instead of hardcoding a C++ source file. The old form was
+  correct while C++ was the only language needing it and a silent failure for
+  the next: C++ source handed to a different compiler fails, the language is
+  never advertised, and its jobs queue forever with no error — the worse
+  direction of the capability gate. The mapping is exhaustive, so an eighth
+  language must answer.
+- **The probe now has tests**, in both directions: a usable work root advertises
+  C++, and one the probe cannot use withholds C++ while leaving every other
+  language advertised.
+- **The custom-script scaffold's comment no longer claims a generality it does
+  not have.** `capabilityRequiresExecutableOutput` means "grading execs a file
+  it just produced", which is C++ alone — Java is compiled and answers `false`,
+  so it takes the interpreted branch. Recorded rather than guessed at, and the
+  C++ compile line now passes `-std=c++20` to match what generated cases use.


### PR DESCRIPTION
Closes #1352.

## The defect

The compile-and-exec capability probe gates whether a runner advertises C++ at all, and `docs/cpp-support.md` records it catching a real production case (a `noexec` work root at v0.5.33). It hardcoded `probe.cpp` and `int main(void)`, and had **no test of any kind**.

Hardcoding was correct while C++ was the only language answering `capabilityRequiresExecutableOutput` — and a silent failure for the next one: C++ source handed to a different compiler fails, the language is never advertised, and `RunnerLanguageGate` then refuses every runner for it, so its jobs **queue forever** with no error, no failed test and no log line. That is the worse direction of the gate, and the same shape that lost Racket.

The probe program is now answered per language by an exhaustive switch, so an eighth language cannot reach the probe without supplying one.

## Tests

Both directions, which is what the gate depends on:

- a usable work root advertises `cpp`;
- a work root the probe cannot use **withholds `cpp` while leaving every other language advertised** — failing closed for one capability rather than all of them.

Plus a conformance test that the probe-program mapping agrees with `capabilityRequiresExecutableOutput` across `allCases`.

## Also here

The custom-script scaffold's comment claimed "a seventh compiled language gets the compile form for free". It does not. `capabilityRequiresExecutableOutput` means *"grading execs a file it just produced"*, which is C++ alone — Java is compiled too and answers `false`, because its `.class` files are **read** by the JVM. So Java takes the interpreted branch, where `java solution.java` works only by single-file source mode.

Making that branch correct needs a different fact ("grading builds before running"), which is a decision to take on its own evidence rather than fold in here — so it is **recorded in the comment rather than guessed at**. The C++ compile line gains `-std=c++20` to match what generated cases actually use.

## Verification

```
✔ Test run with 6 tests in 2 suites passed   (RunnerExecProbeTests + RunnerProfileDetectorTests)
✔ Test run with 18 tests in 1 suite passed   (TestScriptTemplates)
```

`format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_