### PR TITLE
fix(ui): S0 defect sweep from the widget-layer audit

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -133,11 +133,11 @@ if (root) {
 }());
 
 // ── Floating action popovers (per-student extension / grade-override) ────────
-// The <details class="ext-details"> panels on the student-submissions page use
-// an absolutely-positioned .action-panel that opens downward. They live inside
-// .results-table, which clips its overflow (for the rounded corners), so a
-// panel on a row near the bottom of the table is cut off — the Save button
-// disappears below the table edge and can't even be scrolled to.
+// The <details class="ext-details"> panels on the roster and submission pages
+// hold an .action-panel or .ext-panel form. They live inside .results-table,
+// which clips its overflow (for the rounded corners), so a panel on a row near
+// the bottom of the table is cut off — the Save button disappears below the
+// table edge and can't even be scrolled to.
 //
 // When a panel opens, promote it to position:fixed and place it next to its
 // summary button, clamped to stay fully within the viewport: below the button
@@ -145,10 +145,11 @@ if (root) {
 // scroll if it is somehow taller than the screen. position:fixed also escapes
 // the table's overflow clip. Phones keep the CSS static-flow panel (the
 // max-width:640px rule), which is in normal flow and never overflows.
+//
+// Delegated on the document (capture phase — `toggle` does not bubble) so
+// panels rebuilt by a background poll repaint keep floating without rebinding.
 (function floatingActionPopovers() {
-    const details = Array.from(document.querySelectorAll('details.ext-details'))
-        .filter((d) => d.querySelector('.action-panel'));
-    if (details.length === 0) return;
+    const PANEL_SELECTOR = '.action-panel, .ext-panel';
 
     const GAP = 6;      // px between the summary button and the panel
     const MARGIN = 8;   // min px kept clear of every viewport edge
@@ -157,16 +158,23 @@ if (root) {
 
     let active = null;  // the <details> whose panel is currently floated
 
-    const clear = (panel) => FLOATED.forEach((prop) => { panel.style[prop] = ''; });
+    const panelOf = (d) => d.querySelector(PANEL_SELECTOR);
+
+    const clear = (panel) => {
+        if (!panel) return;
+        panel.classList.remove('is-floating');
+        FLOATED.forEach((prop) => { panel.style[prop] = ''; });
+    };
 
     function place(d) {
         const summary = d.querySelector('summary');
-        const panel = d.querySelector('.action-panel');
+        const panel = panelOf(d);
         if (!summary || !panel) return;
         // On phones the CSS drops the panel into static flow — leave it there.
         if (isPhone()) { clear(panel); return; }
 
         // Float it, cap its height to the viewport, and measure at the cap.
+        panel.classList.add('is-floating');
         panel.style.position = 'fixed';
         panel.style.right = 'auto';
         panel.style.overflowY = 'auto';
@@ -193,19 +201,20 @@ if (root) {
 
     const reposition = () => { if (active && active.open) place(active); };
 
-    details.forEach((d) => {
-        d.addEventListener('toggle', () => {
-            if (d.open) {
-                // Native <details> allow several open at once; only float one.
-                if (active && active !== d) active.open = false;
-                active = d;
-                place(d);
-            } else {
-                clear(d.querySelector('.action-panel'));
-                if (active === d) active = null;
-            }
-        });
-    });
+    document.addEventListener('toggle', (e) => {
+        const d = e.target;
+        if (!(d instanceof Element) || !d.matches('details.ext-details')) return;
+        if (!panelOf(d)) return;
+        if (d.open) {
+            // Native <details> allow several open at once; only float one.
+            if (active && active !== d) active.open = false;
+            active = d;
+            place(d);
+        } else {
+            clear(panelOf(d));
+            if (active === d) active = null;
+        }
+    }, true);
 
     // Keep the floated panel glued to its button as the page scrolls/resizes.
     // Capture phase so it also fires for scrolls inside nested scroll areas.

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1208,6 +1208,11 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .ext-field-label { font-size: var(--text-sm); color: var(--gray-700); }
 .ext-field-input { width: 100%; margin-top: .2rem; }
 .ext-panel-actions { display: flex; gap: .3rem; }
+/* While app.js floats a popover to position:fixed (escaping the table's
+   overflow clip) it reads as an overlay, so it carries the pop elevation.
+   .action-panel already has the shadow statically; .ext-panel gains it only
+   while floated so its in-flow rendering is unchanged. */
+.ext-panel.is-floating, .action-panel.is-floating { box-shadow: var(--shadow-pop); z-index: 10; }
 
 /* ── Submission view (submission.leaf) ───────────────── */
 /* Migrated out of submission.leaf's embedded <style> block (v0.4.x UI audit)

--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -10,7 +10,7 @@
 </div>
 
 #if(error == "course_fields_required"):
-<div class="form-error">Course code and name are required.</div>
+<div class="form-error" role="alert">Course code and name are required.</div>
 #endif
 
 <!-- ── Create course ───────────────────────────────── -->

--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -10,7 +10,7 @@ MCP
     <h2>MCP service accounts</h2>
 
     #if(!enabled):
-    <div class="form-error">
+    <div class="form-error" role="status">
         The MCP endpoint is not active, so tokens cannot be minted. Set
         <code>MCP_MODE=read_only</code> or <code>MCP_MODE=read_write</code>
         and <code>PUBLIC_BASE_URL</code> (or <code>MCP_ISSUER</code>/<code>MCP_RESOURCE</code>),
@@ -27,16 +27,16 @@ MCP
     #endif
     #endif
     #if(error == "username_required"):
-    <div class="form-error">A username is required.</div>
+    <div class="form-error" role="alert">A username is required.</div>
     #endif
     #if(error == "username_taken"):
-    <div class="form-error">That username is already in use.</div>
+    <div class="form-error" role="alert">That username is already in use.</div>
     #endif
     #if(error == "mcp_disabled"):
-    <div class="form-error">Cannot mint a token while the MCP endpoint is inactive.</div>
+    <div class="form-error" role="alert">Cannot mint a token while the MCP endpoint is inactive.</div>
     #endif
     #if(error == "enroll_failed"):
-    <div class="form-error">Could not update the account's course enrollment.</div>
+    <div class="form-error" role="alert">Could not update the account's course enrollment.</div>
     #endif
 
     #if(mintedToken):

--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -161,10 +161,11 @@ Runner #(runner.workerID)
         .getAttribute ? document.querySelector('[data-runner-id]').getAttribute('data-runner-id') : '';
 
     setInterval(function () {
+        if (document.hidden) return;
         ChickadeeRelativeTime.applyRelativeTimes();
         updateOfflineBadge();
         if (!RUNNER_ID) return;
-        fetch('/admin/runners')
+        fetch('/admin/runners', { headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' }, cache: 'no-store' })
             .then(function (r) { return r.ok ? r.json() : null; })
             .then(function (rows) {
                 if (!Array.isArray(rows)) return;

--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -9,7 +9,7 @@ Server Health Alerts
     #extend("_flash")
 
     #if(!enabled):
-    <div class="flash flash-neutral">
+    <div class="flash flash-neutral" role="status">
         Alerting is currently <strong>disabled</strong>.  Set <code>ALERT_ENABLED=1</code> in the
         environment and restart the server to begin evaluating rules.
     </div>

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -306,13 +306,10 @@ tr.assignment-draggable td {
 /* .add-section-details* and .section-block.section-dragging now live in the
    global stylesheet (shared with assignment-edit.leaf). */
 </style>
-<script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/section-items-dnd.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
-
-    ChickadeeRelativeTime.applyRelativeTimes();
 
     // ── Dashboard diagnostic cards: headline + sparkline, click cycles ────────
     //   24h / 7d / 30d.  Polls /instructor/metrics/cards (course-scoped) and

--- a/Resources/Views/connected-agents.leaf
+++ b/Resources/Views/connected-agents.leaf
@@ -45,7 +45,7 @@ Connected agents
             </tr>
         #endfor
         #if(rows.isEmpty):
-            <tr><td colspan="7" class="text-muted">No connected agents.</td></tr>
+            <tr><td colspan="#if(isAdmin):7#else:6#endif" class="text-muted">No connected agents.</td></tr>
         #endif
         </tbody>
     </table></div>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -39,7 +39,7 @@ LEARN
     <p class="bs-conn-line">This course pushes grades as <strong>#(syncIdentity.name)</strong>.</p>
     #endif
     #if(syncIdentity.needsReconnect):
-    <div class="form-error">
+    <div class="form-error" role="status">
         This course's designated LEARN identity is disconnected — grade pushes are
         paused until they reconnect, or a connected co-instructor takes over below.
     </div>
@@ -177,7 +177,8 @@ LEARN
                           onsubmit="return confirm('Re-push every student's best grade for #(row.title) to LEARN?')">
                         #csrfFormField()
                         <button class="btn action-btn bs-push-btn" type="submit"
-                                title="Re-push all grades for #(row.title)">
+                                title="Re-push all grades for #(row.title)"
+                                aria-label="Re-push all grades for #(row.title)">
                             <svg aria-hidden="true" viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
                                 <path d="M8 1.5a.5.5 0 0 1 .5.5v8.793l2.646-2.647a.5.5 0 0 1 .708.708l-3.5 3.5a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L7.5 10.793V2a.5.5 0 0 1 .5-.5z"/>
                                 <path d="M1 13.5a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 0 1h-13a.5.5 0 0 1-.5-.5z"/>

--- a/Resources/Views/instructor-enroll-csv.leaf
+++ b/Resources/Views/instructor-enroll-csv.leaf
@@ -9,7 +9,7 @@ Enrol from CSV — #(courseCode)
 </div>
 
 #if(error):
-<div class="form-error section-gap">#(error)</div>
+<div class="form-error section-gap" role="alert">#(error)</div>
 #endif
 
 <section class="page-section">

--- a/changelog.d/ui-s0-defect-sweep.md
+++ b/changelog.d/ui-s0-defect-sweep.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **UI defect sweep (audit S0).** The connected-agents empty state no longer
+  spans a phantom column for non-admins; the runner-detail poll now sends
+  `X-Background-Refresh` (so watching the dashboard no longer holds the idle
+  session open) and pauses while the tab is hidden; the LEARN re-push button
+  gained its missing `aria-label`; static state banners and post-redirect
+  error banners now carry `role="status"` / `role="alert"` respectively; a
+  dead `relative-time.js` include was removed from the assignments page; and
+  the grade-override popover on the assignment-submissions page now gets the
+  same viewport-clamped floating as its course-page sibling — delegated, so
+  popovers rebuilt by a background poll repaint keep floating too.

--- a/docs/ui-consistency-audit.md
+++ b/docs/ui-consistency-audit.md
@@ -316,6 +316,17 @@ hoist; D8 with S3). Zero design decisions; every fix is a line or two.
 Include a render-test or `.mjs` assertion where one is cheap (D1: the
 colspan follows the `isAdmin` flag; D2: assert headers on the poll fetch).
 
+**Status: done.** D1–D5 and D7 landed in the S0 PR. D7 went slightly
+further than parity: `app.js` now floats `.ext-panel` and `.action-panel`
+alike, the binding is **delegated** (capture-phase `toggle` on the
+document) so panels rebuilt by a poll repaint keep floating — which was a
+latent break for instructor-students' register popovers after the first
+5-second repaint — and a floated `.ext-panel` carries `--shadow-pop` via
+`.is-floating` without changing its in-flow rendering. The banner-role
+fixes follow the `_flash` split: action-failure banners got
+`role="alert"`, persistent-state banners (`admin-mcp`'s endpoint-inactive
+notice, `instructor-brightspace`'s reconnect notice) got `role="status"`.
+
 ### S1 — One list-filter pattern (M) — the prompting example
 
 **Target state.** Every list filter is visually and semantically the same


### PR DESCRIPTION
Slice **S0** of the [widget-layer UI audit](https://github.com/JimWallace/Chickadee/blob/main/docs/ui-consistency-audit.md) (#1396): the incidental defects, fixed as written, no design decisions.

- **D1** `connected-agents`: empty-state row's `colspan` now follows the `isAdmin` column count (was hardcoded 7 over a 6-column table for non-admins).
- **D2** `admin-runner`: the 5s poll now sends `Accept` + `X-Background-Refresh: 1` and skips hidden tabs — watching the runner dashboard no longer resets the idle-logout timer.
- **D3** `instructor-brightspace`: the icon-only LEARN re-push button gains its missing `aria-label` (the one gap among 49 icon buttons).
- **D4** banner ARIA roles, following the `_flash` convention: post-redirect action failures get `role="alert"` (admin-mcp error banners, admin-course, instructor-enroll-csv); persistent state banners get `role="status"` (alerts' disabled notice, admin-mcp's endpoint-inactive notice, instructor-brightspace's reconnect notice).
- **D5** `assignments`: dead `relative-time.js` include + `applyRelativeTimes()` call removed (zero consuming nodes on the page).
- **D7** `app.js` popover float parity: `.ext-panel` popovers now get the same viewport-clamped `position:fixed` float as `.action-panel` ones (the grade-override popover could clip against the table's overflow edge). The binding is now **delegated** (capture-phase `toggle`), which also fixes a latent break: popovers rebuilt by the 5-second roster poll lost their float on the first repaint. A floated `.ext-panel` carries `--shadow-pop` via a new `.is-floating` rule; its in-flow rendering is unchanged.

D6 lands with S7 (diagnostics-wrapper hoist), D8 with S3 (poll-guard alignment), per the plan. The audit doc's S0 section carries the status note.

**Gates run locally:** `scripts/check-styles.sh` (×2, green), `scripts/eslint.sh` (clean), `node --test Tests/BrowserRunnerJSTests` (317 pass / 0 fail). Ratchet position unchanged (inline-script delta nets to zero: +1 hidden-guard line, −1 dead call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9

---
_Generated by [Claude Code](https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9)_