### PR TITLE
perf(zip): narrow the process-wide zip lock to construction + spawn

### DIFF
--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -326,16 +326,16 @@ func zipContainsNotebook(_ zipData: Data) -> Bool {
 
     guard (try? zipData.write(to: tmp)) != nil else { return false }
 
-    let proc = Process()
-    proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-    proc.arguments = ["-l", tmp.path]
-    let pipe = closeOnExecPipe()
-    proc.standardOutput = pipe
-    proc.standardError = closeOnExecPipe()
-    guard (try? proc.run()) != nil else { return false }
-    let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
-    proc.waitUntilExit()
-    let output = String(data: outputData, encoding: .utf8) ?? ""
+    // Must go through the shared helper: a naked `run()` here races every
+    // lock-serialized zip spawn in the codebase (Foundation's EFAULT race —
+    // see ZipProcessSerialization.swift).
+    guard
+        let result = try? runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-l", tmp.path]
+        )
+    else { return false }
+    let output = String(data: result.stdout, encoding: .utf8) ?? ""
     return output.contains(".ipynb")
 }
 

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -17,7 +17,7 @@ enum ScriptZipError: Error {
     case zipFailed
 }
 
-/// Packs `sourceDir` into `zipPath` via `/usr/bin/zip -q -r`, running
+/// Packs `sourceDir` into `zipPath` via `/usr/bin/zip -q -r`, spawned
 /// under the shared zip process lock (see `ZipProcessSerialization.swift`)
 /// so it can't race the async helpers in `ZipArchiver.swift` or the
 /// other sync zip helpers in this file.  Throws `ScriptZipError.zipFailed`
@@ -33,17 +33,12 @@ func repackZipFromDirectory(zipPath: String, sourceDir: URL) throws {
         try writeEmptyZip(at: zipPath)
         return
     }
-    try withZipProcessLock {
-        let zip = Process()
-        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-        zip.currentDirectoryURL = sourceDir
-        zip.arguments = ["-q", "-r", zipPath, "."]
-        zip.standardOutput = closeOnExecPipe()
-        zip.standardError = closeOnExecPipe()
-        try runProcessWithEFAULTRetry(zip)
-        zip.waitUntilExit()
-        guard zip.terminationStatus == 0 else { throw ScriptZipError.zipFailed }
-    }
+    let result = try runZipProcessCapturingStdout(
+        executablePath: "/usr/bin/zip",
+        arguments: ["-q", "-r", zipPath, "."],
+        workingDirectory: sourceDir
+    )
+    guard result.terminationStatus == 0 else { throw ScriptZipError.zipFailed }
 }
 
 /// True when `dir` contains at least one regular file (searched recursively).
