### PR TITLE
refactor(ui): S3 — server-rendered poll fragments

### DIFF
--- a/Public/relative-time.js
+++ b/Public/relative-time.js
@@ -44,9 +44,24 @@
         });
     }
 
+    // "Has this thing gone quiet?" — the client half of the server's
+    // RunnerStaleness rule (5 minutes without a check-in reads as offline).
+    // Lived as two copy-pasted `Date.now() - t > 5 * 60 * 1000` expressions in
+    // page scripts; both are gone, and the server now decides the initial
+    // state so first paint and later ticks agree.
+    var STALE_AFTER_MS = 5 * 60 * 1000;
+
+    function isStale(isoString, thresholdMs) {
+        if (!isoString) return false;
+        var t = new Date(isoString).getTime();
+        if (Number.isNaN(t)) return false;
+        return (Date.now() - t) > (thresholdMs || STALE_AFTER_MS);
+    }
+
     global.ChickadeeRelativeTime = {
         formatRelative: formatRelative,
-        applyRelativeTimes: applyRelativeTimes
+        applyRelativeTimes: applyRelativeTimes,
+        isStale: isStale
     };
 
     if (document.readyState === 'loading') {

--- a/Public/table-poll.js
+++ b/Public/table-poll.js
@@ -1,0 +1,110 @@
+// Shared background refresh for a server-rendered table (UI audit S3).
+//
+//   <table class="results-table sortable-table" id="…"
+//          data-poll-url="/instructor/students-data?fragment=rows"
+//          data-poll-interval="5000">
+//
+// Every interval the table's <tbody> is replaced with freshly rendered rows
+// fetched from `data-poll-url` — HTML the SERVER renders from the same Leaf
+// partial the page itself used. Before this, three pages each rebuilt every
+// row by concatenating HTML strings in an inline script, duplicating the
+// markup (role <select>s, CSRF fields, icon SVGs, a whole register-student
+// popover) in a second place that could drift from the template silently, and
+// did.
+//
+// After a swap the shared row behaviours are re-applied in a fixed order —
+// relative times, then sort, then filter — because each depends on the last:
+// sorting a date column reads the timestamps, and filtering hides rows the
+// sort has already ordered. Page-specific work (a count, a badge overlay)
+// listens for the `chickadee:table-repaint` event rather than editing this
+// file.
+//
+// Polling is suppressed while the tab is hidden, while focus is inside the
+// table (a repaint would yank a half-open <select> away), and while the
+// table's filter box has focus. Requests carry `X-Background-Refresh: 1`, so
+// a dashboard left open in a tab cannot keep a session alive — the one thing
+// all three copies were supposed to do and one of them didn't.
+(function (global) {
+    'use strict';
+
+    var DEFAULT_INTERVAL_MS = 5000;
+
+    function filterInputFor(table) {
+        if (!table.id) return null;
+        return document.querySelector('input[data-list-filter="' + table.id + '"]');
+    }
+
+    function shouldSkip(table) {
+        if (document.hidden) return true;
+        if (table.contains(document.activeElement)) return true;
+        var filter = filterInputFor(table);
+        return !!(filter && document.activeElement === filter);
+    }
+
+    function refresh(table) {
+        var url = table.getAttribute('data-poll-url');
+        var tbody = table.querySelector('tbody');
+        if (!url || !tbody) return Promise.resolve(false);
+
+        return fetch(url, {
+            headers: { 'Accept': 'text/html', 'X-Background-Refresh': '1' },
+            cache: 'no-store',
+            credentials: 'same-origin'
+        }).then(function (res) {
+            // A redirect or an auth failure means the session ended server-side;
+            // reload so the login page is what the user actually sees.
+            if (res.redirected || res.status === 401 || res.status === 403) {
+                window.location.reload();
+                return null;
+            }
+            if (!res.ok) return null;
+            return res.text();
+        }).then(function (html) {
+            if (html === null || html === undefined) return false;
+            tbody.innerHTML = html;
+            if (global.ChickadeeRelativeTime) {
+                global.ChickadeeRelativeTime.applyRelativeTimes(tbody);
+            }
+            if (global.ChickadeeSortableTable) {
+                global.ChickadeeSortableTable.apply(table);
+            }
+            if (global.ChickadeeListFilter) {
+                global.ChickadeeListFilter.apply(filterInputFor(table));
+            }
+            table.dispatchEvent(new CustomEvent('chickadee:table-repaint', { bubbles: true }));
+            return true;
+        }).catch(function () {
+            // Keep the rows already on screen: the next tick self-heals, and a
+            // transient blip must not blank a roster someone is reading.
+            return false;
+        });
+    }
+
+    function start(table) {
+        var interval = parseInt(table.getAttribute('data-poll-interval'), 10) || DEFAULT_INTERVAL_MS;
+        setInterval(function () {
+            if (shouldSkip(table)) return;
+            refresh(table);
+        }, interval);
+    }
+
+    function init() {
+        document.querySelectorAll('table[data-poll-url]').forEach(start);
+    }
+
+    global.ChickadeeTablePoll = { refresh: refresh, shouldSkip: shouldSkip };
+
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    }
+
+    // Node export for the .mjs unit tests (Tests/BrowserRunnerJSTests);
+    // browsers take the global above.
+    if (typeof module === 'object' && module.exports) {
+        module.exports = global.ChickadeeTablePoll;
+    }
+})(typeof self !== 'undefined' ? self : this);

--- a/Resources/Views/_student-rows.leaf
+++ b/Resources/Views/_student-rows.leaf
@@ -1,0 +1,87 @@
+    #for(student in enrolledStudents):
+        <tr class="student-row-link#if(student.isPending): student-row-pending#endif"
+            data-student-id="#(student.id)"
+            #if(!student.isPending):data-href="#(student.submissionsURL)"#endif>
+            <td>
+                #if(student.isPending):
+                <strong class="students-pending-name">#(student.displayName)</strong>
+                <span class="students-pending-note">awaiting first login</span>
+                #else:
+                <a href="#(student.submissionsURL)"><strong>#(student.displayName)</strong></a>
+                #endif
+            </td>
+            <td>
+                #if(student.isPending):
+                <code class="students-pending-username">#(student.username)</code>
+                #else:
+                <a href="#(student.submissionsURL)"><code>#(student.username)</code></a>
+                #endif
+            </td>
+            <td class="role-cell">
+                #if(student.isPending):
+                <span class="students-pending-role">(pending)</span>
+                #elseif(rosterReadOnly):
+                #(student.role)
+                #else:
+                <form method="post" action="/courses/#(currentUser.activeCourse.id)/role/#(student.id)"
+                      class="inline-form students-role-form">
+                    #csrfFormField()
+                    <select name="role" class="form-input students-role-select" aria-label="Per-course role"
+                            onchange="this.form.submit()">
+                        <option value="student"#if(student.role == "student"): selected#endif>Student</option>
+                        <option value="ta"#if(student.role == "ta"): selected#endif>TA</option>
+                        <option value="instructor"#if(student.role == "instructor"): selected#endif>Instructor</option>
+                    </select>
+                </form>
+                #endif
+            </td>
+            <td class="js-relative-time"
+                #if(student.lastSeenAtISO):data-iso="#(student.lastSeenAtISO)"#endif>
+                #(student.lastSeenAtText)
+            </td>
+            <td>
+                #if(!rosterReadOnly):
+                <div class="students-row-actions">
+                    #if(student.isPending):
+                    <details class="ext-details form-flush">
+                        <summary class="btn action-btn action-btn-tight" title="Register this student now"
+                                 aria-label="Register pending student">Register</summary>
+                        <form method="post" action="#(student.registerURL)" class="ext-panel">
+                            #csrfFormField()
+                            <p class="students-register-hint">Materialize <code>#(student.username)</code> into a real account now (for grade-sync testing). They appear on assignment rosters immediately; their real login adopts this account.</p>
+                            <label class="ext-field-label">
+                                Display name
+                                <input type="text" name="displayName" placeholder="#(student.username)" class="ext-field-input">
+                            </label>
+                            <label class="ext-field-label">
+                                Student number (optional)
+                                <input type="text" name="studentID" class="ext-field-input">
+                            </label>
+                            <label class="ext-field-label">
+                                Email (optional)
+                                <input type="email" name="email" class="ext-field-input">
+                            </label>
+                            <label class="ext-field-label">
+                                SSO subject (optional)
+                                <input type="text" name="externalSubject" placeholder="leave blank to adopt by username" class="ext-field-input">
+                            </label>
+                            <div class="ext-panel-actions">
+                                <button class="btn action-btn" type="submit">Register</button>
+                            </div>
+                        </form>
+                    </details>
+                    #endif
+                    <form method="post" action="#(student.unenrollURL)"
+                          class="inline-form">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger students-unenroll-btn" type="submit"
+                                title="Remove from course" aria-label="Remove from course"
+                                onclick="return confirm('Remove @#(student.username) from this course?')">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                        </button>
+                    </form>
+                </div>
+                #endif
+            </td>
+        </tr>
+    #endfor

