### PR TITLE
fix(grading): refuse the grader-only + browser combination at every door

### DIFF
--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -27,6 +27,17 @@ func currentManifestGradingMode(_ manifest: String?) -> String {
     return (dict["gradingMode"] as? String) ?? "worker"
 }
 
+/// Reads the `graderOnlyFiles` list straight from a manifest JSON string —
+/// same access pattern as `currentManifestGradingMode` — empty when the field
+/// is absent or the manifest can't be parsed.
+func currentManifestGraderOnlyFiles(_ manifest: String?) -> [String] {
+    guard
+        let manifest,
+        let dict = (try? JSONSerialization.jsonObject(with: Data(manifest.utf8))) as? [String: Any]
+    else { return [] }
+    return (dict["graderOnlyFiles"] as? [String]) ?? []
+}
+
 /// Sets the test setup's `gradingMode` to `mode` when it differs.  Returns the
 /// effective mode.
 ///
@@ -34,8 +45,12 @@ func currentManifestGradingMode(_ manifest: String?) -> String {
 /// notebook page to host the browser runner, so the stored value could never
 /// execute (`TestProperties.effectiveGradingMode` would pin it to worker
 /// anyway — the refusal keeps the stored state honest rather than silently
-/// inert).  The section-adoption paths check the submission mode first and
-/// skip the sync, so this guard only fires on an explicit request.
+/// inert).  Also refuses `browser` while the manifest marks grader-only
+/// files: browser grading ships the whole setup workspace into the student's
+/// kernel, which is exactly what a grader-only mark exists to prevent —
+/// `author_script` refuses the same combination from the other side.  The
+/// section-adoption paths check both conditions first and skip the sync, so
+/// these guards only fire on an explicit request.
 func setManifestGradingMode(
     setup: APITestSetup, to mode: String, on db: any Database
 ) async throws -> String {
@@ -44,6 +59,11 @@ func setManifestGradingMode(
     {
         throw AppError.badRequest(
             reason: uploadModeGradingConflictMessage)
+    }
+    if mode == GradingMode.browser.rawValue,
+        !currentManifestGraderOnlyFiles(setup.manifest).isEmpty
+    {
+        throw AppError.badRequest(reason: graderOnlyGradingConflictMessage)
     }
     if currentManifestGradingMode(setup.manifest) != mode {
         try await mutateManifest(setup: setup, on: db) { dict in
@@ -58,6 +78,14 @@ func setManifestGradingMode(
 let uploadModeGradingConflictMessage =
     "An upload-only assignment is graded by the native worker; it cannot use browser grading. "
     + "Switch the grading mode to \"worker\" first."
+
+/// One message for every door of the grader-only/browser refusal (mode
+/// switch, zip upload — and `author_script`, which words the same rule from
+/// the marking direction). Browser grading streams the setup workspace into
+/// the student's kernel, so a grader-only file cannot be withheld there.
+let graderOnlyGradingConflictMessage =
+    "This assignment marks grader-only files, which browser grading would deliver to every "
+    + "student's kernel. Remove the graderOnly marks first, or keep worker grading."
 
 /// The upload-only-language coherence rule's message, shared by the
 /// setup-upload API, the submission-mode editor and the MCP tools.

--- a/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
@@ -278,12 +278,15 @@ struct SetAssignmentCourseSectionTool: ContentTool {
         {
             sectionName = section.name
             if let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) {
-                // An upload-only assignment keeps worker grading rather than
-                // adopting a browser default (which would be refused — no
-                // notebook page to grade in); the move itself still succeeds.
+                // An upload-only assignment — or one marking grader-only
+                // files — keeps worker grading rather than adopting a browser
+                // default (which would be refused: no notebook page to grade
+                // in, or withheld files the browser path would deliver); the
+                // move itself still succeeds.
                 if section.defaultGradingMode == GradingMode.browser.rawValue,
                     currentManifestSubmissionMode(setup.manifest)
                         == SubmissionMode.uploadOnly.rawValue
+                        || !currentManifestGraderOnlyFiles(setup.manifest).isEmpty
                 {
                     gradingMode = currentManifestGradingMode(setup.manifest)
                 } else {

--- a/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
@@ -78,6 +78,14 @@ struct SetGradingModeTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: uploadModeGradingConflictMessage)
         }
+        // Same treatment for grader-only files: author_script refuses marking
+        // them on a browser-graded assignment, and this is the reverse door.
+        if mode == GradingMode.browser.rawValue,
+            !currentManifestGraderOnlyFiles(setup.manifest).isEmpty
+        {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: graderOnlyGradingConflictMessage)
+        }
         let effective = try await setManifestGradingMode(setup: setup, to: mode, on: context.db)
         return Output(assignmentPublicID: assignment.publicID, gradingMode: effective)
     }

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -63,9 +63,11 @@ struct BrowserRunnerRoutes: RouteCollection {
         // Grader-only files (answer keys, reserved holdout sets) must never reach
         // a browser-graded student — the whole stored zip is streamed into the
         // kernel's filesystem, which a determined student can inspect. Stream a filtered
-        // copy with those entries removed. The common case declares none (a
-        // grader-only file forces worker grading, see docs/datasets.md), so the
-        // empty case takes the no-copy streaming fast path.
+        // copy with those entries removed. Every authoring door now refuses the
+        // grader-only + browser combination (author_script, set_grading_mode, the
+        // zip upload; section adoption keeps worker grading), so this filter is
+        // the backstop for setups that predate the rule — the common case
+        // declares none and takes the no-copy streaming fast path.
         let graderOnly = setup.decodedManifest()?.graderOnlyFiles ?? []
         guard !graderOnly.isEmpty else {
             return try await req.fileio.asyncStreamFile(at: setup.zipPath)

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -98,6 +98,15 @@ struct TestSetupRoutes: RouteCollection {
             throw AppError.unprocessable(reason: uploadModeGradingConflictMessage)
         }
 
+        // Grader-only files under browser grading would deliver the withheld
+        // bytes to every student's kernel — refused at every authoring door
+        // (`author_script` from the marking side, `set_grading_mode` from the
+        // mode side) and here so a zip-borne manifest can't smuggle the
+        // combination in either.
+        if manifest.gradingMode == .browser, !manifest.graderOnlyFiles.isEmpty {
+            throw AppError.unprocessable(reason: graderOnlyGradingConflictMessage)
+        }
+
         // An assignment in a language with no editor kernel is upload-only
         // by construction (EditorSupport.uploadOnly), so a notebook submission
         // mode would promise students an editor that cannot serve them.  Asked

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Sections.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Sections.swift
@@ -177,15 +177,18 @@ extension CourseAdminRoutes {
         // paths produce identical (sorted-key) manifest bytes — the
         // manifest-hash retest gate depends on that determinism.
         //
-        // An upload-only assignment skips the sync rather than failing the
-        // move: adopting a browser default would be refused (no notebook page
-        // to grade in), and a drag into a section is not the place to surface
-        // that — the assignment simply keeps worker grading.
+        // An upload-only assignment — or one marking grader-only files —
+        // skips the sync rather than failing the move: adopting a browser
+        // default would be refused (no notebook page to grade in, or withheld
+        // files the browser path would deliver), and a drag into a section is
+        // not the place to surface that — the assignment simply keeps worker
+        // grading.
         if let sectionUUID = newSectionID,
             let section = try await APICourseSection.find(sectionUUID, on: req.db),
             let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db),
             !(section.defaultGradingMode == GradingMode.browser.rawValue
-                && currentManifestSubmissionMode(setup.manifest) == SubmissionMode.uploadOnly.rawValue)
+                && (currentManifestSubmissionMode(setup.manifest) == SubmissionMode.uploadOnly.rawValue
+                    || !currentManifestGraderOnlyFiles(setup.manifest).isEmpty))
         {
             _ = try await setManifestGradingMode(setup: setup, to: section.defaultGradingMode, on: req.db)
         }

--- a/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
@@ -258,6 +258,55 @@ import VaporTesting
         }
     }
 
+    /// A zip-borne manifest pairing browser grading with grader-only files is
+    /// refused at upload, like the upload-only + browser pair beside it: the
+    /// browser path delivers the whole workspace to the student's kernel, so
+    /// the marks could not be honored. The refusal fires during manifest
+    /// validation, before the zip's own contents are checked.
+    @Test func uploadRejectsGraderOnlyFilesWithBrowserGrading() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCGO", archivedCode: "LCGP")
+
+            let boundary = "LCGraderOnly"
+            let manifest =
+                #"{"schemaVersion":1,"gradingMode":"browser","graderOnlyFiles":["answers.py"],"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#
+            var body = ByteBufferAllocator().buffer(capacity: 512)
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"_csrf\"\r\n\r\n")
+            body.writeString(fx.csrf)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"manifest\"\r\n\r\n")
+            body.writeString(manifest)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"courseID\"\r\n\r\n")
+            body.writeString(fx.active.courseID.uuidString)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString(
+                "Content-Disposition: form-data; name=\"files\"; filename=\"setup.zip\"\r\n"
+                    + "Content-Type: application/zip\r\n\r\n")
+            body.writeString("PK")
+            body.writeString("\r\n--\(boundary)--\r\n")
+
+            try await app.asyncTest(
+                .POST, "/api/v1/testsetups",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+                    req.body = .init(buffer: body)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .unprocessableEntity,
+                        "grader-only + browser manifest must be rejected, got \(res.status)")
+                    let bodyText = res.body.string
+                    #expect(
+                        bodyText.contains("grader-only"),
+                        "rejection should carry the grader-only conflict message, got: \(bodyText)")
+                })
+        }
+    }
+
     @Test func uploadRejectsUnparseableMinimumRunnerVersion() async throws {
         try await withApp(app) { _ in
             let fx = try await setupInstructorWithBothCourses(activeCode: "LCMV", archivedCode: "LCMW")

--- a/Tests/APITests/MCP/CourseSectionToolsTests.swift
+++ b/Tests/APITests/MCP/CourseSectionToolsTests.swift
@@ -87,6 +87,41 @@ import Vapor
         }
     }
 
