### PR TITLE
refactor(ui): S5 — one confirmation seam

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -88,6 +88,58 @@ if (root) {
     }
 }
 
+// ── Destructive-action confirmation ────────────────────────────────────────
+// One seam for "are you sure?" (UI audit S5). A form or control declares the
+// question in markup:
+//
+//   <form … data-confirm="Delete this assignment? Students will lose access.">
+//   <button … data-confirm="Revoke this agent? It loses access immediately.">
+//
+// It replaces 49 hand-written inline handlers (an onclick or onsubmit whose
+// body called the native dialog directly). Those were not just repetitive:
+// the same action carried different wording on different pages, and the two
+// pages that rebuilt rows in JS carried a *second* copy of each message that
+// could drift from the first.
+//
+// It is also the seam any future improvement needs. Swapping the native
+// dialog for a styled one, or requiring a typed course code before a
+// destructive delete, is a change to this function — not to 49 call sites.
+//
+// (The guard in check-styles.sh greps for the native call, and cannot tell
+// markup from prose about markup — so this comment describes the old idiom
+// rather than quoting it. Same lesson as the Leaf-comment finding in #1266.)
+//
+// Clicks are handled in the CAPTURE phase so a cancelled action also stops the
+// handlers layered around it (row-click navigation, popover toggles) rather
+// than merely stopping the default. Submits are handled in the bubble phase,
+// which runs before inplace-forms.js's own submit listener (app.js loads
+// first) — and that one bails on `defaultPrevented`, so a cancelled submit
+// stays cancelled.
+(function confirmActions() {
+    function accepted(el) {
+        const message = el.getAttribute('data-confirm');
+        return !message || window.confirm(message);
+    }
+
+    document.addEventListener('click', (e) => {
+        const el = e.target instanceof Element ? e.target.closest('[data-confirm]') : null;
+        // A <form data-confirm> asks on submit, not on every click inside it.
+        if (!el || el.tagName === 'FORM') return;
+        if (accepted(el)) return;
+        e.preventDefault();
+        e.stopPropagation();
+    }, true);
+
+    document.addEventListener('submit', (e) => {
+        const form = e.target;
+        if (!(form instanceof Element) || !form.matches('[data-confirm]')) return;
+        // A submitter with its own question already asked during the click —
+        // the secondary "Clear"/"Remove" buttons that carry `formaction`.
+        if (e.submitter && e.submitter.hasAttribute('data-confirm')) return;
+        if (!accepted(form)) e.preventDefault();
+    });
+}());
+
 // ── Nav dropdown menus ─────────────────────────────────────────────────────
 // Click-to-open menus for nav items that carry more than one option (the
 // Instructor course picker, the account/log-out menu).  Each is a

--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -47,6 +47,16 @@
             : (kind === 'ok' || kind === 'success') ? 'var(--green)' : 'var(--gray-500)';
     }
 
+    // ── Destructive-action confirmation ──
+    //
+    // The JS-side entry to the same seam `data-confirm` uses (app.js). A call
+    // site that has no element to hang an attribute on — a delete triggered
+    // from inside an editor's own click handler — asks here, so replacing the
+    // native dialog later is still a one-place change.
+    function confirmAction(message) {
+        return window.confirm(message);
+    }
+
     // ── Fetch error handling ──
     //
     // One error-message extractor for failed fetch bodies (#1126 — two
@@ -504,6 +514,7 @@
         escapeHtml: escapeHtml,
         escapeAttr: escapeHtml,
         getCsrfToken: getCsrfToken,
+        confirmAction: confirmAction,
         setStatus: setStatus,
         extractErrorMessage: extractErrorMessage,
         fetchJSON: fetchJSON,

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -2247,7 +2247,7 @@
                     if (idx2 < 0) return;
                     var family = familiesState[idx2];
                     var caseCount = (family.cases || []).length;
