### PR TITLE
perf: Tier-3 contained remainder — pass-outcome log level, Postgres session bounds

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
@@ -572,21 +572,31 @@ extension OperationalDiagnosticsService {
             )
         )
 
+        // Non-pass outcomes log at info — they are what the documented triage
+        // flow greps for (docs/operational-diagnostics.md). Passes log at
+        // debug: they carry no diagnostic signal beyond the counts already in
+        // assignment_result_summary, and at info a 40-test green suite wrote
+        // ~40 formatted records through the synchronous console handler per
+        // result. A silenced debug record still builds its metadata dict, but
+        // skips the handler's formatting and the serialized stdout write —
+        // which is where the per-result cost was.
         for outcome in collection.outcomes {
-            logger.info(
-                "observability",
-                metadata: logMetadata(
-                    event: .testResultSummary,
-                    submission: submission,
-                    context: context,
-                    extra: [
-                        "test_id": .string(normalizedTestID(for: outcome)),
-                        "status": .string(outcome.status.rawValue),
-                        "execution_ms": .stringConvertible(outcome.executionTimeMs),
-                        "error_message_summary": .string(compactSummary(outcome.shortResult)),
-                    ]
-                )
+            let metadata = logMetadata(
+                event: .testResultSummary,
+                submission: submission,
+                context: context,
+                extra: [
+                    "test_id": .string(normalizedTestID(for: outcome)),
+                    "status": .string(outcome.status.rawValue),
+                    "execution_ms": .stringConvertible(outcome.executionTimeMs),
+                    "error_message_summary": .string(compactSummary(outcome.shortResult)),
+                ]
             )
+            if outcome.status == .pass {
+                logger.debug("observability", metadata: metadata)
+            } else {
+                logger.info("observability", metadata: metadata)
+            }
         }
 
         logger.info(

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -170,6 +170,43 @@ enum DatabaseConfigurationError: Error, LocalizedError {
     }
 }
 
+/// Session-level bounds sent to Postgres as startup parameters on every
+/// pooled connection (both the main and the least-privilege MCP pool).
+///
+/// #1159 was a pool-starvation incident: one slow admin-dashboard scan held
+/// its event loop's only connection and starved every other query on that
+/// loop. The pool is now 4/loop and the dashboard reads are cached, but
+/// nothing bounded how long a single pathological statement could hold a
+/// pooled connection — these do. Values are deliberate constants, not
+/// configuration: they exist to be generous ceilings that only a defect can
+/// reach, so there is nothing an operator should tune.
+enum PostgresSessionBounds {
+    /// 60 s: far above any legitimate single statement (the widest query in
+    /// the app is the 72 h-clamped metrics window; migrations at current
+    /// data sizes are sub-second), far below "holds a pooled connection
+    /// indefinitely". Applies to migrations too — a future migration
+    /// genuinely expected to exceed it should `SET statement_timeout = 0`
+    /// for its own session rather than raising this.
+    static let statementTimeoutMs = 60_000
+
+    /// 5 min: kills sessions idle *inside a transaction*. Generous because
+    /// the course-bundle import legitimately writes files between statements
+    /// of its import transaction; a connection wedged mid-transaction now
+    /// dies in minutes instead of never.
+    static let idleInTransactionSessionTimeoutMs = 300_000
+
+    /// The exact parameter list appended to both pools' startup options.
+    /// Postgres rejects an unknown parameter name at connection time, so a
+    /// typo here fails the whole `api-tests-postgres` lane loudly rather
+    /// than silently binding nothing.
+    static var startupParameters: [(String, String)] {
+        [
+            ("statement_timeout", String(statementTimeoutMs)),
+            ("idle_in_transaction_session_timeout", String(idleInTransactionSessionTimeoutMs)),
+        ]
+    }
+}
+
 extension DatabaseID {
     static let chickadee = DatabaseID(string: "chickadee")
     /// Optional dedicated pool for the MCP path, backed by a least-privilege
@@ -238,6 +275,9 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
         if let searchPath = settings.postgresSearchPath, !searchPath.isEmpty {
             configuration.searchPath = searchPath
         }
+        configuration.coreConfiguration.options.additionalStartupParameters +=
+            PostgresSessionBounds.startupParameters
+
         // Default 4/loop on Postgres (#1159): the driver default of 1/loop is
         // the documented ConnectionPoolTimeoutError incident class — one
         // long-held connection per event loop starves every other query on
@@ -267,6 +307,8 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
             if let searchPath = settings.postgresSearchPath, !searchPath.isEmpty {
                 mcpConfiguration.searchPath = searchPath
             }
+            mcpConfiguration.coreConfiguration.options.additionalStartupParameters +=
+                PostgresSessionBounds.startupParameters
             app.databases.use(
                 .postgres(configuration: mcpConfiguration, maxConnectionsPerEventLoop: poolSize),
                 as: .mcp)

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -1,5 +1,6 @@
 import Fluent
 import Foundation
+import Logging
 import Testing
 import VaporTesting
 
@@ -817,5 +818,111 @@ import VaporTesting
 
     private func encodedBody<T: Encodable>(_ value: T) throws -> ByteBuffer {
         ByteBuffer(data: try JSONEncoder().encode(value))
+    }
+
+    // MARK: - test_result_summary log levels
+
+    /// Per-outcome `test_result_summary` records log non-pass outcomes at
+    /// info — they are what the documented triage flow greps for — and passes
+    /// at debug, so a green suite contributes no per-test records at the
+    /// production log level. The capturing handler accepts every level, so
+    /// the assertion pins the level each record was *emitted* at, not a
+    /// threshold effect.
+    @Test func testResultSummaryLogsPassesAtDebugAndFailuresAtInfo() async throws {
+        try await withApp(app) { _ in
+            let (_, submission) = try await makeSubmission(submissionID: "sub_log_levels")
+            submission.workerID = "runner-log-levels"
+            submission.status = "assigned"
+            try await submission.update(on: app.db)
+
+            func outcome(_ name: String, _ status: TestStatus) -> TestOutcome {
+                TestOutcome(
+                    testName: name,
+                    testClass: nil,
+                    tier: .pub,
+                    status: status,
+                    shortResult: status == .pass ? "passed" : "expected 42, got 41",
+                    longResult: nil,
+                    executionTimeMs: 10,
+                    memoryUsageBytes: nil,
+                    attemptNumber: 1,
+                    isFirstPassSuccess: false
+                )
+            }
+            let collection = TestOutcomeCollection(
+                submissionID: try submission.requireID(),
+                testSetupID: submission.testSetupID,
+                attemptNumber: submission.attemptNumber ?? 1,
+                buildStatus: .passed,
+                compilerOutput: nil,
+                outcomes: [outcome("public.passing", .pass), outcome("public.failing", .fail)],
+                totalTests: 2,
+                passCount: 1,
+                failCount: 1,
+                errorCount: 0,
+                timeoutCount: 0,
+                executionTimeMs: 20,
+                jobStartedAt: Date(timeIntervalSince1970: 4_000),
+                runnerVersion: "runner-test/1.0",
+                timestamp: Date(timeIntervalSince1970: 4_001)
+            )
+
+            let sink = CapturedRecordSink()
+            var logger = Logger(label: "observability.level.test")
+            logger.handler = LevelCapturingLogHandler(sink: sink)
+
+            await app.diagnostics.recordWorkerResult(
+                collection: collection, submission: submission, on: app.db, logger: logger)
+
+            let testRecords = sink.records.filter { $0.metadata["event"] == "test_result_summary" }
+            #expect(testRecords.count == 2)
+            let passing = try #require(testRecords.first { $0.metadata["test_id"]?.contains("passing") == true })
+            #expect(passing.level == .debug)
+            let failing = try #require(testRecords.first { $0.metadata["test_id"]?.contains("failing") == true })
+            #expect(failing.level == .info)
+        }
+    }
+}
+
+// MARK: - Capturing log handler
+
+private final class CapturedRecordSink: @unchecked Sendable {
+    // @unchecked: every access to `stored` holds `lock`. A LogHandler is a
+    // value type copied into the Logger, so the shared mutable store has to
+    // sit behind a reference the handler captures.
+    struct Record {
+        let level: Logger.Level
+        let metadata: [String: String]
+    }
+
+    private let lock = NSLock()
+    private var stored: [Record] = []
+
+    func append(level: Logger.Level, metadata: Logger.Metadata) {
+        lock.lock()
+        defer { lock.unlock() }
+        stored.append(Record(level: level, metadata: metadata.mapValues { "\($0)" }))
+    }
+
+    var records: [Record] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stored
+    }
+}
+
+private struct LevelCapturingLogHandler: LogHandler {
+    let sink: CapturedRecordSink
+
+    var metadata: Logger.Metadata = [:]
+    var logLevel: Logger.Level = .trace
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: LogEvent) {
+        sink.append(level: event.level, metadata: event.metadata ?? [:])
     }
 }

