### PR TITLE
perf(notebook): one role read per request, one dataset slice per change

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -34,9 +34,15 @@ func requireCourseRole(
 ) async throws {
     guard !caller.isAdmin else { return }
     guard let callerID = caller.id else { throw Abort(.unauthorized) }
-    guard let role = try await courseRole(of: callerID, inCourse: courseID, db: db) else {
-        throw Abort(.forbidden)
-    }
+    try requireResolvedCourseRole(
+        try await courseRole(of: callerID, inCourse: courseID, db: db), atLeast: minimum)
+}
+
+/// The role-floor policy of `requireCourseRole`, over an already-resolved
+/// role — shared with the request-memoized variant below so the two cannot
+/// drift.
+private func requireResolvedCourseRole(_ role: CourseRole?, atLeast minimum: CourseRole) throws {
+    guard let role else { throw Abort(.forbidden) }
     guard role >= minimum else { throw Abort(.forbidden) }
 }
 
@@ -115,8 +121,13 @@ func enrolledCoursesWithRoles(
 func isCourseStaff(_ user: APIUser, inCourse courseID: UUID, db: Database) async throws -> Bool {
     if user.isAdmin { return true }
     guard let userID = user.id else { return false }
-    guard let role = try await courseRole(of: userID, inCourse: courseID, db: db) else { return false }
-    return role >= .ta
+    return resolvedRoleIsStaff(try await courseRole(of: userID, inCourse: courseID, db: db))
+}
+
+/// The staff floor (TA and up) over an already-resolved role — shared with
+/// the request-memoized variant below so the two cannot drift.
+private func resolvedRoleIsStaff(_ role: CourseRole?) -> Bool {
+    role.map { $0 >= .ta } ?? false
 }
 
 /// True when `user` is staff (role >= `.ta`) in *any* non-archived enrolled
@@ -274,4 +285,60 @@ func saveSeededEnrollment(userID: UUID, courseID: UUID, on db: Database) async t
         userID: userID, courseID: courseID,
         role: isAdmin ? .instructor : .student
     ).save(on: db)
+}
+
+// MARK: - Per-request role memoization (#1382 item 3)
+
+/// Request-storage key for the per-request `(user, course) → role` memo.
+private struct CourseRoleMemoKey: StorageKey {
+    typealias Value = [CourseRoleMemoIdentity: CourseRole?]
+}
+
+/// One (user, course) lookup in the per-request memo.
+private struct CourseRoleMemoIdentity: Hashable {
+    let userID: UUID
+    let courseID: UUID
+}
+
+extension Request {
+    /// `courseRole(of:inCourse:db:)` memoized on the request — the same
+    /// per-request caching `resolveActiveCourse` gets.  The notebook page
+    /// resolved the identical (user, course) role four times per load through
+    /// its enrollment guard, staff check, effectively-open check, and
+    /// closed-assignment gate; each request now pays for one enrollment read.
+    /// A nil role ("not enrolled") is memoized too — entry presence, not
+    /// value, marks the cache hit.
+    func cachedCourseRole(of userID: UUID, inCourse courseID: UUID) async throws -> CourseRole? {
+        let identity = CourseRoleMemoIdentity(userID: userID, courseID: courseID)
+        if let cached = storage[CourseRoleMemoKey.self]?[identity] { return cached }
+        let role = try await courseRole(of: userID, inCourse: courseID, db: db)
+        var memo = storage[CourseRoleMemoKey.self] ?? [:]
+        memo[identity] = role
+        storage[CourseRoleMemoKey.self] = memo
+        return role
+    }
+
+    /// `isCourseStaff(_:inCourse:db:)` over the memoized role — the same TA+
+    /// floor (`resolvedRoleIsStaff`), one enrollment read per request.
+    func cachedIsCourseStaff(_ user: APIUser, inCourse courseID: UUID) async throws -> Bool {
+        if user.isAdmin { return true }
+        guard let userID = user.id else { return false }
+        return resolvedRoleIsStaff(try await cachedCourseRole(of: userID, inCourse: courseID))
+    }
+
+    /// `requireCourseRole(caller:courseID:atLeast:db:)` over the memoized
+    /// role — the same floor policy (`requireResolvedCourseRole`).
+    func cachedRequireCourseRole(
+        caller: APIUser, courseID: UUID, atLeast minimum: CourseRole
+    ) async throws {
+        guard !caller.isAdmin else { return }
+        guard let callerID = caller.id else { throw Abort(.unauthorized) }
+        try requireResolvedCourseRole(
+            try await cachedCourseRole(of: callerID, inCourse: courseID), atLeast: minimum)
+    }
+
+    /// `requireCourseEnrollment(caller:courseID:db:)` over the memoized role.
+    func cachedRequireCourseEnrollment(caller: APIUser, courseID: UUID) async throws {
+        try await cachedRequireCourseRole(caller: caller, courseID: courseID, atLeast: .student)
+    }
 }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -40,7 +40,7 @@ extension WebRoutes {
         else {
             throw Abort(.notFound)
         }
-        try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
+        try await req.cachedRequireCourseEnrollment(caller: user, courseID: setup.courseID)
 
         let query = try req.query.decode(NotebookQuery.self)
         let fileKind = notebookFileKind(from: query.file)
@@ -48,7 +48,7 @@ extension WebRoutes {
         // `user.isInstructor`). It gates two things here: who may see the
         // reference solution at all, and who keeps an editable editor on a
         // closed assignment.
-        let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
+        let isStaff = try await req.cachedIsCourseStaff(user, inCourse: setup.courseID)
         // The reference solution is staff-only. The student notebook route is
         // reachable by any enrolled student (and now, read-only, for closed
         // assignments), so guard the solution view here rather than relying on
@@ -94,7 +94,7 @@ extension WebRoutes {
             // Preview counts as open for staff and closed for students — handled
             // inside isAssignmentEffectivelyOpen — so staff get an editable
             // notebook on a Preview assignment and students see it read-only.
-            isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db))
+            isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, req: req))
         } else {
             isClosed = false
         }
