### PR TITLE
fix(worker): name the student's own file when the upload has no filename

### DIFF
--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -648,20 +648,28 @@ extension WorkerDaemon {
                     studentNotebookName: job.submissionFilename.map {
                         URL(fileURLWithPath: $0).lastPathComponent
                     })
-                return (
-                    refused.map(protectedFileSkippedWarning) + warnings,
+                // nil `forcedLanguage` means the extractor trusted the
+                // notebook's own metadata, which for an unrecognised kernel
+                // falls back to Python — so the hint has to agree. Spelled
+                // `?? .python` at the call site rather than behind a named
+                // constant: `no-language-defaults.sh` permits a nil-coalescing
+                // fallback precisely because it stays VISIBLE here, and hiding
+                // it behind a name is the shape that guard exists to prevent.
+                let hintLanguage = forcedLanguage ?? .python
+                // The hint names the student's file. When the upload carries no
+                // filename — every ARCHIVE submission, since a zip stores nil —
+                // it is derived from what the submission directory actually
+                // held, which is the only place the student's own files can
+                // still be told apart from the instructor's. Without it the
+                // generated C++ wrapper globbed the merged workspace and graded
+                // `helpers.cpp` instead of `solution.cpp` (#1390).
+                let studentModule =
                     preferredStudentModuleFilename(
                         submissionFilename: job.submissionFilename,
-                        // nil means the extractor trusted the notebook's own
-                        // metadata, which for an unrecognised kernel falls back
-                        // to Python — so the hint has to agree, and both sites
-                        // spell `?? .python` rather than sharing a named
-                        // constant. That is deliberate: `no-language-defaults.sh`
-                        // permits a nil-coalescing fallback precisely because it
-                        // stays VISIBLE at the call site, and hiding it behind a
-                        // name is the shape that guard exists to prevent.
-                        language: forcedLanguage ?? .python)
-                )
+                        language: hintLanguage)
+                    ?? studentModuleFromSubmittedFiles(
+                        in: paths.submissionDir, language: hintLanguage)
+                return (refused.map(protectedFileSkippedWarning) + warnings, studentModule)
             }
         }
     }

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -187,6 +187,41 @@ func preferredStudentModuleFilename(
     return nil
 }
 
+/// The student's own source file, chosen from what the SUBMISSION contained.
+///
+/// The fallback for when `preferredStudentModuleFilename` has nothing to go on,
+/// which is every archive upload: a zip carries no filename
+/// (`fallbackFilename = isZip ? nil : …`), so no hint was written at all and the
+/// generated C++ wrapper fell back to globbing `*.cpp` in the merged workspace —
+/// where it took the alphabetically-first candidate and graded the instructor's
+/// `helpers.cpp` instead of the student's `solution.cpp` (#1390).
+///
+/// PROVENANCE, NOT NAME. This reads the submission directory, before the merge,
+/// so every file it can see came from the upload. That is the distinction the
+/// wrapper cannot make — by the time it runs, the student's code and the
+/// instructor's support files are one directory with no way to tell them apart.
+///
+/// Root-level only, because the hint is a bare filename the runtimes resolve
+/// beside themselves. Sorted, so a multi-file upload picks deterministically
+/// rather than by enumeration order; any of the student's own files is a better
+/// answer than an instructor's.
+func studentModuleFromSubmittedFiles(
+    in submissionDirectory: URL, language: AssignmentLanguage
+) -> String? {
+    let wanted = language.sourceFileExtension.lowercased()
+    let entries =
+        (try? FileManager.default.contentsOfDirectory(
+            at: submissionDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles])) ?? []
+    return
+        entries
+        .filter { (try? $0.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true }
+        .map(\.lastPathComponent)
+        .filter { ($0 as NSString).pathExtension.lowercased() == wanted }
+        .min()
+}
+
 func stagedSubmissionDestination(
     submissionDirectory: URL,
     submittedFilename: String

--- a/Tests/WorkerTests/ProtectedWorkspaceFilenameTests.swift
+++ b/Tests/WorkerTests/ProtectedWorkspaceFilenameTests.swift
@@ -122,3 +122,59 @@ import Testing
                 atPath: destination.appendingPathComponent("helpers/publictest_bmi_01.py").path))
     }
 }