+    /// Moving an assignment whose manifest marks grader-only files into a
+    /// browser-default section keeps worker grading rather than failing the
+    /// move — the same skip the upload-only rule gets. Adopting browser would
+    /// deliver the withheld files to every student's kernel.
+    @Test func setAssignmentSectionKeepsWorkerWhenGraderOnlyFilesMarked() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let fx = try await fixture(on: app)
+            let courseID = try fx.course.requireID()
+            try await makeTestSetup(
+                on: app, id: "setup_go", courseID: courseID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"worker","graderOnlyFiles":["answers.py"],"testSuites":[],"timeLimitSeconds":10}"#
+            )
+            let holdoutAssignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_go", courseID: courseID, title: "Holdout Lab")
+            let section = try await makeSection(
+                on: app, name: "Labs", mode: "browser", order: 1, courseID: courseID)
+            let sectionID = try section.requireID()
+
+            let out = try await SetAssignmentCourseSectionTool().execute(
+                .init(
+                    assignmentPublicID: holdoutAssignment.publicID,
+                    courseSectionID: sectionID.uuidString),
+                context(app))
+            #expect(out.gradingMode == "worker")
+
+            // The move itself succeeded; the mode did not adopt.
+            let reloaded = try #require(try await APIAssignment.find(holdoutAssignment.id, on: app.db))
+            #expect(reloaded.sectionID == sectionID)
+            let setup = try #require(try await APITestSetup.find("setup_go", on: app.db))
+            #expect(setup.decodedManifest()?.gradingMode.rawValue == "worker")
+        }
+    }
+
     @Test func setAssignmentSectionMovesAndSyncsGradingMode() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/SetGradingModeToolTests.swift
