### PR TITLE
refactor(ui): S9 — two feedback channels

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -57,6 +57,40 @@
         return window.confirm(message);
     }
 
+    // ── Action failures ──
+    //
+    // The one blocking-error channel (UI audit S9): an inline `.form-error`
+    // banner with `role="alert"`, placed at the top of the surface the action
+    // belongs to, matching what inplace-forms.js and the multipart-upload
+    // handler already do.
+    //
+    // It replaces the native modal dialog the editors used, which stopped the
+    // page to say something the page could show in place — and which, on the
+    // support-file widget, meant one control reported its *upload* failures in
+    // a status line and its *delete* failures in a modal.
+    //
+    // `nearEl` names the surface: the banner goes at the top of that element's
+    // nearest section, so a failure appears next to the thing that failed
+    // rather than at the top of a long editor.
+    function showActionError(message, nearEl) {
+        if (typeof document === 'undefined') return;
+        var host = null;
+        if (nearEl && nearEl.closest) {
+            host = nearEl.closest('.page-section, .section-block, .editor-panel, form') || null;
+        }
+        host = host || document.querySelector('.main') || document.body;
+        var banner = host.querySelector(':scope > .action-error-banner');
+        if (!banner) {
+            banner = document.createElement('div');
+            banner.className = 'form-error action-error-banner';
+            banner.setAttribute('role', 'alert');
+            host.insertBefore(banner, host.firstChild);
+        }
+        banner.textContent = message;
+        if (banner.scrollIntoView) banner.scrollIntoView({ block: 'nearest' });
+        return banner;
+    }
+
     // ── Fetch error handling ──
     //
     // One error-message extractor for failed fetch bodies (#1126 — two
@@ -515,6 +549,7 @@
         escapeAttr: escapeHtml,
         getCsrfToken: getCsrfToken,
         confirmAction: confirmAction,
+        showActionError: showActionError,
         setStatus: setStatus,
         extractErrorMessage: extractErrorMessage,
         fetchJSON: fetchJSON,

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2092,6 +2092,34 @@ tr.drop-adopt  { outline: 2px solid var(--blue); outline-offset: -2px; }
 /* Filter/search inputs keep their authored desktop width via the
    --filter-width custom property (so desktop is unchanged) and span the full
    row on phones. */