--- a/Resources/Views/_user-rows.leaf
+++ b/Resources/Views/_user-rows.leaf
@@ -1,0 +1,52 @@
+        #for(user in users):
+            <tr>
+                <td>
+                    #if(user.displayName):
+                        #(user.displayName)
+                    #else:
+                        —
+                    #endif
+                </td>
+                <td><code>#(user.username)</code></td>
+                <td>
+                    #if(user.role == "mcp"):
+                    <code class="role-fixed">mcp</code>
+                    #else:
+                    <form method="post" action="/admin/users/#(user.id)/role"
+                          class="role-form">
+                        #csrfFormField()
+                        <label class="visually-hidden" for="role-#(user.id)">Role for #(user.username)</label>
+                        <select id="role-#(user.id)" name="role" class="form-input role-select">
+                            <option value="user"  #if(user.role == "user"):selected#endif>user</option>
+                            <option value="admin" #if(user.role == "admin"):selected#endif>admin</option>
+                        </select>
+                        <button class="btn action-btn" type="submit">Save</button>
+                    </form>
+                    #endif
+                </td>
+                <td class="time js-relative-time col-hide-phone" data-iso="#(user.lastSeenAt)">
+                    #if(user.lastSeenAt):
+                        #(user.lastSeenAt)
+                    #else:
+                        —
+                    #endif
+                </td>
+                <td class="time js-relative-time col-hide-phone" data-iso="#(user.createdAt)">#(user.createdAt)</td>
+                <td>
+                    <div class="user-actions">
+                        <a href="/admin/users/#(user.id)"
+                           class="btn action-btn action-btn-icon" title="Manage user" aria-label="Manage user">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+                        </a>
+                        <form method="post" action="/admin/users/#(user.id)/delete" class="user-delete-form">
+                            #csrfFormField()
+                            <button class="btn action-btn action-danger action-btn-icon" type="submit"
+                                    title="Delete user" aria-label="Delete user"
+                                    onclick="return confirm('Delete this user? Their enrollments will be removed. They can log in again to restore their account.')">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                            </button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+        #endfor

--- a/Resources/Views/_worker-rows.leaf
+++ b/Resources/Views/_worker-rows.leaf
@@ -1,0 +1,24 @@
+            #for(worker in workers):
+                <tr data-load="#(worker.assignedJobs)"
+                    data-max-jobs="#(worker.maxConcurrentJobs)"#if(worker.isOffline): class="runner-row-offline"#endif>
+                    <td data-sort-value="#(worker.workerID)">
+                        <a href="/admin/runners/#(worker.workerID)"><code>#(worker.workerID)</code></a>
+                        #if(worker.isOffline):<span class="runner-badge-offline">Offline</span>#endif
+                        #if(worker.hostname != ""):
+                            <br><span class="worker-host">#(worker.hostname)</span>
+                        #endif
+                    </td>
+                    <td data-sort-value="#(worker.runnerVersion)">#if(worker.runnerVersion != ""):#(worker.runnerVersion)#else:—#endif</td>
+                    <td class="time#if(worker.assignedJobs > 0): runner-load-busy#endif" data-sort-value="#(worker.assignedJobs)">
+                        #if(worker.maxConcurrentJobs > 0):
+                            #(worker.assignedJobs)&thinsp;/&thinsp;#(worker.maxConcurrentJobs)
+                        #else:
+                            #(worker.assignedJobs)
+                        #endif
+                    </td>
+                    <td class="time" data-sort-value="#(worker.jobsProcessed)">#(worker.jobsProcessed)</td>
+                    <td class="time" data-sort-value="#if(worker.avgExecutionMs):#(worker.avgExecutionMs)#else:-1#endif">#if(worker.avgExecutionFormatted):#(worker.avgExecutionFormatted)#else:—#endif</td>
+                    <td class="time" data-sort-value="#if(worker.avgQueueWaitMs):#(worker.avgQueueWaitMs)#else:-1#endif">#if(worker.avgQueueWaitFormatted):#(worker.avgQueueWaitFormatted)#else:—#endif</td>
+                    <td class="time js-relative-time" data-iso="#(worker.lastActive)">#(worker.lastActive)</td>
+                </tr>
+            #endfor

--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -6,7 +6,7 @@ Runner #(runner.workerID)
 <section class="page-section">
     <div data-runner-id="#(runner.workerID)" class="runner-header">
         <div>
-            <h2 class="runner-header-title"><code>#(runner.workerID)</code> <span id="runner-offline-badge" class="runner-badge-offline" style="display:none">Offline</span></h2>
+            <h2 class="runner-header-title"><code>#(runner.workerID)</code> <span id="runner-offline-badge" class="runner-badge-offline"#if(!runner.isOffline): style="display:none"#endif>Offline</span></h2>
             <p class="runner-subhead">
                 <span id="runner-hostname">#if(runner.hostname != ""):#(runner.hostname)#else:Unknown host#endif</span>
                 ·
@@ -141,15 +141,13 @@ Runner #(runner.workerID)
 
     var offlineBadge = document.getElementById('runner-offline-badge');
 
-    // Show/hide the offline badge based on how recently the runner checked in.
+    // The badge's initial state is server-rendered; this keeps it honest as
+    // the page ages without a reload, using the shared staleness rule.
     function updateOfflineBadge() {
-        if (offlineBadge) {
-            var laEl = document.getElementById('runner-last-active');
-            var laIso = laEl ? laEl.getAttribute('data-iso') : null;
-            var laMs = laIso ? new Date(laIso).getTime() : 0;
-            var isOffline = laMs > 0 && (Date.now() - laMs) > 5 * 60 * 1000;
-            offlineBadge.style.display = isOffline ? '' : 'none';
-        }
+        if (!offlineBadge) return;
+        var laEl = document.getElementById('runner-last-active');
+        var laIso = laEl ? laEl.getAttribute('data-iso') : null;
+        offlineBadge.style.display = ChickadeeRelativeTime.isStale(laIso) ? '' : 'none';
     }
     ChickadeeRelativeTime.applyRelativeTimes();
     updateOfflineBadge();

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -16,7 +16,8 @@ Users
         </span>
     </div>
     <div class="table-scroll"><table class="results-table sortable-table" id="users-table"