--- a/changelog.d/issue-1382-pass-outcome-log-level.md
+++ b/changelog.d/issue-1382-pass-outcome-log-level.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Per-test result log records for passing outcomes moved to debug level.**
+  Result ingest emitted one info-level `test_result_summary` record per test
+  outcome through the synchronous console handler — ~43 formatted records for
+  a green 40-test suite, per result. Failures, errors and timeouts (what the
+  documented triage flow greps for) stay at info; passes now log at debug,
+  and their counts remain in `assignment_result_summary`.

--- a/changelog.d/issue-1382-postgres-session-bounds.md
+++ b/changelog.d/issue-1382-postgres-session-bounds.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Postgres sessions carry statement and idle-in-transaction timeouts.**
+  Every pooled connection (main and MCP pools) now starts with
+  `statement_timeout = 60s` and `idle_in_transaction_session_timeout = 5min`,
+  so a pathological query or a wedged transaction can no longer hold a pooled
+  connection indefinitely — the missing third bound after the #1159
+  pool-starvation fixes (pool size, cached dashboard reads). The compose
+  Postgres template also documents modest `shared_buffers`/`max_connections`
+  tuning; the stock 100-connection ceiling is below the app's pool ceiling on
+  large hosts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,16 @@ services:
   # db:
   #   image: postgres:16
   #   restart: unless-stopped
