### PR TITLE
refactor(ui): S8 — one timestamp policy

### DIFF
--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -79,7 +79,7 @@ MCP
         #for(account in accounts):
             <tr>
                 <td><code>#(account.username)</code></td>
-                <td class="time">#(account.createdAt)</td>
+                <td class="time js-relative-time" data-iso="#(account.createdAt)">#(account.createdAt)</td>
                 <td>
                     <div class="mcp-course-cell">
                         #for(c in account.enrolledCourses):
@@ -161,9 +161,9 @@ MCP
                 <td>#(grant.agentName)</td>
                 <td><code>#(grant.owner)</code></td>
                 <td><code>#(grant.scope)</code></td>
-                <td class="time">#(grant.createdAt)</td>
-                <td class="time">#if(grant.lastUsedAt):#(grant.lastUsedAt)#else:—#endif</td>
-                <td class="time">#(grant.expiresAt)</td>
+                <td class="time js-relative-time" data-iso="#(grant.createdAt)">#(grant.createdAt)</td>
+                <td class="time#if(grant.lastUsedAt): js-relative-time#endif"#if(grant.lastUsedAt): data-iso="#(grant.lastUsedAt)"#endif>#if(grant.lastUsedAt):#(grant.lastUsedAt)#else:—#endif</td>
+                <td class="time js-relative-time" data-iso="#(grant.expiresAt)">#(grant.expiresAt)</td>
                 <td>
                     #if(grant.revoked):
                     <span class="text-muted">Revoked</span>

--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -134,7 +134,6 @@ Runner #(runner.workerID)
     margin-top: .6rem;
 }
 </style>
-<script src="/relative-time.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -52,7 +52,6 @@ Users
     display: inline;
 }
 </style>
-<script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/list-filter.js?v=#appVersion()"></script>
 <script src="/sortable-table.js?v=#appVersion()"></script>
 <script src="/table-poll.js?v=#appVersion()"></script>

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -183,7 +183,6 @@ tr.runner-row-offline {
     opacity: .5;
 }
 </style>
-<script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/sortable-table.js?v=#appVersion()"></script>
 <script src="/table-poll.js?v=#appVersion()"></script>
 <script>

--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -123,7 +123,6 @@ Server Health Alerts
     </table></div>
     #endif
 </section>
-<script src="/relative-time.js?v=#appVersion()"></script>
 <style>
 .alerts-webhook-input { flex: 1; min-width: min(320px, 100%); }
 .alerts-test-form { margin-bottom: 1.5rem; }

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -22,6 +22,10 @@
          script tags, and they reference ChickadeeUI at parse time
          (e.g. csrf-token captures). -->
     <script src="/chickadee-ui.js?v=#appVersion()"></script>
+    <!-- Same reason, same place: page inline scripts call
+         ChickadeeRelativeTime.applyRelativeTimes() during parse, so it cannot
+         wait for the end of <body>. -->
+    <script src="/relative-time.js?v=#appVersion()"></script>
 </head>
 <body#if(fullBleed): class="page-fullbleed"#endif>
 #extend("_icons")

--- a/Resources/Views/connected-agents.leaf
+++ b/Resources/Views/connected-agents.leaf
@@ -28,9 +28,9 @@ Connected agents
                 <td>#(row.agentName)</td>
                 #if(isAdmin):<td><code>#(row.owner)</code></td>#endif
                 <td><code>#(row.scope)</code></td>
-                <td class="time">#(row.createdAt)</td>
-                <td class="time">#if(row.lastUsedAt):#(row.lastUsedAt)#else:—#endif</td>
-                <td class="time">#(row.expiresAt)</td>
+                <td class="time js-relative-time" data-iso="#(row.createdAt)">#(row.createdAt)</td>
+                <td class="time#if(row.lastUsedAt): js-relative-time#endif"#if(row.lastUsedAt): data-iso="#(row.lastUsedAt)"#endif>#if(row.lastUsedAt):#(row.lastUsedAt)#else:—#endif</td>
+                <td class="time js-relative-time" data-iso="#(row.expiresAt)">#(row.expiresAt)</td>
                 <td>
                     #if(row.revoked):
                     <span class="text-muted">Revoked</span>