-           data-sort-initial="last-seen:desc" data-sort-tiebreak="username">
+           data-sort-initial="last-seen:desc" data-sort-tiebreak="username"
+           data-poll-url="/admin/users-data?fragment=rows" data-poll-interval="5000">
         <thead>
             <tr>
                 <th data-sort-key="name" data-sort-type="text"><button class="sort-header" type="button">Name</button></th>
@@ -28,58 +29,7 @@ Users
             </tr>
         </thead>
         <tbody>
-        #for(user in users):
-            <tr>
-                <td>
-                    #if(user.displayName):
-                        #(user.displayName)
-                    #else:
-                        —
-                    #endif
-                </td>
-                <td><code>#(user.username)</code></td>
-                <td>
-                    #if(user.role == "mcp"):
-                    <code class="role-fixed">mcp</code>
-                    #else:
-                    <form method="post" action="/admin/users/#(user.id)/role"
-                          class="role-form">
-                        #csrfFormField()
-                        <label class="visually-hidden" for="role-#(user.id)">Role for #(user.username)</label>
-                        <select id="role-#(user.id)" name="role" class="form-input role-select">
-                            <option value="user"  #if(user.role == "user"):selected#endif>user</option>
-                            <option value="admin" #if(user.role == "admin"):selected#endif>admin</option>
-                        </select>
-                        <button class="btn action-btn" type="submit">Save</button>
-                    </form>
-                    #endif
-                </td>
-                <td class="time js-relative-time col-hide-phone" data-iso="#(user.lastSeenAt)">
-                    #if(user.lastSeenAt):
-                        #(user.lastSeenAt)
-                    #else:
-                        —
-                    #endif
-                </td>
-                <td class="time js-relative-time col-hide-phone" data-iso="#(user.createdAt)">#(user.createdAt)</td>
-                <td>
-                    <div class="user-actions">
-                        <a href="/admin/users/#(user.id)"
-                           class="btn action-btn action-btn-icon" title="Manage user" aria-label="Manage user">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        </a>
-                        <form method="post" action="/admin/users/#(user.id)/delete" class="user-delete-form">
-                            #csrfFormField()
-                            <button class="btn action-btn action-danger action-btn-icon" type="submit"
-                                    title="Delete user" aria-label="Delete user"
-                                    onclick="return confirm('Delete this user? Their enrollments will be removed. They can log in again to restore their account.')">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
-                            </button>
-                        </form>
-                    </div>
-                </td>
-            </tr>
-        #endfor
+        #extend("_user-rows")
         </tbody>
     </table></div>
 </section>
@@ -105,107 +55,6 @@ Users
 <script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/list-filter.js?v=#appVersion()"></script>
 <script src="/sortable-table.js?v=#appVersion()"></script>
-<script>
-(function () {
-    'use strict';
-
-    var usersTable = document.getElementById('users-table');
-    if (!usersTable) return;
-    var usersBody = usersTable.querySelector('tbody');
-    if (!usersBody) return;
-
-    ChickadeeRelativeTime.applyRelativeTimes(document);
-
-    var usersFilter = document.getElementById('users-filter');
-
-    // ── Auto-refresh ─────────────────────────────────────────────────
-    // Poll /admin/users-data every few seconds and repaint the table so
-    // last-seen times and new/removed users stay current without a manual
-    // reload.  The X-Background-Refresh header tells the server this is a
-    // system-generated poll, so it does NOT reset the session idle timer
-    // (a dashboard left open in a tab can't keep an admin logged in).
-
-    // Shared implementation (Public/chickadee-ui.js, loaded from base.leaf).
-    var escapeHtml = ChickadeeUI.escapeHtml;
-
-    var deleteIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';
-    var editIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>';
-
-    function buildUserRow(user, csrfToken) {
-        var id = escapeHtml(user.id);
-        var username = escapeHtml(user.username);
-        var displayName = user.displayName ? escapeHtml(user.displayName) : '—';
-        var lastSeen = user.lastSeenAt ? escapeHtml(user.lastSeenAt) : '';
-        var created = escapeHtml(user.createdAt);
-        var csrfField = '<input type="hidden" name="_csrf" value="' + escapeHtml(csrfToken) + '">';
-        function roleOption(value) {
-            return '<option value="' + value + '"' + (user.role === value ? ' selected' : '') + '>' + value + '</option>';
-        }
-        // mcp service accounts render read-only so they can't be flipped to a
-        // human role by mistake; humans get the user|admin toggle (#417 G2).
-        var roleCell = user.role === 'mcp'
-            ? '<code class="role-fixed">mcp</code>'
-            : '<form method="post" action="/admin/users/' + id + '/role" class="role-form">'
-                + csrfField
-                + '<label class="visually-hidden" for="role-' + id + '">Role for ' + username + '</label>'
-                + '<select id="role-' + id + '" name="role" class="form-input role-select">'
-                    + roleOption('user') + roleOption('admin')
-                + '</select>'
-                + '<button class="btn action-btn" type="submit">Save</button>'
-            + '</form>';
-        return '<tr>'
-            + '<td>' + displayName + '</td>'
-            + '<td><code>' + username + '</code></td>'
-            + '<td>' + roleCell + '</td>'
-            + '<td class="time js-relative-time col-hide-phone" data-iso="' + lastSeen + '">' + (user.lastSeenAt ? lastSeen : '—') + '</td>'
-            + '<td class="time js-relative-time col-hide-phone" data-iso="' + created + '">' + created + '</td>'
-            + '<td>'
-                + '<div class="user-actions">'
-                    + '<a href="/admin/users/' + id + '" class="btn action-btn action-btn-icon" title="Manage user" aria-label="Manage user">' + editIcon + '</a>'
-                    + '<form method="post" action="/admin/users/' + id + '/delete" class="user-delete-form">'
-                        + csrfField
-                        + '<button class="btn action-btn action-danger action-btn-icon" type="submit" title="Delete user" aria-label="Delete user"'
-                            + ' onclick="return confirm(\'Delete this user? Their enrollments will be removed. They can log in again to restore their account.\')">' + deleteIcon + '</button>'
-                    + '</form>'
-                + '</div>'
-            + '</td>'
-        + '</tr>';
-    }
-
-    function repaintUsers(rows) {
-        if (!Array.isArray(rows)) return;
-        var csrfToken = ChickadeeUI.getCsrfToken();
-        usersBody.innerHTML = rows.map(function (u) { return buildUserRow(u, csrfToken); }).join('');
-        ChickadeeRelativeTime.applyRelativeTimes(usersBody);
-        ChickadeeSortableTable.apply(usersTable);
-        ChickadeeListFilter.apply(usersFilter);
-    }
-
-    async function pollUsers() {
-        // Skip when the tab is hidden, or while an admin is mid-interaction
-        // with the table or filter (repaint would yank focus / a half-open
-        // role <select> out from under them).
-        if (document.hidden) return;
-        if (usersTable.contains(document.activeElement)) return;
-        if (usersFilter && document.activeElement === usersFilter) return;
-        try {
-            var res = await fetch('/admin/users-data', {
-                headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
-                cache: 'no-store'
-            });
-            if (res.redirected || res.status === 401 || res.status === 403) {
-                // Session expired server-side — surface the login redirect.
-                window.location.reload();
-                return;
-            }
-            if (!res.ok) return;
-            repaintUsers(await res.json());
-        } catch (_) {
-            // Keep the current rows on transient polling errors.
-        }
-    }
-    setInterval(pollUsers, 5000);
-})();
-</script>
+<script src="/table-poll.js?v=#appVersion()"></script>
 #endexport
 #endextend

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -56,7 +56,8 @@ Admin
     </div>
 
     <div class="table-scroll"><table id="workers-table" class="results-table sortable-table"