@@ -441,13 +441,13 @@ extension WebRoutes {
     ) async throws -> NotebookContext {
         guard let userID = user.id else { throw Abort(.unauthorized) }
         let setupID = setup.id ?? ""
-        let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
+        let isStaff = try await req.cachedIsCourseStaff(user, inCourse: setup.courseID)
         let viewMode = try await resolveNotebookViewMode(
             req: req, setup: setup, assignment: assignment,
             fileKind: fileKind, isStaff: isStaff, requested: requestedView)
         let isClosed: Bool
         if let assignment {
-            isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db))
+            isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, req: req))
         } else {
             isClosed = false
         }
@@ -582,19 +582,19 @@ extension WebRoutes {
             throw Abort(.notFound)
         }
 
-        try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
+        try await req.cachedRequireCourseEnrollment(caller: user, courseID: setup.courseID)
 
         // Same closed-assignment gate as the notebook page, applied to the raw
         // content endpoint so a student can't fetch a not-yet-opened lab's
         // starter notebook by hitting `/notebook/source` directly.  A
         // legitimately reachable closed assignment already has a participation
         // row (or a submission), so this never fires on normal page loads.
-        let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
+        let isStaff = try await req.cachedIsCourseStaff(user, inCourse: setup.courseID)
         if !isStaff,
             let assignment = try await APIAssignment.query(on: req.db)
                 .filter(\.$testSetupID == setupID)
                 .first(),