--- a/Resources/Views/instructor-activity.leaf
+++ b/Resources/Views/instructor-activity.leaf
@@ -45,7 +45,7 @@ Activity
             <tbody>
                 #for(row in rows):
                 <tr>
-                    <td>#(row.timestamp)</td>
+                    <td class="js-relative-time" data-iso="#(row.timestampISO)">#(row.timestamp)</td>
                     <td>#(row.actor)</td>
                     <td>
                         <span class="activity-category">#(row.category)</span>

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -127,7 +127,6 @@ Students
     vertical-align: middle;
 }
 </style>
-<script src="/relative-time.js?v=#appVersion()"></script>
 <script src="/list-filter.js?v=#appVersion()"></script>
 <script src="/sortable-table.js?v=#appVersion()"></script>
 <script src="/table-poll.js?v=#appVersion()"></script>

--- a/Sources/APIServer/Services/CourseActivityService.swift
+++ b/Sources/APIServer/Services/CourseActivityService.swift
@@ -24,6 +24,11 @@ import Vapor
 /// One row of the timeline, already formatted for display.
 struct CourseActivityRow: Encodable, Sendable {
     let timestamp: String
+    /// The same instant in ISO-8601, for `js-relative-time` to render as
+    /// "3 hours ago" with the absolute value in the tooltip. Activity is
+    /// human-activity, which the timestamp policy renders relative
+    /// (docs/ui-design.md); `timestamp` remains the no-JS fallback.
+    let timestampISO: String
     let actor: String
     /// Coarse grouping shown as a chip: "Content edit" or the audit category.
     let category: String
@@ -66,9 +71,11 @@ enum CourseActivityService {
             .prefix(limit)
 
         let formatter = waterlooDateTimeFormatter()
+        let iso = ISO8601DateFormatter()
         return merged.map { entry in
             CourseActivityRow(
                 timestamp: formatter.string(from: entry.sortKey),
+                timestampISO: iso.string(from: entry.sortKey),
                 actor: entry.actor,
                 category: entry.category,
                 summary: entry.summary,

--- a/changelog.d/ui-s8-timestamps.md
+++ b/changelog.d/ui-s8-timestamps.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Timestamps follow one policy (audit S8).** Times that answer "how recently"
+  — activity feeds, when an agent was authorized or last used, when its access
+  expires — now render as "3 hours ago" with the exact time in the tooltip,
+  matching the last-seen columns that already did. Audit-log and retention
+  dates stay exact, deliberately. Three columns on the connected-agents tables
+  had been showing raw machine timestamps and now read as plain English.

--- a/docs/ui-consistency-audit.md
+++ b/docs/ui-consistency-audit.md
@@ -731,6 +731,24 @@ columns, brightspace last-sync, slip-day dates; hoist the
 offline-threshold rule into `relative-time.js`
 (`ChickadeeRelativeTime.isStale(iso, ms)`) for the two inline copies.
 
+**Status: done** (the `isStale` hoist and the dead include landed early, in
+S3 and S0 respectively). `relative-time.js` now loads from `base.leaf`,
+retiring five per-page includes — the arrangement that let a page load it
+with nothing to render. Converted: the activity feed's "When" (the one
+column that needed a new server field, `timestampISO`, since its display
+string is Waterloo-formatted), and the agent tables' Authorized / Last used
+/ Expires on both `connected-agents` and the admin MCP tab.
+
+Those agent columns turned out to need **no server change at all**: their
+"formatted" strings were already ISO-8601, so the page had been showing
+users raw `2026-08-14T03:04:09Z` timestamps. Marking them up both fixes
+that and gives the policy's tooltip for free. Expiry is included under the
+policy as a **countdown** — "in 3 days" is what a reader wants from an
+expiry, and it is the same reading as recency.
+
+Audit and retention stay absolute and monospaced, deliberately: there the
+exact instant is the content.
+
 ### S9 — Feedback channels (M)
 
 **Target state:** two channels. Passive/progress feedback is a

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -193,6 +193,27 @@ If two pages need the same rule, it belongs in `Public/styles.css`, not
 copied into both `<style>` blocks — the duplicate-selector guard fails CI on
 copies, and the page-style ratchet fails CI on growth.
 
+## Timestamps
+
+Two renderings, chosen by what the reader is asking (UI audit S8):
+
+- **Human activity** — "last seen", "authorized", "last used", "fired",
+  "completed", an activity feed — renders **relative** via
+  `<td class="js-relative-time" data-iso="…">`, which
+  `Public/relative-time.js` (loaded from `base.leaf`) rewrites to "3 hours
+  ago" and gives an absolute `title`.  The reader wants recency, and a
+  relative value answers that at a glance.  A **countdown** (a token's
+  expiry) is the same case: "in 3 days" beats a date.
+- **Forensic or compliance** times — the audit log, retention dates —
+  render **absolute**, in `--font-mono`, deliberately.  Here the exact
+  instant *is* the content, and "2 months ago" would destroy it.
+
+The server-formatted string stays in the cell as the no-JS fallback, so a
+column degrades to an absolute date rather than to nothing.  Staleness
+questions ("is this runner offline?") use
+`ChickadeeRelativeTime.isStale(iso)`, whose threshold is the client half of
+`RunnerStaleness` — never a hand-written `Date.now() - t > …` comparison.
+
 ## Class names must resolve
 
 A class name assigned in a template or in first-party `Public/*.js` must


### PR DESCRIPTION
Slice **S8** of the [widget-layer UI audit](https://github.com/JimWallace/Chickadee/blob/main/docs/ui-consistency-audit.md).

The audit found 9 relative-time sites and ~25 raw ones, with **no stated policy** for which is which. There is one now, written down in `ui-design.md`:

- **Human activity and countdowns render relative** — "last seen", "authorized", "last used", "fired", an activity feed, and a token's expiry — with the absolute value in the tooltip. The reader wants recency; "in 3 days" is what an expiry is actually asking.
- **Forensic and compliance times stay absolute** and monospaced — the audit log, retention dates — because there the exact instant *is* the content.

`relative-time.js` now loads from `base.leaf`, retiring five per-page includes — the arrangement that let a page load it with nothing to render (the dead include S0 removed).

## The script tag's placement is load-bearing

The first version of this slice put the shared script tag at the end of the document body, where the retired per-page includes had sat. That is wrong once the script is shared: pages carry **inline** scripts that call `ChickadeeRelativeTime` at parse time, and an inline script in the body runs *before* a deferred one placed after it. The Students page threw `ChickadeeRelativeTime is not defined` on every load.

It now loads from the document head. The regression was caught by the repaint integration probe added later in the series, and the fix is relocated **into this commit** so no merged state in the series is ever broken — a bisect never lands on the page error.

## The agent tables needed no server change

Converting Authorized / Last used / Expires on `connected-agents` and the admin MCP tab turned out to require nothing server-side: their "formatted" strings **were already ISO-8601**, so those pages had been showing users raw `2026-08-14T03:04:09Z` timestamps. Marking them up fixes that *and* gives the tooltip for free.

Only the activity feed needed a new field (`timestampISO`), because its display string is Waterloo-formatted.

The server-formatted string stays in every cell as the no-JS fallback, so a column degrades to an absolute date rather than to nothing.

**Gates:** style guards, 78 render tests, visual regression, and both editor smokes (Chromium + WebKit) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9