+/* Modal overlay + card (test-editor-modal.js). The scrim uses the palette's
+   --overlay-bg rather than a raw rgba(), so it has a dark-mode value; the card
+   uses the one elevation token (UI audit S9). `hidden` does the showing and
+   hiding, so JS toggles an attribute rather than writing display. */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--overlay-bg);
+}
+.modal-overlay[hidden] { display: none; }
+.modal-card {
+    background: var(--surface);
+    color: var(--gray-900);
+    border-radius: var(--radius-lg);
+    width: min(960px, 96vw);
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--shadow-pop);
+}
+
+/* Injected by ChickadeeUI.showActionError — the one blocking-error surface,
+   shared with inplace-forms.js's banner (UI audit S9). */
+.action-error-banner { margin-bottom: .75rem; }
 .filter-input { width: var(--filter-width, 16rem); max-width: 100%; }
 /* Label preceding a list-filter control — one look for the live
    (data-list-filter) and GET-form (activity/audit) variants alike. */

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -35,6 +35,14 @@
 (function (global) {
     'use strict';
 
+    // Where a blocking suite-editor error is shown: the editor's own container
+    // when it is on the page, else the shared helper's fallback. Looked up per
+    // call rather than captured, because the edit surface is re-rendered in
+    // place (ChickadeeUI.refreshEditSurface) and a captured node goes stale.
+    function suiteErrorHost() {
+        return document.getElementById('suite-sections');
+    }
+
     // ── Upload classification (folded in from the retired suite-list.js,
     // #1126 — that file was ~90% dead; only this classification survived) ──
     //
@@ -590,7 +598,7 @@
         function expandInlineEditor(opts) {
             opts = opts || {};
             var renderer = (window.ChickadeeTestRenderers || {})[opts.mechanism];
-            if (!renderer) { alert('This test type is unavailable — reload the page.'); return; }
+            if (!renderer) { ChickadeeUI.showActionError('This test type is unavailable — reload the page.', suiteErrorHost()); return; }
 
             // Section: caller-supplied, else inherited from the edited item's row.
             var sectionID = (opts.sectionID != null) ? opts.sectionID : null;
@@ -625,7 +633,7 @@
                 var tb = container.querySelector('tbody[data-section-id="' + sidSel + '"]')
                     || container.querySelector('tbody[data-section-id=""]')
                     || container.querySelector('tbody');
-                if (!tb) { alert('No section to add this test to.'); return; }
+                if (!tb) { ChickadeeUI.showActionError('No section to add this test to.', suiteErrorHost()); return; }
                 var rootDrop = tb.querySelector('.suite-root-drop');
                 if (rootDrop) tb.insertBefore(tr, rootDrop); else tb.appendChild(tr);
             }
@@ -815,8 +823,8 @@
                 // would wipe the instructor's other unsaved mutations).
                 console.error('Suite save failed:', err);
                 var msg = (err && err.message) ? err.message : String(err);
-                alert('Suite save failed: ' + msg
-                    + '\n\nYour edit is still in the page — try again, or reload to recover.');
+                ChickadeeUI.showActionError('Suite save failed: ' + msg
+                    + ' — your edit is still in the page, so try again, or reload to recover.', suiteErrorHost());
             })
             .finally(function () {
                 pushInFlight = false;
@@ -1112,7 +1120,7 @@
             })
             .catch(function (err) {
                 console.error('Section reorder failed:', err);
-                alert('Section reorder failed: ' + (err.message || err) + '\n\nReload the page to recover.');
+                ChickadeeUI.showActionError('Section reorder failed: ' + (err.message || err) + ' — reload the page to recover.', suiteErrorHost());
             });
         }
 
@@ -1209,7 +1217,7 @@
                     .filter(function (it) { return it.kind === 'check' && it.checkID !== cid2; })
                     .map(function (it) { return it.check; });
                 saveChecksViaSuite(remaining)
-                    .catch(function (err) { alert('Could not delete check: ' + (err.message || err)); });
+                    .catch(function (err) { ChickadeeUI.showActionError('Could not delete check: ' + (err.message || err), suiteErrorHost()); });
                 return;
             }
 
@@ -1234,7 +1242,7 @@
                 schedulePush();
             })
             .catch(function (err) {
-                alert('Could not delete: ' + (err.message || err));
+                ChickadeeUI.showActionError('Could not delete: ' + (err.message || err), suiteErrorHost());
             });
         });
 
@@ -1323,7 +1331,7 @@
                         });
                     });
                 });
-                chain.catch(function (err) { alert('Upload failed: ' + (err.message || err)); });
+                chain.catch(function (err) { ChickadeeUI.showActionError('Upload failed: ' + (err.message || err), suiteErrorHost()); });
             });
         }
 

--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -142,15 +142,15 @@
         overlay.id = 'test-editor-overlay';
         overlay.setAttribute('role', 'dialog');
         overlay.setAttribute('aria-modal', 'true');
-        overlay.style.cssText =
-            'display:none;position:fixed;inset:0;z-index:1000;align-items:center;' +
-            'justify-content:center;background:rgba(0,0,0,.5)';
+        // Styling lives in styles.css (.modal-overlay / .modal-card): the scrim
+        // used a raw rgba() here, which bypassed the --overlay-bg token and so
+        // had no dark-mode value, and the card hand-rolled a shadow the palette
+        // already owns (UI audit S9).
+        overlay.className = 'modal-overlay';
+        overlay.hidden = true;
 
         var card = document.createElement('div');
-        card.style.cssText =
-            'background:var(--surface);color:var(--gray-900);border-radius:.5rem;' +
-            'width:min(960px,96vw);max-height:92vh;display:flex;flex-direction:column;' +
-            'box-shadow:0 8px 32px rgba(0,0,0,.25)';
+        card.className = 'modal-card';
 
         // A kind this assignment's language cannot render is DISABLED with its
         // reason, not hidden. The menu offered all ten check kinds on every