@@ -112,24 +107,17 @@ enum ZipUploadValidationError: Error, CustomStringConvertible {
 /// dashed separator lines; each entry has seven space-separated columns
 /// (Length, Method, Size, Cmpr, Date, Time, CRC-32) before the name.
 func validateZipUploadSize(zipPath: String, limits: ZipUploadLimits = .default) throws {
-    let (status, data): (Int32, Data) = try withZipProcessLock {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        process.arguments = ["-v", zipPath]
-        let out = closeOnExecPipe()
-        process.standardOutput = out
-        process.standardError = closeOnExecPipe()
-        do {
-            try runProcessWithEFAULTRetry(process)
-        } catch {
-            throw ZipUploadValidationError.inspectionFailed
-        }
-        let captured = out.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        return (process.terminationStatus, captured)
+    let result: ZipProcessResult
+    do {
+        result = try runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-v", zipPath]
+        )
+    } catch {
+        throw ZipUploadValidationError.inspectionFailed
     }
-    guard status == 0,
-        let text = String(data: data, encoding: .utf8)
+    guard result.terminationStatus == 0,
+        let text = String(data: result.stdout, encoding: .utf8)
     else {
         throw ZipUploadValidationError.inspectionFailed
     }
@@ -170,20 +158,13 @@ struct RunnerSetupPackage {
 }
 
 func listZipEntries(zipPath: String) -> [String] {
-    let result: (Int32, Data)? = try? withZipProcessLock {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        process.arguments = ["-Z1", zipPath]
-        let out = closeOnExecPipe()
-        process.standardOutput = out
-        process.standardError = closeOnExecPipe()
-        try runProcessWithEFAULTRetry(process)
-        let captured = out.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        return (process.terminationStatus, captured)
-    }
-    guard let (status, data) = result, status == 0,
-        let text = String(data: data, encoding: .utf8)
+    guard
+        let result = try? runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-Z1", zipPath]
+        ),
+        result.terminationStatus == 0,
+        let text = String(data: result.stdout, encoding: .utf8)
     else { return [] }
     return
         text
@@ -304,20 +285,14 @@ func removeScriptFromZip(zipPath: String, filename: String) throws {
 }
 
 func extractZipEntry(zipPath: String, entryName: String) -> Data? {
-    let result: (Int32, Data)? = try? withZipProcessLock {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        process.arguments = ["-p", zipPath, entryName]
-        let out = closeOnExecPipe()
-        process.standardOutput = out
-        process.standardError = closeOnExecPipe()
-        try runProcessWithEFAULTRetry(process)
-        let captured = out.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-        return (process.terminationStatus, captured)
-    }
-    guard let (status, data) = result, status == 0 else { return nil }
-    return data
+    guard
+        let result = try? runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-p", zipPath, entryName]
+        ),
+        result.terminationStatus == 0
+    else { return nil }
+    return result.stdout
 }
 
 func buildFileResponse(data: Data, filename: String) -> Response {

--- a/Sources/Core/ZipArchiver.swift
+++ b/Sources/Core/ZipArchiver.swift
@@ -107,27 +107,15 @@ public func listZipContents(zipPath: String) throws -> [String] {
     guard FileManager.default.fileExists(atPath: "/usr/bin/unzip") else {
         throw ZipArchiverError.executableNotFound("/usr/bin/unzip")
     }
-    // Serialize the entire Process lifecycle (see ZipProcessSerialization.swift).
-    // Sync path holds the lock across read + wait too since both touch
-    // the same Pipe / Process state.
-    return try withZipProcessLock {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-        proc.arguments = ["-Z1", zipPath]
-        // CLOEXEC before the spawn: an unrelated process started concurrently
-        // must not inherit these write ends, or the drain below cannot reach
-        // EOF until that process exits (#1233).
-        let outPipe = closeOnExecPipe()
-        proc.standardOutput = outPipe
-        proc.standardError = closeOnExecPipe()  // discard
-        try runProcessWithEFAULTRetry(proc)
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
-        // unzip -Z1 exits 0 (OK) or 11 (no matching files) — both are fine here.
-        let output = String(data: data, encoding: .utf8) ?? ""
-        return output.split(separator: "\n", omittingEmptySubsequences: true)
-            .map(String.init)
-    }
+    // Spawn serialized, drain + wait overlapped (see ZipProcessSerialization.swift).
+    let result = try runZipProcessCapturingStdout(
+        executablePath: "/usr/bin/unzip",
+        arguments: ["-Z1", zipPath]
+    )
+    // unzip -Z1 exits 0 (OK) or 11 (no matching files) — both are fine here.
+    let output = String(data: result.stdout, encoding: .utf8) ?? ""
+    return output.split(separator: "\n", omittingEmptySubsequences: true)
+        .map(String.init)
 }
 
 // MARK: - Private helper

--- a/Sources/Core/ZipProcessSerialization.swift
+++ b/Sources/Core/ZipProcessSerialization.swift
@@ -19,32 +19,44 @@
 //
 // Both mitigations now live here and are used by every zip subprocess:
 //
-//   1. `withZipProcessLock { ... }` serializes the entire zip Process
-//      lifecycle (Process + Pipe construction, property setting, spawn,
-//      and, for sync paths, the wait and read).  Async paths release
-//      inside the continuation closure once the spawn returns; the
-//      terminationHandler runs on Foundation's monitoring queue and
-//      resumes the continuation independently.
+//   1. `withZipProcessLock { ... }` serializes the racy window only:
+//      Process + Pipe construction, property setting, and the spawn.
+//      Everything after the spawn happens outside the lock — the async
+//      path (`ZipArchiver.swift`'s `runZipProcess`) releases once the
+//      spawn returns and lets the terminationHandler resume the
+//      continuation from Foundation's monitoring queue, and the sync
+//      helper below (`runZipProcessCapturingStdout`) drains stdout and
+//      waits for exit after releasing.  Concurrent zip operations
+//      overlap everything but their spawns.
 //
 //   2. `runProcessWithEFAULTRetry(_:)` retries `Process.run()` once
 //      after a 10 ms backoff if it throws `NSPOSIXErrorDomain` /
 //      `EFAULT`.  Absorbs the residual race that the lock can't catch
 //      (cross-process kernel state, etc.).
 //
-// Zip operations are infrequent (test setup upload, course bundle
-// import, suite save, support-file extraction).  The cost of both
-// mitigations is negligible.
+// The sync paths originally held the lock across the child's whole
+// runtime (spawn + drain + wait).  That was tolerable while zip
+// subprocesses were rare (test setup upload, course bundle import), but
+// the notebook-open and dashboard paths now list/extract zip entries
+// per page view, and a whole-runtime lock is a server-wide cap of one
+// zip operation at a time — with each contender parking a
+// cooperative-pool thread in a blocking `NSLock.lock()`.  The lock's
+// scope is therefore the spawn window only, which is all the Foundation
+// race ever spanned; the child's runtime was never part of it, as the
+// async path demonstrated from the day it was written.
 
 import Foundation
 
-/// Process-wide lock held across the **entire** zip subprocess
-/// lifecycle.  See file header for rationale.
+/// Process-wide lock held across zip subprocess **construction + spawn**.
+/// See file header for rationale.
 private let zipProcessLock = NSLock()
 
 /// Serializes `body` against every other zip Process invocation in the
-/// codebase.  Use for the synchronous extract / list / extract-entry
-/// paths.  Async paths can hold the lock just for the spawn — see
-/// `ZipArchiver.swift`'s `runZipProcess`.
+/// codebase.  `body` must contain only the racy window — Process/Pipe
+/// construction through `run()` — never the child's drain or wait.
+/// Prefer `runZipProcessCapturingStdout` (sync) or the manual
+/// acquire/release pair in `ZipArchiver.swift`'s `runZipProcess` (async)
+/// over calling this directly.
 public func withZipProcessLock<T>(_ body: () throws -> T) rethrows -> T {
     zipProcessLock.lock()
     defer { zipProcessLock.unlock() }
@@ -77,4 +89,48 @@ public func runProcessWithEFAULTRetry(_ proc: Process) throws {
         Thread.sleep(forTimeInterval: 0.01)
         try proc.run()
     }
+}
+
+/// Exit status + captured stdout of a synchronous zip subprocess run.
+public struct ZipProcessResult: Sendable {
+    public let terminationStatus: Int32
+    public let stdout: Data
+}
+
+/// Runs a zip/unzip subprocess synchronously: construction + spawn under
+/// the process-wide zip lock, stdout drain + exit wait **outside** it.
+/// This is the one sync entry point — every synchronous zip subprocess
+/// in the codebase goes through here so the narrow lock scope and the
+/// EFAULT retry cannot be forgotten at a call site.
+///
+/// stdout is always drained (an undrained pipe deadlocks the child once
+/// it writes past the ~64 KB OS pipe buffer); callers that don't need it
+/// just ignore `ZipProcessResult.stdout`.  stderr is sunk to the null
+/// device — every former call site discarded it, and the null device
+/// can't fill.
+public func runZipProcessCapturingStdout(
+    executablePath: String,
+    arguments: [String],
+    workingDirectory: URL? = nil
+) throws -> ZipProcessResult {
+    let (process, stdoutPipe) = try withZipProcessLock { () throws -> (Process, Pipe) in
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        if let workingDirectory {
+            process.currentDirectoryURL = workingDirectory
+        }
+        // CLOEXEC before the spawn: with the lock no longer held across the
+        // drain, another zip child can be spawned while this one's stdout is
+        // being read — it must not inherit this write end, or the drain
+        // below cannot reach EOF until that unrelated child exits (#1233).
+        let stdoutPipe = closeOnExecPipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = FileHandle.nullDevice
+        try runProcessWithEFAULTRetry(process)
+        return (process, stdoutPipe)
+    }
+    let stdout = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return ZipProcessResult(terminationStatus: process.terminationStatus, stdout: stdout)
 }

--- a/Tests/APITests/ZipFixtureSupport.swift
+++ b/Tests/APITests/ZipFixtureSupport.swift
@@ -25,8 +25,10 @@
 // in the suite.
 //
 // The lock has to cover CONSTRUCTION, not just the spawn — that is what the
-// header above means by "the whole Process API surface" — so the `Process` and
-// its `Pipe`s are built inside the closure rather than handed to it.
+// header above means by "the whole Process API surface".
+// `runZipProcessCapturingStdout` builds the `Process` and its `Pipe` inside
+// the locked window, so routing through it is what keeps this fixture inside
+// the serialization regime.
 
 import Core
 import Foundation
@@ -43,16 +45,12 @@ func writeZipFixture(
     to zipPath: String,
     sourceLocation: SourceLocation = #_sourceLocation
 ) throws {
-    let status = try withZipProcessLock { () throws -> Int32 in
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-        process.currentDirectoryURL = directory
-        process.arguments = ["-q", "-r", zipPath, "."]
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
-        try process.run()
-        process.waitUntilExit()
-        return process.terminationStatus
-    }
-    #expect(status == 0, "zip command must succeed", sourceLocation: sourceLocation)
+    let result = try runZipProcessCapturingStdout(
+        executablePath: "/usr/bin/zip",
+        arguments: ["-q", "-r", zipPath, "."],
+        workingDirectory: directory
+    )
+    #expect(
+        result.terminationStatus == 0, "zip command must succeed",
+        sourceLocation: sourceLocation)
 }

--- a/Tests/CoreTests/ZipProcessSerializationTests.swift
+++ b/Tests/CoreTests/ZipProcessSerializationTests.swift
@@ -1,0 +1,121 @@
+// Tests/CoreTests/ZipProcessSerializationTests.swift
+//
+// Pins the one sync zip-subprocess entry point (`runZipProcessCapturingStdout`):
+// stdout capture, exit-status reporting, and — the property the narrow lock
+// scope exists for — correct results when many zip subprocesses run at once.
+// The process-wide lock covers construction + spawn only, so concurrent
+// children overlap their drains and waits; the concurrency test below is the
+// regression net for that overlapped regime.
+//
+// `.serialized` between tests (repo convention for subprocess-spawning
+// suites); the concurrency test runs its subprocesses in parallel *within*
+// one test body, which is the shape being pinned.
+
+import Core
+import Foundation
+import Testing
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+final class ZipProcessSerializationTests {
+
+    private let tmpDir: URL
+
+    init() throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-ziplock-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    private var zipToolsPresent: Bool {
+        FileManager.default.fileExists(atPath: "/usr/bin/zip")
+            && FileManager.default.fileExists(atPath: "/usr/bin/unzip")
+    }
+
+    /// Creates `name.zip` in the temp dir containing `entries` (filename →
+    /// content), returning its path.
+    private func makeZip(named name: String, entries: [String: String]) throws -> String {
+        let srcDir = tmpDir.appendingPathComponent("src-\(name)")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+        for (filename, content) in entries {
+            try content.write(
+                to: srcDir.appendingPathComponent(filename), atomically: true, encoding: .utf8)
+        }
+        let zipPath = tmpDir.appendingPathComponent("\(name).zip").path
+        let result = try runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/zip",
+            arguments: ["-q", "-r", zipPath, "."],
+            workingDirectory: srcDir
+        )
+        try #require(result.terminationStatus == 0)
+        return zipPath
+    }
+
+    @Test func capturesStdoutAndZeroExitStatus() throws {
+        guard zipToolsPresent else { return }
+        let zipPath = try makeZip(named: "capture", entries: ["greeting.txt": "hello zip"])
+
+        let list = try runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-Z1", zipPath]
+        )
+        #expect(list.terminationStatus == 0)
+        let names = try #require(String(bytes: list.stdout, encoding: .utf8))
+        #expect(names.contains("greeting.txt"))
+
+        let extracted = try runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-p", zipPath, "greeting.txt"]
+        )
+        #expect(extracted.terminationStatus == 0)
+        #expect(String(bytes: extracted.stdout, encoding: .utf8) == "hello zip")
+    }
+
+    @Test func reportsNonZeroExitStatus() throws {
+        guard zipToolsPresent else { return }
+        let missing = tmpDir.appendingPathComponent("does-not-exist.zip").path
+        let result = try runZipProcessCapturingStdout(
+            executablePath: "/usr/bin/unzip",
+            arguments: ["-Z1", missing]
+        )
+        #expect(result.terminationStatus != 0)
+    }
+
+    /// Many zip subprocesses at once, each with a distinct expected output.
+    /// With the lock released before the drain, children run concurrently;
+    /// every task must still read exactly its own child's stdout. A wrong
+    /// pairing (crossed pipes, a drain seeing another child's EOF) or a
+    /// revived spawn race fails this loudly.
+    @Test func concurrentZipSubprocessesEachGetTheirOwnOutput() async throws {
+        guard zipToolsPresent else { return }
+        let entryCount = 12
+        var entries: [String: String] = [:]
+        for index in 0..<entryCount {
+            entries["entry-\(index).txt"] = "content-\(index)"
+        }
+        let zipPath = try makeZip(named: "concurrent", entries: entries)
+
+        try await withThrowingTaskGroup(of: (Int, String).self) { group in
+            for index in 0..<entryCount {
+                group.addTask {
+                    let result = try runZipProcessCapturingStdout(
+                        executablePath: "/usr/bin/unzip",
+                        arguments: ["-p", zipPath, "entry-\(index).txt"]
+                    )
+                    try #require(result.terminationStatus == 0)
+                    let output = try #require(String(bytes: result.stdout, encoding: .utf8))
+                    return (index, output)
+                }
+            }
+            var seen = 0
+            for try await (index, output) in group {
+                #expect(output == "content-\(index)")
+                seen += 1
+            }
+            #expect(seen == entryCount)
+        }
+    }
+}

