### PR TITLE
perf(metrics): hydrate only the columns the metric folds read

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
@@ -61,8 +61,15 @@ extension OperationalDiagnosticsService {
         let loadPoints = try await runnerLoadPoints(since: windowStart, on: req.db)
         let activeSnapshots = await req.application.workerActivityStore.snapshotsSortedByRecent()
             .filter { now.timeIntervalSince($0.lastActive) <= configuration.activeRunnerWindowSeconds }
+        // Only the columns the summary fold below reads — hydrating full
+        // rows here was the same shape the timeseries endpoint had (#1382
+        // item 7); see metricsTimeSeriesSnapshot for why the fold itself
+        // stays in Swift.
         let recentMetrics = try await JobExecutionMetric.query(on: req.db)
             .filter(\.$completedAt >= windowStart)
+            .field(\.$finalStatus)
+            .field(\.$queueWaitMs)
+            .field(\.$executionMs)
             .all()
         let maxQueueDepth = try await maxQueueDepthSince(windowStart: windowStart, now: now, on: req.db)
         let peakLoadSnapshot = peakLoadPoint(from: loadPoints)
@@ -133,18 +140,31 @@ extension OperationalDiagnosticsService {
         )
         let window = resolved.window
 
-        // Runner snapshots are pre-aggregated per bucket (in SQL on Postgres);
-        // request / job metrics are submission-bound, so they stay raw.
+        // Runner snapshots are pre-aggregated per bucket (in SQL on Postgres).
         let runners = try await runnerTimeseriesSummaries(window: window, on: req.db)
 
+        // Request / job metrics stay a Swift fold over raw rows, but only the
+        // columns the accumulators read are hydrated (the window is clamped
+        // to 72h, so the row count is bounded).  The per-bucket p95 is why
+        // the fold cannot move into SQL: SQLite has no percentile aggregate,
+        // and Postgres `percentile_disc` picks rank ceil(n·p) (1-based) where
+        // `MetricBucketAccumulators.percentile` picks floor((n−1)·p)
+        // (0-based) — they disagree at e.g. n = 10, so a SQL path would
+        // silently change reported percentiles per backend.  Unordered on
+        // purpose: the accumulators bucket by index and sort within
+        // `percentile95`, so a DB sort here is wasted work.
         let requestMetrics = try await APIRequestMetric.query(on: req.db)
             .filter(\.$finishedAt >= window.windowStart)
-            .sort(\.$finishedAt, .ascending)
+            .field(\.$finishedAt)
+            .field(\.$durationMs)
             .all()
 
         let jobMetrics = try await JobExecutionMetric.query(on: req.db)
             .filter(\.$completedAt >= window.windowStart)
-            .sort(\.$completedAt, .ascending)
+            .field(\.$completedAt)
+            .field(\.$finalStatus)
+            .field(\.$queueWaitMs)
+            .field(\.$executionMs)
             .all()
 
         let requests = MetricBucketAccumulators.accumulateRequestMetrics(requestMetrics, window: window)

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -377,6 +377,12 @@ import VaporTesting
                     #expect(payload.activeRunners >= 1)
                     #expect(payload.jobsProcessed24h == 1)
                     #expect(payload.queueWait.averageMs != nil)
+                    // The fixture metric is the only row, so every summary
+                    // statistic must equal its values exactly — pinning the
+                    // numbers, not just their presence.
+                    #expect(payload.queueWait.p95Ms == 1000)
+                    #expect(payload.execution.averageMs == 4000)
+                    #expect(payload.execution.p95Ms == 4000)
                     #expect(payload.jobStatusCounts.first(where: { $0.status == "passed" })?.count == 1)
                     #expect(payload.runnerLoads.isEmpty == false)
                     #expect(payload.compatibility.compatibleAssignmentAttempts == 0)
@@ -393,7 +399,14 @@ import VaporTesting
                     #expect(payload.windowHours == 24)
                     #expect(payload.bucketMinutes == 15)
                     #expect(payload.buckets.isEmpty == false)
-                    #expect(payload.buckets.contains(where: { $0.completedJobs == 1 }))
+                    // Each fixture is its bucket's only member, so the
+                    // per-bucket p95s must equal the fixture values exactly.
+                    let jobBucket = payload.buckets.first(where: { $0.completedJobs == 1 })
+                    #expect(jobBucket?.passedCount == 1)
+                    #expect(jobBucket?.queueWaitP95Ms == 1000)
+                    #expect(jobBucket?.executionP95Ms == 4000)
+                    let requestBucket = payload.buckets.first(where: { $0.requestCount == 1 })
+                    #expect(requestBucket?.requestP95Ms == 150)
                     #expect(
                         payload.buckets.contains(where: {
                             ($0.requestCount > 0) || ($0.avgRunnerUtilizationPercent != nil)

--- a/changelog.d/issue-1382-metrics-timeseries-projection.md
+++ b/changelog.d/issue-1382-metrics-timeseries-projection.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **The metrics timeseries and snapshot endpoints stop hydrating full metric
+  rows.** `/admin/metrics/timeseries` loaded every `request_metrics` and
+  `job_execution_metrics` row in the window as complete models (and sorted
+  them for an order-insensitive fold); `/admin/metrics` did the same for its
+  job summary. Both now fetch only the two-to-four scalar columns their
+  accumulators read. The per-bucket fold itself deliberately stays in Swift:
+  SQLite has no percentile aggregate and Postgres `percentile_disc` uses a
+  different rank rule than the existing p95, so a SQL fold would change
+  reported percentiles per backend. Endpoint values are now pinned exactly
+  (p95s included) by the observability tests.


### PR DESCRIPTION
Item 7 of the #1382 scalability-audit handover (item 4 shipped in #1398; items 2, 3, 5, 6, 8, 9 in #1385 / #1387 / #1389).

## What was wrong

`GET /admin/metrics/timeseries` (`metricsTimeSeriesSnapshot`) loaded **every `request_metrics` and `job_execution_metrics` row in the window** as full Fluent models — and sorted them in the database, although the downstream fold buckets by index and is order-insensitive. `/admin/metrics` (`metricsSnapshot`) had the same shape for its job summary one screen up. Both are reachable from the read-only admin MCP an agent may poll.

## What changed, and what deliberately did not

- Both request/job queries now project only the scalar columns the accumulators read — `(finished_at, duration_ms)` for requests, `(completed_at, final_status, queue_wait_ms, execution_ms)` for jobs — using the same `.field()` projection `runnerTimeseriesSummaries`' fallback already uses. The two DB sorts are gone.
- **The per-bucket fold stays in Swift, on purpose.** The handover suggests matching the runner snapshots' SQL pre-aggregation, but the prior session's deferral note holds up: the per-bucket p95 cannot move into SQL without changing its meaning. SQLite has no percentile aggregate, and Postgres `percentile_disc` picks rank ⌈n·p⌉ (1-based) where `MetricBucketAccumulators.percentile` picks ⌊(n−1)·p⌋ (0-based) — they disagree at e.g. n = 10, so a SQL path would silently report different percentiles per backend. That reasoning is now a comment at the query site so it doesn't get re-attempted blindly. The window is already clamped to 72 h, so the row count the fold sees is bounded; the projection removes the full-model hydration cost, which was the unbounded-ish part in practice.

## Verification

- Per the handover's item-2 warning, the endpoint's *values* were pinned first and verified against the pre-change loaders, then re-run against the projection: snapshot `queueWait.p95Ms` / `execution.averageMs` / `execution.p95Ms`, and per-bucket `requestP95Ms`, `queueWaitP95Ms`, `executionP95Ms`, `passedCount` (single-row fixtures make each p95 equal its fixture value exactly).
- `ObservabilityTests` (14) and `AdminMCPToolsTests` (47, includes `get_metrics_timeseries` / `get_metrics_snapshot`) green locally on SQLite; the `api-tests-postgres` lane runs the same suites against Postgres in CI, exercising the projected queries on both backends.
- `scripts/format.sh` / `scripts/lint.sh` / `scripts/swiftlint.sh --strict` clean. One `changelog.d/` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7)_