@@ -339,12 +339,12 @@
             if (typeSelect.value !== kind) typeSelect.value = kind;
             refreshDescription();
             enterMode(mechanism, kind);
-            overlay.style.display = 'flex';
+            overlay.hidden = false;
             setTimeout(function () { if (!editingItem && !opts.presetType) typeSelect.focus(); }, 0);
         }
 
         function close() {
-            overlay.style.display = 'none';
+            overlay.hidden = true;
             if (activeRenderer && typeof activeRenderer.cleanup === 'function') {
                 try { activeRenderer.cleanup(); } catch (e) { /* ignore */ }
             }
@@ -383,7 +383,7 @@
         closeBtn.addEventListener('click', close);
         overlay.addEventListener('click', function (e) { if (e.target === overlay) close(); });
         document.addEventListener('keydown', function (e) {
-            if (e.key === 'Escape' && overlay.style.display !== 'none') close();
+            if (e.key === 'Escape' && !overlay.hidden) close();
         });
 
         // ── "+ Add Test" dropdown ──────────────────────────────────────────

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -5,7 +5,6 @@
 </div>
 #endif
 
-#extend("_flash")
 
 <!-- `data-ck-inplace` marks every form on this page whose handler answers with
      a redirect to the chromed standalone editor.  That is right standalone and
@@ -114,7 +113,7 @@
                 <button class="btn action-btn" type="button" id="add-support-file-btn"
                         title="Upload a data file (CSV, JSON, etc.) bundled with the assignment">+ Add Support File</button>
                 <input type="file" id="support-file-upload-input" hidden multiple>
-                <span id="support-file-upload-status" class="upload-status-inline"></span>
+                <span id="support-file-upload-status" class="upload-status-inline" role="status" aria-live="polite"></span>
             </div>
         </div>
         <table class="results-table" id="notebook-files-table">
@@ -214,7 +213,7 @@
         <h2>Global Inputs</h2>
         <div class="toolbar toolbar--end">
             <button type="button" class="btn action-btn" id="global-input-add">+ Add Input</button>
-            <span id="global-inputs-status" class="upload-status-inline"></span>
+            <span id="global-inputs-status" class="upload-status-inline" role="status" aria-live="polite"></span>
         </div>
     </div>
     <table class="results-table" id="global-inputs-table">
@@ -270,7 +269,7 @@
                        id="suite-default-time-limit" value="#(timeLimitSeconds)"
                        title="Seconds each test may run before it is killed and recorded as a timeout. Individual tests can override this in the test editor.">
                 s
-                <span id="suite-default-limit-status" class="upload-status-inline"></span>
+                <span id="suite-default-limit-status" class="upload-status-inline" role="status" aria-live="polite"></span>
             </label>
             <!-- Add Section — form POST + full page reload.  Mirrors the
                  dashboard pattern (Resources/Views/assignments.leaf:29-51)
@@ -320,7 +319,7 @@
         <h2>Achievements</h2>
         <div class="toolbar toolbar--end">
             <button type="button" class="btn action-btn" id="achievement-add">+ Add Achievement</button>
-            <span id="achievements-status" class="upload-status-inline"></span>
+            <span id="achievements-status" class="upload-status-inline" role="status" aria-live="polite"></span>
         </div>
     </div>
     <table class="results-table" id="achievements-table">
@@ -760,12 +759,12 @@
             );
             if (!resp.ok) {
                 var errText = await resp.text();
-                alert('Remove failed: ' + resp.status + ' ' + errText);
+                ChickadeeUI.showActionError('Remove failed: ' + resp.status + ' ' + errText, btn);
                 return;
             }
             ChickadeeUI.refreshEditSurface();
         } catch (e) {
-            alert('Remove failed: ' + e.message);
+            ChickadeeUI.showActionError('Remove failed: ' + e.message, btn);
         }
     });
 })();

--- a/Resources/Views/_family-editor-body.leaf
+++ b/Resources/Views/_family-editor-body.leaf
@@ -111,5 +111,5 @@
                     No cases yet.  Add at least one to save this family.
                 </p>
             </div>