+  #   # Modest tuning over the stock image. max_connections must clear the
+  #   # app's pool ceiling of 4 connections x event loops (loops = host
+  #   # cores): 200 covers a 32-core host with headroom, where the stock 100
+  #   # would not. Per-session statement/idle bounds are set by the app
+  #   # itself (PostgresSessionBounds in DatabaseConfiguration.swift), not
+  #   # here.
+  #   command: >-
+  #     postgres
+  #     -c shared_buffers=256MB
+  #     -c max_connections=200
   #   environment:
   #     POSTGRES_DB: chickadee
   #     POSTGRES_USER: chickadee

--- a/docs/operational-diagnostics.md
+++ b/docs/operational-diagnostics.md
@@ -125,7 +125,10 @@ Server-side structured log events include:
 - `result_received`
 - `job_finalised`
 - `assignment_result_summary`
-- `test_result_summary`
+- `test_result_summary` — per test outcome; **info for fail/error/timeout,
+  debug for pass** (a green suite contributes no per-test records at the
+  production log level; the pass/fail counts are in
+  `assignment_result_summary`)
 - `job_recovery`
 
 Runner-side structured log events include:


### PR DESCRIPTION
Items 13 and 15 of the #1382 scalability-audit handover, bundled per the ground rules' "one PR per item or coherent bundle" (the #1389 precedent). Two commits, one per item, each independently revertable. (Items 4, 7, 11 shipped in #1398 / #1401 / #1409; 2, 3, 5, 6, 8, 9 earlier.)

## Item 13 — per-outcome result logging (commit `94eff60d`)

Result ingest emitted one info-level `test_result_summary` record per test outcome through the synchronous console handler — ~43 formatted records for a green 40-test suite, per result, at the production `LOG_LEVEL=info`. The docs promise this event for *failure* triage ("separate test failures from infrastructure or execution issues"), so the fix keeps that intact rather than deleting the event: **failures, errors and timeouts stay at info; passes move to debug**. A green suite now contributes zero per-test records at the production level (its counts are already in `assignment_result_summary`); an all-failing suite is unchanged — which is when you want the records.

Pinned by a capturing-`LogHandler` test that accepts every level and asserts the *emission* level per outcome status — a pass record at `.debug`, a fail record at `.info` — so the pin is independent of any threshold. Docs state the split.

## Item 15 — Postgres session bounds (commit `fab22bca`)

`DatabaseConfiguration` set only host/port/credentials: no statement timeout, no idle-in-transaction bound, so one pathological query could hold a pooled connection indefinitely. The handover's framing: #1159 (one slow admin scan starving an event loop's pool) got two bounds — pool size 4/loop and the cached dashboard reads — and this is the missing third.

- Both pools (main + least-privilege MCP) now send `statement_timeout = 60s` and `idle_in_transaction_session_timeout = 5min` as **startup parameters** (`PostgresSessionBounds` — deliberate constants with the reasoning in comments; no new env vars, per the standing rule).
- 60 s clears every legitimate statement (the widest window query is clamped to 72 h; migrations at current sizes are sub-second) — a future migration expecting to exceed it should `SET statement_timeout = 0` for its session, and the constant's comment says so.
- 5 min for the idle bound stays generous deliberately: the course-bundle import writes files inside its import transaction.
- **Acceptance is exercised in CI**: Postgres rejects an unknown startup parameter at connection time, so a wrong GUC name fails every connection in the `api-tests-postgres` lane loudly — that lane is the integration test.
- The commented compose Postgres template gains documented `shared_buffers`/`max_connections` tuning (the stock 100-connection ceiling is below the app's `4 × cores` pool ceiling on large hosts). App-side bounds deliberately do not live there — they apply to any deployment shape.

## Verification

`ObservabilityTests` (15, includes the new level pin) and `AppConfigTests` green locally on SQLite; the SQLite path through `configureDatabases` is exercised by every test-app boot and is untouched. `scripts/format.sh` / `scripts/lint.sh` / `scripts/swiftlint.sh --strict` clean. Two `changelog.d/` fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7)_