### PR TITLE
perf: the contained Tier-2 remainder — storage cache, roster aggregates, prune index, authoring writes

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
@@ -277,6 +277,17 @@ extension OperationalDiagnosticsService {
             try await APISubmissionDiagnostics.query(on: db)
                 .filter(\.$finishedAt < jobCutoff)
                 .delete()
+            // Rows whose job never reported completion keep a NULL
+            // finished_at, which `< cutoff` never matches — so they used to
+            // accumulate permanently (#1382 item 8). Age them out on
+            // created_at at the same window: once a full retention period has
+            // passed, the job is not going to finish, and the row's value as
+            // a stuck-job breadcrumb has long been superseded by the health
+            // alerts and logs from the incident itself.
+            try await APISubmissionDiagnostics.query(on: db)
+                .filter(\.$finishedAt == nil)
+                .filter(\.$createdAt < jobCutoff)
+                .delete()
             // Browser-side telemetry: one row per JS error, kernel boot failure
             // and grading failover, each carrying a message and a stack. It was
             // the only diagnostics table with no retention at all, while being

--- a/Sources/APIServer/Diagnostics/StorageUsageCache.swift
+++ b/Sources/APIServer/Diagnostics/StorageUsageCache.swift
@@ -1,0 +1,83 @@
+// Sources/APIServer/Diagnostics/StorageUsageCache.swift
+//
+// Single-flight, short-TTL cache in front of the admin storage breakdown
+// (#1382 item 5).
+//
+// Building the breakdown walks every persistent-volume sink — the flat
+// submissions directory (one stat per submission the deployment has ever
+// kept), the test-setups tree, the results dir, and the whole static asset
+// tree (~400 MB of vendored editor assets) — plus a full (id → setup)
+// projection of the submissions table for byte attribution. That is exactly
+// the work that grows as disk fills, on the one page whose purpose is "are
+// we running out of disk", and it is reachable from the read-only admin MCP
+// (`get_storage_usage`), which an agent may poll.
+//
+// This actor mirrors `MetricsCardCache`: at most one computation in flight
+// (concurrent callers await the same task) and a cached context served for
+// `ttl` seconds, so the walks run at most once per TTL no matter how many
+// pollers ask. A ≤60s-stale answer is fine for a disk-pressure panel; the
+// numbers move on upload timescales, not seconds.
+
+import Foundation
+import Vapor
+
+actor StorageUsageCache {
+    private var cached: AdminStorageContext?
+    private var cachedAt: Date?
+    private var inFlight: Task<AdminStorageContext, Error>?
+    private let ttl: TimeInterval
+
+    init(ttl: TimeInterval = 60) {
+        self.ttl = ttl
+    }
+
+    /// Returns a cached context if it is younger than the TTL, otherwise runs
+    /// `compute` — coalescing concurrent callers onto a single execution so
+    /// the directory walks never stack.
+    func context(
+        now: Date = Date(),
+        compute: @escaping @Sendable () async throws -> AdminStorageContext
+    ) async throws -> AdminStorageContext {
+        if let cached, let cachedAt, now.timeIntervalSince(cachedAt) < ttl {
+            return cached
+        }
+        if let inFlight {
+            return try await inFlight.value
+        }
+
+        let task = Task { try await compute() }
+        inFlight = task
+        do {
+            let result = try await task.value
+            cached = result
+            cachedAt = now
+            inFlight = nil
+            return result
+        } catch {
+            // Don't cache failures, and clear the in-flight slot so the next
+            // caller retries rather than awaiting a dead task.
+            inFlight = nil
+            throw error
+        }
+    }
+}
+
+private struct StorageUsageCacheKey: StorageKey {
+    typealias Value = StorageUsageCache
+}
+
+extension Application {
+    /// Process-wide cache fronting the admin storage breakdown (the
+    /// `/admin/storage` page and the `get_storage_usage` MCP tool share it).
+    var storageUsageCache: StorageUsageCache {
+        get {
+            if let existing = storage[StorageUsageCacheKey.self] {
+                return existing
+            }
+            let created = StorageUsageCache()
+            storage[StorageUsageCacheKey.self] = created
+            return created
+        }
+        set { storage[StorageUsageCacheKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Helpers/StudentSubmissionAggregates.swift
+++ b/Sources/APIServer/Helpers/StudentSubmissionAggregates.swift
@@ -125,6 +125,106 @@ func studentBestGradePercentBySetup(
     return best
 }
 
+// MARK: - By-student variants (instructor roster, #1382 item 6)
+
+/// Per-student submission summary for one assignment's setup: the latest
+/// submission's id and the attempt count — `studentSubmissionSummaryBySetup`
+/// partitioned by student instead of by setup, for the instructor
+/// assignment-submissions roster.
+struct SetupStudentSubmissionSummary {
+    let latestSubmissionID: String
+    let submissionCount: Int
+}
+
+func submissionSummaryByStudent(
+    setupID: String, studentIDs: [UUID], on db: Database
+) async throws -> [UUID: SetupStudentSubmissionSummary] {
+    guard !studentIDs.isEmpty else { return [:] }
+    guard let sql = db as? SQLDatabase else {
+        return try await submissionSummaryByStudentViaFluent(
+            setupID: setupID, studentIDs: studentIDs, on: db)
+    }
+    struct SummaryRow: Decodable {
+        let userID: UUID
+        let id: String
+        let total: Int
+        enum CodingKeys: String, CodingKey {
+            case userID = "user_id"
+            case id
+            case total
+        }
+    }
+    let rows = try await sql.raw(
+        """
+        SELECT user_id, id, total FROM (
+            SELECT user_id, id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY user_id
+                    ORDER BY submitted_at DESC, attempt_number DESC
+                ) AS rn,
+                COUNT(*) OVER (PARTITION BY user_id) AS total
+            FROM \(unsafeRaw: APISubmission.schema)
+            WHERE test_setup_id = \(bind: setupID)
+              AND kind = \(bind: APISubmission.Kind.student)
+              AND user_id IN (\(binds: studentIDs))
+        ) ranked
+        WHERE rn = 1
+        """
+    ).all(decoding: SummaryRow.self)
+    return rows.reduce(into: [:]) {
+        $0[$1.userID] = SetupStudentSubmissionSummary(
+            latestSubmissionID: $1.id, submissionCount: $1.total)
+    }
+}
+
+/// The highest grade percent per student across every result of their
+/// submissions to one setup. Unlike the dashboard's by-setup fold, a best of
+/// exactly 0 IS kept: the roster fold this replaces admitted any grade at or
+/// above 0 (`best >= 0`), so an all-fail student shows "0%" to their
+/// instructor rather than no grade. Students with no gradeable result are
+/// absent.
+func bestGradePercentByStudent(
+    setupID: String, studentIDs: [UUID], on db: Database
+) async throws -> [UUID: Int] {
+    guard !studentIDs.isEmpty else { return [:] }
+    guard let sql = db as? SQLDatabase else {
+        return try await bestGradePercentByStudentViaFluent(
+            setupID: setupID, studentIDs: studentIDs, on: db)
+    }
+    struct BestRow: Decodable {
+        let userID: UUID
+        let bestFraction: Double?
+        enum CodingKeys: String, CodingKey {
+            case userID = "user_id"
+            case bestFraction = "best_fraction"
+        }
+    }
+    let rows = try await sql.raw(
+        """
+        SELECT s.user_id AS user_id,
+            MAX(CASE
+                WHEN r.total_points > 0 AND r.earned_points IS NOT NULL
+                    THEN r.earned_points / r.total_points * 100
+                WHEN r.total_tests > 0 AND r.pass_count IS NOT NULL
+                    THEN CAST(r.pass_count AS DOUBLE PRECISION)
+                        / CAST(r.total_tests AS DOUBLE PRECISION) * 100
+            END) AS best_fraction
+        FROM \(unsafeRaw: APIResult.schema) r
+        INNER JOIN \(unsafeRaw: APISubmission.schema) s ON s.id = r.submission_id
+        WHERE s.test_setup_id = \(bind: setupID)
+          AND s.kind = \(bind: APISubmission.Kind.student)
+          AND s.user_id IN (\(binds: studentIDs))
+        GROUP BY s.user_id
+        """
+    ).all(decoding: BestRow.self)
+    var best: [UUID: Int] = [:]
+    for row in rows {
+        guard let fraction = row.bestFraction else { continue }
+        best[row.userID] = Int(fraction.rounded())
+    }
+    return best
+}
+
 // MARK: - Non-SQL fallbacks
 //
 // Not hit by the sqlite/postgres drivers in use; they load the rows and run
@@ -155,6 +255,62 @@ private func studentSubmissionSummaryBySetupViaFluent(
         }
     }
     return summary
+}
+
+private func submissionSummaryByStudentViaFluent(
+    setupID: String, studentIDs: [UUID], on db: Database
+) async throws -> [UUID: SetupStudentSubmissionSummary] {
+    let rows = try await APISubmission.query(on: db)
+        .filter(\.$testSetupID == setupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .filter(\.$userID ~~ studentIDs)
+        .sort(\.$submittedAt, .descending)
+        .sort(\.$attemptNumber, .descending)
+        .field(\.$id)
+        .field(\.$userID)
+        .all()
+    var summary: [UUID: SetupStudentSubmissionSummary] = [:]
+    for row in rows {
+        guard let id = row.id, let userID = row.userID else { continue }
+        if let existing = summary[userID] {
+            summary[userID] = SetupStudentSubmissionSummary(
+                latestSubmissionID: existing.latestSubmissionID,
+                submissionCount: existing.submissionCount + 1)
+        } else {
+            summary[userID] = SetupStudentSubmissionSummary(
+                latestSubmissionID: id, submissionCount: 1)
+        }
+    }
+    return summary
+}
+
+private func bestGradePercentByStudentViaFluent(
+    setupID: String, studentIDs: [UUID], on db: Database
+) async throws -> [UUID: Int] {
+    let submissions = try await APISubmission.query(on: db)
+        .filter(\.$testSetupID == setupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .filter(\.$userID ~~ studentIDs)
+        .field(\.$id)
+        .field(\.$userID)
+        .all()
+    var studentBySubmissionID: [String: UUID] = [:]
+    for submission in submissions {
+        guard let id = submission.id, let userID = submission.userID else { continue }
+        studentBySubmissionID[id] = userID
+    }
+    guard !studentBySubmissionID.isEmpty else { return [:] }
+    let results = try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ Array(studentBySubmissionID.keys))
+        .all()
+    var best: [UUID: Int] = [:]
+    for row in results {
+        guard let userID = studentBySubmissionID[row.submissionID],
+            let pct = row.gradePercentValue
+        else { continue }
+        if pct > (best[userID] ?? -1) { best[userID] = pct }
+    }
+    return best
 }
 
 private func studentBestGradePercentBySetupViaFluent(

--- a/Sources/APIServer/Migrations/CreateSubmissionDiagnosticsPruneIndex.swift
+++ b/Sources/APIServer/Migrations/CreateSubmissionDiagnosticsPruneIndex.swift
@@ -1,0 +1,27 @@
+import Fluent
+import SQLKit
+
+/// Index for the nightly observability prune's sweep of
+/// `submission_diagnostics`.
+///
+/// The prune deletes `finished_at < cutoff`, but the table — 1:1 with
+/// `submissions`, so it grows monotonically with every graded job — had no
+/// index beyond its primary key, making each nightly pass a full scan that
+/// gets slower exactly as the table gets bigger (#1382 item 8). The same
+/// index serves the never-finished sweep beside it: a btree on `finished_at`
+/// also locates the NULL rows.
+struct CreateSubmissionDiagnosticsPruneIndex: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw(
+            "CREATE INDEX IF NOT EXISTS idx_submission_diagnostics_finished_at ON submission_diagnostics(finished_at)"
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw("DROP INDEX IF EXISTS idx_submission_diagnostics_finished_at").run()
+    }
+}

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -184,7 +184,7 @@ struct TestSetupRoutes: RouteCollection {
             let notebookPath = setupsDir + "\(setupID).ipynb"
             if let data = try await runBlocking(on: req, { extractNotebookFromZip(zipPath: zipPath) }) {
                 let normalized = normalizeNotebookForJupyterLite(data)
-                try normalized.write(to: URL(fileURLWithPath: notebookPath))
+                try await req.fileio.writeFile(.init(data: normalized), at: notebookPath)
                 setup.notebookPath = notebookPath
                 try await setup.save(on: req.db)
                 req.logger.info("Saved flat notebook for setup \(setupID) at \(notebookPath)")
@@ -402,7 +402,7 @@ struct TestSetupRoutes: RouteCollection {
         }
 
         let normalizedNotebook = normalizeNotebookForJupyterLite(notebookBytes)
-        try normalizedNotebook.write(to: URL(fileURLWithPath: notebookPath))
+        try await req.fileio.writeFile(.init(data: normalizedNotebook), at: notebookPath)
 
         if setup.notebookPath == nil {
             setup.notebookPath = notebookPath

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -96,7 +96,7 @@ struct AdminRunnerSnapshotRow: Encodable {
     let lastPollAt: String?
 }
 
-struct AdminStorageRow: Encodable {
+struct AdminStorageRow: Encodable, Sendable {
     let label: String
     let formatted: String
 }
@@ -104,7 +104,7 @@ struct AdminStorageRow: Encodable {
 /// Per-assignment on-disk footprint: its test-suite (test setup) bytes plus
 /// the bytes of every submission graded against that setup.  Sorted largest-
 /// first so an admin can see where space is going.
-struct AdminAssignmentStorageRow: Encodable {
+struct AdminAssignmentStorageRow: Encodable, Sendable {
     let assignmentTitle: String
     let courseCode: String
     let testSuiteFormatted: String
@@ -118,7 +118,7 @@ struct AdminAssignmentStorageRow: Encodable {
     let totalBytes: Int
 }
 
-struct AdminStorageContext: Encodable {
+struct AdminStorageContext: Encodable, Sendable {
     let rows: [AdminStorageRow]
     let totalFormatted: String
     let dbBackend: String

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -213,22 +213,33 @@ struct AdminRoutes: RouteCollection {
 
     /// Measures the persistent-volume sinks (submission/test-setup uploads,
     /// the results+logs dir, the static asset tree) and the database so an
-    /// admin can see where disk is going.  Directory walks are blocking, so
-    /// they run on the thread pool off the event loop.
+    /// admin can see where disk is going.
     ///
     /// `static` so the admin diagnostic MCP tool (`get_storage_usage`) can reuse
     /// the exact same builder as the `/admin/storage` page — the context is
     /// PII-free (assignment/course identifiers + byte counts only).
+    ///
+    /// Cached behind a single-flight TTL (#1382 item 5): the walks stat every
+    /// submission ever kept plus the whole static asset tree, so the page got
+    /// slowest exactly when there was the most disk to account for — and the
+    /// MCP tool made it pollable. The walks now run at most once per TTL.
     static func makeStorageContext(req: Request) async throws -> AdminStorageContext {
-        let submissionsDir = req.application.submissionsDirectory
-        let testSetupsDir = req.application.testSetupsDirectory
-        let resultsDir = req.application.resultsDirectory
-        let publicDir = req.application.directory.publicDirectory
+        let app = req.application
+        return try await app.storageUsageCache.context {
+            try await computeStorageContext(app: app)
+        }
+    }
+
+    /// The uncached breakdown build. Directory walks are blocking, so they
+    /// run on the thread pool off the event loop.
+    private static func computeStorageContext(app: Application) async throws -> AdminStorageContext {
+        let submissionsDir = app.submissionsDirectory
+        let testSetupsDir = app.testSetupsDirectory
+        let resultsDir = app.resultsDirectory
+        let publicDir = app.directory.publicDirectory
 
         func dirSize(_ path: String) async throws -> Int {
-            try await req.application.threadPool.runIfActive(eventLoop: req.eventLoop) {
-                directorySizeBytes(at: path)
-            }.get()
+            try await runBlocking(app: app) { directorySizeBytes(at: path) }
         }
 
         // Per-id footprints feed both the aggregate cards and the per-assignment
@@ -237,23 +248,26 @@ struct AdminRoutes: RouteCollection {
         // "Submissions" card to avoid scanning that (potentially large) dir
         // twice.  Test setups have `shared/`+`notebooks/` subtrees, so the
         // card keeps an authoritative recursive walk.
-        async let submissionSizesFetch = req.application.threadPool.runIfActive(
-            eventLoop: req.eventLoop
-        ) { topLevelFileSizesByID(inDirectory: submissionsDir) }.get()
-        async let setupSizesFetch = req.application.threadPool.runIfActive(
-            eventLoop: req.eventLoop
-        ) { testSetupSizesByID(testSetupsDirectory: testSetupsDir) }.get()
+        async let submissionSizesFetch = runBlocking(app: app) {
+            topLevelFileSizesByID(inDirectory: submissionsDir)
+        }
+        async let setupSizesFetch = runBlocking(app: app) {
+            testSetupSizesByID(testSetupsDirectory: testSetupsDir)
+        }
 
         async let testSetupsBytes = dirSize(testSetupsDir)
         async let resultsBytes = dirSize(resultsDir)
         async let publicBytes = dirSize(publicDir)
         async let dbBytes = databaseSizeBytes(
-            on: req.db, settings: req.application.appConfig.database)
+            on: app.db, settings: app.appConfig.database)
 
-        // Mapping rows for the per-assignment breakdown.
-        async let assignmentsFetch = APIAssignment.query(on: req.db).all()
-        async let coursesFetch = APICourse.query(on: req.db).all()
-        async let submissionLinksFetch = APISubmission.query(on: req.db)
+        // Mapping rows for the per-assignment breakdown.  The (id → setup)
+        // projection is the minimal query byte attribution needs: sizes live
+        // only on disk, keyed by submission id, so each on-disk file's bytes
+        // can only reach its assignment through this map.
+        async let assignmentsFetch = APIAssignment.query(on: app.db).all()
+        async let coursesFetch = APICourse.query(on: app.db).all()
+        async let submissionLinksFetch = APISubmission.query(on: app.db)
             .field(\.$id).field(\.$testSetupID).all()
 
         let submissionSizesByID = try await submissionSizesFetch
@@ -319,7 +333,7 @@ struct AdminRoutes: RouteCollection {
         return AdminStorageContext(
             rows: rows,
             totalFormatted: humanReadableBytes(total),
-            dbBackend: req.application.appConfig.database.backend.rawValue,
+            dbBackend: app.appConfig.database.backend.rawValue,
             assignments: assignmentRows
         )
     }

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
@@ -50,12 +50,12 @@ extension CourseBundleRoutes {
         let contentFilesDir = req.application.contentFilesDirectory
 
         let tally = try await performImportTransaction(
+            app: req.application,
             db: req.db,
             manifest: manifest,
-            extractDir: extractDir,
-            setupsDir: setupsDir,
-            subsDir: subsDir,
-            contentFilesDir: contentFilesDir
+            dirs: BundleImportDirectories(
+                extractDir: extractDir, setupsDir: setupsDir,
+                subsDir: subsDir, contentFilesDir: contentFilesDir)
         )
 
         await AuditLogger.record(
@@ -183,14 +183,15 @@ extension CourseBundleRoutes {
     // (errors in Swift 6 strict mode).
 
     private func performImportTransaction(
+        app: Application,
         db: Database,
         manifest: CourseBundleManifest,
-        extractDir: URL,
-        setupsDir: String,
-        subsDir: String,
-        contentFilesDir: String
+        dirs: BundleImportDirectories
     ) async throws -> ImportTally {
-        try await db.transaction { (db) -> ImportTally in
+        let extractDir = dirs.extractDir
+        let subsDir = dirs.subsDir
+        let contentFilesDir = dirs.contentFilesDir
+        return try await db.transaction { (db) -> ImportTally in
             // 6a. Check for course code conflicts (moved inside transaction)
             let existingCourse = try await APICourse.query(on: db)
                 .filter(\.$code == manifest.course.code)
@@ -248,8 +249,8 @@ extension CourseBundleRoutes {
 
             // 6f. Create test setups → setupIDMap[bundleID] = new live ID
             let setupIDMap = try await importBundledTestSetups(
-                manifest: manifest, extractDir: extractDir, setupsDir: setupsDir,
-                courseID: t.courseID, db: db, tally: &t)
+                manifest: manifest, dirs: dirs, courseID: t.courseID,
+                app: app, db: db, tally: &t)
 
             // 6g. Create assignments
             try await importBundledAssignments(
@@ -388,30 +389,49 @@ private func importBundledEnrollments(
     }
 }
 
+/// The filesystem destinations a bundle import writes into, bundled so the
+/// import helpers stay within the parameter-count limit.
+struct BundleImportDirectories: Sendable {
+    let extractDir: URL
+    let setupsDir: String
+    let subsDir: String
+    let contentFilesDir: String
+}
+
 private func importBundledTestSetups(
     manifest: CourseBundleManifest,
-    extractDir: URL,
-    setupsDir: String,
+    dirs: BundleImportDirectories,
     courseID: UUID,
+    app: Application,
     db: Database,
     tally: inout ImportTally
 ) async throws -> [String: String] {
+    let extractDir = dirs.extractDir
+    let setupsDir = dirs.setupsDir
     var setupIDMap: [String: String] = [:]
     for bundledSetup in manifest.testSetups {
         let newSetupID = "setup_\(UUID().uuidString.lowercased().prefix(8))"
         let newZipPath = setupsDir + "\(newSetupID).zip"
 
-        // Copy zip from bundle into testsetups dir.
+        // Copy zip from bundle into testsetups dir — a whole test setup
+        // archive per loop turn, on the thread pool rather than the
+        // cooperative pool (#1382 item 9; app-scoped because this runs
+        // inside the import transaction, whose closure cannot capture the
+        // request).
         let srcZip = extractDir.appendingPathComponent(bundledSetup.zipFilename)
-        try FileManager.default.copyItem(
-            at: srcZip,
-            to: URL(fileURLWithPath: newZipPath))
+        try await runBlocking(app: app) {
+            try FileManager.default.copyItem(
+                at: srcZip,
+                to: URL(fileURLWithPath: newZipPath))
+        }
 
         // Extract .ipynb if present (browser-mode setups).
         var notebookPath: String?
         if let nbData = extractNotebookFromZip(zipPath: newZipPath) {
             let nbPath = setupsDir + "\(newSetupID).ipynb"
-            try nbData.write(to: URL(fileURLWithPath: nbPath))
+            try await runBlocking(app: app) {
+                try nbData.write(to: URL(fileURLWithPath: nbPath))
+            }
             notebookPath = nbPath
         }
 

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -305,7 +305,7 @@ extension DraftAssignmentRoutes {
         case .redirect(toURL: let url): return req.redirect(to: url)
         }
 
-        let paths = try writeNewAssignmentNotebookAndPlanPaths(req: req, validated: validated)
+        let paths = try await writeNewAssignmentNotebookAndPlanPaths(req: req, validated: validated)
 
         let setupPackage = try rebuildNewAssignmentSuiteZip(
             validated: validated,
@@ -449,7 +449,7 @@ extension DraftAssignmentRoutes {
     fileprivate func writeNewAssignmentNotebookAndPlanPaths(
         req: Request,
         validated: ValidatedSaveNewAssignment
-    ) throws -> NewAssignmentPaths {
+    ) async throws -> NewAssignmentPaths {
         let assignmentNotebook = normalizeNotebookForJupyterLite(validated.assignmentNotebookRaw)
         let setupID = validated.draftSetup?.id ?? "setup_\(UUID().uuidString.lowercased().prefix(8))"
         let setupsDir = req.application.testSetupsDirectory
@@ -462,7 +462,7 @@ extension DraftAssignmentRoutes {
         try FileManager.default.createDirectory(atPath: notebookDir, withIntermediateDirectories: true)
         let notebookPath = notebookDir + notebookFilename
         let zipPath = validated.draftSetup?.zipPath ?? (setupsDir + "\(setupID).zip")
-        try assignmentNotebook.write(to: URL(fileURLWithPath: notebookPath))
+        try await req.fileio.writeFile(.init(data: assignmentNotebook), at: notebookPath)
         return NewAssignmentPaths(setupID: setupID, notebookPath: notebookPath, zipPath: zipPath)
     }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -29,16 +29,20 @@ extension InstructorDashboardRoutes {
         async let enrolledStudentCountFetch = enrolledStudentCount(forCourse: assignment.courseID, on: req.db)
 
         let students = try await loadAssignmentSubmissionsStudents(req: req, assignment: assignment)
-        let studentIDs = Set(students.compactMap(\.id))
+        let studentIDs = students.compactMap(\.id)
 
-        let submissions = try await loadAssignmentSubmissionRows(
+        // Per-student summary (latest pick + attempt count) and best grade
+        // ("highest grade wins" across all result sources) are SQL aggregates
+        // (#1382 item 6): this page used to load every attempt by every
+        // student plus a grade fold over all of them, on a page instructors
+        // refresh during a deadline. The metric cards read only the last 30
+        // days of timestamps, so that window is all that's fetched for them.
+        async let summaryFetch = submissionSummaryByStudent(
+            setupID: assignment.testSetupID, studentIDs: studentIDs, on: req.db)
+        async let bestFetch = bestGradePercentByStudent(
+            setupID: assignment.testSetupID, studentIDs: studentIDs, on: req.db)
+        async let recentFetch = loadRecentSubmissionTimestamps(
             req: req, assignment: assignment, studentIDs: studentIDs)
-        let submissionsByStudentID = submissionsGroupedByStudentID(submissions)
-        let submissionIDs = submissions.compactMap(\.id)
-        // Best grade percentage per submission across ALL result sources
-        // (browser and worker alike) — "highest grade wins".
-        let bestPercentBySubmissionID = try await bestGradePercentBySubmissionID(
-            for: submissionIDs, on: req.db)
 
         // Instructor grade overrides for this assignment, indexed by student.
         let overrideMap = try await loadGradeOverridePercents(
@@ -58,9 +62,26 @@ extension InstructorDashboardRoutes {
                 assignmentID: assignment.requireID(), on: req.db)
         }
 
+        let summaryByStudentID = try await summaryFetch
+        let bestByStudentID = try await bestFetch
+
+        // The latest submission per student, refetched as O(students) rows
+        // for their timestamps.
+        let latestIDs = summaryByStudentID.values.map(\.latestSubmissionID)
+        let latestRows =
+            latestIDs.isEmpty
+            ? []
+            : try await APISubmission.query(on: req.db)
+                .filter(\.$id ~~ latestIDs)
+                .all()
+        let latestRowByID = Dictionary(
+            latestRows.compactMap { row in row.id.map { ($0, row) } },
+            uniquingKeysWith: { first, _ in first })
+
         let lookups = StudentRowLookups(
-            submissionsByStudentID: submissionsByStudentID,
-            bestPercentBySubmissionID: bestPercentBySubmissionID,
+            summaryByStudentID: summaryByStudentID,
+            latestRowByID: latestRowByID,
+            bestByStudentID: bestByStudentID,
             overrideByStudentID: overrideByStudentID,
             spentRevealUserIDs: spentRevealUserIDs)
         let fmt = waterlooDateTimeFormatter()
@@ -73,10 +94,11 @@ extension InstructorDashboardRoutes {
             )
         }
 
+        let recentSubmissions = try await recentFetch
         let enrolledStudentRosterCount = try await enrolledStudentCountFetch
         let metrics = buildAssignmentSubmissionsMetrics(
             rows: rows,
-            submissions: submissions,
+            submissions: recentSubmissions,
             enrolledStudentRosterCount: enrolledStudentRosterCount
         )
 
@@ -108,34 +130,33 @@ extension InstructorDashboardRoutes {
             .all()
     }
 
-    private func loadAssignmentSubmissionRows(
-        req: Request, assignment: APIAssignment, studentIDs: Set<UUID>
+    /// The last 31 days of roster submissions, field-limited to identity +
+    /// timestamp — all the metric cards read (the 24h count and the
+    /// 24h/7d/30d trend buckets, whose earliest bucket starts within 30
+    /// calendar days), so the fetch is bounded by the window rather than the
+    /// term. The extra day is timezone margin; the bucketing drops
+    /// out-of-range rows either way.
+    private func loadRecentSubmissionTimestamps(
+        req: Request, assignment: APIAssignment, studentIDs: [UUID]
     ) async throws -> [APISubmission] {
         guard !studentIDs.isEmpty else { return [] }
+        let cutoff = Date().addingTimeInterval(-31 * 24 * 60 * 60)
         return try await APISubmission.query(on: req.db)
             .filter(\.$testSetupID == assignment.testSetupID)
             .filter(\.$kind == APISubmission.Kind.student)
             .filter(\.$userID ~~ studentIDs)
-            .sort(\.$submittedAt, .descending)
+            .filter(\.$submittedAt >= cutoff)
+            .field(\.$id)
+            .field(\.$submittedAt)
             .all()
-    }
-
-    private func submissionsGroupedByStudentID(
-        _ submissions: [APISubmission]
-    ) -> [UUID: [APISubmission]] {
-        var submissionsByStudentID: [UUID: [APISubmission]] = [:]
-        for row in submissions {
-            guard let userID = row.userID else { continue }
-            submissionsByStudentID[userID, default: []].append(row)
-        }
-        return submissionsByStudentID
     }
 
     /// Per-assignment lookup tables shared by every roster row build, bundled
     /// so `buildAssignmentStudentRow` stays within the parameter-count limit.
     private struct StudentRowLookups {
-        let submissionsByStudentID: [UUID: [APISubmission]]
-        let bestPercentBySubmissionID: [String: Int]
+        let summaryByStudentID: [UUID: SetupStudentSubmissionSummary]
+        let latestRowByID: [String: APISubmission]
+        let bestByStudentID: [UUID: Int]
         let overrideByStudentID: [UUID: Int]
         let spentRevealUserIDs: Set<UUID>
     }
@@ -147,20 +168,10 @@ extension InstructorDashboardRoutes {
         fmt: DateFormatter
     ) -> AssignmentStudentRow? {
         guard let studentID = student.id else { return nil }
-        let history = lookups.submissionsByStudentID[studentID] ?? []
-        let latest = history.first
-        let runnerBestGradePercent: Int? = {
-            var best = -1
-            for submission in history {
-                guard let subID = submission.id,
-                    let pct = lookups.bestPercentBySubmissionID[subID]
-                else {
-                    continue
-                }
-                if pct > best { best = pct }
-            }
-            return best >= 0 ? best : nil
-        }()
+        let summary = lookups.summaryByStudentID[studentID]
+        let latest = summary.flatMap { lookups.latestRowByID[$0.latestSubmissionID] }
+        let submissionCount = summary?.submissionCount ?? 0
+        let runnerBestGradePercent = lookups.bestByStudentID[studentID]
         // An instructor override is the student's effective grade — it feeds
         // both the displayed grade and the median metric.
         let override = lookups.overrideByStudentID[studentID]
@@ -177,12 +188,12 @@ extension InstructorDashboardRoutes {
             gradeText: bestGradePercent.map { "\($0)%" } ?? "—",
             gradeIsOverridden: override != nil,
             gradeOverridePercent: override ?? runnerBestGradePercent ?? 0,
-            submissionCount: history.count,
+            submissionCount: submissionCount,
             hasLatestSubmission: latest != nil,
             latestSubmissionID: latest?.id ?? "",
             latestSubmittedAtText: latest?.submittedAt.map { fmt.string(from: $0) } ?? "—",
             latestSubmittedAtEpoch: latest?.submittedAt.map { Int($0.timeIntervalSince1970) } ?? 0,
-            additionalSubmissionCount: max(history.count - 1, 0),
+            additionalSubmissionCount: max(submissionCount - 1, 0),
             fullHistoryURL: "/instructor/\(assignmentIDRaw)/students/\(studentID.uuidString)/history",
             bestGradePercent: bestGradePercent,
             secretRevealSpent: lookups.spentRevealUserIDs.contains(studentID)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+NotebookTools.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+NotebookTools.swift
@@ -193,7 +193,7 @@ extension PublishedAssignmentRoutes {
             testSetupsDirectory: req.application.testSetupsDirectory, setupID: assignment.testSetupID)
         _ = try ensureDraftNotebookDirectory(
             testSetupsDirectory: req.application.testSetupsDirectory, setupID: assignment.testSetupID)
-        try normalized.write(to: URL(fileURLWithPath: draftPath))
+        try await req.fileio.writeFile(.init(data: normalized), at: draftPath)
 
         _ = try await ensureUserNotebookWorkingCopy(
             req: req, setupID: assignment.testSetupID, userID: userID, fallbackSetup: setup,

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -96,7 +96,7 @@ extension PublishedAssignmentRoutes {
             return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
 
-        try persistAssignmentNotebook(
+        try await persistAssignmentNotebook(
             req: req,
             assignment: assignment,
             setup: setup,
@@ -360,7 +360,7 @@ extension PublishedAssignmentRoutes {
         assignmentNotebookRaw: Data,
         uploadedFile: File?,
         hasUpload: Bool
-    ) throws {
+    ) async throws {
         let assignmentNotebook = normalizeNotebookForJupyterLite(assignmentNotebookRaw)
         let notebookPath: String = {
             if hasUpload {
@@ -377,7 +377,7 @@ extension PublishedAssignmentRoutes {
             }
             return setup.notebookPath ?? (req.application.testSetupsDirectory + "\(assignment.testSetupID).ipynb")
         }()
-        try assignmentNotebook.write(to: URL(fileURLWithPath: notebookPath))
+        try await req.fileio.writeFile(.init(data: assignmentNotebook), at: notebookPath)
         setup.notebookPath = notebookPath
     }
 

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -28,7 +28,7 @@ func enqueueRunnerValidationSubmission(
     let subID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
     let ext = (sanitizedFilename as NSString).pathExtension
     let filePath = submissionsDir + "\(subID).\(ext)"
-    try solutionNotebookData.write(to: URL(fileURLWithPath: filePath))
+    try await req.fileio.writeFile(.init(data: solutionNotebookData), at: filePath)
 
     let priorCount = try await APISubmission.query(on: req.db)
         .filter(\.$testSetupID == setupID)
@@ -68,6 +68,7 @@ func enqueueRunnerValidationSubmission(
         setupID: setupID,
         templateNotebookData: solutionNotebookData,
         testSetupsDirectory: req.application.testSetupsDirectory,
+        app: req.application,
         on: req.db)
 
     try await materialized.saveClaimable(on: req.db)
@@ -156,6 +157,7 @@ func materializeValidationGrading(
     setupID: String,
     templateNotebookData: Data,
     testSetupsDirectory: String,
+    app: Application,
     on db: any Database
 ) async -> MaterializedValidationSubmission {
     await resolveAndCacheValidationMaterialization(
@@ -163,6 +165,7 @@ func materializeValidationGrading(
         setupID: setupID,
         templateNotebookData: templateNotebookData,
         testSetupsDirectory: testSetupsDirectory,
+        app: app,
         on: db)
     return MaterializedValidationSubmission(submission: submission)
 }
@@ -175,6 +178,7 @@ private func resolveAndCacheValidationMaterialization(
     setupID: String,
     templateNotebookData: Data,
     testSetupsDirectory: String,
+    app: Application,
     on db: any Database
 ) async {
     do {
@@ -222,7 +226,10 @@ private func resolveAndCacheValidationMaterialization(
                 substitutions: resolution.substitutions,
                 strict: false)
         {
-            try? substituted.write(to: URL(fileURLWithPath: submission.zipPath + ".grading"))
+            let sidecarPath = submission.zipPath + ".grading"
+            try? await runBlocking(app: app) {
+                try substituted.write(to: URL(fileURLWithPath: sidecarPath))
+            }
         }
 
         let materialization = SubmissionMaterialization(

--- a/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+NotebookSave.swift
@@ -266,7 +266,7 @@ extension WebRoutes {
                 testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id ?? "")
             _ = try ensureDraftNotebookDirectory(
                 testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id ?? "")
-            try normalized.write(to: URL(fileURLWithPath: draftPath))
+            try await req.fileio.writeFile(.init(data: normalized), at: draftPath)
             return NotebookSaveOutcome(
                 validationStatus: nil, message: "Solution saved to the draft.")
         }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -417,6 +417,10 @@ func registerMigrations(on app: Application) {
     // `AddSessionsCreatedAt` above, which is what creates the column.
     app.migrations.add(CreateSessionReaperIndex())
 
+    // Observability prune sweep over submission_diagnostics (#1382 item 8).
+    // Index-only; the table is created far above.
+    app.migrations.add(CreateSubmissionDiagnosticsPruneIndex())
+
     // Data backfill, registered LAST on purpose: it full-queries `APITestSetup`,
     // which is only safe once every migration that adds a column to
     // `test_setups` has already run (the #1077 boot-order hazard, inverted —

--- a/Tests/APITests/AssignmentSubmissionsRosterPinTests.swift
+++ b/Tests/APITests/AssignmentSubmissionsRosterPinTests.swift
@@ -1,0 +1,93 @@
+// Tests/APITests/AssignmentSubmissionsRosterPinTests.swift
+//
+// Pins the VALUES the instructor assignment-submissions roster derives from
+// the per-assignment submission history (#1382 item 6) — best grade across
+// attempts, the latest-submission pick, the attempt count, and the derived
+// metric cards — so the aggregate rewrite of the page's loaders cannot
+// change a fold's meaning without a test noticing. Written and verified
+// against the pre-aggregate loaders first.
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized)
+struct AssignmentSubmissionsRosterPinTests {
+
+    @Test func rosterPinsGradeLatestCountAndMetricsAcrossAttempts() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            // Student A: three attempts at 40%, 80%, 20% — best 80, latest #3.
+            let alice = try await arInsertStudent(username: "roster_alice", on: app)
+            try await arEnrollStudentInTestCourse(alice, on: app)
+            let aliceID = try alice.requireID()
+            // Student B: one attempt at 60%.
+            let bob = try await arInsertStudent(username: "roster_bob", on: app)
+            try await arEnrollStudentInTestCourse(bob, on: app)
+            let bobID = try bob.requireID()
+
+            try await arInsertSetup(id: "roster_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "roster_setup", title: "Roster Lab", isOpen: true, on: app)
+
+            for (index, percentPair) in [(2, 5), (4, 5), (1, 5)].enumerated() {
+                let attempt = index + 1
+                _ = try await arInsertSubmission(
+                    id: "sub_roster_a\(attempt)", testSetupID: "roster_setup",
+                    userID: aliceID, attemptNumber: attempt, on: app)
+                let result = APIResult(
+                    id: "res_roster_a\(attempt)", submissionID: "sub_roster_a\(attempt)")
+                try await result.saveWithCollection(
+                    json: #"{"passCount":\#(percentPair.0),"totalTests":\#(percentPair.1)}"#,
+                    on: app.db)
+            }
+            _ = try await arInsertSubmission(
+                id: "sub_roster_b1", testSetupID: "roster_setup",
+                userID: bobID, attemptNumber: 1, on: app)
+            let bobResult = APIResult(id: "res_roster_b1", submissionID: "sub_roster_b1")
+            try await bobResult.saveWithCollection(
+                json: #"{"passCount":3,"totalTests":5}"#, on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/submissions",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(
+                        body.contains("<td>80%"),
+                        "A row's grade is the best across ALL attempts")
+                    #expect(
+                        !body.contains("<td>20%"),
+                        "The latest attempt's lower grade must not displace the best")
+                    #expect(
+                        body.contains(#"/submissions/sub_roster_a3" class="submission-history-latest""#),
+                        "The latest-submission link points at the newest attempt")
+                    #expect(
+                        body.contains("+2 more"),
+                        "The history link counts every prior attempt")
+                    #expect(
+                        body.contains("<td>60%"),
+                        "A single-attempt student's grade renders")
+                    #expect(
+                        body.contains(">2/2<"),
+                        "Students Submitted counts distinct submitters over the roster")
+                    #expect(
+                        body.contains(">2.0<"),
+                        "Avg attempts averages per submitted student: (3 + 1) / 2")
+                    #expect(
+                        body.contains(">70%<"),
+                        "Median grade is the median of per-student bests: {80, 60} → 70")
+                    #expect(
+                        body.contains("3 attempts: 1 student"),
+                        "The attempts distribution bins by per-student count")
+                })
+        }
+    }
+}

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -509,6 +509,62 @@ import VaporTesting
         }
     }
 
+    /// Never-finished `submission_diagnostics` rows (a job that died before
+    /// reporting) keep a NULL `finished_at`, which the retention filter's
+    /// `< cutoff` never matches — so they used to accumulate permanently.
+    /// They now age out on `created_at` at the same window, while recent
+    /// in-flight rows and finished rows keep their existing behaviour
+    /// (#1382 item 8).
+    @Test func prunePassAgesOutNeverFinishedSubmissionDiagnostics() async throws {
+        try await withApp(app) { _ in
+            let retentionDays = app.diagnostics.configuration.jobMetricRetentionDays
+            let expired = Date().addingTimeInterval(-Double(retentionDays + 5) * 86400)
+
+            let staleID = try await makeSubmissionDiagnostics(
+                submissionID: "sub_diag_stale", finishedAt: nil, createdAt: expired)
+            let freshID = try await makeSubmissionDiagnostics(
+                submissionID: "sub_diag_fresh", finishedAt: nil, createdAt: Date())
+            let finishedOldID = try await makeSubmissionDiagnostics(
+                submissionID: "sub_diag_done_old", finishedAt: expired, createdAt: expired)
+            let finishedNewID = try await makeSubmissionDiagnostics(
+                submissionID: "sub_diag_done_new", finishedAt: Date(), createdAt: expired)
+
+            await app.diagnostics.pruneNow(on: app.db, logger: app.logger)
+
+            #expect(
+                try await APISubmissionDiagnostics.find(staleID, on: app.db) == nil,
+                "A never-finished row past the retention window is aged out")
+            #expect(
+                try await APISubmissionDiagnostics.find(freshID, on: app.db) != nil,
+                "A recent in-flight row survives")
+            #expect(
+                try await APISubmissionDiagnostics.find(finishedOldID, on: app.db) == nil,
+                "A finished row past retention is pruned, as before")
+            #expect(
+                try await APISubmissionDiagnostics.find(finishedNewID, on: app.db) != nil,
+                "A recently finished row survives regardless of its creation time")
+        }
+    }
+
+    /// Like `makeClientDiagnostic`: `created_at` is a `.create` timestamp, so
+    /// it is stamped on save and then backdated with an update. The row's id
+    /// carries a foreign key to `submissions`, so each needs a real
+    /// submission behind it.
+    private func makeSubmissionDiagnostics(
+        submissionID: String, finishedAt: Date?, createdAt: Date
+    ) async throws -> String {
+        let (setup, _) = try await makeSubmission(submissionID: submissionID)
+        let row = APISubmissionDiagnostics()
+        row.id = submissionID
+        row.testSetupID = try setup.requireID()
+        row.kind = APISubmission.Kind.student
+        row.finishedAt = finishedAt
+        try await row.create(on: app.db)
+        row.createdAt = createdAt
+        try await row.update(on: app.db)
+        return submissionID
+    }
+
     /// Regression test for the admin runner page showing `Total < Queue
     /// Wait`. Models the production failure mode: the runner's wall clock
     /// is offset relative to the server, so the runner-reported

--- a/Tests/APITests/StorageUsageCacheTests.swift
+++ b/Tests/APITests/StorageUsageCacheTests.swift
@@ -1,0 +1,91 @@
+// Tests/APITests/StorageUsageCacheTests.swift
+//
+// Pins the storage-breakdown cache's contract (#1382 item 5): a TTL-fresh
+// context is served without recomputing, expiry recomputes, concurrent
+// callers coalesce onto one computation, and failures are never cached.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct StorageUsageCacheTests {
+
+    private actor ComputeCounter {
+        private(set) var count = 0
+        func bump() { count += 1 }
+    }
+
+    private static func makeContext(total: String) -> AdminStorageContext {
+        AdminStorageContext(rows: [], totalFormatted: total, dbBackend: "sqlite", assignments: [])
+    }
+
+    @Test func servesCachedContextWithinTTLAndRecomputesAfter() async throws {
+        let cache = StorageUsageCache(ttl: 60)
+        let counter = ComputeCounter()
+        let start = Date()
+
+        let first = try await cache.context(now: start) {
+            await counter.bump()
+            return Self.makeContext(total: "1 B")
+        }
+        let second = try await cache.context(now: start.addingTimeInterval(30)) {
+            await counter.bump()
+            return Self.makeContext(total: "2 B")
+        }
+        #expect(first.totalFormatted == "1 B")
+        #expect(second.totalFormatted == "1 B", "A TTL-fresh context is served from cache")
+        #expect(await counter.count == 1)
+
+        let third = try await cache.context(now: start.addingTimeInterval(61)) {
+            await counter.bump()
+            return Self.makeContext(total: "3 B")
+        }
+        #expect(third.totalFormatted == "3 B", "An expired context recomputes")
+        #expect(await counter.count == 2)
+    }
+
+    @Test func concurrentCallersCoalesceOntoOneComputation() async throws {
+        let cache = StorageUsageCache(ttl: 60)
+        let counter = ComputeCounter()
+
+        let results = await withThrowingTaskGroup(of: String.self) { group in
+            for _ in 0..<4 {
+                group.addTask {
+                    try await cache.context {
+                        await counter.bump()
+                        try await Task.sleep(nanoseconds: 50_000_000)
+                        return Self.makeContext(total: "coalesced")
+                    }.totalFormatted
+                }
+            }
+            var collected: [String] = []
+            while let value = try? await group.next() {
+                collected.append(value)
+            }
+            return collected
+        }
+
+        #expect(results == ["coalesced", "coalesced", "coalesced", "coalesced"])
+        #expect(await counter.count == 1, "Concurrent callers share one in-flight computation")
+    }
+
+    @Test func failuresAreNotCached() async throws {
+        struct ComputeFailed: Error {}
+        let cache = StorageUsageCache(ttl: 60)
+        let counter = ComputeCounter()
+
+        await #expect(throws: ComputeFailed.self) {
+            try await cache.context {
+                await counter.bump()
+                throw ComputeFailed()
+            }
+        }
+        let recovered = try await cache.context {
+            await counter.bump()
+            return Self.makeContext(total: "ok")
+        }
+        #expect(recovered.totalFormatted == "ok", "The next caller retries after a failure")
+        #expect(await counter.count == 2)
+    }
+}

--- a/Tests/APITests/StudentSubmissionAggregatesTests.swift
+++ b/Tests/APITests/StudentSubmissionAggregatesTests.swift
@@ -145,6 +145,67 @@ import VaporTesting
         }
     }
 
+    // MARK: - By-student variants (instructor roster, #1382 item 6)
+
+    @Test func summaryByStudentPicksLatestAndCountsPerStudent() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let alice = try await wrStudentUser(on: app)
+            let aliceID = try alice.requireID()
+            _ = try await loginUser(username: "student2", password: "pass", role: "student", on: app)
+            let bob = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "student2").first())
+            let bobID = try bob.requireID()
+
+            try await wrInsertSetup(id: "agg_roster", on: app)
+            try await wrInsertSubmission(
+                id: "agg_r_a1", testSetupID: "agg_roster", userID: aliceID, attemptNumber: 1, on: app)
+            try await wrInsertSubmission(
+                id: "agg_r_a2", testSetupID: "agg_roster", userID: aliceID, attemptNumber: 2, on: app)
+            try await wrInsertSubmission(
+                id: "agg_r_b1", testSetupID: "agg_roster", userID: bobID, attemptNumber: 1, on: app)
+            // Noise: another setup's attempt must not leak into this roster.
+            try await wrInsertSetup(id: "agg_roster_other", on: app)
+            try await wrInsertSubmission(
+                id: "agg_r_other", testSetupID: "agg_roster_other", userID: aliceID,
+                attemptNumber: 3, on: app)
+
+            let summary = try await submissionSummaryByStudent(
+                setupID: "agg_roster", studentIDs: [aliceID, bobID], on: app.db)
+
+            #expect(summary.count == 2)
+            #expect(summary[aliceID]?.latestSubmissionID == "agg_r_a2")
+            #expect(summary[aliceID]?.submissionCount == 2)
+            #expect(summary[bobID]?.latestSubmissionID == "agg_r_b1")
+            #expect(summary[bobID]?.submissionCount == 1)
+        }
+    }
+
+    @Test func bestPercentByStudentKeepsAnAllFailZero() async throws {
+        try await withWebRoutesApp(prefix: "chickadee-agg") { app in
+            _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+
+            try await wrInsertSetup(id: "agg_roster_zero", on: app)
+            try await wrInsertSubmission(
+                id: "agg_rz1", testSetupID: "agg_roster_zero", userID: userID, attemptNumber: 1,
+                on: app)
+            try await wrInsertResult(
+                submissionID: "agg_rz1",
+                outcomes: [
+                    wrMakeOutcome(name: "t1", status: .fail),
+                    wrMakeOutcome(name: "t2", status: .fail),
+                ], on: app)
+
+            // Unlike the dashboard's by-setup fold (which hides a 0 behind its
+            // sentinel), the roster fold admits 0 — an instructor sees "0%".
+            let best = try await bestGradePercentByStudent(
+                setupID: "agg_roster_zero", studentIDs: [userID], on: app.db)
+            #expect(best == [userID: 0])
+        }
+    }
+
     @Test func bestPercentOmitsAnAllFailZero() async throws {
         try await withWebRoutesApp(prefix: "chickadee-agg") { app in
             _ = try await loginUser(username: "student1", password: "pass", role: "student", on: app)

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -662,7 +662,8 @@ import VaporTesting
             let template = try Data(contentsOf: URL(fileURLWithPath: sub.zipPath))
             _ = await materializeValidationGrading(
                 submission: sub, setupID: setupID, templateNotebookData: template,
-                testSetupsDirectory: self.app.testSetupsDirectory, on: self.app.db)
+                testSetupsDirectory: self.app.testSetupsDirectory, app: self.app,
+                on: self.app.db)
 
             // The cache record is stamped on the row.
             #expect(sub.materializationJSON != nil)
@@ -754,7 +755,8 @@ import VaporTesting
             let template = try Data(contentsOf: URL(fileURLWithPath: sub.zipPath))
             _ = await materializeValidationGrading(
                 submission: sub, setupID: setupID, templateNotebookData: template,
-                testSetupsDirectory: self.app.testSetupsDirectory, on: self.app.db)
+                testSetupsDirectory: self.app.testSetupsDirectory, app: self.app,
+                on: self.app.db)
 
             // Sidecar carries the resolved int, not the raw placeholder.
             let sidecar = sub.zipPath + ".grading"

--- a/changelog.d/instructor-blocking-writes.md
+++ b/changelog.d/instructor-blocking-writes.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Instructor-side file writes come off the cooperative pool.** The nine
+  synchronous notebook/zip writes left behind by the student-path fix — the
+  setup upload's flat-notebook extraction, the notebook edit save, both
+  assignment save paths, the draft solution writes, the validation
+  submission write and its personalization sidecar, and the course-bundle
+  import's per-setup zip copy + notebook write — now go through
+  `req.fileio.writeFile`, or the thread pool where the code runs inside the
+  import transaction and cannot hold a request (#1382 item 9).

--- a/changelog.d/instructor-roster-aggregates.md
+++ b/changelog.d/instructor-roster-aggregates.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The instructor assignment-submissions roster no longer loads every
+  attempt to render.** The per-student latest pick, attempt count, and best
+  grade are computed by the database (the same window-function and MAX
+  aggregates the student dashboard now uses, partitioned by student), and
+  the metric cards fetch only the last month of submission timestamps —
+  their trend windows never look further back — instead of the full history
+  a deadline-day refresh used to re-fold (#1382 item 6). An all-fail
+  student still shows "0%" to their instructor, and the roster's values are
+  pinned by render tests written against the pre-aggregate loaders.

--- a/changelog.d/storage-breakdown-cache.md
+++ b/changelog.d/storage-breakdown-cache.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **The admin storage breakdown is cached behind a single-flight TTL.**
+  Building it stats every submission file ever kept plus the whole static
+  asset tree, so the "are we running out of disk" page got slowest exactly
+  when there was the most disk to account for — and the read-only admin
+  MCP's `get_storage_usage` made it pollable. The `/admin/storage` page and
+  the MCP tool now share one cached context; the walks run at most once per
+  minute no matter how many pollers ask (#1382 item 5).

--- a/changelog.d/submission-diagnostics-prune.md
+++ b/changelog.d/submission-diagnostics-prune.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **The observability prune no longer full-scans `submission_diagnostics`,
+  and never-finished rows finally age out.** The nightly retention sweep's
+  `finished_at < cutoff` ran unindexed against a table that is 1:1 with
+  submissions, and rows whose job died before reporting (NULL
+  `finished_at`) never matched it — accumulating permanently. The sweep
+  column is indexed now, and never-finished rows are aged out on their
+  creation time at the same retention window (#1382 item 8).


### PR DESCRIPTION
Items 5, 6, 8, and 9 of the #1382 scalability-audit handover, bundled per the ground rules' "one PR per item or coherent bundle" (items 2 and 3 shipped in #1385 / #1387). Four commits, one per item, each independently revertable.

## Item 5 — `/admin/storage` + `get_storage_usage` (commit `a66e7cc`)

Building the breakdown stats every submission file ever kept, walks the test-setups/results trees plus the whole static asset tree (~400 MB of vendored editor assets), and projects the full submissions table for byte attribution — slowest exactly when there is the most disk to account for, and pollable through the read-only admin MCP. The page and the MCP tool now share one cached context via a single-flight TTL actor modeled on `MetricsCardCache` (60 s, concurrent callers coalesce, failures never cached). The compute moved onto the `Application` so the closure crosses the actor cleanly; the breakdown itself is unchanged. On the issue's "aggregate in SQL" suggestion: the `(id → setup)` projection is the *minimal* query byte attribution needs — sizes live only on disk, keyed by submission id — so no SQL aggregate can replace it; the TTL cache is what bounds the work per poll. Cache contract pinned by `StorageUsageCacheTests` (TTL serve, expiry, coalescing, failure-not-cached).

## Item 6 — instructor assignment-submissions roster (commit `c3f4aee`)

The page loaded every attempt by every student plus a grade fold over all of them, on a page instructors refresh during a deadline. Per-student latest pick / attempt count / best grade are now the same window-function and `MAX` aggregates the dashboard gained in #1385, partitioned by student, returning O(roster) rows. Two deliberate semantics:

- **A best of exactly 0 is kept** — the roster fold admitted `best >= 0`, so an all-fail student shows "0%" to their instructor, *unlike* the dashboard's 0-hiding sentinel. The two surfaces genuinely differ and each keeps its own behavior, both pinned by tests.
- The metric cards read only timestamps inside their largest window (24h count, 24h/7d/30d trend buckets), so they fetch one month of field-limited rows instead of the term's history; the bucketing drops out-of-range rows exactly as it did when handed everything.

Roster values pinned by render tests written and **verified against the pre-aggregate loaders first** (best-across-attempts, latest link, "+N more", students-submitted, avg attempts, median, attempts-distribution bins), plus direct loader tests on both database backends.

## Item 8 — `submission_diagnostics` prune (commit `5cbb2d4`)

The nightly retention sweep's `finished_at < cutoff` ran unindexed against a table 1:1 with submissions (full scan, growing forever), and rows whose job died before reporting keep a NULL `finished_at` that the filter never matches — accumulating permanently. Added `idx_submission_diagnostics_finished_at` covering the predicate (the same btree locates the NULL rows), and never-finished rows now age out on `created_at` at the same retention window: once a full period has passed the job is not going to finish, and the row's diagnostic value has been superseded by the incident's own alerts and logs. All four quadrants (stale/fresh × finished/never-finished) pinned by a prune test.

## Item 9 — instructor-side blocking writes (commit `7264d9d`)

The nine synchronous notebook/zip writes #1377 deliberately left behind: the setup upload's flat-notebook extraction, the edited-notebook save, both assignment save paths, the two draft-solution writes, the validation submission write and its personalization sidecar, and the course-bundle import's per-setup zip copy + notebook write. Request-scoped sites use `req.fileio.writeFile`, matching the student paths; the two chains that cannot hold a request — the bundle import runs inside a transaction closure that must not capture it, and the validation materialization is reached through db-scoped helpers — thread the `Application` and use `runBlocking(app:)`, which is the alternative the handover itself names. Two helpers became async to adopt the non-deprecated write; the import's directory params folded into a struct to stay within the parameter-count limit. No behavior changes; the authoring/bundle/validation suites all pass.

## Verification

Local runs across every touched surface: admin routes + admin MCP suites through the new cache, roster/overrides/reveal/retest/sparkline suites, the aggregate loader suite, observability, and the authoring/bundle/worker suites for item 9 — all green. `format.sh` / `lint.sh` / `swiftlint.sh --strict` clean. Four `changelog.d/` fragments, one per item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZvhhypNNTqMGV55BKEEhH