-    <span id="family-editor-status" class="editor-status"></span>
+    <span id="family-editor-status" class="editor-status" role="status" aria-live="polite"></span>
 </div>

--- a/Resources/Views/admin-brightspace.leaf
+++ b/Resources/Views/admin-brightspace.leaf
@@ -6,7 +6,6 @@ LEARN
 <p class="admin-version-banner">Chickadee v#appVersion()</p>
 #extend("_admin-tabs")
 <section class="page-section">
-    #extend("_flash")
 
     <p class="section-intro">
         LEARN grade sync runs as one D2L service account. The app credentials

--- a/Resources/Views/admin-retention.leaf
+++ b/Resources/Views/admin-retention.leaf
@@ -6,7 +6,6 @@ Retention
 <p class="admin-version-banner">Chickadee v#appVersion()</p>
 #extend("_admin-tabs")
 <section class="page-section">
-    #extend("_flash")
 
     <p class="section-intro">
         Archived courses can be restored at any time. #(retentionDays) days

--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -6,7 +6,6 @@ Server Health Alerts
 <p class="admin-version-banner">Chickadee v#appVersion()</p>
 #extend("_admin-tabs")
 <section class="page-section">
-    #extend("_flash")
 
     #if(!enabled):
     <div class="flash flash-neutral" role="status">

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -10,7 +10,6 @@ Create Assignment
 </div>
 #endif
 
-#extend("_flash")
 
 <form class="form form--wide" method="post" action="/instructor/new/save" enctype="multipart/form-data" id="new-assignment-form" novalidate>
     #csrfFormField()
@@ -90,7 +89,7 @@ Create Assignment
                 <button class="btn action-btn" type="button" id="add-support-file-btn"
                         title="Upload a data file (CSV, JSON, etc.) bundled with the assignment">+ Add Support File</button>
                 <input type="file" id="support-file-upload-input" hidden multiple>
-                <span id="support-file-upload-status" class="upload-status-inline"></span>
+                <span id="support-file-upload-status" class="upload-status-inline" role="status" aria-live="polite"></span>
             </div>
             #endif
         </div>
@@ -248,7 +247,7 @@ Create Assignment
         <div class="gen-tests-row">
             <span class="gen-tests-title">Generate Starter Tests</span>
             <button class="btn btn-sm" type="button" id="scan-solution-btn">Scan Solution for Functions</button>
-            <span id="scan-status" class="editor-status"></span>
+            <span id="scan-status" class="editor-status" role="status" aria-live="polite"></span>
         </div>
         <div id="scan-results" style="display:none">
             <p class="card-meta gen-tests-prompt">Select the functions to generate starter tests for:</p>
@@ -518,12 +517,12 @@ Create Assignment
                 );
                 if (!resp.ok) {
                     var errText = await resp.text();
-                    alert('Remove failed: ' + resp.status + ' ' + errText);
+                    ChickadeeUI.showActionError('Remove failed: ' + resp.status + ' ' + errText, btn);
                     return;
                 }
                 window.location.reload();
             } catch (e) {
-                alert('Remove failed: ' + e.message);
+                ChickadeeUI.showActionError('Remove failed: ' + e.message, btn);
             }
         });
     })();

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -126,6 +126,11 @@
 #endif
 #endif
 <main class="main#if(fullBleed): main-fullbleed#endif" id="main-content">
+    <!-- Flash banners render ONCE, here, for every page (UI audit S9).  Nine
+         pages used to include the partial themselves, which meant a redirect
+         that set a flash on any other page silently rendered nothing — the
+         handler had done its job and the user saw no confirmation. -->
+    #extend("_flash")
     #import("content")
 </main>
 <script src="/app.js?v=#appVersion()"></script>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -25,7 +25,6 @@ LEARN
 </section>
 #else:
 