-            data-sort-initial="runner:asc" data-sort-tiebreak="runner">
+            data-sort-initial="runner:asc" data-sort-tiebreak="runner"
+            data-poll-url="/admin/runners?fragment=rows" data-poll-interval="5000">
             <thead>
                 <tr>
                     <th data-sort-key="runner" data-sort-type="text"><button class="sort-header" type="button">Runner</button></th>
@@ -69,29 +70,7 @@ Admin
                 </tr>
             </thead>
             <tbody id="workers-body">
-            #for(worker in workers):
-                <tr data-load="#(worker.assignedJobs)"
-                    data-max-jobs="#(worker.maxConcurrentJobs)">
-                    <td data-sort-value="#(worker.workerID)">
-                        <a href="/admin/runners/#(worker.workerID)"><code>#(worker.workerID)</code></a>
-                        #if(worker.hostname != ""):
-                            <br><span class="worker-host">#(worker.hostname)</span>
-                        #endif
-                    </td>
-                    <td data-sort-value="#(worker.runnerVersion)">#if(worker.runnerVersion != ""):#(worker.runnerVersion)#else:—#endif</td>
-                    <td class="time#if(worker.assignedJobs > 0): runner-load-busy#endif" data-sort-value="#(worker.assignedJobs)">
-                        #if(worker.maxConcurrentJobs > 0):
-                            #(worker.assignedJobs)&thinsp;/&thinsp;#(worker.maxConcurrentJobs)
-                        #else:
-                            #(worker.assignedJobs)
-                        #endif
-                    </td>
-                    <td class="time" data-sort-value="#(worker.jobsProcessed)">#(worker.jobsProcessed)</td>
-                    <td class="time" data-sort-value="#if(worker.avgExecutionMs):#(worker.avgExecutionMs)#else:-1#endif">#if(worker.avgExecutionFormatted):#(worker.avgExecutionFormatted)#else:—#endif</td>
-                    <td class="time" data-sort-value="#if(worker.avgQueueWaitMs):#(worker.avgQueueWaitMs)#else:-1#endif">#if(worker.avgQueueWaitFormatted):#(worker.avgQueueWaitFormatted)#else:—#endif</td>
-                    <td class="time js-relative-time" data-iso="#(worker.lastActive)">#(worker.lastActive)</td>
-                </tr>
-            #endfor
+            #extend("_worker-rows")
             </tbody>
         </table></div>
 </section>
@@ -206,6 +185,7 @@ tr.runner-row-offline {
 </style>
 <script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/sortable-table.js?v=#appVersion()"></script>
+<script src="/table-poll.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -337,68 +317,18 @@ tr.runner-row-offline {
         });
     });
 
-    function renderWorkers(workers) {
-        workers = Array.isArray(workers) ? workers.slice() : [];
-        totalRunnerCount = workers.length;
-        totalRunnerCapacity = workers.reduce(function (sum, worker) {
-            return sum + Number(worker.maxConcurrentJobs || 0);
-        }, 0);
-        totalAssignedJobs = workers.reduce(function (sum, worker) {
-            return sum + Number(worker.assignedJobs || 0);
-        }, 0);
-        if (!Array.isArray(workers) || workers.length === 0) {
-            workersBody.innerHTML = '';
-            renderMaxLoadSummary();
-            return;
-        }
-
-        workersBody.innerHTML = workers.map(function (worker) {
-            var id = escapeHtml(worker.workerID || '');
-            var hostname = escapeHtml(worker.hostname || '');
-            var version = escapeHtml(worker.runnerVersion || '');
-            var assignedJobs = worker.assignedJobs == null ? 0 : worker.assignedJobs;
-            var maxJobs = worker.maxConcurrentJobs == null ? 0 : worker.maxConcurrentJobs;
-            var jobsProcessed = worker.jobsProcessed == null ? 0 : worker.jobsProcessed;
-            var avgRun = escapeHtml(worker.avgExecutionFormatted || '');
-            var avgWait = escapeHtml(worker.avgQueueWaitFormatted || '');
-            var lastActive = escapeHtml(worker.lastActive || '');
-            var detailURL = '/admin/runners/' + encodeURIComponent(worker.workerID || '');
-
-            // Runners not seen in the last 5 minutes are considered offline.
-            var lastActiveMs = lastActive ? new Date(lastActive).getTime() : 0;
-            var isOffline = lastActiveMs > 0 && (Date.now() - lastActiveMs) > 5 * 60 * 1000;
-
-            var idCell = '<a href="' + detailURL + '"><code>' + id + '</code></a>'
-                + (isOffline ? ' <span class="runner-badge-offline">Offline</span>' : '')
-                + (hostname ? '<br><span class="worker-host">' + hostname + '</span>' : '');
-            var loadCell = maxJobs > 0
-                ? (assignedJobs + '&thinsp;/&thinsp;' + maxJobs)
-                : String(assignedJobs);
-            var loadClass = assignedJobs > 0 ? ' runner-load-busy' : '';
-
-            return '<tr'
-                + (isOffline ? ' class="runner-row-offline"' : '')
-                + ' data-load="' + assignedJobs + '"'
-                + ' data-max-jobs="' + maxJobs + '"'
-                + '>'
-                + '<td data-sort-value="' + id + '">' + idCell + '</td>'
-                + '<td data-sort-value="' + version + '">' + (version || '—') + '</td>'
-                + '<td class="time' + loadClass + '" data-sort-value="' + assignedJobs + '">' + loadCell + '</td>'
-                + '<td class="time" data-sort-value="' + jobsProcessed + '">' + jobsProcessed + '</td>'
-                + '<td class="time" data-sort-value="' + (worker.avgExecutionMs == null ? -1 : worker.avgExecutionMs) + '">' + (avgRun || '—') + '</td>'
-                + '<td class="time" data-sort-value="' + (worker.avgQueueWaitMs == null ? -1 : worker.avgQueueWaitMs) + '">' + (avgWait || '—') + '</td>'
-                + '<td class="time js-relative-time" data-iso="' + lastActive + '">' + lastActive + '</td>'
-                + '</tr>';
-        }).join('');
-        ChickadeeRelativeTime.applyRelativeTimes(workersBody);
-        ChickadeeSortableTable.apply(workersTable);
-        renderMaxLoadSummary();
-    }
-
     var workersTable = document.getElementById('workers-table');
+    if (workersTable) {
+        // table-poll.js swaps in server-rendered rows and re-applies the
+        // shared behaviours; the Max Load summary is this page's own read of
+        // them, so it re-derives from the fresh DOM.
+        workersTable.addEventListener('chickadee:table-repaint', function () {
+            recomputeLoadSummaryFromTable();
+            renderMaxLoadSummary();
+        });
+    }
     setInterval(function () {
         ChickadeeRelativeTime.applyRelativeTimes(document);
-        refreshWorkers();
     }, 5000);
     setInterval(refreshCards, 60000);
 

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -62,9 +62,7 @@ Students
 
 <table class="results-table sortable-table" id="enrolled-students-table"
        data-sort-initial="last-seen:desc" data-sort-tiebreak="username"
-       data-archived="#if(courseIsArchived):true#else:false#endif"
-       data-can-manage="#if(canManageRoster):true#else:false#endif"
-       data-course-id="#(currentUser.activeCourse.id)">
+       data-poll-url="/instructor/students-data?fragment=rows" data-poll-interval="5000">
     <thead>
         <tr>
             <th data-sort-key="name" data-sort-type="text"><button class="sort-header" type="button">Name</button></th>
@@ -75,93 +73,7 @@ Students
         </tr>
     </thead>
     <tbody>