--- a/changelog.d/issue-1382-zip-lock-narrowing.md
+++ b/changelog.d/issue-1382-zip-lock-narrowing.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The process-wide zip lock now covers only the spawn.** Synchronous zip
+  subprocess runs (suite-zip list/extract/repack, upload-size validation,
+  notebook detection) held the shared serialization lock across the child's
+  whole runtime — a server-wide cap of one zip operation at a time, with each
+  waiter parking a thread. The lock now covers Process construction + spawn
+  only (the window Foundation's EFAULT race actually spans, and the scope the
+  async path always used); drains and waits overlap. All sync sites route
+  through one shared helper, which also brings the previously-unserialized
+  `zipContainsNotebook` spawn into the lock + retry regime.


### PR DESCRIPTION
Item 4 of the #1382 scalability-audit handover (items 2, 3, 5, 6, 8, 9 shipped in #1385 / #1387 / #1389).

## What was wrong

`withZipProcessLock` — the process-wide `NSLock` every `/usr/bin/zip` / `/usr/bin/unzip` invocation serializes on — was held across **spawn + stdout drain + exit wait** on every synchronous path. That made it a hard server-wide cap of one zip operation at a time, and each contender parked a cooperative-pool thread in a blocking `lock()`. The file's own premise ("zip operations are infrequent") predates the notebook-open and dashboard paths, which now list/extract zip entries per page view.