-#extend("_flash")
 
 <!-- ── LEARN connection (per-instructor identity, #1114) ────── -->
 <section class="bs-section">

--- a/Resources/Views/instructor-mcp.leaf
+++ b/Resources/Views/instructor-mcp.leaf
@@ -11,7 +11,6 @@ MCP
 </section>
 #else:
 
-#extend("_flash")
 
 <section class="page-section">
     <h2>Authoring voice — #(courseCode)</h2>

--- a/Resources/Views/instructor-slip-days.leaf
+++ b/Resources/Views/instructor-slip-days.leaf
@@ -11,7 +11,6 @@ Slip days
 </section>
 #else:
 
-#extend("_flash")
 
 <section class="page-section">
     <h2>Slip days — #(courseCode)</h2>

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -5,7 +5,6 @@ Students
 #export("content"):
 #extend("_instructor-tabs")
 
-#extend("_flash")
 
 <div class="students-titlebar">
     <h1 class="students-title">Enrolled students (<span id="enrolled-count">#(enrolledStudentCount)</span>)</h1>

--- a/changelog.d/ui-s9-feedback.md
+++ b/changelog.d/ui-s9-feedback.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Two feedback channels, not six (audit S9).** Blocking errors now appear as
+  an inline banner next to the thing that failed, replacing every remaining
+  native browser alert box in the UI — including inside the suite editor, where
+  one control reported upload failures inline but delete failures in a modal.
+  Progress and status lines are now announced to screen readers.
+
+### Fixed
+
+- **Confirmation messages after a redirect now show on every page.** The flash
+  banner was rendered by only nine pages, so a successful action that
+  redirected anywhere else completed silently with no confirmation. It now
+  renders once for the whole site.

--- a/docs/ui-consistency-audit.md
+++ b/docs/ui-consistency-audit.md
@@ -773,6 +773,34 @@ admin-mcp keeps its custom body (it renders a copyable `<code>` value —
 genuinely not a text flash). Visual-regression baselines cover the
 layout shift risk on the captured pages.
 
+**Status: done.** Both alert ratchets reached **zero**: there is no native
+`alert()` left in any template or first-party script. The seven
+`suite-table.js` calls and the four support-file delete calls now use
+`ChickadeeUI.showActionError` — an inline `.form-error role="alert"` banner
+placed at the top of the surface that failed, the same channel
+`inplace-forms.js` and the multipart upload already used. That also ends a
+split *inside one widget*: the support-file control reported upload
+failures in a status line and delete failures in a modal dialog.
+
+The nine role-less status spans became `role="status" aria-live="polite"`,
+so progress and completion are announced rather than silently repainted.
+`_flash` now renders **once from `base.leaf`** and the nine per-page
+includes are gone — which fixes a real defect the audit only implied: a
+redirect that set a flash on any of the other ~20 pages rendered nothing at
+all, so the handler did its work and the user saw no confirmation.
+
+The modal overlay moved off `style.cssText` onto `.modal-overlay` /
+`.modal-card`, so its scrim uses `--overlay-bg` (it had a raw `rgba()` with
+no dark-mode value) and its card uses the one elevation token; showing and
+hiding is now the `hidden` attribute rather than a JS `display` write.
+`JS_STYLE_DECISION_BASELINE` 122 → 118.
+
+**A bug in the guard itself surfaced here, and is worth the note:** with
+`set -o pipefail`, a `grep` that matches nothing exits 1, so both alert
+ratchets *crashed the whole script at exactly the count they exist to
+reach*. A ratchet that fails at its own goal has never been tested at its
+goal; the greps now tolerate the empty case.
+
 ---
 
 ## Decisions taken vs deferred

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -67,11 +67,11 @@ if [ -n "$inline_violations" ]; then
 fi
 
 # ── 3. No new native alert() in templates ───────────────────────────────────
-# Baseline = pre-existing alert()s (rare support-file error paths in the
-# assignment editors).  This may only go DOWN; new alert()s must use the
-# inline .form-error banner instead.
-ALERT_BASELINE=4
-alert_count="$(grep -rho 'alert(' "${views[@]}" | wc -l | tr -d ' ')"
+# At ZERO as of the S9 feedback-channel consolidation: every blocking error
+# now uses the inline .form-error banner (ChickadeeUI.showActionError). The
+# baseline may only go DOWN, so from here the rule is absolute.
+ALERT_BASELINE=0
+alert_count="$( { grep -rho 'alert(' "${views[@]}" || true; } | wc -l | tr -d ' ')"
 if [ "$alert_count" -gt "$ALERT_BASELINE" ]; then
   status=1
   echo "ERROR: new native alert() in a template (found ${alert_count}, baseline ${ALERT_BASELINE})."
@@ -88,9 +88,9 @@ fi
 # which the template glob never sees — so an alert() could be laundered out of
 # scope by the very move 3b encourages.  Top-level Public/*.js only; the
 # vendored/generated trees (Public/pyodide, Public/jupyterlite, Public/vendor,
-# Public/runner-wasm) are not ours to lint.
-JS_ALERT_BASELINE=7
-js_alert_count="$(grep -ho 'alert(' Public/*.js | wc -l | tr -d ' ')"
+# Public/runner-wasm) are not ours to lint.  Also at ZERO as of S9.
+JS_ALERT_BASELINE=0
+js_alert_count="$( { grep -ho 'alert(' Public/*.js || true; } | wc -l | tr -d ' ')"
 if [ "$js_alert_count" -gt "$JS_ALERT_BASELINE" ]; then
   status=1
   echo "ERROR: new native alert() in first-party JS (found ${js_alert_count}, baseline ${JS_ALERT_BASELINE})."
@@ -141,7 +141,7 @@ fi
 # (docs/ui-design.md): JS toggles classes or sets a custom property
 # (workbench.js's --wb-left-width is the pattern); it does not decide
 # styling.
-JS_STYLE_DECISION_BASELINE=122
+JS_STYLE_DECISION_BASELINE=118
 js_style_count="$(
   {
     grep -ho 'style="' Public/*.js || true


### PR DESCRIPTION
Slice **S9** of the [widget-layer UI audit](https://github.com/JimWallace/Chickadee/blob/main/docs/ui-consistency-audit.md). Stacked on #1406 (S8).

The audit found **six** ways a failure could surface. There are two now: a `role="status"` line for progress, and an inline `.form-error role="alert"` banner for anything that blocks the user.

## Both alert ratchets are at zero

No native `alert()` remains in any template or first-party script. The seven `suite-table.js` calls and the four support-file delete calls now use `ChickadeeUI.showActionError`, which places the banner at the top of the surface that failed — the same channel `inplace-forms.js` and the multipart upload already used.

That also ends a split **inside a single widget**: the support-file control reported *upload* failures in a status line and *delete* failures in a modal dialog.

## A real defect fixed: flashes that never showed

`_flash` now renders **once from `base.leaf`**, and the nine per-page includes are gone. Previously a redirect that set a flash on any of the other ~20 pages rendered nothing at all — the handler did its work and the user saw no confirmation.

Nine role-less status spans became `role="status" aria-live="polite"`.

## Modal styling off `cssText`

The overlay moved onto `.modal-overlay` / `.modal-card`: its scrim now uses `--overlay-bg` (it had a raw `rgba()` with **no dark-mode value**) and its card uses the one elevation token. Show/hide is the `hidden` attribute rather than a JS `display` write. `JS_STYLE_DECISION_BASELINE` 122 → 118.

## A bug in the guard itself

With `set -o pipefail`, a `grep` that matches nothing exits 1 — so **both alert ratchets crashed the entire `check-styles.sh` run at exactly the count they exist to reach**. A ratchet that fails at its own goal has never been tested at its goal. The greps now tolerate the empty case, which is what let the baselines actually go to 0.

Also worth noting: **ESLint caught two scope errors in this work** (`table`/`tbody` not in scope at the new call sites) that inline template JS would have shipped silently — the concrete reason that code belongs in `Public/*.js`.

**Gates:** style guards, ESLint, 363 JS tests, 235 render tests, visual regression, axe — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9

---
_Generated by [Claude Code](https://claude.ai/code/session_014XJZ47z7aJvpVCPPwc8vp9)_