-    #for(student in enrolledStudents):
-        <tr class="student-row-link#if(student.isPending): student-row-pending#endif"
-            data-student-id="#(student.id)"
-            #if(!student.isPending):data-href="#(student.submissionsURL)"#endif>
-            <td>
-                #if(student.isPending):
-                <strong class="students-pending-name">#(student.displayName)</strong>
-                <span class="students-pending-note">awaiting first login</span>
-                #else:
-                <a href="#(student.submissionsURL)"><strong>#(student.displayName)</strong></a>
-                #endif
-            </td>
-            <td>
-                #if(student.isPending):
-                <code class="students-pending-username">#(student.username)</code>
-                #else:
-                <a href="#(student.submissionsURL)"><code>#(student.username)</code></a>
-                #endif
-            </td>
-            <td class="role-cell">
-                #if(student.isPending):
-                <span class="students-pending-role">(pending)</span>
-                #elseif(rosterReadOnly):
-                #(student.role)
-                #else:
-                <form method="post" action="/courses/#(currentUser.activeCourse.id)/role/#(student.id)"
-                      class="inline-form students-role-form">
-                    #csrfFormField()
-                    <select name="role" class="form-input students-role-select" aria-label="Per-course role"
-                            onchange="this.form.submit()">
-                        <option value="student"#if(student.role == "student"): selected#endif>Student</option>
-                        <option value="ta"#if(student.role == "ta"): selected#endif>TA</option>
-                        <option value="instructor"#if(student.role == "instructor"): selected#endif>Instructor</option>
-                    </select>
-                </form>
-                #endif
-            </td>
-            <td class="js-relative-time"
-                #if(student.lastSeenAtISO):data-iso="#(student.lastSeenAtISO)"#endif>
-                #(student.lastSeenAtText)
-            </td>
-            <td>
-                #if(!rosterReadOnly):
-                <div class="students-row-actions">
-                    #if(student.isPending):
-                    <details class="ext-details form-flush">
-                        <summary class="btn action-btn action-btn-tight" title="Register this student now"
-                                 aria-label="Register pending student">Register</summary>
-                        <form method="post" action="#(student.registerURL)" class="ext-panel">
-                            #csrfFormField()
-                            <p class="students-register-hint">Materialize <code>#(student.username)</code> into a real account now (for grade-sync testing). They appear on assignment rosters immediately; their real login adopts this account.</p>
-                            <label class="ext-field-label">
-                                Display name
-                                <input type="text" name="displayName" placeholder="#(student.username)" class="ext-field-input">
-                            </label>
-                            <label class="ext-field-label">
-                                Student number (optional)
-                                <input type="text" name="studentID" class="ext-field-input">
-                            </label>
-                            <label class="ext-field-label">
-                                Email (optional)
-                                <input type="email" name="email" class="ext-field-input">
-                            </label>
-                            <label class="ext-field-label">
-                                SSO subject (optional)
-                                <input type="text" name="externalSubject" placeholder="leave blank to adopt by username" class="ext-field-input">
-                            </label>
-                            <div class="ext-panel-actions">
-                                <button class="btn action-btn" type="submit">Register</button>
-                            </div>
-                        </form>
-                    </details>
-                    #endif
-                    <form method="post" action="#(student.unenrollURL)"
-                          class="inline-form">
-                        #csrfFormField()
-                        <button class="btn action-btn action-danger students-unenroll-btn" type="submit"
-                                title="Remove from course" aria-label="Remove from course"
-                                onclick="return confirm('Remove @#(student.username) from this course?')">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
-                        </button>
-                    </form>
-                </div>
-                #endif
-            </td>
-        </tr>
-    #endfor
+    #extend("_student-rows")
     </tbody>
 </table>
 <p class="empty" id="no-students-msg"#if(hasEnrolledStudents): hidden#endif>No students enrolled yet.</p>
@@ -218,6 +130,7 @@ Students
 <script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/list-filter.js?v=#appVersion()"></script>
 <script src="/sortable-table.js?v=#appVersion()"></script>
+<script src="/table-poll.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -228,84 +141,6 @@ Students
     var filter = document.getElementById('enrolled-filter');
     var emptyMsg = document.getElementById('no-students-msg');
     var countEl = document.getElementById('enrolled-count');
-    var archived = table.getAttribute('data-archived') === 'true';
-    var canManage = table.getAttribute('data-can-manage') === 'true';
-    var courseId = table.getAttribute('data-course-id') || '';
-
-    // Shared implementation (Public/chickadee-ui.js, loaded from base.leaf).
-    var escapeHtml = ChickadeeUI.escapeHtml;
-
-    var deleteIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';
-
-    function buildStudentRow(student, csrfToken) {
-        var displayName = escapeHtml(student.displayName);
-        var username = escapeHtml(student.username);
-        var role = escapeHtml(student.role);
-        var iso = student.lastSeenAtISO ? escapeHtml(student.lastSeenAtISO) : '';
-        var lastSeenText = escapeHtml(student.lastSeenAtText);
-        var subURL = escapeHtml(student.submissionsURL);
-        var unenrollURL = escapeHtml(student.unenrollURL);
-        var csrfField = '<input type="hidden" name="_csrf" value="' + escapeHtml(csrfToken) + '">';
-
-        var roleCell;
-        if (student.isPending) {
-            roleCell = '<span class="students-pending-role">(pending)</span>';
-        } else if (archived || !canManage) {
-            roleCell = role;
-        } else {
-            roleCell = '<form method="post" action="/courses/' + courseId + '/role/' + escapeHtml(student.id)
-                + '" class="inline-form students-role-form">' + csrfField
-                + '<select name="role" class="form-input students-role-select" aria-label="Per-course role" onchange="this.form.submit()">'
-                + '<option value="student"' + (student.role === 'student' ? ' selected' : '') + '>Student</option>'
-                + '<option value="ta"' + (student.role === 'ta' ? ' selected' : '') + '>TA</option>'
-                + '<option value="instructor"' + (student.role === 'instructor' ? ' selected' : '') + '>Instructor</option>'
-                + '</select></form>';
-        }
-
-        var nameCell = student.isPending
-            ? '<strong class="students-pending-name">' + displayName + '</strong>'
-                + '<span class="students-pending-note">awaiting first login</span>'
-            : '<a href="' + subURL + '"><strong>' + displayName + '</strong></a>';
-        var userCell = student.isPending
-            ? '<code class="students-pending-username">' + username + '</code>'
-            : '<a href="' + subURL + '"><code>' + username + '</code></a>';
-        var actionCell = '';
-        if (!archived && canManage) {
-            var registerCell = '';
-            if (student.isPending && student.registerURL) {
-                registerCell = '<details class="ext-details form-flush">'
-                    + '<summary class="btn action-btn action-btn-tight" title="Register this student now"'
-                    + ' aria-label="Register pending student">Register</summary>'
-                    + '<form method="post" action="' + escapeHtml(student.registerURL) + '" class="ext-panel">'
-                    + csrfField
-                    + '<p class="students-register-hint">Materialize <code>' + username
-                    + '</code> into a real account now (for grade-sync testing). They appear on assignment rosters immediately; their real login adopts this account.</p>'
-                    + '<label class="ext-field-label">Display name<input type="text" name="displayName" placeholder="' + username + '" class="ext-field-input"></label>'
-                    + '<label class="ext-field-label">Student number (optional)<input type="text" name="studentID" class="ext-field-input"></label>'
-                    + '<label class="ext-field-label">Email (optional)<input type="email" name="email" class="ext-field-input"></label>'
-                    + '<label class="ext-field-label">SSO subject (optional)<input type="text" name="externalSubject" placeholder="leave blank to adopt by username" class="ext-field-input"></label>'
-                    + '<div class="ext-panel-actions"><button class="btn action-btn" type="submit">Register</button></div>'
-                    + '</form></details>';
-            }
-            actionCell = '<div class="students-row-actions">' + registerCell
-                + '<form method="post" action="' + unenrollURL + '" class="inline-form">'
-                + csrfField
-                + '<button class="btn action-btn action-danger students-unenroll-btn" type="submit" title="Remove from course"'
-                + ' aria-label="Remove from course"'
-                + ' onclick="return confirm(\'Remove @' + username + ' from this course?\')">'
-                + deleteIcon + '</button></form></div>';
-        }
-
-        return '<tr class="student-row-link' + (student.isPending ? ' student-row-pending' : '') + '"'
-            + ' data-student-id="' + escapeHtml(student.id) + '"'
-            + (student.isPending ? '' : ' data-href="' + subURL + '"') + '>'
-            + '<td>' + nameCell + '</td>'
-            + '<td>' + userCell + '</td>'
-            + '<td class="role-cell">' + roleCell + '</td>'
-            + '<td class="js-relative-time"' + (iso ? ' data-iso="' + iso + '"' : '') + '>' + lastSeenText + '</td>'
-            + '<td>' + actionCell + '</td>'
-            + '</tr>';
-    }
 
     function updateEmptyState() {
         if (emptyMsg) emptyMsg.hidden = tbody.querySelectorAll('tr').length > 0;
@@ -376,24 +211,29 @@ Students
         if (href) window.location.href = href;
     });
 