-            !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db)),
+            !(try await isAssignmentEffectivelyOpen(assignment, for: user, req: req)),
             !(try await studentHasOpenedAssignment(assignment: assignment, userID: userID, on: req.db))
         {
             throw Abort(.forbidden)

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -74,7 +74,7 @@ extension WebRoutes {
         // Block cross-tenant info disclosure: an authenticated student
         // shouldn't be able to learn that a setupID exists in a course
         // they aren't enrolled in, nor see its assignment title.
-        try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
+        try await req.cachedRequireCourseEnrollment(caller: user, courseID: setup.courseID)
         // Browser-graded assignments are submitted from the notebook page, not this form.
         let manifestData = Data(setup.manifest.utf8)
         let manifest = decodeManifest(from: manifestData)
@@ -88,7 +88,7 @@ extension WebRoutes {
         // never opened this (now-closed) upload-mode assignment is sent to
         // their dashboard rather than shown an upload form they cannot submit.
         if let userID = user.id, let assignment {
-            let isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db))
+            let isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, req: req))
             if let redirect = try await closedAssignmentGate(
                 req: req, user: user, userID: userID, assignment: assignment, isClosed: isClosed)
             {

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -181,6 +181,33 @@ func isAssignmentEffectivelyOpen(
     // own course get the preview/future-open bypass (#417 Slice G — was the
     // global `user.isInstructor`).
     let isStaff = try await isCourseStaff(user, inCourse: assignment.courseID, db: db)
+    return try await isAssignmentEffectivelyOpenResolved(
+        assignment, for: user, isStaff: isStaff, on: db, now: now)
+}
+
+/// `isAssignmentEffectivelyOpen` for request handlers: the staff check reads
+/// the request's role memo (#1382 item 3), so the several open/closed checks
+/// a page load performs share one enrollment read.
+func isAssignmentEffectivelyOpen(
+    _ assignment: APIAssignment,
+    for user: APIUser,
+    req: Request,
+    now: Date = Date()
+) async throws -> Bool {
+    let isStaff = try await req.cachedIsCourseStaff(user, inCourse: assignment.courseID)
+    return try await isAssignmentEffectivelyOpenResolved(
+        assignment, for: user, isStaff: isStaff, on: req.db, now: now)
+}
+
+/// The open/closed core over an already-resolved staff bit — shared by both
+/// variants above so the policy cannot drift.
+private func isAssignmentEffectivelyOpenResolved(
+    _ assignment: APIAssignment,
+    for user: APIUser,
+    isStaff: Bool,
+    on db: Database,
+    now: Date
+) async throws -> Bool {
     let gate = assignment.visibility.submissionGate(isStaff: isStaff)
     let baseline = assignment.dueAt
     let extensionDueAt = try await studentExtensionDueAt(for: assignment, user: user, on: db)
@@ -347,7 +374,7 @@ func requireOpenStudentAssignment(
     // vanity-URL resolutions) can submit to that assignment and pollute
     // foreign instructors' queues.  Instructors and admins bypass via
     // `requireCourseEnrollment`'s own short-circuit.
-    try await requireCourseEnrollment(caller: user, courseID: assignment.courseID, db: req.db)
+    try await req.cachedRequireCourseEnrollment(caller: user, courseID: assignment.courseID)
 
     // Lazy schedule enforcement, both directions. The close has always been
     // enforced here as a safety net under the periodic sweep; the open gets
@@ -360,7 +387,7 @@ func requireOpenStudentAssignment(
     // Preview is open for course staff and closed for students — handled
     // uniformly by isAssignmentEffectivelyOpen, so staff use it via the normal
     // open path (bundled solution/tests, normal submission) with no special case.
-    let open = try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db, now: now)
+    let open = try await isAssignmentEffectivelyOpen(assignment, for: user, req: req, now: now)
     guard open else {
         throw AssignmentSubmissionGateError.closed
     }

--- a/Sources/APIServer/Services/DatasetMaterializationCache.swift
+++ b/Sources/APIServer/Services/DatasetMaterializationCache.swift
@@ -1,0 +1,58 @@
+// APIServer/Services/DatasetMaterializationCache.swift
+//
+// Process-local memo of the last dataset materialization per (user, setup),
+// so a notebook visit re-slices and rewrites the per-student dataset files
+// only when an input actually changed (#1382 item 3). `writeDatasetFiles`
+// used to read the source CSV, recompute the student's slice, and overwrite
+// every dataset file on every page visit; the working-copy notebook beside
+// those files has always had an already-exists short-circuit.
+//
+// The fingerprint covers everything that determines the produced bytes —
+// the per-student seed, each dataset spec, and each source file's identity
+// (mtime + size) — so a staff re-seed, a spec edit, and a re-uploaded
+// source each invalidate it, preserving every regeneration trigger the
+// always-rewrite had. Target-file existence is checked separately at skip
+// time so a student who deletes a dataset file still gets it repaired on
+// the next visit. A restart empties the memo, which costs one
+// re-materialization per (user, setup) — the same work a first visit does.
+
+import Foundation
+import Vapor
+
+actor DatasetMaterializationCache {
+    private struct Key: Hashable {
+        let userID: UUID
+        let setupID: String
+    }
+
+    private var fingerprintByKey: [Key: String] = [:]
+
+    /// True when the last recorded materialization for (user, setup) was
+    /// produced from exactly these inputs.
+    func isCurrent(userID: UUID, setupID: String, fingerprint: String) -> Bool {
+        fingerprintByKey[Key(userID: userID, setupID: setupID)] == fingerprint
+    }
+
+    /// Records a completed materialization's inputs.
+    func record(userID: UUID, setupID: String, fingerprint: String) {
+        fingerprintByKey[Key(userID: userID, setupID: setupID)] = fingerprint
+    }
+}
+
+private struct DatasetMaterializationCacheKey: StorageKey {
+    typealias Value = DatasetMaterializationCache
+}
+
+extension Application {
+    var datasetMaterializationCache: DatasetMaterializationCache {
+        get {
+            if let existing = storage[DatasetMaterializationCacheKey.self] {
+                return existing
+            }
+            let created = DatasetMaterializationCache()
+            storage[DatasetMaterializationCacheKey.self] = created
+            return created
+        }
+        set { storage[DatasetMaterializationCacheKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -118,7 +118,7 @@ func closedAssignmentGate(
     // Course staff (TA+ or admin) bypass the closed-assignment gate for their
     // own course (#417 Slice G — was the global `user.isInstructor`).
     if let assignmentCourseID = assignment?.courseID,
-        try await isCourseStaff(user, inCourse: assignmentCourseID, db: req.db)
+        try await req.cachedIsCourseStaff(user, inCourse: assignmentCourseID)
     {
         return nil
     }
@@ -606,8 +606,11 @@ func createSupportFileSymlinks(req: Request, setup: APITestSetup, studentDir: St
 
 /// Materializes per-student dataset slices into the student's JupyterLite working
 /// directory. Dataset files are written as real files (not symlinks) so each student
-/// sees only their own rows. Idempotent — safe to call on every visit; always
-/// overwrites with the current slice so a spec change is picked up automatically.
+/// sees only their own rows. Idempotent — safe to call on every visit; a spec
+/// change, a re-uploaded source, or a staff re-seed is picked up automatically
+/// because each changes the materialization fingerprint (#1382 item 3 — this
+/// used to re-slice and overwrite on every visit; now an unchanged
+/// fingerprint with all targets present skips the slice + write entirely).
 /// A strict no-op when the assignment declares no datasets.
 func writeDatasetFiles(
     req: Request,
@@ -635,21 +638,65 @@ func writeDatasetFiles(
 
     let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
 
-    // Dataset resolution reads the source CSV and materializes a per-student
-    // slice, then writes one file per dataset — synchronous I/O + CPU on
-    // every visit to a dataset-carrying assignment. Thread pool (#1156).
-    try? await runBlocking(on: req) {
-        guard
-            let files = DatasetResolver.resolve(
-                manifest: props, seedHex: seedHex, sourceDirectory: sharedDir)
-        else { return }
-
-        for (filename, content) in files {
-            // Defense-in-depth (#1104): resolver keys are validated bare
-            // filenames, but never join an unvetted name onto the student dir.
-            guard FilenameSafety.bareFilename(filename) != nil else { continue }
-            let dest = studentDir + "/" + filename
-            try? content.write(toFile: dest, atomically: true, encoding: .utf8)
-        }
+    // Skip the slice + write when nothing that determines the bytes has
+    // changed since the last materialization and every target file is still
+    // present (a deleted file is repaired, matching the old always-rewrite).
+    let state: (fingerprint: String, targetsPresent: Bool)? = try? await runBlocking(on: req) {
+        (
+            fingerprint: datasetMaterializationFingerprint(
+                props: props, seedHex: seedHex, sharedDir: sharedDir),
+            targetsPresent: props.datasets.allSatisfy {
+                FileManager.default.fileExists(atPath: studentDir + "/" + $0.file)
+            }
+        )
     }
+    let cache = req.application.datasetMaterializationCache
+    if let state, state.targetsPresent,
+        await cache.isCurrent(userID: userID, setupID: setupID, fingerprint: state.fingerprint)
+    {
+        return
+    }
+
+    // Dataset resolution reads the source CSV and materializes a per-student
+    // slice, then writes one file per dataset — synchronous I/O + CPU. Thread
+    // pool (#1156).
+    let wrote: Bool =
+        (try? await runBlocking(on: req) {
+            guard
+                let files = DatasetResolver.resolve(
+                    manifest: props, seedHex: seedHex, sourceDirectory: sharedDir)
+            else { return false }
+
+            for (filename, content) in files {
+                // Defense-in-depth (#1104): resolver keys are validated bare
+                // filenames, but never join an unvetted name onto the student dir.
+                guard FilenameSafety.bareFilename(filename) != nil else { continue }
+                let dest = studentDir + "/" + filename
+                try? content.write(toFile: dest, atomically: true, encoding: .utf8)
+            }
+            return true
+        }) ?? false
+
+    if wrote, let state {
+        await cache.record(userID: userID, setupID: setupID, fingerprint: state.fingerprint)
+    }
+}
+
+/// Everything that determines the bytes `writeDatasetFiles` produces, folded
+/// into one comparable string: the per-student seed, each dataset spec, and
+/// each source file's (mtime, size) identity. A missing source contributes a
+/// sentinel, so its later appearance also invalidates.
+private func datasetMaterializationFingerprint(
+    props: TestProperties, seedHex: String, sharedDir: String
+) -> String {
+    var parts: [String] = [seedHex]
+    let fm = FileManager.default
+    for spec in props.datasets {
+        let attrs = try? fm.attributesOfItem(atPath: sharedDir + spec.file)
+        let mtime = (attrs?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? -1
+        let size = (attrs?[.size] as? Int) ?? -1
+        let sample = spec.sampleSize.map(String.init) ?? "-"
+        parts.append("\(spec.file)|\(spec.kind.rawValue)|\(sample)|\(mtime)|\(size)")
+    }
+    return parts.joined(separator: "\n")
 }

--- a/Tests/APITests/CourseAccessHelpersTests.swift
+++ b/Tests/APITests/CourseAccessHelpersTests.swift
@@ -71,6 +71,58 @@ import Vapor
         }
     }
 
+    // MARK: - Per-request role memo (#1382 item 3)
+
+    @Test func cachedCourseRoleIsMemoizedPerRequest() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let user = try await makeTestUser(on: app, username: "ta_user")
+            let enrollment = APICourseEnrollment(
+                userID: try user.requireID(), courseID: try course.requireID(), role: .ta)
+            try await enrollment.save(on: app.db)
+
+            let req = Request(application: app, on: app.eventLoopGroup.any())
+            #expect(try await req.cachedIsCourseStaff(user, inCourse: course.requireID()))
+
+            // Downgrade the enrollment behind the request's back: the memoized
+            // answer holds for the rest of THIS request (that is the memo
+            // working — one enrollment read per request)...
+            enrollment.role = .student
+            try await enrollment.save(on: app.db)
+            #expect(try await req.cachedIsCourseStaff(user, inCourse: course.requireID()))
+
+            // ...while a fresh request resolves the new role.
+            let fresh = Request(application: app, on: app.eventLoopGroup.any())
+            #expect(try await fresh.cachedIsCourseStaff(user, inCourse: course.requireID()) == false)
+        }
+    }
+
+    @Test func cachedEnrollmentGuardMatchesTheFreeFunction() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let courseID = try course.requireID()
+            let outsider = try await makeTestUser(on: app, username: "outsider")
+            let member = try await makeTestUser(on: app, username: "member")
+            try await makeTestEnrollment(on: app, userID: member.requireID(), courseID: courseID)
+            let admin = try await makeTestUser(on: app, username: "boss", role: "admin")
+
+            let req = Request(application: app, on: app.eventLoopGroup.any())
+            await #expect(throws: Abort.self) {
+                try await req.cachedRequireCourseEnrollment(caller: outsider, courseID: courseID)
+            }
+            try await req.cachedRequireCourseEnrollment(caller: member, courseID: courseID)
+            // A nil role is memoized too — the denial repeats without a fresh
+            // read, and stays a denial.
+            await #expect(throws: Abort.self) {
+                try await req.cachedRequireCourseEnrollment(caller: outsider, courseID: courseID)
+            }
+            // Admins bypass, as in `requireCourseEnrollment`.
+            try await req.cachedRequireCourseEnrollment(caller: admin, courseID: courseID)
+        }
+    }
+
     @Test func mcpCourseAccessDeniesUnenrolledAdmin() async throws {
         // The MCP path: an admin token is enrollment-scoped — denied before
         // enrolling, allowed after, revoked again on unenroll.

--- a/Tests/APITests/DatasetMaterializationCacheTests.swift
+++ b/Tests/APITests/DatasetMaterializationCacheTests.swift
@@ -1,0 +1,97 @@
+// Tests/APITests/DatasetMaterializationCacheTests.swift
+//
+// Pins the dataset materialization short-circuit (#1382 item 3):
+// `writeDatasetFiles` used to re-slice the source and overwrite every
+// dataset file on every notebook visit; now an unchanged fingerprint with
+// all targets present skips the work, while each regeneration trigger the
+// always-rewrite had — a changed source, a re-seed, a deleted target —
+// still re-materializes.
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct DatasetMaterializationCacheTests {
+
+    private static let manifest = """
+        {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,"datasets":[{"file":"pool.csv","sampleSize":2}]}
+        """
+
+    @Test func materializationSkipsWhenInputsAreUnchanged() async throws {
+        let app = try await makeTestApp(prefix: "chickadee-dsc")
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "DS101")
+            let courseID = try course.requireID()
+            let user = try await makeTestUser(on: app, username: "ds_student")
+            let userID = try user.requireID()
+
+            let setupID = "setup_ds_cache"
+            let setup = APITestSetup(
+                id: setupID, manifest: Self.manifest,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip", courseID: courseID)
+            try await setup.save(on: app.db)
+            try await APIAssignment(
+                testSetupID: setupID, title: "Dataset Lab", dueAt: nil, isOpen: true,
+                courseID: courseID
+            ).save(on: app.db)
+
+            let sharedDir = app.testSetupsDirectory + "shared/\(setupID)/"
+            try FileManager.default.createDirectory(
+                atPath: sharedDir, withIntermediateDirectories: true)
+            let sourcePath = sharedDir + "pool.csv"
+            try "id,v\n1,a\n2,b\n3,c\n4,d\n".write(
+                toFile: sourcePath, atomically: true, encoding: .utf8)
+
+            let studentDir = app.testSetupsDirectory + "student-ds-cache"
+            try FileManager.default.createDirectory(
+                atPath: studentDir, withIntermediateDirectories: true)
+            let targetPath = studentDir + "/pool.csv"
+
+            func visit() async {
+                let req = Request(application: app, on: app.eventLoopGroup.any())
+                await writeDatasetFiles(
+                    req: req, setup: setup, userID: userID, studentDir: studentDir)
+            }
+
+            // First visit materializes the per-student slice.
+            await visit()
+            let sliced = try #require(try? String(contentsOfFile: targetPath, encoding: .utf8))
+            #expect(!sliced.isEmpty)
+
+            // Unchanged inputs: the visit must NOT rewrite the file — the
+            // tamper marker surviving is the skip observably happening (the
+            // old always-rewrite would restore the slice here).
+            try "TAMPERED".write(toFile: targetPath, atomically: true, encoding: .utf8)
+            await visit()
+            #expect(
+                (try? String(contentsOfFile: targetPath, encoding: .utf8)) == "TAMPERED",
+                "An unchanged fingerprint with the target present must skip the rewrite")
+
+            // A changed source (different bytes → different size) invalidates
+            // the fingerprint and re-materializes.
+            try "id,v\n1,a\n2,b\n3,c\n4,d\n5,e\n6,f\n".write(
+                toFile: sourcePath, atomically: true, encoding: .utf8)
+            await visit()
+            let refreshed = try #require(try? String(contentsOfFile: targetPath, encoding: .utf8))
+            #expect(refreshed != "TAMPERED", "A source edit must re-materialize the slice")
+
+            // A deleted target is repaired even with an unchanged fingerprint.
+            try FileManager.default.removeItem(atPath: targetPath)
+            await visit()
+            #expect(
+                FileManager.default.fileExists(atPath: targetPath),
+                "A deleted dataset file is repaired on the next visit")
+
+            // A re-seed (staff action) changes the per-student seed, which
+            // invalidates the fingerprint and re-slices.
+            try "TAMPERED".write(toFile: targetPath, atomically: true, encoding: .utf8)
+            try await APIAssignmentPersonalizationSeed.query(on: app.db).delete()
+            await visit()
+            let reseeded = try #require(try? String(contentsOfFile: targetPath, encoding: .utf8))
+            #expect(reseeded != "TAMPERED", "A re-seed must re-materialize the slice")
+        }
+    }
+}

--- a/changelog.d/notebook-page-request-cost.md
+++ b/changelog.d/notebook-page-request-cost.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The notebook page stops repeating its per-request queries.** The
+  (user, course) role lookup — asked four times per notebook page load by
+  the enrollment guard, the staff check, the effectively-open check, and the
+  closed-assignment gate — is now memoized on the request, the same
+  per-request caching `resolveActiveCourse` already had; the submit form and
+  the submission gate share it (#1382 item 3). Per-student dataset files are
+  no longer re-sliced and rewritten on every visit: an unchanged seed, spec,
+  and source with all files present skips the work, while a re-seed, a spec
+  edit, a re-uploaded source, or a deleted file still re-materializes.


### PR DESCRIPTION
Item 3 of the #1382 scalability-audit handover (item 2 shipped in #1385).

## What was wrong

- `courseRole` / `isCourseStaff` were called **four times per notebook page load** with the same (user, course) key and no per-request memo — the enrollment guard, the staff check, the effectively-open check, and the closed-assignment gate each re-queried the same enrollment row — while `resolveActiveCourse` right next door is request-cached.
- For dataset assignments, `writeDatasetFiles` re-sliced the source CSV and rewrote every per-student dataset file **on every page visit**. The working-copy notebook beside those files has always had an already-exists short-circuit; the datasets did not.

## What changed

**Role memo** (`CourseAccessHelpers.swift`): `Request.cachedCourseRole` memoizes the (user, course) → role read in `req.storage`, copying the `resolveActiveCourse` pattern; nil ("not enrolled") is memoized too, with entry presence marking the hit. `cachedIsCourseStaff` / `cachedRequireCourseRole` / `cachedRequireCourseEnrollment` sit on top. To keep one policy definition, the free functions were refactored to share extracted cores (`resolvedRoleIsStaff`, `requireResolvedCourseRole`) with the cached variants — the db-taking functions are otherwise unchanged for non-request callers (sweeps, MCP, 14 test call sites). `isAssignmentEffectivelyOpen` gains a `req:` variant over a shared resolved-staff core; the `on db:` variant keeps its exact behavior.

Converted flows: notebook page, notebook source, the closed-assignment gate, the submit form, and `requireOpenStudentAssignment` (the submit gate — also hot at deadlines). Each request now pays one enrollment read.

**Dataset short-circuit** (`NotebookWorkingCopyStore.swift` + new `DatasetMaterializationCache` actor): the slice + write is skipped when a fingerprint of everything that determines the bytes — the per-student seed, each dataset spec, each source file's (mtime, size) — matches the last materialization **and** every target file is present. Every regeneration trigger the always-rewrite had is preserved: a staff re-seed, a spec edit, a re-uploaded source, and a deleted target each invalidate. Process-local by design; a restart re-materializes once per (user, setup), the same work a first visit does.

## Verification

- New pins: `cachedCourseRoleIsMemoizedPerRequest` (a mid-request role downgrade is invisible to that request, visible to the next — the memo observably working), the cached-guard policy parity, and `DatasetMaterializationCacheTests` (skip-on-unchanged via a tamper marker surviving a visit, then re-materialization on source edit, on target delete, and on re-seed).
- 99 tests green locally across the touched surfaces: the notebook/submit/workbench route suites, the extension-gate suites that exercise the untouched `db:` open-check variant, and the new pins. `format.sh` / `lint.sh` / `swiftlint.sh --strict` clean. One `changelog.d/` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZvhhypNNTqMGV55BKEEhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZvhhypNNTqMGV55BKEEhH)_