-                    if (!confirm('Delete pattern family "' + family.name + '"? This removes '
+                    if (!ChickadeeUI.confirmAction('Delete pattern family "' + family.name + '"? This removes '
                                  + caseCount + ' generated test script' + (caseCount === 1 ? '' : 's') + '.')) {
                         return;
                     }

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -1202,7 +1202,7 @@
                 var item2 = findByID('check:' + cid2);
                 if (!item2) return;
                 var label = (item2.check && (item2.check.name || item2.check.id)) || cid2;
-                if (!confirm('Delete notebook check "' + label + '"? This removes the generated test script.')) {
+                if (!ChickadeeUI.confirmAction('Delete notebook check "' + label + '"? This removes the generated test script.')) {
                     return;
                 }
                 var remaining = items
@@ -1220,7 +1220,7 @@
             var id = row.getAttribute('data-id');
             var item = findByID(id);
             if (!item) return;
-            if (!confirm('Delete test script "' + item.script + '"? This also removes it as a dependency from other items.')) return;
+            if (!ChickadeeUI.confirmAction('Delete test script "' + item.script + '"? This also removes it as a dependency from other items.')) return;
 
             global.ChickadeeUI.fetchJSON(urls.deleteScript(item.script), {
                 method: 'DELETE', csrfToken: csrfToken
@@ -1276,7 +1276,7 @@
                     ? 'Delete section "' + name + '"?'
                     : 'Delete section "' + name + '"? Its ' + affected + ' test'
                       + (affected === 1 ? '' : 's') + ' will move to Ungrouped.';
-                if (!confirm(msg)) return;
+                if (!ChickadeeUI.confirmAction(msg)) return;
                 var f = document.createElement('form');
                 f.method = 'POST';
                 f.action = action;

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -748,7 +748,7 @@
         if (!btn) return;
         var filename = btn.getAttribute('data-filename');
         if (!filename) return;
-        if (!confirm('Remove support file "' + filename + '"? Students who already use it will fail until you re-add it.')) return;
+        if (!ChickadeeUI.confirmAction('Remove support file "' + filename + '"? Tests that read it will fail until you re-add it.')) return;
         try {
             var resp = await fetch(
                 '/instructor/' + encodeURIComponent(assignmentID) + '/scripts/' + encodeURIComponent(filename),

--- a/Resources/Views/_course-item-row.leaf
+++ b/Resources/Views/_course-item-row.leaf
@@ -76,7 +76,7 @@
                         <div class="content-item-attachment">
                             <a href="#(att.downloadURL)">#(att.displayName)</a>
                             <span class="text-muted content-item-attachment-size">#(att.sizeLabel)</span>
-                            <form method="post" action="/instructor/content-items/#(item.content.id)/attachments/#(att.id)/delete" onsubmit="return confirm('Remove this file?')">
+                            <form method="post" action="/instructor/content-items/#(item.content.id)/attachments/#(att.id)/delete" data-confirm="Remove this file?">
                                 #csrfFormField()
                                 <button class="btn action-btn action-danger btn-tiny" type="submit">Remove</button>
                             </form>
@@ -86,7 +86,7 @@
                     #endif
                 </div>
             </details>
-            <form method="post" action="/instructor/content-items/#(item.content.id)/delete" class="content-item-delete-form" onsubmit="return confirm('Delete this material?')">
+            <form method="post" action="/instructor/content-items/#(item.content.id)/delete" class="content-item-delete-form" data-confirm="Delete this material?">
                 #csrfFormField()
                 <button class="btn action-btn action-danger btn-tiny" type="submit">Delete</button>
             </form>
@@ -186,7 +186,7 @@
                 </form>
             </details>
             <form method="post" action="/instructor/setup/#(item.assignment.setupID)/delete"
-                  onsubmit="return confirm('Delete this unpublished setup? This cannot be undone.')">
+                  data-confirm="Delete this unpublished setup? This cannot be undone.">
                 #csrfFormField()
                 <button class="btn action-btn action-danger" type="submit"
                         aria-label="Delete setup" title="Delete setup">
@@ -209,7 +209,7 @@
                     <svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg>
                 </a>
                 <form method="post" action="/instructor/#(item.assignment.assignmentID)/clone"
-                      onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                      data-confirm="Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.">
                     #csrfFormField()
                     <button class="btn action-btn" type="submit"
                             aria-label="Duplicate assignment" title="Duplicate assignment">
@@ -217,7 +217,7 @@
                     </button>
                 </form>
                 <form method="post" action="/instructor/#(item.assignment.assignmentID)/retest"
-                      onsubmit="return confirm('Retest every submission for this assignment? The worker will re-grade each one against the current test suite.')">
+                      data-confirm="Retest every submission for this assignment? The worker will re-grade each one against the current test suite.">
                     #csrfFormField()
                     <button class="btn action-btn" type="submit"
                             aria-label="Retest all submissions" title="Retest all submissions">
@@ -225,7 +225,7 @@
                     </button>
                 </form>
                 <form method="post" action="/instructor/#(item.assignment.assignmentID)/delete"
-                      onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
+                      data-confirm="Delete this assignment? Students will no longer see it.">
                     #csrfFormField()
                     <button class="btn action-btn action-danger" type="submit"
                             aria-label="Delete assignment" title="Delete assignment">

--- a/Resources/Views/_student-rows.leaf
+++ b/Resources/Views/_student-rows.leaf
@@ -76,7 +76,7 @@
                         #csrfFormField()
                         <button class="btn action-btn action-danger students-unenroll-btn" type="submit"
                                 title="Remove from course" aria-label="Remove from course"
-                                onclick="return confirm('Remove @#(student.username) from this course?')">
+                                data-confirm="Remove @#(student.username) from this course?">
                             <svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg>
                         </button>
                     </form>

--- a/Resources/Views/_user-rows.leaf
+++ b/Resources/Views/_user-rows.leaf
@@ -42,7 +42,7 @@
                             #csrfFormField()
                             <button class="btn action-btn action-danger action-btn-icon" type="submit"
                                     title="Delete user" aria-label="Delete user"
-                                    onclick="return confirm('Delete this user? Their enrollments will be removed. They can log in again to restore their account.')">
+                                    data-confirm="Delete this user? Their enrollments will be removed. They can log in again to restore their account.">
                                 <svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg>
                             </button>
                         </form>

--- a/Resources/Views/account.leaf
+++ b/Resources/Views/account.leaf
@@ -100,7 +100,7 @@ My Account
                     <form method="post" action="/account/unenroll/#(course.id)" class="inline-form">
                         #csrfFormField()
                         <button class="btn action-btn action-danger" type="submit"
-                                onclick="return confirm('Leave #(course.code)?')">Leave</button>
+                                data-confirm="Leave #(course.code)?">Leave</button>
                     </form>
                     #elseif(course.enrollmentMode == "auto"):
                     <span class="chip" title="Auto-enrolled — contact your instructor to be removed">Auto</span>

--- a/Resources/Views/admin-brightspace.leaf
+++ b/Resources/Views/admin-brightspace.leaf
@@ -50,7 +50,7 @@ LEARN
         #endif
         #if(keySource == "authorized"):
         <form method="post" action="/admin/brightspace/clear" class="inline-form"
-              onsubmit="return confirm('Clear the stored LEARN authorization? Grade sync reverts to the env key if set, otherwise it stops.');">
+              data-confirm="Clear the stored LEARN authorization? Grade sync reverts to the env key if set, otherwise it stops.">
             #csrfFormField()
             <button class="btn action-danger" type="submit">Clear authorization</button>
         </form>

--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -52,10 +52,10 @@
             #csrfFormField()
             #if(course.isArchived):
             <button class="btn action-danger" type="submit"
-                    onclick="return confirm('Unarchive #(course.code)? Students will be able to see it again.')">Unarchive</button>
+                    data-confirm="Unarchive #(course.code)? Students will be able to see it again.">Unarchive</button>
             #else:
             <button class="btn action-danger" type="submit"
-                    onclick="return confirm('Archive #(course.code)? Students will no longer see this course.')">Archive</button>
+                    data-confirm="Archive #(course.code)? Students will no longer see this course.">Archive</button>
             #endif
         </form>
         <a href="/admin/courses/#(course.id)/export" class="btn">Export bundle</a>
@@ -234,7 +234,7 @@
                         #csrfFormField()
                         <button class="btn action-btn action-danger action-btn-icon" type="submit"
                                 title="Remove from course" aria-label="Remove from course"
-                                onclick="return confirm('Remove @#(user.username) from #(course.code)?')">
+                                data-confirm="Remove @#(user.username) from #(course.code)?">
                             <svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg>
                         </button>
                     </form>

--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -127,7 +127,7 @@ MCP
                         <form method="post" action="/admin/mcp/accounts/#(account.id)/delete" class="inline-form">
                             #csrfFormField()
                             <button class="btn action-btn action-danger" type="submit"
-                                    onclick="return confirm('Delete this MCP account? Existing tokens stay valid until they expire.')">Delete</button>
+                                    data-confirm="Delete this MCP account? Existing tokens stay valid until they expire.">Delete</button>
                         </form>
                     </div>
                 </td>
@@ -171,7 +171,7 @@ MCP
                     <form method="post" action="/agents/#(grant.id)/revoke" class="inline-form">
                         #csrfFormField()
                         <button class="btn action-btn action-danger" type="submit"
-                                onclick="return confirm('Revoke this agent? It will lose access immediately.')">Revoke</button>
+                                data-confirm="Revoke this agent? It will lose access immediately.">Revoke</button>
                     </form>
                     #endif
                 </td>

--- a/Resources/Views/admin-retention.leaf
+++ b/Resources/Views/admin-retention.leaf
@@ -51,7 +51,7 @@ Retention
                             #csrfFormField()
                             <button class="btn action-btn action-btn-icon" type="submit"
                                     title="Restore course" aria-label="Restore course"
-                                    onclick="return confirm('Restore #(row.code)? Students will be able to see it again and its retention clock resets.')">
+                                    data-confirm="Restore #(row.code)? Students will be able to see it again and its retention clock resets.">
                                 <svg class="icon" aria-hidden="true"><use href="#i-rewind"/></svg>
                             </button>
                         </form>
@@ -64,7 +64,7 @@ Retention
                             #csrfFormField()
                             <button class="btn action-btn action-danger action-btn-icon" type="submit"
                                     title="Delete course" aria-label="Delete course"
-                                    onclick="return confirm('Permanently delete #(row.code) and ALL its data — course, assignments, test suites, and submissions? This cannot be undone.')">
+                                    data-confirm="Permanently delete #(row.code) and ALL its data — course, assignments, test suites, and submissions? This cannot be undone.">
                                 <svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg>
                             </button>
                         </form>

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -118,7 +118,7 @@ Admin
                         #csrfFormField()
                         <button class="btn action-btn action-btn-icon" type="submit"
                                 title="Copy course" aria-label="Copy course"
-                                onclick="return confirm('Copy #(course.code)? All test setups and assignments will be duplicated into a new course.')">
+                                data-confirm="Copy #(course.code)? All test setups and assignments will be duplicated into a new course.">
                             <svg class="icon" aria-hidden="true"><use href="#i-copy"/></svg>
                         </button>
                     </form>
@@ -126,7 +126,7 @@ Admin
                         #csrfFormField()
                         <button class="btn action-btn action-danger action-btn-icon" type="submit"
                                 title="Archive course" aria-label="Archive course"
-                                onclick="return confirm('Archive #(course.code)? Students will no longer see this course.')">
+                                data-confirm="Archive #(course.code)? Students will no longer see this course.">
                             <svg class="icon" aria-hidden="true"><use href="#i-archive"/></svg>
                         </button>
                     </form>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -509,7 +509,7 @@ Create Assignment
             if (!btn) return;
             var filename = btn.getAttribute('data-filename');
             if (!filename || !draftID) return;
-            if (!confirm('Remove support file "' + filename + '"? Tests that read it will fail until you re-add it.')) return;
+            if (!ChickadeeUI.confirmAction('Remove support file "' + filename + '"? Tests that read it will fail until you re-add it.')) return;
             try {
                 var resp = await fetch(
                     '/instructor/new/draft/scripts/' + encodeURIComponent(filename)

--- a/Resources/Views/assignment-student-history.leaf
+++ b/Resources/Views/assignment-student-history.leaf
@@ -36,7 +36,7 @@
                 </a>
             </td>
             <td>
-                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')" class="inline-form">
+                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" data-confirm="Send this submission back to the testing queue?" class="inline-form">
                     #csrfFormField()
                     <input type="hidden" name="returnTo" value="#(historyPath)">
                     <button class="btn action-btn action-btn-icon" type="submit" title="Re-test submission" aria-label="Re-test submission">

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -59,7 +59,7 @@
             <td>
                 <div class="subm-row-actions">
                     #if(row.hasLatestSubmission):
-                        <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.latestSubmissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')" class="form-flush">
+                        <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.latestSubmissionID)/retest" data-confirm="Send this submission back to the testing queue?" class="form-flush">
                             #csrfFormField()
                             <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
                             <button class="btn action-btn action-btn-tight" type="submit"
@@ -86,12 +86,12 @@
                             <div class="ext-panel-actions">
                                 <button class="btn action-btn" type="submit">Save</button>
                                 #if(row.gradeIsOverridden):
-                                <button class="btn action-btn" type="submit" formaction="/instructor/#(assignmentID)/students/#(row.studentUUID)/grade-override/delete" formnovalidate onclick="return confirm('Clear this student’s grade override and revert to the auto-graded result?')">Clear</button>
+                                <button class="btn action-btn" type="submit" formaction="/instructor/#(assignmentID)/students/#(row.studentUUID)/grade-override/delete" formnovalidate data-confirm="Clear this student’s grade override and revert to the auto-graded result?">Clear</button>
                                 #endif
                             </div>
                         </form>
                     </details>
-                    <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/reset-notebook" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected. The student will see the fresh starter automatically on their next visit.')" class="form-flush">
+                    <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/reset-notebook" data-confirm="Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected. The student will see the fresh starter automatically on their next visit." class="form-flush">
                         #csrfFormField()
                         <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
                         <button class="btn action-btn action-danger action-btn-tight" type="submit"
@@ -100,7 +100,7 @@
                         </button>
                     </form>
                     #if(secretRevealEnabled):#if(row.secretRevealSpent):
-                    <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/regrant-reveal-token" onsubmit="return confirm('Re-grant this student’s secret-reveal token? Secret test results will be hidden from them again until they spend it.')" class="form-flush">
+                    <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/regrant-reveal-token" data-confirm="Re-grant this student’s secret-reveal token? Secret test results will be hidden from them again until they spend it." class="form-flush">
                         #csrfFormField()
                         <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
                         <button class="btn action-btn action-btn-tight" type="submit"

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -499,7 +499,7 @@ tr.assignment-draggable td {
         btn.addEventListener('click', function () {
             var name = btn.getAttribute('data-name');
             var action = btn.getAttribute('data-action');
-            if (!confirm('Delete section \u201c' + name + '\u201d? Its assignments will become ungrouped.')) return;
+            if (!ChickadeeUI.confirmAction('Delete section \u201c' + name + '\u201d? Its assignments will become ungrouped.')) return;
             var form = document.createElement('form');
             form.method = 'post';
             form.action = action;

--- a/Resources/Views/connected-agents.leaf
+++ b/Resources/Views/connected-agents.leaf
@@ -38,7 +38,7 @@ Connected agents
                     <form method="post" action="/agents/#(row.id)/revoke" class="agents-revoke-form">
                         #csrfFormField()
                         <button class="btn action-btn action-danger" type="submit"
-                                onclick="return confirm('Revoke this agent? It will lose access immediately.')">Revoke</button>
+                                data-confirm="Revoke this agent? It will lose access immediately.">Revoke</button>
                     </form>
                     #endif
                 </td>

--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -89,7 +89,7 @@
             <td>
                 <div class="student-row-actions">
                     #if(row.submissionCount > 0):
-                    <form method="post" action="#(row.retestPath)" onsubmit="return confirm('Re-test all of this student’s submissions on this assignment?')" class="action-form-flush">
+                    <form method="post" action="#(row.retestPath)" data-confirm="Re-test all of this student’s submissions on this assignment?" class="action-form-flush">
                         #csrfFormField()
                         <button class="btn action-btn action-btn-tight" type="submit" aria-label="Re-test this student’s submissions" title="Re-test every submission this student has on this assignment">
                             <svg class="icon" aria-hidden="true"><use href="#i-refresh"/></svg>
@@ -117,7 +117,7 @@
                             <div class="ext-panel-actions">
                                 <button class="btn action-btn" type="submit">Save</button>
                                 #if(row.hasExtension):
-                                <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate onclick="return confirm('Remove this student’s extension on this assignment?')">Remove</button>
+                                <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate data-confirm="Remove this student’s extension on this assignment?">Remove</button>
                                 #endif
                             </div>
                         </form>
@@ -139,12 +139,12 @@
                             <div class="ext-panel-actions">
                                 <button class="btn action-btn" type="submit">Save</button>
                                 #if(row.gradeIsOverridden):
-                                <button class="btn action-btn" type="submit" formaction="#(row.gradeOverrideClearPath)" formnovalidate onclick="return confirm('Clear this student’s grade override and revert to the auto-graded result?')">Clear</button>
+                                <button class="btn action-btn" type="submit" formaction="#(row.gradeOverrideClearPath)" formnovalidate data-confirm="Clear this student’s grade override and revert to the auto-graded result?">Clear</button>
                                 #endif
                             </div>
                         </form>
                     </details>
-                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" class="action-form-flush">
+                    <form method="post" action="#(row.resetPath)" data-confirm="Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected. The student will see the fresh starter automatically on their next visit." class="action-form-flush">
                         #csrfFormField()
                         <button class="btn action-btn action-danger action-btn-tight" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter">
                             <svg class="icon" aria-hidden="true"><use href="#i-rewind"/></svg>
@@ -232,7 +232,7 @@
             <td>
                 <div class="student-row-actions">
                     #if(row.submissionCount > 0):
-                    <form method="post" action="#(row.retestPath)" onsubmit="return confirm('Re-test all of this student’s submissions on this assignment?')" class="action-form-flush">
+                    <form method="post" action="#(row.retestPath)" data-confirm="Re-test all of this student’s submissions on this assignment?" class="action-form-flush">
                         #csrfFormField()
                         <button class="btn action-btn action-btn-tight" type="submit" aria-label="Re-test this student’s submissions" title="Re-test every submission this student has on this assignment">
                             <svg class="icon" aria-hidden="true"><use href="#i-refresh"/></svg>
@@ -260,7 +260,7 @@
                             <div class="ext-panel-actions">
                                 <button class="btn action-btn" type="submit">Save</button>
                                 #if(row.hasExtension):
-                                <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate onclick="return confirm('Remove this student’s extension on this assignment?')">Remove</button>
+                                <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate data-confirm="Remove this student’s extension on this assignment?">Remove</button>
                                 #endif
                             </div>
                         </form>
@@ -282,12 +282,12 @@
                             <div class="ext-panel-actions">
                                 <button class="btn action-btn" type="submit">Save</button>
                                 #if(row.gradeIsOverridden):
-                                <button class="btn action-btn" type="submit" formaction="#(row.gradeOverrideClearPath)" formnovalidate onclick="return confirm('Clear this student’s grade override and revert to the auto-graded result?')">Clear</button>
+                                <button class="btn action-btn" type="submit" formaction="#(row.gradeOverrideClearPath)" formnovalidate data-confirm="Clear this student’s grade override and revert to the auto-graded result?">Clear</button>
                                 #endif
                             </div>
                         </form>
                     </details>
-                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" class="action-form-flush">
+                    <form method="post" action="#(row.resetPath)" data-confirm="Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected. The student will see the fresh starter automatically on their next visit." class="action-form-flush">
                         #csrfFormField()
                         <button class="btn action-btn action-danger action-btn-tight" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter">
                             <svg class="icon" aria-hidden="true"><use href="#i-rewind"/></svg>

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -124,7 +124,7 @@
                     </a>
                     #endif
                     #if(item.setup.isOpen && item.setup.hasNotebook && item.setup.submissionMode != "uploadOnly"):
-                    <form method="post" action="/testsetups/#(item.setup.id)/reset-notebook" onsubmit="return confirm('Reset your notebook back to the original starter? This discards your current edits for this assignment. Your past submissions are not affected.')" class="inline-form">
+                    <form method="post" action="/testsetups/#(item.setup.id)/reset-notebook" data-confirm="Reset your notebook back to the original starter? This discards your current edits for this assignment. Your past submissions are not affected." class="inline-form">
                         #csrfFormField()
                         <button class="btn action-btn action-btn-icon action-danger" type="submit"
                                 title="Reset notebook to starter (discards current edits; past submissions unaffected)"

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -77,7 +77,7 @@ LEARN
         </form>
         #endif
         <form method="post" action="/instructor/brightspace/disconnect" class="inline-form"
-              onsubmit="return confirm('Disconnect your LEARN account? Courses that push grades as you will pause until someone reconnects.')">
+              data-confirm="Disconnect your LEARN account? Courses that push grades as you will pause until someone reconnects.">
             #csrfFormField()
             <button class="btn action-btn action-danger" type="submit">Disconnect my account</button>
         </form>
@@ -174,7 +174,7 @@ LEARN
                     #if(!courseIsArchived):
                     <form method="post" action="/instructor/#(row.assignmentID)/brightspace/push-all"
                           class="inline-form"
-                          onsubmit="return confirm('Re-push every student's best grade for #(row.title) to LEARN?')">
+                          data-confirm="Re-push every student's best grade for #(row.title) to LEARN?">
                         #csrfFormField()
                         <button class="btn action-btn bs-push-btn" type="submit"
                                 title="Re-push all grades for #(row.title)"
@@ -225,7 +225,7 @@ LEARN
                         <svg class="icon" aria-hidden="true"><use href="#i-link"/></svg>
                     </a>
                     <form method="post" action="#(student.unenrollURL)" class="inline-form"
-                          onsubmit="return confirm('Remove #(student.displayName) from this course?')">
+                          data-confirm="Remove #(student.displayName) from this course?">
                         #csrfFormField()
                         <button class="btn action-btn action-btn-icon action-danger" type="submit"
                                 title="Remove from course" aria-label="Remove from course">

--- a/Resources/Views/instructor-slip-days.leaf
+++ b/Resources/Views/instructor-slip-days.leaf
@@ -113,7 +113,7 @@ Slip days
                             #endif
                             #if(spend.canRefund):
                             <form method="post" action="/instructor/slip-days/refund" class="inline-form"
-                                  onsubmit="return confirm('Refund this slip day? The day is returned to the student and the deadline extension is recomputed (or removed).')">
+                                  data-confirm="Refund this slip day? The day is returned to the student and the deadline extension is recomputed (or removed).">
                                 #csrfFormField()
                                 <input type="hidden" name="spendID" value="#(spend.id)">
                                 <button class="btn action-btn" type="submit">Refund</button>

--- a/Resources/Views/student-assignment-history.leaf
+++ b/Resources/Views/student-assignment-history.leaf
@@ -40,7 +40,7 @@
                 </a>
             </td>
             <td>
-                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')" class="inline-form">
+                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" data-confirm="Send this submission back to the testing queue?" class="inline-form">
                     #csrfFormField()
                     <input type="hidden" name="returnTo" value="#(historyPath)">
                     <button class="btn action-btn action-btn-icon" type="submit" title="Re-test submission" aria-label="Re-test submission">

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -108,7 +108,7 @@ Submission #(submissionID)
 <div class="reveal-token-offer">
     <p class="reveal-token-text">You have <strong>one reveal token</strong> for this assignment. Spending it permanently shows the secret (hidden) test results — names, output, and hints — on all of your past and future submissions here.</p>
     <form method="post" action="/testsetups/#(testSetupID)/reveal-secret"
-          onsubmit="return confirm('Use your one reveal token for this assignment? This permanently reveals the secret test results for all of your submissions on this assignment and cannot be undone.')">
+          data-confirm="Use your one reveal token for this assignment? This permanently reveals the secret test results for all of your submissions on this assignment and cannot be undone.">
         #csrfFormField()
         <input type="hidden" name="submissionID" value="#(submissionID)">
         <button class="btn action-btn" type="submit">Reveal secret tests</button>

--- a/changelog.d/ui-s5-confirm-seam.md
+++ b/changelog.d/ui-s5-confirm-seam.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **One confirmation seam (audit S5).** Every "are you sure?" prompt in the web
+  UI now declares its question in markup and runs through a single handler,
+  replacing 49 hand-written inline confirmation handlers. Cancelling a
+  destructive action now also cancels whatever the button sits inside (row
+  navigation, popovers) rather than only the action itself, and two actions
+  that had drifted into two different wordings — resetting a student's
+  notebook, and removing a support file — now say the same thing everywhere.

--- a/docs/ui-consistency-audit.md
+++ b/docs/ui-consistency-audit.md
@@ -571,6 +571,39 @@ listener reads the submitter).
 baseline 45 → 0 in this slice, then the guard forbids reintroduction.
 This mirrors exactly how `alert()` is already ratcheted.
 
+**Status: done.** All 43 template attributes are now `data-confirm`, and the
+seven JS call sites route through `ChickadeeUI.confirmAction`. Because the
+conversion reached zero in one pass, the guard is an **absolute rule**
+rather than a ratchet: a native `confirm(` outside the seam fails CI.
+
+Clicks are intercepted in the **capture** phase, which is a small upgrade
+on what the inline attributes did: a cancelled delete now also stops the
+handlers layered around the button (row-click navigation, popover toggles),
+where `return false` from an inline `onclick` only stopped the default.
+Submits stay in the bubble phase, where they run before
+`inplace-forms.js`'s listener — which already bails on `defaultPrevented`,
+so a cancelled submit stays cancelled inside the workbench too. A submitter
+carrying its own question (the `formaction` "Clear"/"Remove" buttons) asks
+that question and not the form's.
+
+Two drifted wordings were unified while converting, as planned: the
+reset-notebook pair keeps the longer sentence (it states that the student
+gets the fresh starter automatically — the fact an instructor needs before
+clicking), and the remove-support-file pair keeps "Tests that read it will
+fail", which is true on both pages where the edit page's "Students who
+already use it" was not.
+
+Verified in a real browser rather than by inspection, since a broken seam
+fails *open* — every destructive action would go through unasked:
+cancelling blocks the POST, accepting sends it, and a `formaction`
+submitter asks its own question and posts to its own action.
+
+One process note worth keeping: the first version of the guard failed on
+its own documentation, because the comment quoted the idiom it forbids.
+That is the `#1266` Leaf-comment lesson in a new place — **a scanner cannot
+tell markup from prose about markup** — and the fix is the same one that
+finding produced: describe the forbidden syntax, do not quote it.
+
 ### S6 — Button and label grammar (M)
 
 **Target state,** codified in `ui-design.md`'s component vocabulary:

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -304,6 +304,24 @@ if [ -n "$s4_svg" ]; then
   echo
 fi
 
+# S5: destructive confirmation is data-confirm (handled in app.js). An inline
+# onclick/onsubmit confirm attribute is the idiom it replaced — 49 of them,
+# with the same action worded differently on different pages. Keeping the
+# question in markup is also what makes replacing the native dialog later a
+# one-place change; a call site that re-adds `confirm(` opts itself out of it.
+s5_inline="$(grep -rnE 'on(click|submit)="return (window\.)?confirm\(' "${views[@]}" || true)"
+s5_raw="$(grep -rnE '(^|[^.\w])confirm\(' "${views[@]}" Public/*.js \
+  | grep -v 'ChickadeeUI.confirmAction' | grep -v 'window.confirm' || true)"
+if [ -n "${s5_inline}${s5_raw}" ]; then
+  status=1
+  echo "ERROR: a native confirm() outside the shared seam."
+  echo "       Declare the question in markup with data-confirm=\"…\", or call"
+  echo "       ChickadeeUI.confirmAction(msg) where there is no element to mark."
+  { [ -n "$s5_inline" ] && printf '%s\n' "$s5_inline"
+    [ -n "$s5_raw" ] && printf '%s\n' "$s5_raw"; } | sed 's/^/  /'
+  echo
+fi
+
 # ── 5. Class names must resolve ──────────────────────────────────────────────
 scripts/check-class-resolution.sh || status=1
 


### PR DESCRIPTION
Slice **S5** of the [widget-layer UI audit](https://github.com/JimWallace/Chickadee/blob/main/docs/ui-consistency-audit.md). Stacked on #1403 (S4).

All 43 template confirmation attributes become `data-confirm`, handled by one delegated listener in `app.js`; the seven JS call sites route through `ChickadeeUI.confirmAction`. The conversion reached zero in one pass, so the guard is an **absolute rule** rather than a ratchet.

## Behaviour is slightly better, not just tidier

- **Clicks are intercepted in the capture phase**, so a cancelled delete now also stops the handlers layered around the button (row-click navigation, popover toggles). Returning `false` from an inline `onclick` only stopped the default.
- **Submits stay in the bubble phase**, ahead of `inplace-forms.js` (which bails on `defaultPrevented`), so a cancelled submit stays cancelled inside the workbench too.
- **A submitter with its own question** — the `formaction` Clear/Remove buttons — asks that one rather than the form's.

## Wording unified

- *Reset notebook* keeps the longer sentence: it states the student gets the fresh starter automatically, which is what an instructor needs to know before clicking.
- *Remove support file* keeps "Tests that read it will fail" — true on both pages, where the edit page's "Students who already use it" was not.

## Verified in a browser, deliberately

This seam **fails open** if broken: every destructive action would proceed unasked. So it was tested against a real Chromium rather than by inspection — cancelling blocks the POST, accepting sends it, and a `formaction` submitter posts to its own action.

## One process note

The first version of the guard failed on its **own documentation**, because the comment quoted the idiom it forbids. That is the #1266 Leaf-comment lesson in a new place — a scanner cannot tell markup from prose about markup — so the comment now describes the old idiom instead of quoting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9

---
_Generated by [Claude Code](https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9)_