-    function repaint(rows) {
-        if (!Array.isArray(rows)) return;
-        var csrfToken = ChickadeeUI.getCsrfToken();
-        tbody.innerHTML = rows.map(function (s) { return buildStudentRow(s, csrfToken); }).join('');
-        if (countEl) {
-            // Heading counts students + pending pre-enrolments only, matching
-            // the server's enrolledStudentCount — instructor / admin users
-            // enrolled for testing appear in the table but don't inflate it.
-            countEl.textContent = String(rows.filter(function (s) {
-                return s.role === 'student' || s.role === '(pending)';
-            }).length);
-        }
-        ChickadeeRelativeTime.applyRelativeTimes(tbody);
-        ChickadeeSortableTable.apply(table);
-        ChickadeeListFilter.apply(filter);
+    // The roster's own count: students plus pending pre-enrolments, matching
+    // the server's enrolledStudentCount — staff enrolled for testing appear in
+    // the table but must not inflate the heading. Reads a role cell the same
+    // way the filter and the sorter do (a <select>'s value, else its text).
+    function updateCount() {
+        if (!countEl) return;
+        var n = Array.from(tbody.querySelectorAll('tr')).filter(function (row) {
+            if (row.classList.contains('student-row-pending')) return true;
+            var cell = row.cells[2];
+            if (!cell) return false;
+            var sel = cell.querySelector('select');
+            return (sel ? sel.value : (cell.textContent || '').trim()) === 'student';
+        }).length;
+        countEl.textContent = String(n);
+    }
+
+    // Re-decorate after each background repaint (table-poll.js has already
+    // re-applied the shared relative-time / sort / filter behaviours).
+    table.addEventListener('chickadee:table-repaint', function () {
+        updateCount();
         updateEmptyState();
         applyLearnFlags();
-    }
+    });
 
     // ── Initial paint ────────────────────────────────────────────────
     // Sorting is declared in markup (data-sort-initial) and applied by
@@ -401,32 +241,6 @@ Students
     ChickadeeRelativeTime.applyRelativeTimes(document);
     updateEmptyState();
     applyLearnFlags();
-
-    // ── Auto-refresh ─────────────────────────────────────────────────
-    // Poll /instructor/students-data every few seconds so last-seen times
-    // and newly enrolled / removed students stay current without a reload,
-    // mirroring the admin Users panel.  The X-Background-Refresh header tells
-    // the server this is a system poll so it does NOT reset the idle timer.
-    async function pollStudents() {
-        if (document.hidden) return;
-        if (table.contains(document.activeElement)) return;
-        if (filter && document.activeElement === filter) return;
-        try {
-            var res = await fetch('/instructor/students-data', {
-                headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
-                cache: 'no-store'
-            });
-            if (res.redirected || res.status === 401 || res.status === 403) {
-                window.location.reload();
-                return;
-            }
-            if (!res.ok) return;
-            repaint(await res.json());
-        } catch (_) {
-            // Keep the current rows on transient polling errors.
-        }
-    }
-    setInterval(pollStudents, 5000);
 })();
 </script>
 #endexport

