### PR TITLE
feat(deploy): serve the vendored editor asset trees from nginx

### DIFF
--- a/changelog.d/issue-1382-nginx-static-assets.md
+++ b/changelog.d/issue-1382-nginx-static-assets.md
@@ -1,0 +1,13 @@
+### Added
+
+- **The example nginx vhost serves the vendored editor assets statically.**
+  `deploy/nginx.conf` gains static locations for `/vendor/`,
+  `/jupyterlite/build/`, `/jupyterlite/extensions/` and each kernel's
+  `kernel_packages/` — mirroring `EditorAssetFastPathMiddleware`'s allowlist,
+  isolation headers and immutable/no-cache split exactly, with a `try_files`
+  fallback to the app so a missing or version-skewed root degrades to the
+  proxied behaviour. Verified with a real Chromium kernel boot through the
+  shipped vhost (`crossOriginIsolated` true, per-student file paths still
+  401, 131 of 160 boot requests served without transiting the app). The
+  blue-green container topology deliberately keeps the app-served path; the
+  deploy doc records why and what host-side serving there would take.

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -43,7 +43,9 @@ server {
     # pre-compressed .br/.gz variants and there is no gzip_static here, so a
     # cold fetch of xpython.wasm (~15.7 MB) pays a level-5 gzip each time. The
     # app also compresses compressible types itself, so for proxied responses
-    # this mostly passes an already-gzipped body through.
+    # this mostly passes an already-gzipped body through; files served from
+    # the static locations below gzip on the fly here too — same cost, minus
+    # the app round-trip.
     gzip on;
     gzip_proxied any;
     gzip_vary on;
@@ -66,6 +68,118 @@ server {
         proxy_buffering    off;
         proxy_cache        off;
         proxy_read_timeout 3600s;
+    }
+
+    # ------------------------------------------------------------------
+    # Static fast paths: the vendored editor asset trees, served from disk
+    # without transiting the app.  Mirrors the app's own
+    # EditorAssetFastPathMiddleware allowlist EXACTLY — only trees that are
+    # checked-in vendored bytes by construction are listed.  Anything else
+    # under /jupyterlite/ (notably /jupyterlite/files/users/, the
+    # per-student working copies behind UserFileNamespaceMiddleware) keeps
+    # proxying to the app, so the auth boundary is preserved by
+    # construction rather than by an exclusion list.
+    #
+    # Every location:
+    #   * falls back to the app when the file is absent on disk
+    #     (try_files -> @chickadee_app), so a root that is missing or
+    #     version-skewed degrades to exactly the proxied behaviour;
+    #   * restates ALL FOUR headers.  nginx add_header inheritance resets
+    #     in any block that declares its own add_header, so a location
+    #     setting only Cache-Control would silently drop the isolation
+    #     headers — and a worker script served without COEP is refused by
+    #     the isolated editor page (ERR_BLOCKED_BY_RESPONSE), making
+    #     browser grading silently fail over to the native worker.
+    #
+    # Cache split (same rule as the middleware): filenames carrying a
+    # webpack content-hash component are immutable — a rebuild produces a
+    # new name; everything else is no-cache, because a re-vendor rewrites
+    # bytes IN PLACE under stable names (kernel tarballs included) and
+    # immutable caching would pin stale bytes across an upgrade.  no-cache
+    # still revalidates cheaply: nginx serves ETag/Last-Modified for
+    # static files, so unchanged assets answer 304.
+    #
+    # NOTE (docker/blue-green deployments): this root only exists on a
+    # host that runs the server from a checkout (systemd mode).  The
+    # containerised blue-green deployment symlinks the data volume's
+    # Public/ at /app/Public INSIDE each color's container, so the host
+    # cannot resolve it — there every request simply takes the
+    # @chickadee_app fallback (one stat() of overhead).  See
+    # docs/zero-downtime-deploy.md for what adopting host-side static
+    # serving in that topology would take.
+
+    root /opt/chickadee/Public;
+
+    location ^~ /vendor/ {
+        try_files $uri @chickadee_app;
+        add_header Cross-Origin-Opener-Policy   "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cache-Control "no-cache" always;
+    }
+
+    location ^~ /jupyterlite/build/ {
+        try_files $uri @chickadee_app;
+        add_header Cross-Origin-Opener-Policy   "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cache-Control "no-cache" always;
+
+        # Content-hashed bundle files (e.g. 100.5a28c9e.js): immutable.
+        location ~ "[^/]*\.[0-9a-f]{7,}\.[^/]*$" {
+            try_files $uri @chickadee_app;
+            add_header Cross-Origin-Opener-Policy   "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+        }
+    }
+
+    location ^~ /jupyterlite/extensions/ {
+        try_files $uri @chickadee_app;
+        add_header Cross-Origin-Opener-Policy   "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cache-Control "no-cache" always;
+
+        location ~ "[^/]*\.[0-9a-f]{7,}\.[^/]*$" {
+            try_files $uri @chickadee_app;
+            add_header Cross-Origin-Opener-Policy   "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+        }
+    }
+
+    # One env directory per vendored kernel (chickadee-python, -r, -lua,
+    # -octave, ...).  Matched by pattern rather than by listing languages,
+    # so a newly vendored kernel is covered the day it ships — the whole
+    # xeus tree is vendored bytes.  Startup JSON outside kernel_packages/
+    # deliberately keeps riding the app chain, as it does in the
+    # middleware.
+    location ~ "^/jupyterlite/xeus/[^/]+/kernel_packages/" {
+        try_files $uri @chickadee_app;
+        add_header Cross-Origin-Opener-Policy   "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cache-Control "no-cache" always;
+    }
+
+    # Shared fallback for the static locations: identical proxy config to
+    # "location /" below, so a static miss behaves exactly like a request
+    # that never matched a static location.
+    location @chickadee_app {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+        proxy_intercept_errors on;
+        proxy_hide_header  Cross-Origin-Opener-Policy;
+        proxy_hide_header  Cross-Origin-Embedder-Policy;
+        add_header         Cross-Origin-Opener-Policy  "same-origin" always;
+        add_header         Cross-Origin-Embedder-Policy "require-corp" always;
     }
 
     location / {

--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -304,6 +304,43 @@ column the old code reads) would break the old color too, and auto-rollback of t
 
 ---
 
+## Static editor assets and the container topology
+
+`deploy/nginx.conf` serves the vendored editor asset trees (`/vendor/`,
+`/jupyterlite/build/`, `/jupyterlite/extensions/`, each kernel's
+`kernel_packages/`) straight from disk when the server runs from a host
+checkout, falling back to the app for anything absent — the allowlist,
+headers and cache split mirror `EditorAssetFastPathMiddleware` exactly, and
+`/jupyterlite/files/users/` never matches a static location, so the
+per-student auth boundary is preserved by construction.
+
+The blue-green container deployment cannot take that path as-is. The data
+volume's `Public` is a symlink to `/app/Public` inside whichever container
+created it (`deploy/docker-entrypoint.sh`) — chosen deliberately so a
+redeploy never re-copies ~400 MB of vendored bytes — and a
+container-internal symlink target is unresolvable from the host, so host
+nginx takes the `@chickadee_app` fallback for every asset request there.
+That is safe (it is exactly the pre-static behaviour, served by
+`EditorAssetFastPathMiddleware`), just not faster.
+
+Adopting host-side static serving for the container topology would take,
+per deploy color:
+
+- materialising the image's `Public/` where the host can read it — e.g. a
+  per-color named volume (`-v chickadee-public-<color>:/app/Public`), which
+  Docker populates from the image at container create, on the idle color
+  before cutover so the deploy gap does not grow;
+- flipping an nginx `root`-carrying include at cutover exactly the way
+  `bluegreen-deploy.sh` already flips the upstream include;
+- garbage-collecting the retired color's volume.
+
+That reintroduces a per-new-image ~400 MB copy and adds a second cutover
+artifact — a topology decision, not a config edit. Until someone makes it
+deliberately, the app-served path remains the container deployment's
+design.
+
+---
+
 ## Open items to confirm on the host (Phase 1)
 
 - Run the one-time nginx upstream edit and confirm `nginx -t` passes.


### PR DESCRIPTION
Item 1 of the #1382 scalability-audit handover — the last code item (4, 7, 11, 13, 15 shipped in #1398 / #1401 / #1409 / #1411; 2, 3, 5, 6, 8, 9 earlier). Done deliberately per the handover's warning, with the browser-verified done test executed against the shipped file.

## What changed

`deploy/nginx.conf` (the host/systemd vhost) gains static locations for exactly `EditorAssetFastPathMiddleware`'s allowlist — `/vendor/`, `/jupyterlite/build/`, `/jupyterlite/extensions/`, and each kernel's `kernel_packages/` (matched by pattern, so a newly vendored kernel is covered the day it ships). Everything else under `/jupyterlite/` — notably `files/users/`, the per-student working copies — keeps proxying, so the auth boundary is preserved by construction rather than by exclusion. Every location falls back to the app via `try_files … @chickadee_app`, so a missing or version-skewed root degrades to exactly today's behavior.

## The handover's four traps, each handled and verified

- **Cross-origin isolation**: every static location stamps COOP/COEP/CORP. Two nginx behaviors made this subtle: `add_header` inheritance resets in any block that declares its own, and a `^~` prefix suppresses server-level regex locations — so the hashed-immutable rule lives as a *nested* regex inside each prefix block, with all four headers restated per block.
- **Cache semantics**: content-hashed bundle filenames get `immutable`; everything else — kernel tarballs included — stays `no-cache` (in-place re-vendor, the #574 class) and answers 304 via nginx's own ETag/Last-Modified. Header parity with the app checked byte-for-byte on all four asset classes.
- **`gzip_static`**: not added — no `.gz`/`.br` variants exist; on-the-fly gzip stays (the handover's sanctioned alternative), now minus the app round-trip for static hits.
- **Auth boundary**: `/jupyterlite/files/users/…` probed unauthenticated through the vhost — still 401.

## The done test, executed

Against the **shipped vhost itself** (via `root /opt/chickadee/Public`, app on 8080): a real Chromium `editor-check.mjs` run reports **`crossOriginIsolated = true`**, both isolated workers spawn, the kernel executes, and `input()` round-trips — SMOKE PASS. Measured during that boot: **131 of 160 requests (67 MB) served from the static locations without transiting the app**, and the sampled asset appears once in nginx's access log with zero app-log hits. `nginx -t` validates the file (nginx 1.24.0).

## What this deliberately does not do

The production blue-green container deployment **cannot adopt the static path as-is**: the data volume's `Public` is a symlink to `/app/Public` *inside* each color's container (`docker-entrypoint.sh`) — a design chosen so redeploys never re-copy ~400 MB — and that target is unresolvable from the host. On such a host every asset request takes the `@chickadee_app` fallback (one `stat()` of overhead), i.e. exactly the current behavior. A new section in `docs/zero-downtime-deploy.md` records the constraint and prices what adoption would take (per-color named volumes populated at container create on the idle color, an nginx root-include flip at cutover beside the existing upstream flip, volume GC at retire). That is a deploy-topology decision for the maintainer, not a config edit — left deliberately unmade, and flagged in the issue wrap-up.

One `changelog.d/` fragment; no Swift changes, so the test suites are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhK5NkLkQ9ERRRsUitFqK7)_