+
+/// The student-module hint for an upload that carries no filename.
+///
+/// Every ARCHIVE submission is that upload: a zip stores `filename` as nil
+/// (`WebRoutes+Submission.swift`, `fallbackFilename = isZip ? nil : …`), so no
+/// hint was written and the generated C++ wrapper fell back to globbing `*.cpp`
+/// in the MERGED workspace — where it took the alphabetically-first candidate
+/// and graded the instructor's `helpers.cpp` instead of the student's
+/// `solution.cpp` (#1390).
+///
+/// The fix reads the SUBMISSION directory, before the merge, so provenance
+/// distinguishes the two — which is exactly what the wrapper cannot do.
+@Suite struct StudentModuleFromSubmittedFilesTests {
+
+    private static func directory(_ files: [String: String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ck-submitted-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        for (name, body) in files {
+            try body.write(
+                to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    /// The regression: an instructor's `helpers.cpp` sorts before the student's
+    /// `solution.cpp`, so a name-based rule picks the wrong one. Provenance does
+    /// not see the instructor's file at all.
+    @Test func theHintNamesAFileTheSubmissionActuallyContained() throws {
+        let dir = try Self.directory(["solution.cpp": "int f(int x) { return x; }"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(studentModuleFromSubmittedFiles(in: dir, language: .cpp) == "solution.cpp")
+        // The instructor's helper lives in the test setup, not here — so it can
+        // never be chosen, whatever it is called.
+        #expect(studentModuleFromSubmittedFiles(in: dir, language: .cpp) != "helpers.cpp")
+    }
+
+    /// Deterministic rather than enumeration-ordered, so a multi-file upload
+    /// grades the same way on every runner.
+    @Test func aMultiFileUploadPicksDeterministically() throws {
+        let dir = try Self.directory(["zeta.cpp": "//", "alpha.cpp": "//", "beta.cpp": "//"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(studentModuleFromSubmittedFiles(in: dir, language: .cpp) == "alpha.cpp")
+    }
+
+    /// The extension is the LANGUAGE's, so the same upload answers differently
+    /// per assignment — and answers nil rather than guessing when the student
+    /// submitted nothing in it.
+    @Test func theExtensionComesFromTheAssignmentLanguage() throws {
+        let dir = try Self.directory(["Solution.java": "class Solution {}", "notes.txt": "hi"])
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(studentModuleFromSubmittedFiles(in: dir, language: .java) == "Solution.java")
+        #expect(studentModuleFromSubmittedFiles(in: dir, language: .cpp) == nil)
+        #expect(studentModuleFromSubmittedFiles(in: dir, language: .racket) == nil)
+    }
+}

--- a/changelog.d/1390-student-module-hint-from-provenance.md
+++ b/changelog.d/1390-student-module-hint-from-provenance.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **A zip submission to a C++ (or Java or Racket) assignment is graded against
+  the student's own file again.** An archive upload carries no filename, so no
+  `.chickadee_student_module` hint was written, and the generated C++ wrapper
+  fell back to globbing `*.cpp` in the merged workspace — where it took the
+  alphabetically-first candidate and compiled the instructor's `helpers.cpp`
+  instead of the student's `solution.cpp`, reporting the student's correct work
+  as a missing function. The hint is now derived from what the *submission
+  directory* held, before the merge, which is the only point at which the
+  student's files can still be told apart from the instructor's.


### PR DESCRIPTION
Closes #1390. Follow-up to the residual #1350 deliberately left open.

## The chain

1. An **archive** submission carries no filename — `WebRoutes+Submission.swift:157`, `fallbackFilename = isZip ? nil : (…)`.
2. So `preferredStudentModuleFilename` has nothing to work from and `.chickadee_student_module` is never written.
3. So the generated C++ wrapper falls back to globbing `*.cpp` in the **merged** workspace and takes the alphabetically-first non-test candidate.

Reproduced against the wrapper's own discovery block, with an instructor `helpers.cpp` support file and the student's `solution.cpp`:

```
GRADED AS: helpers.cpp
```

The student's code is never compiled. What they see is the existence guard failing on work they did correctly.

## Fixed at the layer that can tell the two apart

The wrapper **cannot** — by the time it runs, the student's code and the instructor's support files are one directory with no provenance. The worker still has that distinction, so the hint is derived from the **submission directory, before the merge**: every file there came from the upload, whatever it is called.

- Root-level only, because the hint is a bare filename the runtimes resolve beside themselves.
- `min()` rather than enumeration order, so a multi-file upload grades the same way on every runner.
- Keyed on the language's own `sourceFileExtension`, so this fixes **Java and Racket too** — both upload-only, both reading the same hint — rather than only the language the symptom was reported against.

The wrapper's glob stays as the last-resort fallback for an upload that genuinely contains no matching source.

## On #1350's deferral

That issue left this alone for want of evidence about the multi-candidate case, and suggested "refuse when more than one candidate matches". The evidence turned out to point somewhere better: refusing would have broken assignments that legitimately ship a helper `.cpp`, whereas provenance fixes the real case without any behaviour change for correct setups.

## Verification

```
✔ Test run with   7 tests in 2 suites passed   (new + #1357 guard)
✔ Test run with 343 tests in 40 suites passed  (full WorkerTests)
```

Three new tests: the regression itself (the hint names a file the submission contained, and can never be `helpers.cpp`), determinism across a multi-file upload, and that the extension comes from the assignment language (`.java` answers `Solution.java`; `.cpp` and `.racket` answer nil rather than guessing).

`format`/`lint`/`swiftlint` clean — including a `sorted().first` → `min()` fix SwiftLint caught on the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_