### PR TITLE
fix(cpp): refuse a run that exits without reporting a verdict

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyRendererCpp.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRendererCpp.swift
@@ -204,7 +204,18 @@ private func cppShellWrapper(
         \(embeddedSource)
         \(generatedSourceHeredocDelimiter)
         \(compileStep)
-        exec \(shellSingleQuoted("./" + binaryFile))
+        ck_out=$(\(shellSingleQuoted("./" + binaryFile)))
+        ck_rc=$?
+        # The sentinel check. Without it, a student's own exit(0) — in an error
+        # path, which is where an intro submission puts one — exits the binary
+        # with status 0 and this case, every case, reads as a pass. C++ was the
+        # only language with no such guard; Java has had one since it shipped.
+        if ! printf '%s\\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+            echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+            exit 2
+        fi
+        printf '%s\\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+        exit $ck_rc
         """ + "\n"
 }
 

--- a/Tests/APITests/PatternFamilyRendererCppTests.swift
+++ b/Tests/APITests/PatternFamilyRendererCppTests.swift
@@ -268,6 +268,38 @@ import Testing
         #expect(bad.stdout.contains("wrong output"))
     }
 
+    /// A student's own `exit(0)` must not read as a pass.
+    ///
+    /// C++ was the only language with no exit guard: `ck::passed` is a bare
+    /// `std::exit(0)` and the wrapper `exec`'d the binary, so a submission that
+    /// called `exit(0)` in an error path — where an intro submission puts one —
+    /// exited 0 and every case in the assignment passed silently, with no
+    /// verdict JSON at all (#1345).
+    @Test func aSubmissionCallingExitIsAnErrorNotAPass() throws {
+        guard Self.gppAvailable else { return }
+        let script = Self.render(Self.family(.boundaryEquality, expected: .int(9)))
+        let sneaky = try Self.execute(
+            script: script,
+            submission: """
+                #include <cstdlib>
+                int f(int) { std::exit(0); }
+                """)
+        #expect(
+            sneaky.code != 0,
+            "a submission calling exit(0) was graded as a PASS: \(sneaky.stdout)")
+        #expect(
+            sneaky.stderr.contains("did not run to completion"),
+            "the run was not identified as incomplete: \(sneaky.stderr)")
+
+        // And the sentinel never reaches the student-visible result line.
+        let good = try Self.execute(
+            script: script, submission: "int f(int x) { return x * x; }\n")
+        #expect(good.code == 0, "\(good.stdout) \(good.stderr)")
+        #expect(
+            !good.stdout.contains("CK_SENTINEL"),
+            "the sentinel leaked into the result line: \(good.stdout)")
+    }
+
     /// A missing submission is the student's to fix, so the 0-point existence
     /// guard reports it as a graded FAIL with a readable message — which is
     /// what Java has always done for the same student state, while C++ said

--- a/Tests/Fixtures/generated-source/cpp/pattern/approximate_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/approximate_equality/publictest_fam_01.sh
@@ -59,4 +59,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/boundary_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/boundary_equality/publictest_fam_01.sh
@@ -59,4 +59,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/differential/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/differential/publictest_fam_01.sh
@@ -68,4 +68,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/exception_expected/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/exception_expected/publictest_fam_01.sh
@@ -55,4 +55,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/performance_threshold/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/performance_threshold/publictest_fam_01.sh
@@ -61,4 +61,15 @@ if ! g++ -std=c++20 -O2 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/return_type_check/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/return_type_check/publictest_fam_01.sh
@@ -58,4 +58,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/stdout_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/stdout_equality/publictest_fam_01.sh
@@ -69,4 +69,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/unordered_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/unordered_equality/publictest_fam_01.sh
@@ -59,4 +59,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tests/Fixtures/generated-source/cpp/pattern/variable_equality/publictest_fam_01.sh
+++ b/Tests/Fixtures/generated-source/cpp/pattern/variable_equality/publictest_fam_01.sh
@@ -47,4 +47,15 @@ if ! g++ -std=c++20 -O0 '.ck_src_fam_01.cpp' -o '.ck_bin_fam_01' >.ck_build_log 
     cat .ck_build_log 1>&2
     exit 2
 fi
-exec './.ck_bin_fam_01'
+ck_out=$('./.ck_bin_fam_01')
+ck_rc=$?
+# The sentinel check. Without it, a student's own exit(0) — in an error
+# path, which is where an intro submission puts one — exits the binary
+# with status 0 and this case, every case, reads as a pass. C++ was the
+# only language with no such guard; Java has had one since it shipped.
+if ! printf '%s\n' "$ck_out" | grep -q '^CK_SENTINEL$'; then
+    echo "The test did not run to completion. Does the submission call exit()?" 1>&2
+    exit 2
+fi
+printf '%s\n' "$ck_out" | grep -v '^CK_SENTINEL$'
+exit $ck_rc

--- a/Tools/runner-support/test_runtime.hpp
+++ b/Tools/runner-support/test_runtime.hpp
@@ -70,16 +70,40 @@ inline std::string json_escape(const std::string& s) {
     return out;
 }
 
+// ---- the sentinel that makes the shell contract honest ----
+//
+// A student's own `exit(0)` — in an error path, which is exactly where an intro
+// submission puts one — exits the process with status 0, and the wrapper read
+// that as a PASS. Every case in the assignment, silently, with no verdict JSON.
+// This is the hazard R (`quit()`), Lua (`os.exit`), Octave (`exit`) and Java
+// (`System.exit`) each had; C++ was the one language with no guard at all,
+// while the Java renderer's header listed sentinel-checking as a difference
+// between them without noting that C++ was exposed.
+//
+// Every verdict prints this line first and the wrapper refuses to trust a run
+// that did not emit it. Printing it HERE rather than in the generated test is
+// deliberate: a renderer cannot forget it.
+//
+// THE LIMIT, stated because it bounds what this buys: student code and the
+// grading runtime share one process, so a submission that prints this line
+// itself and then exits 0 still passes. That is a deliberate act, not the
+// error-path `exit(0)` this exists to catch, and no in-process guard can close
+// it — the same ceiling Java's sentinel has.
+inline constexpr const char* sentinel_line = "CK_SENTINEL";
+
 // ---- the shell contract's exit codes ----
 [[noreturn]] inline void passed(const std::string& msg) {
+    std::cout << sentinel_line << "\n";
     std::cout << "{\"shortResult\": \"" << json_escape(msg) << "\"}\n";
     std::exit(0);
 }
 [[noreturn]] inline void failed(const std::string& msg) {
+    std::cout << sentinel_line << "\n";
     std::cout << "{\"shortResult\": \"" << json_escape(msg) << "\"}\n";
     std::exit(1);
 }
 [[noreturn]] inline void errored(const std::string& msg) {
+    std::cout << sentinel_line << "\n";
     std::cerr << msg << "\n";
     // A shortResult footer, even though the exit code already says `error`.
     // The shell contract takes the LAST non-empty stdout line as the summary,

--- a/changelog.d/1345-cpp-exit-guard.md
+++ b/changelog.d/1345-cpp-exit-guard.md
@@ -1,0 +1,13 @@
+### Security
+
+- **A C++ submission that calls `exit(0)` no longer passes every test.** C++ was
+  the only language with no exit guard: `ck::passed` is a bare `std::exit(0)`
+  and the wrapper `exec`'d the binary, so a student's own `exit(0)` — in an
+  error path, which is where an intro submission puts one — exited with status 0
+  and every case in the assignment reported a silent pass with no verdict at
+  all. The C++ runtime now prints the sentinel line every other compiled
+  language's runtime prints, and the wrapper refuses a run that did not emit it.
+  The ceiling is stated in both files: student code and the grading runtime
+  share one process, so a submission that prints the sentinel itself and exits
+  is still a pass — a deliberate act, not the error-path `exit(0)` this catches,
+  and the same limit Java's sentinel has.


### PR DESCRIPTION
Closes #1345. Last of the multi-language worker audit.

## The defect

C++ was the **only language with no exit guard**. `ck::passed` is a bare `std::exit(0)` and the wrapper `exec`'d the binary, so the binary's status *was* the script's — and a student's own `exit(0)`, in an error path where an intro submission puts one, exited 0 and the case read as a **pass**. Every case in the assignment, silently, with no verdict JSON at all.

```cpp
int classify(double x) {
    if (x < 0) { std::cerr << "bad\n"; exit(0); }   // → every test passes
    ...
}
```

This is the hazard R (`quit()`), Lua (`os.exit`) and Octave (`exit`) each had in a kernel that could mask the call, and that Java answered natively with a printed sentinel. The Java renderer's own header even lists sentinel-checking as a difference between the two languages — without noting that C++ was the one exposed.

## The fix

The C++ runtime prints the same sentinel line before every verdict, and the wrapper captures stdout, refuses a run that did not emit it, and strips it before the student sees the result. Printing it in the *runtime* rather than in the generated test is the argument Java's already makes: **a renderer cannot forget it.**

## The limit, stated in both files

Student code and the grading runtime share one process, so a submission that prints the sentinel itself and then exits 0 still passes. That is a deliberate act rather than the error-path `exit(0)` this exists to catch, and no in-process guard can close it — the same ceiling Java's sentinel has. Raising it further would need the verdict to carry a per-run secret the student's code cannot read, which is not achievable in-process either. Written into the runtime's comment rather than left implied, so the next reader doesn't mistake this for airtight.

## Verification

New execution test asserting a submission calling `exit(0)` is **not** a pass and is identified as incomplete, plus that the sentinel never leaks into the student-visible result line:

```
✔ Test run with 21 tests in 1 suite passed   (CppRendererExecutionTests)
✔ Test run with  5 tests in 1 suite passed   (CppNativeGradingTests)
✔ Test run with 32 tests in 4 suites passed  (re-verified after container restart)
```

Goldens regenerated (9 C++ files). `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_