### PR TITLE
refactor(personalization): derive support-file extensions from the descriptor

### DIFF
--- a/Sources/APIServer/Services/PersonalizationEvaluator.swift
+++ b/Sources/APIServer/Services/PersonalizationEvaluator.swift
@@ -368,6 +368,17 @@ enum PersonalizationEvaluator {
         else {
             return []
         }
+        // The five "loaded by FILE" languages differ only in WHICH extension,
+        // and each used to spell it as a literal — four hand-written copies of a
+        // fact `LanguageDescriptor` already owns, in a function whose whole job
+        // is to be language-generic. They agree today; nothing made them keep
+        // agreeing.
+        func filesWithThisLanguagesSourceExtension() -> [String] {
+            let wanted = language.sourceFileExtension.lowercased()
+            return entries.filter { (($0 as NSString).pathExtension).lowercased() == wanted }
+                .sorted()
+        }
+
         switch language {
         case .python:
             return entries.compactMap { entry -> String? in
@@ -377,23 +388,23 @@ enum PersonalizationEvaluator {
                 return stem
             }.sorted()
         case .r:
-            return entries.filter { (($0 as NSString).pathExtension).lowercased() == "r" }.sorted()
+            return filesWithThisLanguagesSourceExtension()
         case .racket:
             // Loaded by FILE like R and Lua — the driver `dynamic-require`s each
             // helper and copies its bindings into the expression namespace, so
             // there is no module identifier to validate.
-            return entries.filter { (($0 as NSString).pathExtension).lowercased() == "rkt" }.sorted()
+            return filesWithThisLanguagesSourceExtension()
         case .lua:
             // Like R, the driver loads these by FILE (`dofile`), not by module
             // name, so there is no identifier to validate — any `.lua` beside
             // the assignment is a candidate helper.
-            return entries.filter { (($0 as NSString).pathExtension).lowercased() == "lua" }.sorted()
+            return filesWithThisLanguagesSourceExtension()
         case .octave:
             // Loaded by file too — the driver evaluates each helper's text
             // behind a `1;` script guard (the same trick the grading runtime's
             // load_student uses), so a one-function-per-file helper registers
             // under its own name rather than executing as a bare body.
-            return entries.filter { (($0 as NSString).pathExtension).lowercased() == "m" }.sorted()
+            return filesWithThisLanguagesSourceExtension()
         case .cpp:
             // Included by FILE into the driver's single translation unit —
             // headers first, then sources (the extracted reference solution
@@ -409,8 +420,7 @@ enum PersonalizationEvaluator {
             // C++: javac resolves declarations across every file in one
             // invocation regardless of the order they are named in, so a plain
             // sort is enough for deterministic driver bytes.
-            return entries.filter { (($0 as NSString).pathExtension).lowercased() == "java" }
-                .sorted()
+            return filesWithThisLanguagesSourceExtension()
         }
     }
 

--- a/changelog.d/1392-support-file-extension-derivation.md
+++ b/changelog.d/1392-support-file-extension-derivation.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **The personalization driver derives each language's support-file extension
+  from its descriptor** instead of re-listing it. Five arms of
+  `supportFileEntries` filtered on a hard-coded `"r"` / `"rkt"` / `"lua"` /
+  `"m"` / `"java"`, each duplicating `LanguageDescriptor.sourceFileExtension`.
+  They agreed, but nothing made them keep agreeing: a drifted extension would
+  have silently found no support files, so an `=` expression calling a helper
+  the instructor did ship would fail as an undefined function.


### PR DESCRIPTION
Closes #1392.

`supportFileEntries` switches over `AssignmentLanguage` to decide which support files a personalization driver auto-loads, and five of its arms did the identical thing — filter the directory by one extension, sort — with the extension written as a **literal**:

```swift
case .r:      … == "r"    …
case .racket: … == "rkt"  …
case .lua:    … == "lua"  …
case .octave: … == "m"    …
case .java:   … == "java" …
```

Every one duplicated `LanguageDescriptor.sourceFileExtension`, inside a function whose whole job is to be language-generic. That is the shape this audit kept finding, and it was already recorded as open in `docs/multi-language-audit.md`.

## No live defect — that's the point

They agree today. Nothing made them *keep* agreeing, and the failure mode is quiet: a drifted extension, or an eighth language added by copying a neighbouring arm, finds no support files — so an `=` expression calling a helper the instructor **did** ship fails as an undefined function, pointing at the instructor's own expression rather than at the discovery that skipped the file.

## The switch stays exhaustive

Deliberately not collapsed into the helper. Python validates module identifiers (`__init__` excluded, stems must be valid identifiers) and C++ orders headers before sources, so those arms are genuinely different — and a new language must still answer.

## Verification

```
✔ Test run with 46 tests in 12 suites passed   (Personalization*)
```

Behaviour is unchanged, which is the point of the change rather than a caveat to it. `format`/`lint`/`swiftlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSFkd7vm8AApUkSd1dKoVB)_