The Foundation EFAULT race the lock exists for spans Process/Pipe construction and the spawn — never the child's runtime. The async path (`ZipArchiver.runZipProcess`) has released after the spawn since it was written, with the terminationHandler running concurrently to lock-held spawns; that scope is now the sync scope too. Narrowed, not removed, per the handover.

## What changed

- **One shared sync entry point**: `runZipProcessCapturingStdout` in `ZipProcessSerialization.swift` holds the lock for construction + spawn only, then drains stdout and waits **outside** it. Concurrent zip operations now overlap everything but their spawns.
- **All six sync sites route through it**: `listZipContents` (Core), `repackZipFromDirectory`, `validateZipUploadSize`, `listZipEntries`, `extractZipEntry` (TestSetupZipHelpers), and `zipContainsNotebook` (NotebookContentHelpers). Per-site status/UTF-8/error semantics are unchanged — each site keeps its exact guard structure.
- **A defect found while converting**: `zipContainsNotebook` was a naked `proc.run()` — no lock, no EFAULT retry — racing every serialized zip spawn in the codebase. It is now inside the regime.
- **Two latent deadlock shapes removed as a side effect**: stdout is now always drained (`repackZipFromDirectory` previously attached a pipe it never read — safe only while `-q` kept output under the 64 KB pipe buffer), and discarded stderr goes to the null device instead of an undrained pipe.
- The test fixture `writeZipFixture` rides the same helper (it previously used non-CLOEXEC bare `Pipe()`s and a retry-less `run()`).

## Verification

- New `ZipProcessSerializationTests` (CoreTests): stdout capture + exit-status reporting, non-zero status, and the concurrency pin — twelve overlapping `unzip -p` children, each task asserting it read exactly its own child's output. That is the regression net for the overlapped drain/wait regime the narrowed lock creates.
- Existing suites over every converted call site pass locally: `ZipArchiverTests`, `ZipUploadValidationTests`, `ZipEntryListCacheTests`, `AssignmentHelpersUtilityTests`, `AssignmentHelpersManifestTests`, `AuthorScriptToolTests`, `PatternFamilyApplyTests`, `SuiteRouteTests`, `EmptySuitePersonalizationTests`, `AssignmentRoutesPublishTests`, `DeleteSupportFileToolTests` (154 tests across the runs).
- `scripts/format.sh` / `scripts/lint.sh` / `scripts/swiftlint.sh --strict` clean. One `changelog.d/` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7)_