+++ b/Tests/APITests/MCP/SetGradingModeToolTests.swift
@@ -74,4 +74,41 @@ import Vapor
             }
         }
     }
+
+    private let workerGraderOnlyManifest =
+        #"{"schemaVersion":1,"gradingMode":"worker","graderOnlyFiles":["answers.py"],"testSuites":[],"timeLimitSeconds":10}"#
+
+    /// Browser grading delivers the setup workspace into the student's kernel,
+    /// so a manifest marking grader-only files refuses the switch — the
+    /// reverse of author_script's refusal to mark files on a browser-graded
+    /// assignment. Before this door closed, author-under-worker-then-switch
+    /// reached the combination every authoring surface half-forbids.
+    @Test func refusesBrowserWhileManifestMarksGraderOnlyFiles() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, manifest: workerGraderOnlyManifest)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetGradingModeTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, gradingMode: "browser"), context(app))
+            }
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(setup.decodedManifest()?.gradingMode.rawValue == "worker")
+        }
+    }
+
+    /// The refusal is scoped to marked files: a worker-graded assignment with
+    /// none switches to browser exactly as before.
+    @Test func allowsBrowserWhenNoGraderOnlyFilesMarked() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let workerManifest =
+                #"{"schemaVersion":1,"gradingMode":"worker","graderOnlyFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
+            let assignment = try await fixture(on: app, manifest: workerManifest)
+            let out = try await SetGradingModeTool().execute(
+                .init(assignmentPublicID: assignment.publicID, gradingMode: "browser"), context(app))
+            #expect(out.gradingMode == "browser")
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(setup.decodedManifest()?.gradingMode.rawValue == "browser")
+        }
+    }
 }