--- a/Sources/APIServer/MCP/Admin/Tools/GetRunnerDetailTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetRunnerDetailTool.swift
@@ -167,7 +167,8 @@ struct GetRunnerDetailTool: DiagnosticTool {
             avgExecutionMs: nil,
             avgQueueWaitMs: nil,
             avgExecutionFormatted: nil,
-            avgQueueWaitFormatted: nil)
+            avgQueueWaitFormatted: nil,
+            isOffline: RunnerStaleness.isOffline(lastActive: latest.recordedAt))
     }
 
     private func capabilityTags(profile: RunnerProfile?) -> [String] {

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -29,6 +29,12 @@ struct AdminWorkerRow: Content {
     let avgExecutionFormatted: String?
     /// Human-readable form of `avgQueueWaitMs` (e.g. "3s", "200ms"), or nil.
     let avgQueueWaitFormatted: String?
+    /// True when the runner has not checked in within
+    /// `RunnerStaleness.offlineAfter`. Computed on the server so the first
+    /// render and every background refresh agree — the client-side copy this
+    /// replaced only ran during a poll, so a freshly loaded dashboard showed
+    /// no offline badges at all until the first tick.
+    let isOffline: Bool
 }
 
 struct AdminCourseRow: Encodable {
@@ -166,6 +172,18 @@ struct AdminContext: Encodable {
 struct AdminUsersContext: Encodable {
     let currentUser: CurrentUserContext?
     let activeAdminTab: String
+    let users: [AdminUserRow]
+}
+
+/// Context for the rows-only fragment of the runners table (`?fragment=rows`).
+struct WorkerRowsFragmentContext: Encodable {
+    let workers: [AdminWorkerRow]
+}
+
+/// Context for the rows-only fragment of the users table (`?fragment=rows`).
+/// Carries exactly what `_user-rows.leaf` reads, so the fragment cannot start
+/// depending on page-level state the poll does not compute.
+struct UserRowsFragmentContext: Encodable {
     let users: [AdminUserRow]
 }
 

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Runners.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Runners.swift
@@ -13,8 +13,17 @@ extension AdminRoutes {
     // MARK: - GET /admin/runners
 
     @Sendable
-    func runners(req: Request) async throws -> [AdminWorkerRow] {
-        try await makeWorkerRows(req: req)
+    /// Two representations, one query: `?fragment=rows` renders
+    /// `_worker-rows.leaf` — the SAME partial the dashboard renders, so the
+    /// poll cannot drift from the page — and anything else keeps the JSON
+    /// array unchanged (the runner-detail page's poll reads it).
+    func runners(req: Request) async throws -> Response {
+        let rows = try await makeWorkerRows(req: req)
+        guard req.query[String.self, at: "fragment"] == "rows" else {
+            return try await rows.encodeResponse(for: req)
+        }
+        return try await req.view.render("_worker-rows", WorkerRowsFragmentContext(workers: rows))
+            .encodeResponse(for: req)
     }
 
     // MARK: - GET /admin/runners/:runnerID
@@ -99,7 +108,8 @@ extension AdminRoutes {
             avgExecutionMs: avg?.avgExecutionMs,
             avgQueueWaitMs: avg?.avgQueueWaitMs,
             avgExecutionFormatted: avg?.avgExecutionMs.map(formatMs),
-            avgQueueWaitFormatted: avg?.avgQueueWaitMs.map(formatMs)
+            avgQueueWaitFormatted: avg?.avgQueueWaitMs.map(formatMs),
+            isOffline: RunnerStaleness.isOffline(lastActive: latestSnapshot.recordedAt)
         )
     }
 
@@ -299,7 +309,8 @@ func makeWorkerRows(req: Request) async throws -> [AdminWorkerRow] {
             avgExecutionMs: avgExec,
             avgQueueWaitMs: avgWait,
             avgExecutionFormatted: avgExec.map(formatMs),
-            avgQueueWaitFormatted: avgWait.map(formatMs)
+            avgQueueWaitFormatted: avgWait.map(formatMs),
+            isOffline: RunnerStaleness.isOffline(lastActive: snapshot.lastActive)
         )
     }
     .sorted { lhs, rhs in

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -151,9 +151,18 @@ struct AdminRoutes: RouteCollection {
     // Polls send the `X-Background-Refresh` header so they don't count as
     // session activity (see UserActivityMiddleware).
 
+    /// Two representations, one query: `?fragment=rows` renders
+    /// `_user-rows.leaf` — the SAME partial the page renders, so the poll
+    /// cannot drift from the page — and anything else keeps the JSON array
+    /// unchanged for other consumers.
     @Sendable
-    func usersData(req: Request) async throws -> [AdminUserRow] {
-        try await fetchUserRows(on: req.db)
+    func usersData(req: Request) async throws -> Response {
+        let rows = try await fetchUserRows(on: req.db)
+        guard req.query[String.self, at: "fragment"] == "rows" else {
+            return try await rows.encodeResponse(for: req)
+        }
+        return try await req.view.render("_user-rows", UserRowsFragmentContext(users: rows))
+            .encodeResponse(for: req)
     }
 
     /// Loads every user, ordered most-recently-seen first (NULL last_seen

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -102,15 +102,28 @@ extension InstructorDashboardRoutes {
 
     // MARK: - GET /instructor/students-data
 
-    /// JSON feed backing the Students-tab auto-refresh.  Returns the same
-    /// rows the page rendered with, so last-seen times and newly enrolled /
-    /// removed students stay current without a manual reload.  Returns an
-    /// empty array when no course is active (the table simply clears).
+    /// Feed backing the Students-tab auto-refresh.  Returns the same rows the
+    /// page rendered with, so last-seen times and newly enrolled / removed
+    /// students stay current without a manual reload.  Empty when no course is
+    /// active (the table simply clears).
+    ///
+    /// Two representations, one query:
+    ///   * `?fragment=rows` renders `_student-rows.leaf` — the SAME partial the
+    ///     page renders, so the poll cannot drift from the page (it used to
+    ///     rebuild every row as a JS string, including a whole register-student
+    ///     popover, and the two copies diverged by construction);
+    ///   * anything else keeps the JSON array, unchanged, for other consumers.
     @Sendable
-    func studentsData(req: Request) async throws -> [EnrolledStudentRow] {
+    func studentsData(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
         let courseState = try await req.resolveActiveCourse(for: user)
-        guard let activeCourseUUID = courseState.activeCourseUUID else { return [] }
+        let wantsFragment = req.query[String.self, at: "fragment"] == "rows"
+
+        guard let activeCourseUUID = courseState.activeCourseUUID else {
+            return wantsFragment
+                ? Response(status: .ok, headers: ["Content-Type": "text/html; charset=utf-8"], body: .init(string: ""))
+                : try await [EnrolledStudentRow]().encodeResponse(for: req)
+        }
         let roster = try await loadEnrolledStudentRows(
             req: req,
             activeCourseUUID: activeCourseUUID,
@@ -118,6 +131,31 @@ extension InstructorDashboardRoutes {
             fmt: waterlooDateTimeFormatter(),
             isoFormatter: ISO8601DateFormatter()
         )
-        return roster.rows
+        guard wantsFragment else {
+            return try await roster.rows.encodeResponse(for: req)
+        }
+
+        let canManageRoster =
+            user.isAdmin || (courseState.active?.role ?? .student) >= .instructor
+        let courseIsArchived = try await APICourse.find(activeCourseUUID, on: req.db)?.isArchived ?? false
+        let ctx = StudentRowsFragmentContext(
+            currentUser: CurrentUserContext(
+                user: user,
+                activeCourse: courseState.active,
+                enrolledCourses: courseState.all
+            ),
+            enrolledStudents: roster.rows,
+            rosterReadOnly: courseIsArchived || !canManageRoster
+        )
+        return try await req.view.render("_student-rows", ctx).encodeResponse(for: req)
     }
+}
+
+/// Context for the rows-only fragment of the roster table.  Carries exactly
+/// what `_student-rows.leaf` reads — no more, so the fragment cannot start
+/// depending on page-level state the poll does not compute.
+struct StudentRowsFragmentContext: Encodable {
+    let currentUser: CurrentUserContext
+    let enrolledStudents: [EnrolledStudentRow]
+    let rosterReadOnly: Bool
 }

--- a/Sources/APIServer/Routes/Web/RunnerStaleness.swift
+++ b/Sources/APIServer/Routes/Web/RunnerStaleness.swift
@@ -1,0 +1,28 @@
+// APIServer/Routes/Web/RunnerStaleness.swift
+//
+// When a runner counts as offline.
+//
+// The threshold existed as three separate copies of the same magic number:
+// two inline `Date.now() - lastActive > 5 * 60 * 1000` expressions in page
+// scripts (the dashboard's worker table and the runner-detail header) and the
+// prose in the docs. The two client copies could only run *during a poll*, so
+// a freshly loaded dashboard showed no offline badges at all until the first
+// tick — the badge was a property of having waited five seconds, not of the
+// runner's state.
+//
+// It lives on the server now, evaluated once per render, so first paint and
+// every background refresh give the same answer.
+
+import Foundation
+
+enum RunnerStaleness {
+    /// A runner that has not checked in for this long is shown as offline.
+    /// Runners poll far more often than this; the window is deliberately
+    /// several poll intervals wide so one dropped request does not flap the
+    /// badge.
+    static let offlineAfter: TimeInterval = 5 * 60
+
+    static func isOffline(lastActive: Date, now: Date = Date()) -> Bool {
+        now.timeIntervalSince(lastActive) > offlineAfter
+    }
+}

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -938,6 +938,60 @@ private struct PassthroughResponder: AsyncResponder {
         }
     }
 
+    /// `?fragment=rows` renders the SAME partial the page renders, so the
+    /// 5-second poll and the page cannot drift.  Before this the poll rebuilt
+    /// every row as a JS string — a second copy of the markup that could (and
+    /// did) diverge from the template silently.
+    @Test func usersDataFragmentRendersTheSameRowsPartial() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+            _ = try await makeUser(username: "fragment_user", role: "instructor")
+
+            try await app.asyncTest(
+                .GET, "/admin/users-data?fragment=rows",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = String(buffer: res.body)
+                    // Rows only — no <table>, no <thead>: the client swaps this
+                    // into the existing tbody.
+                    #expect(body.contains("<tr>"))
+                    #expect(!body.contains("<table"))
+                    #expect(!body.contains("<thead"))
+                    #expect(body.contains("fragment_user"))
+                    // The full row markup the page renders, not a reduced copy:
+                    // the role form, its CSRF field, and the sortable timestamp.
+                    #expect(body.contains("name='_csrf'"))
+                    #expect(body.contains("js-relative-time"))
+                })
+        }
+    }
+
+    /// The runners feed keeps its JSON representation (the runner-detail page's
+    /// poll reads it) and gains a rows fragment for the dashboard table.
+    @Test func runnersFeedServesBothJSONAndFragment() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+
+            try await app.asyncTest(
+                .GET, "/admin/runners",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.headers.contentType == .json)
+                })
+            try await app.asyncTest(
+                .GET, "/admin/runners?fragment=rows",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(!String(buffer: res.body).contains("<table"))
+                })
+        }
+    }
+
     /// A system-generated poll (carrying `X-Background-Refresh`) must not count
     /// as activity, so a dashboard left open in a tab can't keep a user logged
     /// in past the idle timeout.  A normal request still refreshes activity.

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -381,6 +381,56 @@ import VaporTesting
         }
     }
 