--- a/changelog.d/issue-1382-grader-only-browser-doors.md
+++ b/changelog.d/issue-1382-grader-only-browser-doors.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Grader-only files and browser grading can no longer be combined.**
+  `author_script` already refused marking a file grader-only on a
+  browser-graded assignment, but the combination was still reachable from the
+  other side: switching a worker-graded assignment with grader-only files to
+  browser grading succeeded, leaving every student's kernel boot to rebuild a
+  filtered setup zip per download — and any tests referencing the withheld
+  files broken. `set_grading_mode` and the zip upload now refuse the pair
+  (matching the existing upload-only/browser refusal), section adoption keeps
+  worker grading instead of failing the move, and the per-download filter
+  remains as the backstop for setups created before the rule.


### PR DESCRIPTION
Item 11 of the #1382 scalability-audit handover (items 4 and 7 shipped in #1398 / #1401; 2, 3, 5, 6, 8, 9 earlier).

## The verification the item asked for

The item said: *"Verify reachability before doing any work. The code comment claims a grader-only file forces worker grading, which would make this path unreachable… If it is reachable, cache the filtered artifact."*

**It is reachable, and the comment's claim was only half-enforced.** `author_script` refuses `graderOnly: true` on a browser-graded assignment — but `set_grading_mode` had no reciprocal check, so *author-under-worker-then-switch* produced a browser-graded assignment with grader-only files. A zip-borne manifest pairing them was accepted too. In that state, every student's kernel boot pays the copy + re-zip + unstreamed buffer the item flagged — and worse, any test referencing the withheld files simply breaks, since the browser runner never receives them.

## Why close the doors instead of caching

The reachable state is not a hot path to optimize; it is a misconfiguration one authoring surface already refuses. Caching the filtered zip would entrench a state that half the surface forbids and that grades wrong. So the resolution mirrors the existing **upload-only/browser** refusal, shape for shape:

- **`setManifestGradingMode`** (the shared chokepoint) refuses `browser` while the manifest marks grader-only files; `set_grading_mode` pre-checks for a proper tool error, exactly as it does for upload-only.
- **Both section-adoption paths** (MCP `set_assignment_course_section`, web `moveToSection`) keep worker grading instead of failing the move — the same skip upload-only assignments get, because a drag into a section is not the place to surface a refusal.
- **The zip upload** refuses a zip-borne manifest pairing them, beside the existing upload-only pair refusal, so the combination can't be smuggled in.
- **The download filter stays**, as the backstop for setups created before the rule — its comment now says that instead of claiming unreachability. No caching added; after this the population that pays the filter is legacy-only.

## Verification

- New pins: `set_grading_mode` refuses the switch and leaves the manifest untouched; the no-grader-only switch still succeeds (scoping); section adoption moves the assignment but keeps worker mode; the upload 422s with the grader-only message before zip-content checks.
- Adjacent suites green locally: `BrowserManifestGraderOnlyStripTests`, `AuthorScriptToolTests` (the original refusal), `BrowserRunnerRoutesTests` (the filter backstop), `SectionRoutesTests`, `GraderOnlyFilesTests` — 102 tests across the direct + adjacent runs.
- `scripts/format.sh` / `scripts/lint.sh` / `scripts/swiftlint.sh --strict` clean. One `changelog.d/` fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7)_