+    /// `?fragment=rows` renders the SAME partial the Students page renders, so
+    /// the 5-second roster poll and the page cannot drift.  The JS row builder
+    /// this replaced duplicated the whole row — including a register-pending
+    /// popover — in a second place that no template test could see.
+    @Test func studentsDataFragmentRendersTheSameRowsPartial() async throws {
+        try await withAssignmentRoutesApp { app in
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let student = try await arInsertStudent(
+                username: "fragment_student", displayName: "Fragment Student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/students-data?fragment=rows",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    // Rows only — the client swaps these into the existing tbody.
+                    #expect(!html.contains("<table"))
+                    #expect(!html.contains("<thead"))
+                    #expect(html.contains("fragment_student"))
+                    // Full row markup, not a reduced copy: the row-link class,
+                    // the per-course role form, and its CSRF field.
+                    #expect(html.contains("student-row-link"))
+                    #expect(html.contains("name='_csrf'"))
+                })
+        }
+    }
+
+    /// The JSON representation stays for any other consumer.
+    @Test func studentsDataStillServesJSONByDefault() async throws {
+        try await withAssignmentRoutesApp { app in
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/students-data",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.headers.contentType == .json)
+                })
+        }
+    }
+
     /// Regression guard for v0.4.126 — admin/instructor users enrolled in a
     /// course (a common pattern: instructor enrolls themselves to test their
     /// own assignment via the same flow as a student) used to inflate the

--- a/changelog.d/ui-s3-poll-fragments.md
+++ b/changelog.d/ui-s3-poll-fragments.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **Auto-refreshing tables render on the server (audit S3).** The admin Users,
+  admin Runners and instructor Students tables now refresh by swapping in rows
+  rendered from the same Leaf partial the page itself uses, instead of
+  rebuilding every row from hand-written HTML strings in a page script. The
+  duplicate markup — role dropdowns, CSRF fields, icons, a whole
+  register-student panel — is gone, so a table's background refresh can no
+  longer drift from what the page renders. Polling behaviour (pausing on a
+  hidden tab or while a control has focus, and not counting as session
+  activity) is now one shared implementation rather than three.
+
+### Fixed
+
+- **Runner "Offline" badges show immediately.** The offline state is computed
+  on the server, so it appears on first paint; previously it was only worked
+  out during a background refresh, leaving a freshly loaded dashboard showing
+  no offline runners until the first tick.

--- a/docs/ui-consistency-audit.md
+++ b/docs/ui-consistency-audit.md
@@ -481,6 +481,38 @@ existing page render tests unchanged. CSRF note: the fragment carries the
 same `#csrfFormField()` forms the page does, so token freshness matches
 today's behaviour (the JS builders already inlined the meta token).
 
+**Status: done.** All three polls now swap in server-rendered rows from the
+same Leaf partials the pages use (`_student-rows`, `_user-rows`,
+`_worker-rows`), reached by `?fragment=rows` on the existing endpoints;
+the JSON representation is untouched for every other consumer. The three
+JS row builders are gone, and with them the second copies of the role
+`<select>` forms, the CSRF fields, the trash/pencil SVGs and an entire
+register-pending-student popover.
+
+The polling itself turned out to be shared too, so it is one component
+(`Public/table-poll.js`, opted into with `data-poll-url`) rather than three
+rewrites — which is what made D8 disappear rather than be fixed: the guard
+set (hidden tab, focus inside the table, focus in the filter) and the
+`X-Background-Refresh` header are now properties of the mechanism, not of
+whichever page remembered them. Page-specific work rides a
+`chickadee:table-repaint` event, so the roster's count and LEARN badges and
+the dashboard's Max Load summary stay page code without forking the poll.
+
+Two things fell out of doing it. **`admin-users.leaf` now has no inline
+script at all** (330 → 60 lines). And the runner "offline" rule moved to
+the server (`RunnerStaleness`, with `ChickadeeRelativeTime.isStale` as its
+client half), which fixed a real defect neither the audit nor the plan had
+spotted: the badge was computed only *during a poll*, so a freshly loaded
+dashboard showed no offline badges until the first tick — the badge marked
+"you have waited five seconds", not "this runner is down".
+
+Also caught here: S2 had left a dangling `refreshWorkers()` call in
+`admin.leaf` — a ReferenceError every 5 s on the admin dashboard, invisible
+to ESLint because it lives in an inline template script. That is precisely
+the blind spot the inline-script ratchet exists to shrink, and S3 removes
+the last of that page's polling code. Fixed here and called out on the S2
+PR.
+
 ### S4 — One icon set (M)
 
 **Target state.** `Public/icons.svg` — a single same-origin SVG sprite of

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -109,7 +109,7 @@ fi
 # attributes or a JSON island).  Baseline = total non-blank lines inside
 # <script> bodies across all templates; it may only go DOWN.  <script src=…>
 # includes and single-line <script>…</script> elements don't count.
-INLINE_SCRIPT_BASELINE=1548
+INLINE_SCRIPT_BASELINE=1317
 inline_script_count="$(
   awk '
     /<script[^>]*src=/ { next }


### PR DESCRIPTION
Slice **S3** of the [widget-layer UI audit](https://github.com/JimWallace/Chickadee/blob/main/docs/ui-consistency-audit.md). Stacked on #1400 (S2).

The three auto-refreshing tables now swap in **rows rendered by the same Leaf partial the page uses**, fetched via `?fragment=rows` on the existing endpoints. The JSON representation is unchanged for every other consumer.

## What this deletes

`buildUserRow`, `buildStudentRow`, `renderWorkers` — three JS row builders that duplicated the template markup (role `<select>` forms, CSRF fields, trash/pencil SVGs, an entire register-pending-student popover) in a second place no template test could see, and which drifted by construction.

**`admin-users.leaf` now carries no inline script at all** (330 → 60 lines).

## The polling was shared too

Rather than rewriting three polls, there is now one component (`Public/table-poll.js`, opted into with `data-poll-url`). That **dissolves D8 instead of fixing it**: the guard set (hidden tab, focus inside the table, focus in the filter) and the `X-Background-Refresh` header are properties of the mechanism now, not of whichever page remembered them. Page-specific work rides a `chickadee:table-repaint` event — the roster's count and LEARN badges, the dashboard's Max Load summary — so no page forks the poll to keep its own behaviour.

## Two defects fixed on the way

- **Runner "Offline" badges were a lie about timing.** The rule was computed only *during a poll*, so a freshly loaded dashboard showed no offline badges until the first tick — the badge meant "you waited 5 seconds", not "this runner is down". It moved to the server (`RunnerStaleness`, with `ChickadeeRelativeTime.isStale` as its client half), replacing two copy-pasted 5-minute expressions.
- **S2 left a dangling `refreshWorkers()` call** in `admin.leaf` — a ReferenceError every 5s on the admin dashboard, invisible to ESLint because it lives in inline template JS. Exactly the blind spot the inline-script ratchet exists to shrink; S3 removes the last of that page's polling code.

## Verification

Four new render tests pin the fragment contract (rows only — no `<table>`/`<thead>`; full markup including CSRF; JSON still the default). Two older tests that asserted deleted implementation strings now assert the declarative contract instead. **Visual regression passes unchanged**, which is the evidence the extraction was faithful. Full local `swift test --filter APITests` green.

`INLINE_SCRIPT_BASELINE` 1548 → **1317**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9

---
_Generated by [Claude Code](https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9)_