### PR TITLE
UI ratchet: convert the editor surface to class-based styling, sweep its hooks to js-

### DIFF
--- a/Public/achievements-editor.js
+++ b/Public/achievements-editor.js
@@ -100,8 +100,8 @@
                     + '<td>' + summary(row) + '</td>'
                     + '<td class="time">'
                     + ChickadeeUI.accordion.CARET_HTML + ' '
-                    + '<button type="button" class="btn action-btn ach-edit" data-i="' + i + '">Edit</button> '
-                    + '<button type="button" class="btn action-btn action-danger ach-remove" data-i="' + i + '">Remove</button>'
+                    + '<button type="button" class="btn action-btn js-ach-edit" data-i="' + i + '">Edit</button> '
+                    + '<button type="button" class="btn action-btn action-danger js-ach-remove" data-i="' + i + '">Remove</button>'
                     + '</td>';
                 tbody.appendChild(tr);
             });
@@ -156,7 +156,7 @@
             container.appendChild(condTemplate.content.cloneNode(true));
             var rowEl = container.lastElementChild;
             var sig = rowEl.querySelector('.am-cond-signal');
-            var cmp = rowEl.querySelector('.am-cond-comparator');
+            var cmp = rowEl.querySelector('.js-am-cond-comparator');
             var val = rowEl.querySelector('.am-cond-value');
             var unit = rowEl.querySelector('.am-cond-unit');
             var ref = rowEl.querySelector('.am-cond-testref');
@@ -210,7 +210,7 @@
 
             function showScopeFields() {
                 var scope = scopeSel.value;
-                Array.prototype.slice.call(host.querySelectorAll('.am-scope-field')).forEach(function (f) {
+                Array.prototype.slice.call(host.querySelectorAll('.js-am-scope-field')).forEach(function (f) {
                     var scopes = (f.getAttribute('data-scope') || '').split(/\s+/);
                     f.style.display = scopes.indexOf(scope) >= 0 ? '' : 'none';
                 });
@@ -259,7 +259,7 @@
                             }
                             return {
                                 signal: signal,
-                                comparator: rowEl.querySelector('.am-cond-comparator').value,
+                                comparator: rowEl.querySelector('.js-am-cond-comparator').value,
                                 value: Number(rowEl.querySelector('.am-cond-value').value || 0)
                             };
                         });
@@ -292,9 +292,9 @@
         if (addBtn) addBtn.addEventListener('click', function () { expand(-1); });
 
         block.addEventListener('click', function (e) {
-            var edit = e.target.closest && e.target.closest('.ach-edit');
+            var edit = e.target.closest && e.target.closest('.js-ach-edit');
             if (edit) { expand(Number(edit.getAttribute('data-i'))); return; }
-            var rm = e.target.closest && e.target.closest('.ach-remove');
+            var rm = e.target.closest && e.target.closest('.js-ach-remove');
             if (rm) {
                 var ri = Number(rm.getAttribute('data-i'));
                 var snapshot = state.slice();

--- a/Public/global-inputs-editor.js
+++ b/Public/global-inputs-editor.js
@@ -15,17 +15,17 @@
 
     var core = ChickadeeInputsCore;
     var editor = core.createEditor({
-        row: 'global-input-row',
-        name: 'global-input-name',
-        value: 'global-input-value',
-        valid: 'global-input-row-valid',
-        remove: 'global-input-remove'
+        row: 'js-global-input-row',
+        name: 'js-global-input-name',
+        value: 'js-global-input-value',
+        valid: 'js-global-input-row-valid',
+        remove: 'js-global-input-remove'
     }, {});
 
     function init() {
         var block = document.getElementById('global-inputs-block');
         if (!block) return;
-        var tbody = block.querySelector('tbody.global-inputs-body');
+        var tbody = block.querySelector('tbody.js-global-inputs-body');
         var addBtn = document.getElementById('global-input-add');
         var status = document.getElementById('global-inputs-status');
         var assignmentID = block.getAttribute('data-assignment-id') || '';
@@ -78,16 +78,16 @@
         editor.refreshAllRows(tbody);
 
         block.addEventListener('input', function (e) {
-            var tr = e.target.closest && e.target.closest('tr.global-input-row');
+            var tr = e.target.closest && e.target.closest('tr.js-global-input-row');
             if (tr) {
                 editor.refreshAllRows(tbody);
                 saver.schedule();
             }
         });
         block.addEventListener('click', function (e) {
-            var btn = e.target.closest && e.target.closest('.global-input-remove');
+            var btn = e.target.closest && e.target.closest('.js-global-input-remove');
             if (btn && block.contains(btn)) {
-                var tr = btn.closest('tr.global-input-row');
+                var tr = btn.closest('tr.js-global-input-row');
                 if (tr) { tr.remove(); editor.refreshAllRows(tbody); saver.schedule(); }
             }
         });

--- a/Public/inputs-editor-core.js
+++ b/Public/inputs-editor-core.js
@@ -88,7 +88,9 @@
 
     /// Creates the panel-specific editor helpers.  `classes` names the CSS
     /// hooks: { row, name, value, valid, remove }; `rowOptions` tunes the
-    /// generated row markup: { inputFontSize, removeCell: 'class'|'inline' }.
+    /// generated row markup: { removeCell: 'class'|'inline' }.  Styling is
+    /// the shared editor-table cell vocabulary (styles.css), identical to
+    /// the server-rendered rows of the same tables.
     function createEditor(classes, rowOptions) {
         rowOptions = rowOptions || {};
 
@@ -108,7 +110,7 @@
                     nameOk = false;
                 }
             }
-            nameEl.style.borderColor = (!name || nameOk) ? '' : 'var(--red)';
+            nameEl.classList.toggle('input-invalid', !!(name && !nameOk));
             nameEl.title = (name && RESERVED_NAMES[name])
                 ? "'" + name + "' is reserved for Chickadee's personalization seed."
                 : '';
@@ -132,19 +134,15 @@
                     : 'Treated as a bare string. Wrap in quotes for a JSON string, or check syntax for list/dict.';
             }
 
-            // Reset all classification cues, then apply the current one so
-            // toggling between modes doesn't leave stale colours.
-            valueEl.style.borderColor = '';
-            valueEl.style.backgroundColor = '';
+            // Classification cues are classes (styles.css: .input-expression is
+            // the green per-student tint, .input-attention the amber
+            // needs-a-look border — both with dark-mode values via the
+            // palette); toggling both every pass means switching modes cannot
+            // leave a stale cue behind.
             valueEl.title = hint;
-            if (classified.kind === 'expression') {
-                // Subtle green tint keeps per-student rows visually distinct
-                // from literal rows on both light and dark themes.
-                valueEl.style.backgroundColor = 'rgba(45, 143, 71, .07)';
-                if (!valueOk) valueEl.style.borderColor = 'var(--amber)';
-            } else if (rawVal && !valueOk) {
-                valueEl.style.borderColor = 'var(--amber)';
-            }
+            valueEl.classList.toggle('input-expression', classified.kind === 'expression');
+            valueEl.classList.toggle('input-attention',
+                classified.kind === 'expression' ? !valueOk : !!(rawVal && !valueOk));
 
             if (check) check.textContent = (nameOk && valueOk) ? '✓' : '';
         }
@@ -159,23 +157,22 @@
             '<svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg>';
 
         function addEmptyRow(tbody) {
-            var fontSize = rowOptions.inputFontSize ? 'font-size:' + rowOptions.inputFontSize + ';' : '';
             var removeCellOpen = rowOptions.removeCell === 'inline'
-                ? '<td style="width:2.5rem;text-align:right">'
+                ? '<td class="cell-remove">'
                 : '<td class="time">'; // right-aligned utility cell
-            var removeBtnStyle = rowOptions.removeCell === 'inline'
-                ? ' style="padding:.2rem .4rem;display:inline-flex;align-items:center"'
+            var removeBtnClass = rowOptions.removeCell === 'inline'
+                ? ' icon-btn-xs'
                 : '';
             var tr = document.createElement('tr');
             tr.className = classes.row;
             tr.innerHTML =
-                '<td style="width:14rem;white-space:nowrap">'
-              +   '<span class="' + classes.valid + '" style="display:inline-block;width:1rem;color:var(--green);font-size:.95rem;text-align:center"></span>'
-              +   '<input type="text" class="form-input ' + classes.name + '" value="" placeholder="Input Name" style="width:calc(100% - 1.5rem);padding:.2rem .4rem;' + fontSize + 'font-family:monospace">'
+                '<td class="cell-name">'
+              +   '<span class="' + classes.valid + ' cell-check"></span>'
+              +   '<input type="text" class="form-input ' + classes.name + ' cell-input input-mono" value="" placeholder="Input Name">'
               + '</td>'
-              + '<td><input type="text" class="form-input ' + classes.value + '" value="" placeholder=\'12, "hello", [1, 2, 3], or = seed % 26\' style="width:100%;padding:.2rem .4rem;' + fontSize + 'font-family:monospace"></td>'
+              + '<td><input type="text" class="form-input ' + classes.value + ' cell-input cell-input--fill input-mono" value="" placeholder=\'12, "hello", [1, 2, 3], or = seed % 26\'></td>'
               + removeCellOpen
-              +   '<button type="button" class="btn action-btn action-danger ' + classes.remove + '" title="Remove input" aria-label="Remove input"' + removeBtnStyle + '>'
+              +   '<button type="button" class="btn action-btn action-danger' + removeBtnClass + ' ' + classes.remove + '" title="Remove input" aria-label="Remove input">'
               +   TRASH_SVG + '</button></td>';
             tbody.appendChild(tr);
             refreshRow(tr, tbody);

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -134,7 +134,7 @@
         var lastSelectedKind = 'boundary_equality';
 
         /// Reads section variables for the given family id out of the
-        /// server-rendered `.section-vars-body` tbody in the family row's
+        /// server-rendered `.js-section-vars-body` tbody in the family row's
         /// enclosing section block.  Returns `{ vars, sectionName }`.
         /// Picks up any unsaved edits to the Shared Inputs table too —
         /// auto-compute sees the live value the instructor just typed,
@@ -148,11 +148,11 @@
             if (!block) return { vars: [], sectionName: null, sectionID: null };
             var sectionID = block.getAttribute('data-section-id') || null;
             var sectionName = (block.querySelector('.section-header strong') || {}).textContent || null;
-            var varTbody = block.querySelector('tbody.section-vars-body');
+            var varTbody = block.querySelector('tbody.js-section-vars-body');
             if (!varTbody) return { vars: [], sectionName: sectionName, sectionID: sectionID };
-            var vars = Array.from(varTbody.querySelectorAll('tr.section-var-row')).map(function (tr) {
-                var name = (tr.querySelector('.section-var-name') || {}).value || '';
-                var raw  = (tr.querySelector('.section-var-value') || {}).value || '';
+            var vars = Array.from(varTbody.querySelectorAll('tr.js-section-var-row')).map(function (tr) {
+                var name = (tr.querySelector('.js-section-var-name') || {}).value || '';
+                var raw  = (tr.querySelector('.js-section-var-value') || {}).value || '';
                 name = name.trim();
                 if (!name) return null;
                 var parsed;
@@ -176,11 +176,11 @@
             var block = document.querySelector('.section-block[data-section-id="' + safe + '"]');
             if (!block) return { vars: [], sectionName: null, sectionID: null };
             var sectionName = (block.querySelector('.section-header strong') || {}).textContent || null;
-            var varTbody = block.querySelector('tbody.section-vars-body');
+            var varTbody = block.querySelector('tbody.js-section-vars-body');
             if (!varTbody) return { vars: [], sectionName: sectionName, sectionID: sectionID };
-            var vars = Array.from(varTbody.querySelectorAll('tr.section-var-row')).map(function (tr) {
-                var name = (tr.querySelector('.section-var-name') || {}).value || '';
-                var raw  = (tr.querySelector('.section-var-value') || {}).value || '';
+            var vars = Array.from(varTbody.querySelectorAll('tr.js-section-var-row')).map(function (tr) {
+                var name = (tr.querySelector('.js-section-var-name') || {}).value || '';
+                var raw  = (tr.querySelector('.js-section-var-value') || {}).value || '';
                 name = name.trim();
                 if (!name) return null;
                 var parsed;
@@ -479,7 +479,7 @@
         }
 
         function rebuildCasesHeader(paramNames) {
-            var th = ['<th style="width:2.25rem">#</th>', '<th>Label</th>'];
+            var th = ['<th class="case-num-col">#</th>', '<th>Label</th>'];
             if (!paramNames.length) {
                 th.push('<th>Args (JSON)</th>');
             } else {
@@ -494,24 +494,24 @@
                     var hd = currentParamHasDefault && currentParamHasDefault[i];
                     var labelBase = t ? (escHtml(p) + ': ' + escHtml(t)) : escHtml(p);
                     var labelFull = hd
-                        ? (labelBase + '<span style="color:var(--gray-500);font-weight:normal"> ?</span>')
+                        ? (labelBase + '<span class="th-note"> ?</span>')
                         : labelBase;
-                    th.push('<th><code style="font-size:.7rem">' + labelFull + '</code></th>');
+                    th.push('<th><code class="th-code">' + labelFull + '</code></th>');
                 });
             }
             var expectedHeader = currentReturnType
-                ? 'Expected <code style="font-size:.7rem;font-weight:normal">: ' + escHtml(currentReturnType) + '</code>'
+                ? 'Expected <code class="th-code">: ' + escHtml(currentReturnType) + '</code>'
                 : 'Expected';
             // A differential family authors no expected value — the reference
             // computes one per case. The column stays (the row layout is
             // positional) and says so instead.
             if (kindInput && kindInput.value === 'differential') {
-                expectedHeader = 'Expected <span style="color:var(--gray-500);font-weight:normal">'
+                expectedHeader = 'Expected <span class="th-note">'
                     + '(computed by the reference)</span>';
             }
             th.push('<th>' + expectedHeader + '</th>');
-            th.push('<th>Hint <span style="color:var(--gray-500);font-weight:normal">(optional)</span></th>');
-            th.push('<th style="width:4rem"></th>');
+            th.push('<th>Hint <span class="th-note">(optional)</span></th>');
+            th.push('<th class="fv-action-col"></th>');
             casesHeader.innerHTML = th.join('');
         }
 
@@ -528,12 +528,12 @@
             var argVarRefs   = Array.isArray(c.argVarRefs)   ? c.argVarRefs   : [];
             var tds = [];
             // Column 1: auto-numbered sequence (readonly, regenerated on reorder).
-            tds.push('<td class="pf-case-num" style="text-align:center;color:var(--gray-500);font-size:.75rem"></td>');
-            tds.push('<td><input type="text" class="form-input pf-case-label" value="' + escHtml(c.label) + '" placeholder="e.g. bmi < 18.5 is underweight" style="width:100%;padding:.2rem .4rem;font-size:.8rem"></td>');
+            tds.push('<td class="js-pf-case-num cell-num"></td>');
+            tds.push('<td><input type="text" class="form-input js-pf-case-label cell-input cell-input--fill" value="' + escHtml(c.label) + '" placeholder="e.g. bmi < 18.5 is underweight"></td>');
 
             if (!paramNames.length) {
                 // No param names yet — single free-form JSON args field.
-                tds.push('<td><input type="text" class="form-input pf-case-args" value="' + escHtml(JSON.stringify(c.args || [])) + '" placeholder="[18.49]" style="width:100%;padding:.2rem .4rem;font-size:.8rem;font-family:monospace"></td>');
+                tds.push('<td><input type="text" class="form-input js-pf-case-args cell-input cell-input--fill input-mono" value="' + escHtml(JSON.stringify(c.args || [])) + '" placeholder="[18.49]"></td>');
             } else {
                 paramNames.forEach(function (_, i) {
                     // Display precedence: variable reference (`$name`) > literal
@@ -559,7 +559,7 @@
                         ? '\u2014 ' + languageLabel() + ' default \u2014'
                         : '\u2014 default \u2014';
                     var placeholder = hasDefault ? defaultHint : 'e.g. 18.49 or underweight';
-                    tds.push('<td><input type="text" class="form-input pf-case-arg" data-arg-index="' + i + '" value="' + escHtml(val) + '" placeholder="' + escHtml(placeholder) + '" style="width:100%;padding:.2rem .4rem;font-size:.8rem;font-family:monospace"></td>');
+                    tds.push('<td><input type="text" class="form-input js-pf-case-arg cell-input cell-input--fill input-mono" data-arg-index="' + i + '" value="' + escHtml(val) + '" placeholder="' + escHtml(placeholder) + '"></td>');
                 });
             }
             // Expected cell. Display precedence: per-student ref (`$name`,
@@ -567,16 +567,16 @@
             var expectedDisplay = c.expectedVarRef
                 ? '$' + c.expectedVarRef
                 : (c.expected == null ? '' : renderTypedCellValue(c.expected));
-            tds.push('<td><input type="text" class="form-input pf-case-expected" value="' + escHtml(expectedDisplay) + '" placeholder="e.g. underweight or $expr" style="width:100%;padding:.2rem .4rem;font-size:.8rem;font-family:monospace"></td>');
-            tds.push('<td><input type="text" class="form-input pf-case-hint" value="' + escHtml(c.hint || '') + '" placeholder="shown to students on failure" style="width:100%;padding:.2rem .4rem;font-size:.8rem"></td>');
-            tds.push('<td><button type="button" class="btn action-btn action-danger pf-case-remove" style="padding:.2rem .4rem;font-size:.75rem">Remove</button></td>');
+            tds.push('<td><input type="text" class="form-input js-pf-case-expected cell-input cell-input--fill input-mono" value="' + escHtml(expectedDisplay) + '" placeholder="e.g. underweight or $expr"></td>');
+            tds.push('<td><input type="text" class="form-input js-pf-case-hint cell-input cell-input--fill" value="' + escHtml(c.hint || '') + '" placeholder="shown to students on failure"></td>');
+            tds.push('<td><button type="button" class="btn action-btn action-danger btn-xs js-pf-case-remove">Remove</button></td>');
 
             var tr = document.createElement('tr');
             tr.innerHTML = tds.join('');
             casesBody.appendChild(tr);
             // Author-set expected values — a literal OR a per-student `$ref` —
             // are marked manual so the auto-computer doesn't overwrite them.
-            var expCell = tr.querySelector('.pf-case-expected');
+            var expCell = tr.querySelector('.js-pf-case-expected');
             if (expCell && expCell.value.trim() !== '') {
                 expCell.dataset.manual = '1';
                 refreshExpectedCellHighlight(expCell, collectDeclaredInputNames());
@@ -586,7 +586,7 @@
         }
 
         function renumberCases() {
-            Array.from(casesBody.querySelectorAll('.pf-case-num')).forEach(function (td, i) {
+            Array.from(casesBody.querySelectorAll('.js-pf-case-num')).forEach(function (td, i) {
                 var n = i + 1;
                 td.textContent = (n < 10 ? '0' + n : String(n));
             });
@@ -704,19 +704,19 @@
                     return fv.name && fv.name.trim() === v.name;
                 });
                 var tr = document.createElement('tr');
-                tr.className = 'pf-var-section-row';
+                tr.className = 'js-pf-var-section-row';
                 tr.setAttribute('data-section-var', '1');
                 var preview = '';
                 try { preview = JSON.stringify(v.value); }
                 catch (_) { preview = String(v.value); }
-                var textDeco = familyShadow ? 'line-through' : 'none';
+                var shadowCls = familyShadow ? ' cell-shadowed' : '';
                 var shadowNote = familyShadow
-                    ? '<span class="card-meta" style="font-size:.7rem;color:var(--amber);margin-left:.4rem">shadowed by family variable below</span>'
+                    ? '<span class="cell-warn-note">shadowed by family variable below</span>'
                     : '';
                 tr.innerHTML =
                     '<td></td>'
-                  + '<td style="vertical-align:top;padding:.3rem .4rem"><code style="font-family:monospace;font-size:.8rem;text-decoration:' + textDeco + '">' + escHtml(v.name) + '</code>' + shadowNote + '</td>'
-                  + '<td style="vertical-align:top;padding:.3rem .4rem;font-family:monospace;font-size:.78rem;color:var(--gray-600);text-decoration:' + textDeco + '">' + escHtml(preview) + '</td>'
+                  + '<td class="cell-tight"><code class="cell-code' + shadowCls + '">' + escHtml(v.name) + '</code>' + shadowNote + '</td>'
+                  + '<td class="cell-tight cell-preview' + shadowCls + '">' + escHtml(preview) + '</td>'
                   + '<td></td>';
                 variablesBody.appendChild(tr);
             });
@@ -728,14 +728,14 @@
                     // and value pass their checks.  Replaces the v0.4.94
                     // "✓ referenced as $name" / "✓ parsed as dict" text
                     // lines beneath each input.
-                    '<td class="pf-var-row-valid" style="vertical-align:middle;text-align:center;color:var(--green);font-size:1rem"></td>'
-                  + '<td style="vertical-align:top">'
-                  +   '<input type="text" class="form-input pf-var-name" data-var-index="' + i + '" value="' + escHtml(v.name || '') + '" placeholder="e.g. patient_database" style="width:100%;padding:.2rem .4rem;font-size:.8rem;font-family:monospace">'
+                    '<td class="js-pf-var-row-valid cell-check-col"></td>'
+                  + '<td>'
+                  +   '<input type="text" class="form-input js-pf-var-name cell-input cell-input--fill input-mono" data-var-index="' + i + '" value="' + escHtml(v.name || '') + '" placeholder="e.g. patient_database">'
                   + '</td>'
-                  + '<td style="vertical-align:top">'
-                  +   '<input type="text" class="form-input pf-var-value" data-var-index="' + i + '" value="' + escHtml(v.value == null ? '' : JSON.stringify(v.value)) + '" placeholder="{&quot;p01&quot;: {...}} or [1, 2, 3]" style="width:100%;padding:.2rem .4rem;font-size:.8rem;font-family:monospace">'
+                  + '<td>'
+                  +   '<input type="text" class="form-input js-pf-var-value cell-input cell-input--fill input-mono" data-var-index="' + i + '" value="' + escHtml(v.value == null ? '' : JSON.stringify(v.value)) + '" placeholder="{&quot;p01&quot;: {...}} or [1, 2, 3]">'
                   + '</td>'
-                  + '<td style="vertical-align:top"><button type="button" class="btn action-btn action-danger pf-var-remove" data-var-index="' + i + '" style="padding:.2rem .4rem;font-size:.75rem">Remove</button></td>';
+                  + '<td><button type="button" class="btn action-btn action-danger btn-xs js-pf-var-remove" data-var-index="' + i + '">Remove</button></td>';
                 variablesBody.appendChild(tr);
                 refreshVarRowStatus(tr);
             });
@@ -755,24 +755,21 @@
         /// until something's typed — no placeholder noise.
         function refreshVarRowStatus(row) {
             if (!row) return;
-            var nameEl   = row.querySelector('.pf-var-name');
-            var valueEl  = row.querySelector('.pf-var-value');
-            var validEl  = row.querySelector('.pf-var-row-valid');
+            var nameEl   = row.querySelector('.js-pf-var-name');
+            var valueEl  = row.querySelector('.js-pf-var-value');
+            var validEl  = row.querySelector('.js-pf-var-row-valid');
             if (!nameEl || !valueEl || !validEl) return;
 
             var name   = nameEl.value.trim();
             var rawVal = valueEl.value;
 
-            // Name validity.
+            // Name validity.  An empty row stays silent — not an error.
             var nameOk = false;
             var nameError = null;
-            if (!name) {
-                // Empty row — silent, not an error.
-                nameEl.style.borderColor = '';
-            } else if (!isValidServerIdentifier(name)) {
+            if (name && !isValidServerIdentifier(name)) {
                 nameError = 'Use letters, digits and underscores, starting with a letter or underscore.';
-            } else {
-                var allNames = Array.from(variablesBody.querySelectorAll('.pf-var-name'))
+            } else if (name) {
+                var allNames = Array.from(variablesBody.querySelectorAll('.js-pf-var-name'))
                     .map(function (el) { return el.value.trim(); });
                 var dup = allNames.filter(function (n) { return n === name; }).length > 1;
                 if (dup) {
@@ -781,23 +778,18 @@
                     nameOk = true;
                 }
             }
-            nameEl.style.borderColor = nameError ? 'var(--red)' : '';
+            nameEl.classList.toggle('input-invalid', !!nameError);
             nameEl.title = nameError || '';
 
-            // Value validity.
+            // Value validity.  Empty stays silent until typed; the bare-string
+            // fallback (almost always a typo in dict/list JSON) gets the amber
+            // needs-a-look cue.
             var parsed = tryParseVarValue(rawVal);
-            var valueOk = false;
-            var valueError = null;
-            if (parsed.kind === 'empty') {
-                valueEl.style.borderColor = '';  // silent until typed
-            } else if (parsed.strict) {
-                valueOk = true;
-                valueEl.style.borderColor = '';
-            } else {
-                // Bare-string fallback — almost always a typo in dict/list JSON.
-                valueError = 'Treated as a bare string. Wrap in quotes for a JSON string, or check the syntax for list/dict.';
-                valueEl.style.borderColor = 'var(--amber)';
-            }
+            var valueOk = parsed.kind !== 'empty' && !!parsed.strict;
+            var valueError = (parsed.kind !== 'empty' && !parsed.strict)
+                ? 'Treated as a bare string. Wrap in quotes for a JSON string, or check the syntax for list/dict.'
+                : null;
+            valueEl.classList.toggle('input-attention', !!valueError);
             valueEl.title = valueError || (valueOk ? 'Parsed as ' + parsed.kind : '');
 
             // Row-level checkmark: only when BOTH are valid.
@@ -818,14 +810,14 @@
         /// red-flag a valid per-student ref.
         function collectDeclaredInputNames() {
             var names = new Set();
-            Array.from(variablesBody ? variablesBody.querySelectorAll('.pf-var-name') : []).forEach(function (el) {
+            Array.from(variablesBody ? variablesBody.querySelectorAll('.js-pf-var-name') : []).forEach(function (el) {
                 var n = (el.value || '').trim();
                 if (n && isValidServerIdentifier(n)) names.add(n);
             });
             (currentSectionVariables || []).forEach(function (v) {
                 if (v && v.name && isValidServerIdentifier(v.name)) names.add(v.name);
             });
-            Array.from(document.querySelectorAll('.global-input-name')).forEach(function (el) {
+            Array.from(document.querySelectorAll('.js-global-input-name')).forEach(function (el) {
                 var n = (el.value || '').trim();
                 if (n && isValidServerIdentifier(n)) names.add(n);
             });
@@ -834,10 +826,10 @@
 
         function refreshAllArgCellVarHighlighting() {
             var declaredVarNames = collectDeclaredInputNames();
-            Array.from(casesBody ? casesBody.querySelectorAll('.pf-case-arg') : []).forEach(function (cell) {
+            Array.from(casesBody ? casesBody.querySelectorAll('.js-pf-case-arg') : []).forEach(function (cell) {
                 refreshArgCellHighlight(cell, declaredVarNames);
             });
-            Array.from(casesBody ? casesBody.querySelectorAll('.pf-case-expected') : []).forEach(function (cell) {
+            Array.from(casesBody ? casesBody.querySelectorAll('.js-pf-case-expected') : []).forEach(function (cell) {
                 refreshExpectedCellHighlight(cell, declaredVarNames);
             });
         }
@@ -845,44 +837,34 @@
         function refreshArgCellHighlight(cell, declaredNames) {
             var raw = (cell.value || '').trim();
             var match = raw.match(VAR_REF_RE);
-            cell.style.fontStyle = '';
-            cell.style.color = '';
-            cell.style.borderColor = '';
+            cell.classList.remove('input-ref-ok', 'input-ref-missing');
             cell.title = '';
             if (!match) return;
             var name = match[1];
             if (declaredNames && declaredNames.has(name)) {
-                cell.style.fontStyle = 'italic';
-                cell.style.color = 'var(--green)';
+                cell.classList.add('input-ref-ok');
                 cell.title = 'Bound to input $' + name;
             } else {
-                cell.style.color = 'var(--red)';
-                cell.style.borderColor = 'var(--red)';
+                cell.classList.add('input-ref-missing');
                 cell.title = 'No input named $' + name + ' is declared (Variables table or Global Inputs).';
             }
         }
 
         /// Highlight for the Expected cell.  A `$name` ref gets the green/red
-        /// treatment (per-student expected); a non-ref literal is left alone so
-        /// it keeps any auto-compute / manual styling rather than being cleared
-        /// when an unrelated keystroke triggers a bulk refresh.
+        /// treatment (per-student expected); a non-ref literal only sheds the
+        /// ref cues, keeping any auto-compute / manual styling rather than
+        /// being cleared when an unrelated keystroke triggers a bulk refresh.
         function refreshExpectedCellHighlight(cell, declaredNames) {
             var raw = (cell.value || '').trim();
             var match = raw.match(VAR_REF_RE);
-            if (!match) {
-                cell.style.fontStyle = '';
-                cell.style.borderColor = '';
-                return;  // leave color/title to auto-compute / manual styling
-            }
+            cell.classList.remove('input-ref-ok', 'input-ref-missing');
+            if (!match) return;  // leave title to auto-compute / manual styling
             var name = match[1];
-            cell.style.fontStyle = 'italic';
             if (declaredNames && declaredNames.has(name)) {
-                cell.style.color = 'var(--green)';
-                cell.style.borderColor = '';
+                cell.classList.add('input-ref-ok');
                 cell.title = '$' + name + ' — per-student expected (resolved at grading time)';
             } else {
-                cell.style.color = 'var(--red)';
-                cell.style.borderColor = 'var(--red)';
+                cell.classList.add('input-ref-missing');
                 cell.title = 'No input named $' + name + ' is declared (Variables table or Global Inputs).';
             }
         }
@@ -898,8 +880,8 @@
             var rows = Array.from(variablesBody.querySelectorAll('tr'));
             var out = [];
             rows.forEach(function (row, i) {
-                var nameEl  = row.querySelector('.pf-var-name');
-                var valueEl = row.querySelector('.pf-var-value');
+                var nameEl  = row.querySelector('.js-pf-var-name');
+                var valueEl = row.querySelector('.js-pf-var-value');
                 var name    = (nameEl  ? nameEl.value  : '').trim();
                 var rawVal  = (valueEl ? valueEl.value : '').trim();
                 if (!name && !rawVal) return; // empty row — drop silently
@@ -942,14 +924,14 @@
                 var rows = variablesBody ? variablesBody.querySelectorAll('tr') : [];
                 var last = rows[rows.length - 1];
                 if (last) {
-                    var nameInputNew = last.querySelector('.pf-var-name');
+                    var nameInputNew = last.querySelector('.js-pf-var-name');
                     if (nameInputNew) nameInputNew.focus();
                 }
             });
         }
         if (variablesBody) {
             variablesBody.addEventListener('click', function (e) {
-                var btn = e.target && e.target.closest('.pf-var-remove');
+                var btn = e.target && e.target.closest('.js-pf-var-remove');
                 if (!btn) return;
                 // Sync first so the other rows' in-progress edits don't
                 // disappear when we drop this one.
@@ -1123,15 +1105,15 @@
             var out = [];
             for (var i = 0; i < rows.length; i++) {
                 var row = rows[i];
-                var label = row.querySelector('.pf-case-label').value.trim();
-                var rawExp = row.querySelector('.pf-case-expected').value;
+                var label = row.querySelector('.js-pf-case-label').value.trim();
+                var rawExp = row.querySelector('.js-pf-case-expected').value;
                 if (rawExp.trim() === '') rawExp = '';
                 var caseNum = (i + 1 < 10 ? '0' + (i + 1) : String(i + 1));
                 var args = [];
                 var argsProvided = [];
                 var argVarRefs   = [];
                 if (paramNames.length === 0) {
-                    var rawArgs = (row.querySelector('.pf-case-args') || {}).value || '';
+                    var rawArgs = (row.querySelector('.js-pf-case-args') || {}).value || '';
                     rawArgs = rawArgs.trim();
                     if (rawArgs !== '') {
                         try { args = JSON.parse(rawArgs); }
@@ -1142,7 +1124,7 @@
                     argVarRefs   = args.map(function () { return null; });
                 } else {
                     for (var a = 0; a < paramNames.length; a++) {
-                        var cell = row.querySelector('.pf-case-arg[data-arg-index="' + a + '"]');
+                        var cell = row.querySelector('.js-pf-case-arg[data-arg-index="' + a + '"]');
                         var raw = cell ? cell.value : '';
                         var trimmed = raw.trim();
                         var paramTypeHint = currentParamTypes ? currentParamTypes[a] : null;
@@ -1201,7 +1183,7 @@
                     }
                 }
                 if (!label) throw new Error('Case ' + caseNum + ': label is required');
-                var hintCell = row.querySelector('.pf-case-hint');
+                var hintCell = row.querySelector('.js-pf-case-hint');
                 var hint = hintCell ? hintCell.value.trim() : '';
                 var caseObj = {
                     key: caseNum,
@@ -1230,12 +1212,12 @@
         function readCasesFromTableRaw() {
             var rows = Array.from(casesBody.querySelectorAll('tr'));
             return rows.map(function (row) {
-                var label = row.querySelector('.pf-case-label').value;
-                var rawExp = row.querySelector('.pf-case-expected').value;
+                var label = row.querySelector('.js-pf-case-label').value;
+                var rawExp = row.querySelector('.js-pf-case-expected').value;
                 var args = [];
                 var argsProvided = [];
                 var argVarRefs   = [];
-                var cells = row.querySelectorAll('.pf-case-arg');
+                var cells = row.querySelectorAll('.js-pf-case-arg');
                 if (cells.length) {
                     Array.from(cells).forEach(function (c, idx) {
                         var raw = c.value;
@@ -1258,7 +1240,7 @@
                         argVarRefs.push(null);
                     });
                 } else {
-                    var single = row.querySelector('.pf-case-args');
+                    var single = row.querySelector('.js-pf-case-args');
                     if (single) {
                         try { args = JSON.parse(single.value); if (!Array.isArray(args)) args = []; } catch (_) { args = []; }
                         argsProvided = args.map(function () { return true; });
@@ -1276,7 +1258,7 @@
                 } else if (rawExpTrim !== '') {
                     expected = coerceByType(rawExp, currentReturnType);
                 }
-                var hintCell = row.querySelector('.pf-case-hint');
+                var hintCell = row.querySelector('.js-pf-case-hint');
                 var hint = hintCell ? hintCell.value.trim() : '';
                 var obj = {
                     label: label,
@@ -1539,7 +1521,7 @@
             addCaseRow(null, paramNames);
         });
         casesBody.addEventListener('click', function (e) {
-            var btn = e.target && e.target.closest('.pf-case-remove');
+            var btn = e.target && e.target.closest('.js-pf-case-remove');
             if (btn) {
                 var tr = btn.closest('tr');
                 if (tr) tr.remove();
@@ -2018,14 +2000,14 @@
         function rescheduleAutoComputeForVariableRefCases() {
             if (!casesBody) return;
             Array.from(casesBody.querySelectorAll('tr')).forEach(function (row) {
-                var hasVarRef = Array.from(row.querySelectorAll('.pf-case-arg'))
+                var hasVarRef = Array.from(row.querySelectorAll('.js-pf-case-arg'))
                     .some(function (cell) {
                         var v = (cell.value || '').trim();
                         return VAR_REF_RE.test(v);
                     });
                 if (!hasVarRef) return;
                 // Don't clobber the instructor's manual expected value.
-                var expectedEl = row.querySelector('.pf-case-expected');
+                var expectedEl = row.querySelector('.js-pf-case-expected');
                 if (expectedEl && expectedEl.dataset.manual === '1' && expectedEl.value.trim() !== '') return;
                 scheduleAutoCompute(row);
             });
@@ -2058,7 +2040,7 @@
             var paramNames = paramsInput.value.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
             if (!paramNames.length) return;  // fallback JSON-args mode: no auto-compute
 
-            var expectedEl = row.querySelector('.pf-case-expected');
+            var expectedEl = row.querySelector('.js-pf-case-expected');
             if (!expectedEl) return;
             if (expectedEl.dataset.manual === '1' && expectedEl.value.trim() !== '') return;
             // A per-student `$name` Expected is resolved server-side per
@@ -2078,8 +2060,8 @@
             });
             if (variablesBody) {
                 Array.from(variablesBody.querySelectorAll('tr')).forEach(function (vrow) {
-                    var n = (vrow.querySelector('.pf-var-name') || {}).value;
-                    var v = (vrow.querySelector('.pf-var-value') || {}).value;
+                    var n = (vrow.querySelector('.js-pf-var-name') || {}).value;
+                    var v = (vrow.querySelector('.js-pf-var-value') || {}).value;
                     if (!n) return;
                     n = n.trim();
                     if (!isValidServerIdentifier(n)) return;
@@ -2091,7 +2073,7 @@
 
             var args = [];
             for (var i = 0; i < paramNames.length; i++) {
-                var cell = row.querySelector('.pf-case-arg[data-arg-index="' + i + '"]');
+                var cell = row.querySelector('.js-pf-case-arg[data-arg-index="' + i + '"]');
                 var raw = cell ? cell.value : '';
                 if (raw.trim() === '') {
                     // Optional param with a default: skip it so the
@@ -2115,6 +2097,11 @@
             callSolution(fnName, args, { captureStdout: captureStdout }).then(function (res) {
                 if (!row.parentElement) return;
                 if (expectedEl.dataset.manual === '1' && expectedEl.value.trim() !== '') return;
+                // Every outcome repaints the cell's cue from a clean slate —
+                // stale cues from a previous compute must not linger.
+                expectedEl.classList.remove(
+                    'input-auto', 'input-attention', 'input-invalid',
+                    'input-ref-ok', 'input-ref-missing');
                 if (res.ok && res.returnedNone) {
                     // The solution function returned None.  Don't write
                     // the string "null" to the cell — that used to
@@ -2126,16 +2113,14 @@
                     expectedEl.value = '';
                     expectedEl.placeholder = '⚠ solution returned None';
                     expectedEl.title = 'The solution function returned None. Did you mean to print() and use the Stdout equality kind?';
-                    expectedEl.style.borderColor = 'var(--amber)';
-                    expectedEl.style.color = '';
+                    expectedEl.classList.add('input-attention');
                     delete expectedEl.dataset.autoComputed;
                 } else if (res.ok) {
                     expectedEl.placeholder = 'e.g. underweight';
                     expectedEl.value = renderTypedCellValue(res.value);
                     expectedEl.dataset.autoComputed = '1';
                     expectedEl.title = 'Auto-computed from solution notebook';
-                    expectedEl.style.color = 'var(--gray-500)';
-                    expectedEl.style.borderColor = '';
+                    expectedEl.classList.add('input-auto');
                 } else if (res.timedOut) {
                     expectedEl.value = '';
                     expectedEl.placeholder = '⚠ ' + res.error;
@@ -2148,7 +2133,7 @@
                     expectedEl.title = res.error.indexOf('notebook load') >= 0
                         ? 'A top-level cell in the solution notebook ran longer than ' + (LOAD_TIMEOUT_MS / 1000) + ' seconds. Look for an infinite loop, a slow I/O call, or a blocking input() OUTSIDE the function under test (e.g. in a setup cell that runs at notebook open).'
                         : 'Solution call did not return within ' + (TIMEOUT_MS / 1000) + ' seconds. Check for an infinite loop or blocking I/O in the solution notebook.';
-                    expectedEl.style.borderColor = 'var(--red)';
+                    expectedEl.classList.add('input-invalid');
                 } else if (res.unsupported) {
                     // The solution returned a value of a type that
                     // doesn't round-trip through JSON in a way the
@@ -2167,8 +2152,7 @@
                     expectedEl.value = '';
                     expectedEl.placeholder = '⚠ solution returned ' + reasonText;
                     expectedEl.title = "Auto-compute can't represent " + reasonText + ". Type the Expected value manually, or change the solution to return a JSON-friendly type (str, int, float, bool, list, dict).";
-                    expectedEl.style.borderColor = 'var(--amber)';
-                    expectedEl.style.color = '';
+                    expectedEl.classList.add('input-attention');
                     delete expectedEl.dataset.autoComputed;
                 } else {
                     // v0.4.112: surface the failure in the cell itself
@@ -2178,7 +2162,7 @@
                     // function / etc.
                     expectedEl.placeholder = '⚠ ' + (res.error || 'auto-compute failed');
                     expectedEl.title = 'Solution raised: ' + res.error;
-                    expectedEl.style.borderColor = 'var(--red)';
+                    expectedEl.classList.add('input-invalid');
                 }
             });
         }
@@ -2186,28 +2170,29 @@
         casesBody.addEventListener('input', function (e) {
             var t = e.target;
             if (!t || !t.classList) return;
-            if (t.classList.contains('pf-case-arg')) {
+            if (t.classList.contains('js-pf-case-arg')) {
                 // Live-highlight the `$name` binding state so the instructor
                 // can see whether their ref resolves (family + section vars +
                 // Global Inputs / `=` expressions).
                 refreshArgCellHighlight(t, collectDeclaredInputNames());
                 scheduleAutoCompute(t.closest('tr'));
-            } else if (t.classList.contains('pf-case-expected')) {
+            } else if (t.classList.contains('js-pf-case-expected')) {
                 // Live-highlight a per-student `$name` Expected ref; mark the
                 // cell manual so auto-compute won't clobber an author value.
                 // Clearing the cell re-enables auto-compute.
                 refreshExpectedCellHighlight(t, collectDeclaredInputNames());
                 if (VAR_REF_RE.test(t.value.trim())) {
+                    t.classList.remove('input-auto');
                     t.dataset.manual = '1';
                     delete t.dataset.autoComputed;
                 } else if (t.value.trim() === '') {
-                    t.style.color = '';
+                    t.classList.remove('input-auto');
                     t.title = '';
                     delete t.dataset.manual;
                     delete t.dataset.autoComputed;
                     scheduleAutoCompute(t.closest('tr'));
                 } else {
-                    t.style.color = '';
+                    t.classList.remove('input-auto');
                     t.title = '';
                     t.dataset.manual = '1';
                     delete t.dataset.autoComputed;
@@ -2225,8 +2210,8 @@
                      || document.getElementById('suite-config-body');
         if (suiteBody) {
             suiteBody.addEventListener('click', function (e) {
-                var editBtn = e.target && e.target.closest('.family-edit-btn');
-                var delBtn  = e.target && e.target.closest('.family-delete-btn');
+                var editBtn = e.target && e.target.closest('.js-family-edit-btn');
+                var delBtn  = e.target && e.target.closest('.js-family-delete-btn');
                 if (editBtn) {
                     var fid = editBtn.getAttribute('data-family-id');
                     var idx = familiesState.findIndex(function (f) { return f.id === fid; });

--- a/Public/section-inputs-editor.js
+++ b/Public/section-inputs-editor.js
@@ -16,18 +16,18 @@
 
     var core = ChickadeeInputsCore;
     var editor = core.createEditor({
-        row: 'section-var-row',
-        name: 'section-var-name',
-        value: 'section-var-value',
-        valid: 'section-var-row-valid',
-        remove: 'section-var-remove'
-    }, { inputFontSize: '.78rem', removeCell: 'inline' });
+        row: 'js-section-var-row',
+        name: 'js-section-var-name',
+        value: 'js-section-var-value',
+        valid: 'js-section-var-row-valid',
+        remove: 'js-section-var-remove'
+    }, { removeCell: 'inline' });
 
     /// Per-form auto-save with debounce + in-flight coalescing.  Returns
     /// a public { flush } object that the main-form submit handler can
     /// await before letting the assignment save through.
     function wireAutoSave(form) {
-        var tbody = form.querySelector('tbody.section-vars-body');
+        var tbody = form.querySelector('tbody.js-section-vars-body');
         if (!tbody) return { flush: function () { return Promise.resolve(); } };
 
         function doPost() {
@@ -58,16 +58,16 @@
         editor.refreshAllRows(tbody);
 
         form.addEventListener('input', function (e) {
-            var tr = e.target.closest && e.target.closest('tr.section-var-row');
+            var tr = e.target.closest && e.target.closest('tr.js-section-var-row');
             if (tr) {
                 editor.refreshAllRows(tbody);
                 saver.schedule();
             }
         });
         form.addEventListener('click', function (e) {
-            var btn = e.target.closest && e.target.closest('.section-var-remove');
+            var btn = e.target.closest && e.target.closest('.js-section-var-remove');
             if (btn && form.contains(btn)) {
-                var tr = btn.closest('tr.section-var-row');
+                var tr = btn.closest('tr.js-section-var-row');
                 if (tr) { tr.remove(); editor.refreshAllRows(tbody); saver.schedule(); }
             }
         });
@@ -87,12 +87,12 @@
         // "+ Add Input" buttons (one per section).  Buttons live in the
         // section header, not inside the form, so look up the form by
         // data-section-id.
-        document.querySelectorAll('button.section-var-add').forEach(function (btn) {
+        document.querySelectorAll('button.js-section-var-add').forEach(function (btn) {
             btn.addEventListener('click', function () {
                 var sid = btn.getAttribute('data-section-id') || '';
                 var form = document.querySelector('form.section-vars-form[data-section-id="' + sid + '"]');
                 if (!form) return;
-                var tbody = form.querySelector('tbody.section-vars-body');
+                var tbody = form.querySelector('tbody.js-section-vars-body');
                 if (tbody) editor.addEmptyRow(tbody);
             });
         });

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1921,11 +1921,64 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .section-spacer { flex: 1; }
 .section-vars-form { margin: .25rem 0 .5rem; }
 .section-vars-table { font-size: var(--text-sm); width: 100%; }
-.section-var-namecell { width: 14rem; white-space: nowrap; }
-.section-var-valid { display: inline-block; width: 1rem; color: var(--green); font-size: var(--text-md); text-align: center; }
-.section-var-name-input { width: calc(100% - 1.5rem); padding: .2rem .4rem; font-size: var(--text-sm); font-family: monospace; }
-.section-var-value-input { width: 100%; padding: .2rem .4rem; font-size: var(--text-sm); font-family: monospace; }
-.section-var-removecell { width: 2.5rem; text-align: right; }
+
+/* ── Editor-table cells ─────────────────────────────────
+   One vocabulary for the dense tables the assignment editors build in JS
+   (suite-table.js, pattern-family-editor.js, inputs-editor-core.js) and
+   their server-rendered twins in the suite-section and global-inputs
+   markup.  The builders assign these classes instead of writing style
+   strings (docs/ui-design.md, "JS does not make styling decisions"), and
+   sharing them with the server-rendered rows keeps the two from drifting
+   apart — the JS-added section rows ran a different font size than the
+   server-rendered rows of the same table until this block unified them. */
+/* Form control sized for a dense table cell; width comes from the column
+   role, not baked into the control. */
+.cell-input { padding: .2rem .4rem; font-size: var(--text-sm); }
+.cell-input--fill { width: 100%; }
+.cell-input--name { width: 12rem; }   /* suite display-name column */
+.cell-input--points { width: 4rem; }  /* numeric points column */
+/* Leading cell carrying the row-valid check plus the name input, which
+   shares the cell's width with the 1rem check. */
+.cell-name { width: 14rem; white-space: nowrap; }
+.cell-name .cell-input { width: calc(100% - 1.5rem); }
+.cell-check { display: inline-block; width: 1rem; color: var(--green); font-size: var(--text-md); text-align: center; }
+/* The td form of the row-valid check (its own leading column). */
+.cell-check-col { vertical-align: middle; text-align: center; color: var(--green); font-size: var(--text-md); }
+/* Right-aligned remove-button cell. */
+.cell-remove { width: 2.5rem; text-align: right; }
+/* Auto-numbered sequence cell (case tables). */
+.cell-num { text-align: center; color: var(--gray-500); font-size: var(--text-xs); }
+/* Read-only (locked) value cells: tightened padding, code-shaped name,
+   muted preview.  A locked row shadowed by a same-named family variable
+   is struck through and carries an inline amber note. */
+.cell-tight { padding: .3rem .4rem; }
+.cell-code { font-size: var(--text-sm); }
+.cell-preview { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--gray-600); }
+.cell-shadowed { text-decoration: line-through; }
+.cell-warn-note { font-size: var(--text-2xs); color: var(--amber); margin-left: .4rem; }
+/* Stacked title + meta inside a suite-row name cell. */
+.cell-stack { display: flex; flex-direction: column; gap: .15rem; }
+.cell-title { font-size: var(--text-base); }
+/* Case-table header annotations (the pattern-family editor rebuilds its
+   header row in JS): a code-shaped type note and a de-emphasized hint. */
+.th-code { font-size: var(--text-2xs); font-weight: normal; }
+.th-note { color: var(--gray-500); font-weight: normal; }
+
+/* ── Editor value-state cues ────────────────────────────
+   Toggled by the editors on form controls.  Classes rather than JS-written
+   colours so every cue has a dark-mode value via the palette.  Sheet order
+   is deliberate: when a transition briefly stacks two cues, the red
+   invalid/broken-ref border outranks the amber attention border, which
+   outranks the informational tints. */
+.input-auto { color: var(--gray-500); }        /* value auto-computed from the solution */
+.input-expression { background: color-mix(in srgb, var(--green) 7%, var(--surface)); } /* per-student `=` row */
+.input-ref-ok { font-style: italic; color: var(--green); }  /* `$name` resolves */
+.input-attention { border-color: var(--amber); }            /* needs a look */
+.input-invalid { border-color: var(--red); }                /* rejected name/value */
+.input-ref-missing { font-style: italic; color: var(--red); border-color: var(--red); } /* `$name` undeclared */
+/* Monospace form control (names, JSON/code-shaped values). */
+.input-mono { font-family: var(--font-mono); }
+
 .icon-btn-xs { padding: .2rem .4rem; display: inline-flex; align-items: center; }
 
 /* Small inline icon-button (edit/cancel pencils in section + assignment headers). */
@@ -1951,10 +2004,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .assign-header-edit { padding: .75rem 1rem; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--gray-50); }
 .assign-header-edit-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: .6rem; }
 .field-gap { margin-bottom: .5rem; }
-
-/* Global-inputs editor rows (edit page). */
-.global-input-name-input { width: calc(100% - 1.5rem); padding: .2rem .4rem; font-family: monospace; }
-.global-input-value-input { width: 100%; padding: .2rem .4rem; font-family: monospace; }
 
 /* Suite editor container + editor-block header headings. */
 .suite-editor-section { margin-top: 1.25rem; }
@@ -1990,8 +2039,10 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .gen-template-row { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .4rem; }
 .gen-template-label { font-size: var(--text-sm); display: flex; align-items: center; gap: .3rem; }
 .gen-tests-prompt { margin-bottom: .4rem; }
-/* Right-aligned action buttons inside a table cell (notebook files table). */
-.cell-actions { display: flex; gap: .4rem; justify-content: flex-end; flex-wrap: wrap; }
+/* Right-aligned action buttons inside a table cell (notebook files table,
+   suite rows).  Centered cross-axis so an accordion caret sits level with
+   the buttons beside it. */
+.cell-actions { display: flex; gap: .4rem; justify-content: flex-end; flex-wrap: wrap; align-items: center; }
 /* Inline upload-status text (colour also set by JS on error). */
 .upload-status-inline { font-size: var(--text-sm); color: var(--gray-500); margin-left: .5rem; }
 /* A function checkbox item in the generate-tests checklist (built in JS). */
@@ -2123,6 +2174,42 @@ tr.drop-adopt  { outline: 2px solid var(--blue); outline-offset: -2px; }
     display: flex;
     flex-direction: column;
     box-shadow: var(--shadow-pop);
+}
+/* The card's internals (test-editor-modal.js builds them in JS): pinned
+   header/footer bars around a scrolling body. */
+.modal-head,
+.modal-foot {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    padding: .75rem 1rem;
+    flex-shrink: 0;
+}
+.modal-head { border-bottom: 1px solid var(--border); }
+.modal-foot { border-top: 1px solid var(--border); }
+.modal-title { font-weight: 600; flex: 1; }
+.modal-close { font-size: var(--text-lg); color: var(--gray-500); padding: .1rem .3rem; }
+.modal-body {
+    padding: .75rem 1rem;
+    overflow: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: .6rem;
+}
+/* Vertical stack of editor fields/cards (the modal's mechanism panels and
+   the test-renderer-built forms). */
+.editor-stack { display: flex; flex-direction: column; gap: .6rem; }
+/* Field-stack width modifiers for editor rows. */
+.field-stack--grow { flex: 1; min-width: 16rem; }
+.field-stack--narrow { width: 11rem; }
+/* CodeMirror host box in the Test Editor. */
+.editor-cm-mount {
+    min-height: 240px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: auto;
+    font-size: var(--text-base);
 }
 
 /* The lead heading of a tabbed page's content, where the page's own <h1> is

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -9,7 +9,7 @@
 //     updates item.sectionID; clears dependsOn to avoid orphan parents;
 //     debounced `PUT /suite` persists)
 //   - handles tier / points / display-name inline edits on rows
-//   - handles section rename toggle (.section-edit-toggle / -cancel),
+//   - handles section rename toggle (.js-section-edit-toggle / -cancel),
 //     section delete (JS confirm + dynamic form POST), and section
 //     drag-reorder (AJAX `POST /suite-sections/reorder`)
 //
@@ -354,16 +354,16 @@
                 + '<td' + indent + '><div class="suite-name-cell">'
                 +   '<span class="suite-drag-handle" draggable="true" title="Drag to reorder or adopt">⋮⋮</span>'
                 +   connector
-                +   '<input type="text" class="form-input suite-display-name" value="' + nameVal + '" style="width:12rem;padding:.25rem .5rem;font-size:.8rem">'
+                +   '<input type="text" class="form-input js-suite-display-name cell-input cell-input--name" value="' + nameVal + '">'
                 +   depBadgeHTML(item.dependsOn)
                 + '</div></td>'
-                + '<td><select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">'
+                + '<td><select class="form-input js-suite-tier cell-input">'
                 +   tierOptions(item.tier)
                 + '</select></td>'
-                + '<td><input type="number" class="form-input suite-points" min="0" max="100" value="' + pts + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
-                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
-                +   '<button class="btn action-btn suite-edit-btn" type="button" data-filename="' + escAttr(item.script) + '" title="Edit script" aria-label="Edit script" style="padding:.3rem .45rem"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
-                +   '<button class="btn action-btn action-danger suite-delete-btn" type="button" title="Delete script" aria-label="Delete script" style="padding:.3rem .45rem"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
+                + '<td><input type="number" class="form-input js-suite-points cell-input cell-input--points" min="0" max="100" value="' + pts + '"></td>'
+                + '<td class="time"><div class="cell-actions">'
+                +   '<button class="btn action-btn action-btn-icon js-suite-edit-btn" type="button" data-filename="' + escAttr(item.script) + '" title="Edit script" aria-label="Edit script"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon action-danger js-suite-delete-btn" type="button" title="Delete script" aria-label="Delete script"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
                 + '</div></td>'
                 + '</tr>';
         }
@@ -381,21 +381,21 @@
                 + '<td' + indent + '><div class="suite-name-cell">'
                 +   '<span class="suite-drag-handle" draggable="true" title="Drag to reorder or adopt">⋮⋮</span>'
                 +   connector
-                +   '<div style="display:flex;flex-direction:column;gap:.15rem">'
-                +     '<strong style="font-size:.85rem">' + escHtml(family.name || family.id || '') + '</strong>'
-                +     '<span class="card-meta" style="font-size:.72rem">' + caseText + '</span>'
+                +   '<div class="cell-stack">'
+                +     '<strong class="cell-title">' + escHtml(family.name || family.id || '') + '</strong>'
+                +     '<span class="card-meta hint-xs">' + caseText + '</span>'
                 +   '</div>'
                 + '</div></td>'
-                + '<td><select class="form-input suite-family-tier" style="padding:.25rem .5rem;font-size:.8rem">'
+                + '<td><select class="form-input js-suite-family-tier cell-input">'
                 +   ['public','secret','release'].map(function (t) {
                         return '<option value="' + t + '"' + (t === tier ? ' selected' : '') + '>' + t + '</option>';
                     }).join('')
                 + '</select></td>'
-                + '<td><input type="number" class="form-input suite-family-points" min="0" max="100" value="' + defaultPoints + '" title="Points per case — applied to every generated test" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
-                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap;align-items:center">'
+                + '<td><input type="number" class="form-input js-suite-family-points cell-input cell-input--points" min="0" max="100" value="' + defaultPoints + '" title="Points per case — applied to every generated test"></td>'
+                + '<td class="time"><div class="cell-actions">'
                 +   ChickadeeUI.accordion.CARET_HTML
-                +   '<button class="btn action-btn family-edit-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Edit family" aria-label="Edit family" style="padding:.3rem .45rem"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
-                +   '<button class="btn action-btn action-danger family-delete-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Delete family" aria-label="Delete family" style="padding:.3rem .45rem"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon js-family-edit-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Edit family" aria-label="Edit family"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon action-danger js-family-delete-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Delete family" aria-label="Delete family"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
                 + '</div></td>'
                 + '</tr>';
         }
@@ -412,21 +412,21 @@
                 + '<td' + indent + '><div class="suite-name-cell">'
                 +   '<span class="suite-drag-handle" draggable="true" title="Drag to reorder">⋮⋮</span>'
                 +   connector
-                +   '<div style="display:flex;flex-direction:column;gap:.15rem">'
-                +     '<strong style="font-size:.85rem">' + escHtml(label) + '</strong>'
-                +     '<span class="card-meta" style="font-size:.72rem">' + escHtml(kind || 'notebook check') + '</span>'
+                +   '<div class="cell-stack">'
+                +     '<strong class="cell-title">' + escHtml(label) + '</strong>'
+                +     '<span class="card-meta hint-xs">' + escHtml(kind || 'notebook check') + '</span>'
                 +   '</div>'
                 + '</div></td>'
-                + '<td><select class="form-input suite-check-tier" style="padding:.25rem .5rem;font-size:.8rem">'
+                + '<td><select class="form-input js-suite-check-tier cell-input">'
                 +   ['public','secret','release'].map(function (t) {
                         return '<option value="' + t + '"' + (t === tier ? ' selected' : '') + '>' + t + '</option>';
                     }).join('')
                 + '</select></td>'
-                + '<td><input type="number" class="form-input suite-check-points" min="0" max="100" value="' + points + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
-                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap;align-items:center">'
+                + '<td><input type="number" class="form-input js-suite-check-points cell-input cell-input--points" min="0" max="100" value="' + points + '"></td>'
+                + '<td class="time"><div class="cell-actions">'
                 +   ChickadeeUI.accordion.CARET_HTML
-                +   '<button class="btn action-btn check-edit-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Edit notebook check" aria-label="Edit notebook check" style="padding:.3rem .45rem"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
-                +   '<button class="btn action-btn action-danger check-delete-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Delete notebook check" aria-label="Delete notebook check" style="padding:.3rem .45rem"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon js-check-edit-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Edit notebook check" aria-label="Edit notebook check"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon action-danger js-check-delete-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Delete notebook check" aria-label="Delete notebook check"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
                 + '</div></td>'
                 + '</tr>';
         }
@@ -447,8 +447,14 @@
             if (!el || !container.contains(el)) return null;
             var row = el.closest && el.closest('tr[data-id]');
             if (!row) return null;
-            var cls = (el.className || '').split(/\s+/).filter(function (c) {
-                return c && c.indexOf('form-') !== 0;
+            // The js- behaviour hook is the element's identity within its row;
+            // styling classes (form-*, cell-*) are shared across cells and
+            // would restore focus to the wrong control.
+            var classes = (el.className || '').split(/\s+/);
+            var cls = classes.filter(function (c) {
+                return c.indexOf('js-') === 0;
+            })[0] || classes.filter(function (c) {
+                return c && c.indexOf('form-') !== 0 && c.indexOf('cell-') !== 0;
             })[0];
             if (!cls) return null;
             var start = null, end = null;
@@ -782,7 +788,7 @@
         function captureLiveEdit() {
             var el = document.activeElement;
             if (!el || !container.contains(el) || !el.classList) return null;
-            if (el.classList.contains('suite-display-name')) {
+            if (el.classList.contains('js-suite-display-name')) {
                 var row = el.closest('tr[data-kind="script"]');
                 if (!row) return null;
                 return {
@@ -1131,8 +1137,8 @@
             if (scriptRow) {
                 var item = findByID(scriptRow.getAttribute('data-id'));
                 if (!item) return;
-                var tierEl = scriptRow.querySelector('.suite-tier');
-                var ptsEl  = scriptRow.querySelector('.suite-points');
+                var tierEl = scriptRow.querySelector('.js-suite-tier');
+                var ptsEl  = scriptRow.querySelector('.js-suite-points');
                 if (tierEl) item.tier = tierEl.value;
                 if (ptsEl)  item.points = Math.max(0, parseInt(ptsEl.value) || 0);
                 schedulePush();
@@ -1142,8 +1148,8 @@
             if (familyRow) {
                 var fitem = findByID(familyRow.getAttribute('data-id'));
                 if (!fitem || !fitem.family) return;
-                var tierElF = familyRow.querySelector('.suite-family-tier');
-                var ptsElF  = familyRow.querySelector('.suite-family-points');
+                var tierElF = familyRow.querySelector('.js-suite-family-tier');
+                var ptsElF  = familyRow.querySelector('.js-suite-family-points');
                 var nextDefaults = Object.assign({}, fitem.family.defaults || {});
                 if (tierElF) nextDefaults.tier = tierElF.value;
                 if (ptsElF)  nextDefaults.points = Math.max(0, parseInt(ptsElF.value) || 0);
@@ -1155,8 +1161,8 @@
             if (checkRow) {
                 var citem = findByID(checkRow.getAttribute('data-id'));
                 if (!citem || !citem.check) return;
-                var tierElC = checkRow.querySelector('.suite-check-tier');
-                var ptsElC  = checkRow.querySelector('.suite-check-points');
+                var tierElC = checkRow.querySelector('.js-suite-check-tier');
+                var ptsElC  = checkRow.querySelector('.js-suite-check-points');
                 var nextCheck = Object.assign({}, citem.check);
                 if (tierElC) nextCheck.tier = tierElC.value;
                 if (ptsElC)  nextCheck.points = Math.max(0, parseInt(ptsElC.value) || 0);
@@ -1167,7 +1173,7 @@
 
         container.addEventListener('input', function (e) {
             var target = e.target;
-            if (!target || !target.classList || !target.classList.contains('suite-display-name')) return;
+            if (!target || !target.classList || !target.classList.contains('js-suite-display-name')) return;
             var row = target.closest('tr[data-kind="script"]');
             if (!row) return;
             var item = findByID(row.getAttribute('data-id'));
@@ -1178,7 +1184,7 @@
 
         container.addEventListener('change', function (e) {
             var target = e.target;
-            if (!target || !target.classList || !target.classList.contains('suite-display-name')) return;
+            if (!target || !target.classList || !target.classList.contains('js-suite-display-name')) return;
             schedulePush();
         });
 
@@ -1187,7 +1193,7 @@
         // pre-populated; Delete drops the check and re-saves the list via the
         // single PUT /suite write path.
         container.addEventListener('click', function (e) {
-            var editBtn = e.target.closest && e.target.closest('.check-edit-btn');
+            var editBtn = e.target.closest && e.target.closest('.js-check-edit-btn');
             if (editBtn) {
                 let row = editBtn.closest('tr[data-kind="check"]');
                 if (!row) return;
@@ -1202,7 +1208,7 @@
                 });
                 return;
             }
-            var delBtn = e.target.closest && e.target.closest('.check-delete-btn');
+            var delBtn = e.target.closest && e.target.closest('.js-check-delete-btn');
             if (delBtn) {
                 var row2 = delBtn.closest('tr[data-kind="check"]');
                 if (!row2) return;
@@ -1221,7 +1227,7 @@
                 return;
             }
 
-            var btn = e.target.closest && e.target.closest('.suite-delete-btn');
+            var btn = e.target.closest && e.target.closest('.js-suite-delete-btn');
             if (!btn) return;
             var row = btn.closest('tr[data-kind="script"]');
             if (!row) return;
@@ -1249,7 +1255,7 @@
         // ── Section-header inline edit (rename toggle + delete) ──
 
         container.addEventListener('click', function (e) {
-            var toggle = e.target.closest && e.target.closest('.section-edit-toggle');
+            var toggle = e.target.closest && e.target.closest('.js-section-edit-toggle');
             if (toggle) {
                 var header = toggle.closest('.section-header');
                 if (!header) return;
@@ -1263,7 +1269,7 @@
                 }
                 return;
             }
-            var cancel = e.target.closest && e.target.closest('.section-edit-cancel');
+            var cancel = e.target.closest && e.target.closest('.js-section-edit-cancel');
             if (cancel) {
                 var header2 = cancel.closest('.section-header');
                 if (!header2) return;
@@ -1273,7 +1279,7 @@
                 if (edit2) edit2.style.display = 'none';
                 return;
             }
-            var del = e.target.closest && e.target.closest('.section-delete-btn');
+            var del = e.target.closest && e.target.closest('.js-section-delete-btn');
             if (del) {
                 var action = del.getAttribute('data-action');
                 var name = del.getAttribute('data-name') || 'this section';

--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -178,22 +178,22 @@
         }).join('');
 
         card.innerHTML =
-            '<div style="display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;border-bottom:1px solid var(--border);flex-shrink:0">' +
-            '  <div id="test-editor-title" style="font-weight:600;flex:1">Add Test</div>' +
-            '  <button type="button" id="test-editor-close" class="btn-link" aria-label="Close" title="Close" style="font-size:1.1rem;color:var(--gray-500);padding:.1rem .3rem">✕</button>' +
+            '<div class="modal-head">' +
+            '  <div id="test-editor-title" class="modal-title">Add Test</div>' +
+            '  <button type="button" id="test-editor-close" class="btn-link modal-close" aria-label="Close" title="Close">✕</button>' +
             '</div>' +
-            '<div style="padding:.75rem 1rem;overflow:auto;flex:1;display:flex;flex-direction:column;gap:.6rem">' +
-            '  <label id="test-editor-type-row" style="font-size:.85rem;display:flex;flex-direction:column;gap:.2rem">' +
+            '<div class="modal-body">' +
+            '  <label id="test-editor-type-row" class="field-stack">' +
             '    What do you want to test?' +
-            '    <select class="form-input" id="test-editor-type" style="padding:.3rem .5rem;font-size:.85rem">' + optionsHTML + '</select>' +
-            '    <span id="test-editor-desc" class="card-meta" style="font-size:.78rem;line-height:1.3;min-height:1.2em"></span>' +
+            '    <select class="form-input editor-input" id="test-editor-type">' + optionsHTML + '</select>' +
+            '    <span id="test-editor-desc" class="card-meta"></span>' +
             '  </label>' +
-            '  <div id="test-editor-body" style="display:flex;flex-direction:column;gap:.6rem"></div>' +
+            '  <div id="test-editor-body" class="editor-stack"></div>' +
             '</div>' +
-            '<div style="display:flex;align-items:center;gap:.6rem;padding:.75rem 1rem;border-top:1px solid var(--border);flex-shrink:0">' +
+            '<div class="modal-foot">' +
             '  <button class="btn btn-primary" id="test-editor-save" type="button">Save</button>' +
             '  <button class="btn" id="test-editor-cancel" type="button">Cancel</button>' +
-            '  <span id="test-editor-status" style="font-size:.8rem;color:var(--gray-500);margin-left:.5rem"></span>' +
+            '  <span id="test-editor-status" class="editor-status"></span>' +
             '</div>';
 
         overlay.appendChild(card);
@@ -238,9 +238,8 @@
 
         function showPanel(mechanism) {
             Object.keys(panels).forEach(function (m) {
+                panels[m].el.classList.add('editor-stack');
                 panels[m].el.style.display = (m === mechanism) ? 'flex' : 'none';
-                panels[m].el.style.flexDirection = 'column';
-                panels[m].el.style.gap = '.6rem';
             });
         }
 
@@ -387,7 +386,7 @@
         });
 
         // ── "+ Add Test" dropdown ──────────────────────────────────────────
-        // Each server-rendered `.section-add-test-btn` is upgraded in place to a
+        // Each server-rendered `.js-section-add-test-btn` is upgraded in place to a
         // <details> dropdown whose menu is the instructor-facing catalog,
         // grouped. Picking a type stashes the target section and opens the modal
         // already in that type (`presetType`) — no redundant picker inside the
@@ -420,7 +419,7 @@
         }
 
         function enhanceAddTestButtons() {
-            var btns = document.querySelectorAll('.section-add-test-btn');
+            var btns = document.querySelectorAll('.js-section-add-test-btn');
             for (var i = 0; i < btns.length; i++) {
                 var btn = btns[i];
                 if (!btn.parentNode) continue;

--- a/Public/test-renderer-check.js
+++ b/Public/test-renderer-check.js
@@ -26,22 +26,23 @@
         } catch (e) { return { common: [], kinds: {} }; }
     }
 
-    function el(tag, attrs, style) {
+    // Styling rides on classes from styles.css (the editor-form vocabulary) —
+    // the third `style` parameter this helper used to take is gone, so a new
+    // call site cannot smuggle a style string past the CSS guards.
+    function el(tag, attrs) {
         var node = document.createElement(tag);
         if (attrs) for (var k in attrs) if (Object.prototype.hasOwnProperty.call(attrs, k)) node.setAttribute(k, attrs[k]);
-        if (style) node.style.cssText = style;
         return node;
     }
 
     function buildControl(field) {
-        var common = 'padding:.3rem .5rem;font-size:.85rem';
         if (field.control === 'textarea') {
-            var ta = el('textarea', { 'class': 'form-input', 'data-field': field.name, rows: String(field.rows || 4) }, common + ';font-family:monospace');
+            var ta = el('textarea', { 'class': 'form-input editor-input input-mono', 'data-field': field.name, rows: String(field.rows || 4) });
             if (field.placeholder) ta.placeholder = field.placeholder;
             return ta;
         }
         if (field.control === 'select') {
-            var sel = el('select', { 'class': 'form-input', 'data-field': field.name }, common);
+            var sel = el('select', { 'class': 'form-input editor-input', 'data-field': field.name });
             (field.enumOptions || []).forEach(function (opt) {
                 var o = el('option', { value: opt.value });
                 o.textContent = opt.label;
@@ -59,8 +60,8 @@
         }
         var input = el('input', {
             type: field.control === 'number' ? 'number' : 'text',
-            'class': 'form-input', 'data-field': field.name
-        }, common);
+            'class': 'form-input editor-input', 'data-field': field.name
+        });
         if (field.control === 'number') {
             if (field.valueType === 'optionalFloat') { input.setAttribute('step', 'any'); }
             else { input.setAttribute('step', '1'); input.setAttribute('min', '0'); }
@@ -78,20 +79,20 @@
         // fail with a message they only saw afterwards.
         var reasonText = field.unsupportedReason || null;
         var help = (field.help || reasonText) ? (function () {
-            var p = el('p', { 'class': 'card-meta' }, 'font-size:.72rem;margin:0');
+            var p = el('p', { 'class': 'card-meta hint-xs' });
             p.textContent = reasonText || field.help;
             return p;
         })() : null;
         if (field.control === 'checkbox') {
-            var row = el('label', null, 'font-size:.82rem;display:flex;align-items:center;gap:.3rem');
+            var row = el('label', { 'class': 'checkbox-row' });
             row.appendChild(buildControl(field));
             row.appendChild(document.createTextNode(' ' + field.label));
             if (!help) return row;
-            var wrap = el('div', null, 'display:flex;flex-direction:column;gap:.2rem');
+            var wrap = el('div', { 'class': 'field-stack' });
             wrap.appendChild(row); wrap.appendChild(help);
             return wrap;
         }
-        var label = el('label', null, 'font-size:.85rem;display:flex;flex-direction:column;gap:.2rem');
+        var label = el('label', { 'class': 'field-stack' });
         label.appendChild(document.createTextNode(field.label));
         label.appendChild(buildControl(field));
         if (help) label.appendChild(help);
@@ -191,23 +192,24 @@
         mount: function (bodyEl /*, ctx */) {
             schema = loadSchema();
 
-            var nameLabel = el('label', null, 'font-size:.85rem;display:flex;flex-direction:column;gap:.2rem');
+            var nameLabel = el('label', { 'class': 'field-stack' });
             nameLabel.appendChild(document.createTextNode('Display name (shown to students)'));
-            nameInput = el('input', { type: 'text', 'class': 'form-input', placeholder: '(auto-generated when blank)' }, 'padding:.3rem .5rem;font-size:.85rem');
+            nameInput = el('input', { type: 'text', 'class': 'form-input editor-input', placeholder: '(auto-generated when blank)' });
             nameLabel.appendChild(nameInput);
             bodyEl.appendChild(nameLabel);
 
-            var note = el('p', { 'class': 'card-meta' }, 'font-size:.72rem;margin:.1rem 0 0');
+            var note = el('p', { 'class': 'card-meta hint-xs' });
             note.textContent = 'Tier (visibility) and points are edited inline on the test suite row. New checks default to public and 1 point.';
             bodyEl.appendChild(note);
 
-            fieldsBody = el('div', null, 'display:flex;flex-direction:column;gap:.5rem');
-            commonBody = el('div', null, 'display:flex;flex-direction:column;gap:.5rem');
+            fieldsBody = el('div', { 'class': 'editor-stack' });
+            commonBody = el('div', { 'class': 'editor-stack' });
             bodyEl.appendChild(fieldsBody);
             bodyEl.appendChild(commonBody);
 
             Object.keys(schema.kinds).forEach(function (kind) {
-                var card = el('div', { 'data-kind': kind }, 'display:none;flex-direction:column;gap:.5rem');
+                var card = el('div', { 'data-kind': kind, 'class': 'editor-stack' });
+                card.style.display = 'none'; // shown by reset()'s kind switch
                 (schema.kinds[kind] || []).forEach(function (f) { card.appendChild(renderField(f)); });
                 fieldsBody.appendChild(card);
                 kindCards[kind] = card;

--- a/Public/test-renderer-script.js
+++ b/Public/test-renderer-script.js
@@ -109,10 +109,12 @@ import {
         });
     }
 
-    function el(tag, attrs, style) {
+    // Styling rides on classes from styles.css (the editor-form vocabulary) —
+    // the third `style` parameter this helper used to take is gone, so a new
+    // call site cannot smuggle a style string past the CSS guards.
+    function el(tag, attrs) {
         var node = document.createElement(tag);
         if (attrs) for (var k in attrs) if (Object.prototype.hasOwnProperty.call(attrs, k)) node.setAttribute(k, attrs[k]);
-        if (style) node.style.cssText = style;
         return node;
     }
 
@@ -161,21 +163,21 @@ import {
             statusFn = (ctx && ctx.setStatus) || function () {};
 
             // Filename + template controls (create only).
-            newControls = el('div', null, 'display:flex;flex-direction:column;gap:.5rem');
-            var nameLabel = el('label', null, 'font-size:.85rem;display:flex;flex-direction:column;gap:.2rem');
+            newControls = el('div', { 'class': 'editor-stack' });
+            var nameLabel = el('label', { 'class': 'field-stack' });
             nameLabel.appendChild(document.createTextNode('Filename'));
             nameInput = el('input', {
-                type: 'text', 'class': 'form-input',
+                type: 'text', 'class': 'form-input editor-input',
                 placeholder: 'e.g. test_correctness.' + extensionFor(null)
-            }, 'padding:.3rem .5rem;font-size:.85rem');
+            });
             nameLabel.appendChild(nameInput);
             newControls.appendChild(nameLabel);
 
-            var tplRow = el('div', null, 'display:flex;align-items:center;gap:.5rem;flex-wrap:wrap');
-            var tplCaption = el('span', null, 'font-size:.8rem;color:var(--gray-500)');
+            var tplRow = el('div', { 'class': 'toolbar' });
+            var tplCaption = el('span', { 'class': 'card-meta' });
             tplCaption.textContent = 'Template:';
             tplRow.appendChild(tplCaption);
-            templateSel = el('select', { 'class': 'form-input' }, 'padding:.25rem .5rem;font-size:.8rem;max-width:28rem');
+            templateSel = el('select', { 'class': 'form-input editor-input' });
             templateGroups().forEach(function (g) {
                 var og = el('optgroup', { label: g.group });
                 g.items.forEach(function (it) { var o = el('option', { value: it.value }); o.textContent = it.label; og.appendChild(o); });
@@ -183,31 +185,31 @@ import {
             });
             var blank = el('option', { value: 'blank' }); blank.textContent = 'Blank'; templateSel.appendChild(blank);
             tplRow.appendChild(templateSel);
-            applyBtn = el('button', { type: 'button', 'class': 'btn' }, 'padding:.2rem .6rem;font-size:.8rem');
+            applyBtn = el('button', { type: 'button', 'class': 'btn btn-sm' });
             applyBtn.textContent = 'Apply';
             tplRow.appendChild(applyBtn);
             newControls.appendChild(tplRow);
             bodyEl.appendChild(newControls);
 
             // CodeMirror mount.
-            cmMount = el('div', { id: 'cm-editor-mount' }, 'min-height:240px;border:1px solid var(--border);border-radius:.3rem;overflow:auto;font-size:.875rem');
+            cmMount = el('div', { id: 'cm-editor-mount', 'class': 'editor-cm-mount' });
             bodyEl.appendChild(cmMount);
 
             // Hint (shown to students on failure) + per-test time limit —
             // visible in all modes, side by side on one row.
-            var metaRow = el('div', null, 'display:flex;align-items:flex-end;gap:.6rem;flex-wrap:wrap');
-            var hintLabel = el('label', null, 'font-size:.8rem;display:flex;flex-direction:column;gap:.2rem;flex:1;min-width:16rem');
+            var metaRow = el('div', { 'class': 'toolbar' });
+            var hintLabel = el('label', { 'class': 'field-stack field-stack--grow' });
             hintLabel.appendChild(document.createTextNode('Hint (optional — shown to students when this test fails)'));
-            hintInput = el('input', { type: 'text', 'class': 'form-input', placeholder: 'e.g. Re-read the function’s docstring for the expected return type.' }, 'padding:.25rem .5rem;font-size:.85rem');
+            hintInput = el('input', { type: 'text', 'class': 'form-input editor-input', placeholder: 'e.g. Re-read the function’s docstring for the expected return type.' });
             hintLabel.appendChild(hintInput);
             metaRow.appendChild(hintLabel);
-            var limitLabel = el('label', null, 'font-size:.8rem;display:flex;flex-direction:column;gap:.2rem;width:11rem');
+            var limitLabel = el('label', { 'class': 'field-stack field-stack--narrow' });
             limitLabel.appendChild(document.createTextNode('Time limit (s, blank = default)'));
             timeLimitInput = el('input', {
-                type: 'number', 'class': 'form-input', min: '1', max: '600',
+                type: 'number', 'class': 'form-input editor-input', min: '1', max: '600',
                 placeholder: 'assignment default',
                 title: 'Seconds this one test may run before it is killed and recorded as a timeout. Blank inherits the assignment default.'
-            }, 'padding:.25rem .5rem;font-size:.85rem');
+            });
             limitLabel.appendChild(timeLimitInput);
             metaRow.appendChild(limitLabel);
             bodyEl.appendChild(metaRow);

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -217,21 +217,21 @@
         </div>
     </div>
     <table class="results-table" id="global-inputs-table">
-        <tbody class="global-inputs-body">
+        <tbody class="js-global-inputs-body">
             #for(v in globalVariableRows):
-            <tr class="global-input-row">
-                <td class="section-var-namecell">
-                    <span class="global-input-row-valid section-var-valid"></span>
-                    <input type="text" class="form-input global-input-name global-input-name-input"
+            <tr class="js-global-input-row">
+                <td class="cell-name">
+                    <span class="js-global-input-row-valid cell-check"></span>
+                    <input type="text" class="form-input js-global-input-name cell-input input-mono"
                            value="#(v.name)" placeholder="Input Name">
                 </td>
                 <td>
-                    <input type="text" class="form-input global-input-value global-input-value-input"
+                    <input type="text" class="form-input js-global-input-value cell-input cell-input--fill input-mono"
                            value="#(v.valueJSON)"
                            placeholder='12, "hello", [1, 2, 3], or = seed % 26'>
                 </td>
                 <td class="time">
-                    <button type="button" class="btn action-btn action-danger global-input-remove"
+                    <button type="button" class="btn action-btn action-danger js-global-input-remove"
                             title="Remove input" aria-label="Remove input">
                         <svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg>
                     </button>
@@ -361,7 +361,7 @@
         <!-- Conditions (individual + classWide).  The signal dropdown options
              render from AchievementSignalPresentation (the single source of
              truth); the row layout is cloned per condition by the editor JS. -->
-        <div class="am-scope-field am-conditions-wrap" data-scope="individual classWide">
+        <div class="js-am-scope-field" data-scope="individual classWide">
             <div class="subhead-label">
                 Earned when
                 <select class="form-input form-input--inline" id="am-match">
@@ -374,15 +374,15 @@
             <button type="button" class="btn action-btn" id="am-add-condition">+ Add condition</button>
         </div>
 
-        <label class="form-label field-gap am-scope-field" data-scope="classWide">
+        <label class="form-label field-gap js-am-scope-field" data-scope="classWide">
             Class share &#8805; (%)
             <input type="number" class="form-input" id="am-classPercent" min="0" max="100">
         </label>
-        <label class="form-label field-gap am-scope-field" data-scope="classWide">
+        <label class="form-label field-gap js-am-scope-field" data-scope="classWide">
             Bonus points
             <input type="number" class="form-input" id="am-points" min="0">
         </label>
-        <label class="form-label field-gap am-scope-field" data-scope="record">
+        <label class="form-label field-gap js-am-scope-field" data-scope="record">
             Ranked by
             <select class="form-input" id="am-recordDimension">
                 <option value="firstToSubmit">First to submit</option>
@@ -401,7 +401,7 @@
                 <option value="#(opt.value)" data-unit="#(opt.unit)" data-is-test="#(opt.isTest)">#(opt.label)</option>
                 #endfor
             </select>
-            <select class="form-input am-cond-comparator">
+            <select class="form-input js-am-cond-comparator">
                 <option value="atLeast">at least</option>
                 <option value="atMost">at most</option>
                 <option value="equals">exactly</option>
@@ -550,7 +550,7 @@
     // ── Section inputs JS extracted to Public/section-inputs-editor.js
     //    (loaded above).
     //
-    // Per-section "+ Add Test" buttons (`.section-add-test-btn`) are upgraded
+    // Per-section "+ Add Test" buttons (`.js-section-add-test-btn`) are upgraded
     // in place by the unified Test Editor modal (test-editor-modal.js) into a
     // <details> dropdown of the test-type catalog. Picking a type stashes
     // `window.__chickadeeTargetSection` and opens the modal already in that
@@ -652,7 +652,7 @@
             return;
         }
         // Edit an existing saved script → shell (renderer fetches the body).
-        var se = t.closest && t.closest('.suite-edit-btn');
+        var se = t.closest && t.closest('.js-suite-edit-btn');
         if (se) {
             var name = se.getAttribute('data-filename');
             if (name) modal.open({ editing: { mechanism: 'script', id: name, item: { script: name, hint: scriptHint(name) } } });

--- a/Resources/Views/_family-editor-body.leaf
+++ b/Resources/Views/_family-editor-body.leaf
@@ -101,7 +101,7 @@
                             <th>Label</th>
                             <!-- One arg column per detected parameter; columns are rebuilt
                                  dynamically when the function changes. -->
-                            <th class="pf-case-expected-col">Expected</th>
+                            <th>Expected</th>
                             <th class="fv-action-col"></th>
                         </tr>
                     </thead>

--- a/Resources/Views/_suite-sections.leaf
+++ b/Resources/Views/_suite-sections.leaf
@@ -27,7 +27,7 @@
             <!-- View mode -->
             <div class="section-view">
                 <strong>#(sec.name)</strong>
-                <button class="btn-link section-edit-toggle icon-btn-text" type="button"
+                <button class="btn-link js-section-edit-toggle icon-btn-text" type="button"
                         title="Edit section" aria-label="Edit section">
                     <svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg>
                 </button>
@@ -35,9 +35,9 @@
                      name; the section-vars-form below just renders the tbody
                      and keeps its action= for the auto-save POST. -->
                 <span class="section-spacer"></span>
-                <button type="button" class="btn action-btn btn-xs section-var-add"
+                <button type="button" class="btn action-btn btn-xs js-section-var-add"
                         data-section-id="#(sec.sectionID)">+ Add Input</button>
-                <button type="button" class="btn action-btn btn-xs section-add-test-btn"
+                <button type="button" class="btn action-btn btn-xs js-section-add-test-btn"
                         data-section-id="#(sec.sectionID)">+ Add Test</button>
             </div>
 
@@ -50,10 +50,10 @@
                     <input class="form-input section-name-input" type="text" name="name" value="#(sec.name)" required>
                     <button class="btn btn-primary btn-compact" type="submit">Save</button>
                 </form>
-                <button class="btn action-btn action-danger section-delete-btn" type="button"
+                <button class="btn action-btn action-danger js-section-delete-btn" type="button"
                         data-action="#(sectionActionBase)/#(sec.sectionID)/delete#(sectionActionQuery)"
                         data-name="#(sec.name)">Delete</button>
-                <button class="btn-link section-edit-cancel icon-btn-text" type="button"
+                <button class="btn-link js-section-edit-cancel icon-btn-text" type="button"
                         aria-label="Cancel" title="Cancel">✕</button>
             </div>
         </div>
@@ -67,15 +67,15 @@
               action="#(sectionActionBase)/#(sec.sectionID)/variables#(sectionActionQuery)"
               data-section-id="#(sec.sectionID)">
             <table class="results-table section-vars-table">
-                <tbody class="section-vars-body">
+                <tbody class="js-section-vars-body">
                     #for(v in sec.variables):
-                    <tr class="section-var-row">
-                        <td class="section-var-namecell">
-                            <span class="section-var-row-valid section-var-valid"></span>
-                            <input type="text" class="form-input section-var-name section-var-name-input" value="#(v.name)" placeholder="Input Name">
+                    <tr class="js-section-var-row">
+                        <td class="cell-name">
+                            <span class="js-section-var-row-valid cell-check"></span>
+                            <input type="text" class="form-input js-section-var-name cell-input input-mono" value="#(v.name)" placeholder="Input Name">
                         </td>
-                        <td><input type="text" class="form-input section-var-value section-var-value-input" value="#(v.valueJSON)" placeholder="[{...}, {...}] or {&quot;k&quot;: 1}"></td>
-                        <td class="section-var-removecell"><button type="button" class="btn action-btn action-danger icon-btn-xs section-var-remove"
+                        <td><input type="text" class="form-input js-section-var-value cell-input cell-input--fill input-mono" value="#(v.valueJSON)" placeholder="[{...}, {...}] or {&quot;k&quot;: 1}"></td>
+                        <td class="cell-remove"><button type="button" class="btn action-btn action-danger icon-btn-xs js-section-var-remove"
                                     title="Remove input" aria-label="Remove input"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button></td>
                     </tr>
                     #endfor
@@ -85,7 +85,7 @@
     #else:
         <div class="section-create-toolbar"
              data-section-id="#(sec.sectionID)">
-            <button type="button" class="btn action-btn btn-xs section-add-test-btn"
+            <button type="button" class="btn action-btn btn-xs js-section-add-test-btn"
                     data-section-id="#(sec.sectionID)">+ Add Test</button>
         </div>
     #endif

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -80,7 +80,7 @@
         <div class="section-view">
             <strong>#(section.name)</strong>
             <span class="section-mode-note">tested in #if(section.defaultGradingMode == "worker"):Chickadee#else:Student Browser#endif</span>
-            <button class="btn-link section-edit-toggle icon-btn-text" type="button"
+            <button class="btn-link js-section-edit-toggle icon-btn-text" type="button"
                     title="Edit section" aria-label="Edit section">
                 <svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg>
             </button>
@@ -98,10 +98,10 @@
                 </select>
                 <button class="btn btn-primary btn-compact" type="submit">Save</button>
             </form>
-            <button class="btn action-btn action-danger section-delete-btn" type="button"
+            <button class="btn action-btn action-danger js-section-delete-btn" type="button"
                     data-action="/instructor/sections/#(section.sectionID)/delete"
                     data-name="#(section.name)">Delete</button>
-            <button class="btn-link section-edit-cancel icon-btn-text" type="button"
+            <button class="btn-link js-section-edit-cancel icon-btn-text" type="button"
                     aria-label="Cancel" title="Cancel">✕</button>
         </div>
     </div>
@@ -170,7 +170,7 @@
                 <th>Actions</th>
             </tr>
         </thead>
-        <tbody class="assignments-body" data-section-id="#(section.sectionID)">
+        <tbody data-section-id="#(section.sectionID)">
         #if(section.items.isEmpty):
         <tr class="section-empty-row">
             <td colspan="6" class="section-empty-cell">
@@ -471,7 +471,7 @@ tr.assignment-draggable td {
     }
 
     // ── Section edit mode ─────────────────────────────────────────────────────
-    document.querySelectorAll('.section-edit-toggle').forEach(function (btn) {
+    document.querySelectorAll('.js-section-edit-toggle').forEach(function (btn) {
         btn.addEventListener('click', function () {
             var header = btn.closest('.section-header');
             if (!header) return;
@@ -483,7 +483,7 @@ tr.assignment-draggable td {
         });
     });
 
-    document.querySelectorAll('.section-edit-cancel').forEach(function (btn) {
+    document.querySelectorAll('.js-section-edit-cancel').forEach(function (btn) {
         btn.addEventListener('click', function () {
             var header = btn.closest('.section-header');
             if (!header) return;
@@ -492,7 +492,7 @@ tr.assignment-draggable td {
         });
     });
 
-    document.querySelectorAll('.section-delete-btn').forEach(function (btn) {
+    document.querySelectorAll('.js-section-delete-btn').forEach(function (btn) {
         btn.addEventListener('click', function () {
             var name = btn.getAttribute('data-name');
             var action = btn.getAttribute('data-action');

--- a/Tests/BrowserRunnerJSTests/pattern-family-editor.test.mjs
+++ b/Tests/BrowserRunnerJSTests/pattern-family-editor.test.mjs
@@ -271,7 +271,7 @@ test("editor carries the per-student expectedVarRef + Global-Inputs wiring", () 
     'editor must serialize a $name Expected cell into expectedVarRef');
   assert.ok(editorSource.includes('collectDeclaredInputNames'),
     'editor must union Global Input names so per-student refs are not red-flagged');
-  assert.ok(editorSource.includes('global-input-name'),
+  assert.ok(editorSource.includes('js-global-input-name'),
     'editor must read Global Input names from the DOM');
 });
 

--- a/Tests/BrowserRunnerJSTests/section-inputs-adoption.test.mjs
+++ b/Tests/BrowserRunnerJSTests/section-inputs-adoption.test.mjs
@@ -69,11 +69,11 @@ test('the shared core classifies a section expression as an expression', () => {
 
 test('a mixed literal/expression panel builds a payload carrying both keys', () => {
   const editor = Core.createEditor({
-    row: 'section-var-row',
-    name: 'section-var-name',
-    value: 'section-var-value',
-    valid: 'section-var-row-valid',
-    remove: 'section-var-remove',
+    row: 'js-section-var-row',
+    name: 'js-section-var-name',
+    value: 'js-section-var-value',
+    valid: 'js-section-var-row-valid',
+    remove: 'js-section-var-remove',
   });
 
   // Minimal stand-in for the rows the panel reads; only the two input

--- a/Tests/BrowserRunnerJSTests/section-reorder-url.test.mjs
+++ b/Tests/BrowserRunnerJSTests/section-reorder-url.test.mjs
@@ -83,7 +83,7 @@ test('both authoring pages supply a reorderSections builder', async () => {
 test('the create page no longer binds its own section handlers', async () => {
   const src = await fs.readFile(path.resolve('Resources/Views/assignment-new.leaf'), 'utf8');
   // suite-table.js owns all three; the page used to bind duplicates on top.
-  for (const marker of ['section-edit-toggle', 'section-edit-cancel', 'section-delete-btn']) {
+  for (const marker of ['js-section-edit-toggle', 'js-section-edit-cancel', 'js-section-delete-btn']) {
     assert.ok(
       !src.includes(`closest('.${marker}')`),
       `create page still binds a handler for .${marker}; suite-table.js owns it`,

--- a/changelog.d/ui-ratchet-editor-surface.md
+++ b/changelog.d/ui-ratchet-editor-surface.md
@@ -1,0 +1,24 @@
+### Changed
+
+- **The assignment-editor surface stopped writing its own styling from JS.**
+  The pattern-family editor, suite table, inputs editors, Test Editor modal
+  and both test renderers now assign classes from a shared editor-table
+  vocabulary in `styles.css` (`.cell-*`, `.th-*`, `.modal-*`, `.editor-stack`)
+  instead of carrying style strings, taking the `JS_STYLE_DECISION_BASELINE`
+  ratchet from 118 to its floor of 14 (the sanctioned popover-geometry and
+  custom-property writes). Validity cues — invalid names, per-student `=`
+  tints, `$name` resolution, auto-computed values — are toggled classes with
+  palette colours, so they now adapt to dark mode; the previous
+  `rgba(45,143,71,.07)` expression tint and the off-scale `.7rem`/`.78rem`
+  font sizes are gone. JS-added inputs rows and their server-rendered twins
+  share one set of classes, removing a live drift (the two ran different
+  font sizes in the same table); the global-inputs rows join the same
+  dense-table size as every other editor table.
+
+- **The editors' behaviour-only class hooks took the `js-` prefix.** All
+  pattern-family, suite-table, inputs-editor, section-CRUD and
+  achievements-editor hooks were renamed (`pf-case-remove` →
+  `js-pf-case-remove`, etc.), and two dead hooks were deleted outright,
+  shrinking the class-resolution allowlist from 67 entries to 18. The suite
+  table's focus restore now keys on the `js-` hook rather than the first
+  styling class it happens to find.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -181,6 +181,22 @@ of action buttons" and four pill implementations; the page-style ratchet
   `data-sort-tiebreak="<key>"` the tie-break; a page that repaints rows calls
   `ChickadeeSortableTable.apply(table)`.  Never hand-roll a sorter or a sort
   glyph — the guard fails on both.
+- **Editor-table cells** — the dense tables the assignment editors build in
+  JS (suite table, pattern-family cases/variables, inputs panels) and their
+  server-rendered twins share one cell vocabulary: `.cell-input`
+  (+ `--fill`/`--name`/`--points` widths), `.cell-name` + `.cell-check` /
+  `.cell-check-col`, `.cell-remove`, `.cell-num`, `.cell-stack` +
+  `.cell-title`, locked rows `.cell-tight`/`.cell-code`/`.cell-preview`
+  (+ `.cell-shadowed`, `.cell-warn-note`), JS-rebuilt headers `.th-code` /
+  `.th-note`, action clusters `.cell-actions`.  **Value-state cues are
+  toggled classes**, never JS-written colours: `.input-expression`
+  (per-student `=` tint), `.input-attention` (amber), `.input-invalid`
+  (red), `.input-ref-ok` / `.input-ref-missing` (`$name` resolution),
+  `.input-auto` (auto-computed), `.input-mono` (monospace control).
+- **`.modal-overlay`/`.modal-card`** + `.modal-head`/`-title`/`-close`/
+  `-body`/`-foot`, **`.editor-stack`**, `.editor-cm-mount`,
+  `.field-stack--grow`/`--narrow`, `.editor-input`, `.editor-status` — the
+  Test Editor modal shell and the editor-built forms inside it.
 - **`.diagnostics-cards`** + `.diagnostic-card/-label/-value` — stat tiles.
 - **`.chip`**, `.chip-row` — neutral tags.  `.tier` + `.tier-*` — status
   badges (defined variants only: open/closed/extended/preview/unpublished).
@@ -266,6 +282,13 @@ direct `.style` writes.
 Existing violations are a **shrink-only ratchet**
 (`JS_STYLE_DECISION_BASELINE` in `scripts/check-styles.sh`): `style="…"`
 strings, non-`display` `.style` writes, and `cssText` may only decrease.
+The editor surface (pattern-family editor, suite table, inputs editors,
+test-editor modal, both test renderers) was converted to class toggles in
+the ratchet follow-up pass, which took the baseline to its floor — what the
+count still sees is the sanctioned remainder: `app.js`'s popover geometry,
+two custom-property writes the crude grep cannot tell apart from styling,
+the flash/collapse behaviour in `chickadee-ui.js`, and one `.style` read.
+A new entry above that floor is a regression, not headroom.
 
 ## Page-local styles
 

--- a/docs/ui-ratchet-handoff.md
+++ b/docs/ui-ratchet-handoff.md
@@ -1,148 +1,222 @@
-# UI ratchet — handoff for the next pass (2026-08)
+# UI ratchet — instructions for the next pass (2026-08, rev 2)
 
-The widget-layer audit ([ui-consistency-audit.md](ui-consistency-audit.md))
-shipped as S0–S10 and is closed. **The editor-surface pass that this brief
-originally queued as items 1–3 has since shipped too** (the pass that
-converted the pattern-family editor, suite table, inputs editors, Test
-Editor modal and both test renderers to the shared `.cell-*` / `.modal-*` /
-`.input-*` vocabulary, swept the editors' hooks to `js-` names, and salvaged
-then closed PR #1384). This brief is for whoever continues from there:
-where the remaining mass actually sits, and the trap that will cost you a
-day if you walk into it cold.
+You are continuing a multi-pass effort to make Chickadee's web UI consistent
+and maintainable. Two passes are complete: the widget-layer audit
+([ui-consistency-audit.md](ui-consistency-audit.md), shipped as S0–S10) and
+the editor-surface pass (branch `claude/ui-ratchet-consistency-xc5wbn`, which
+converted the assignment editors' JS-written styling to the shared `.cell-*` /
+`.modal-*` / `.input-*` vocabulary, swept the editors' behaviour hooks to
+`js-` names, and salvaged then closed PR #1384).
 
-Everything below is measured, not estimated. Re-measure before you act —
-the commands are given.
+Read before acting: the **UI / Stylesheet Conventions** section of
+`CLAUDE.md`, [ui-design.md](ui-design.md) (tokens, component vocabulary,
+page archetypes, "JS does not make styling decisions"), and — before touching
+either authoring template — [leaf-decomposition-review.md](leaf-decomposition-review.md).
+
+Everything below is measured, not estimated. **Re-measure before you act**;
+the commands are in "Verification" at the bottom.
 
 ---
 
 ## Where things stand
 
-| ratchet | at audit | now | headroom |
+| ratchet | at audit | now | status |
 |---|---:|---:|---|
-| `INLINE_SCRIPT_BASELINE` | 1968 | **1317** | none — sits at the count |
-| `PAGE_STYLE_BASELINE` | 913 | **689** | none |
-| `JS_STYLE_DECISION_BASELINE` | 122 | **14** | none — **at its floor** |
-| `ALERT_BASELINE` | 4 | **0** | absolute |
-| `JS_ALERT_BASELINE` | 7 | **0** | absolute |
-| axe moderate/minor | 12 | **0** | absolute in practice |
-| class-resolution allowlist | 67 | **18** | shrink-only |
+| `INLINE_SCRIPT_BASELINE` | 1968 | **1317** | ← the remaining mass; P1 |
+| `PAGE_STYLE_BASELINE` | 913 | **689** | shrink opportunistically; P3 |
+| `JS_STYLE_DECISION_BASELINE` | 122 | **14** | **at its floor — done** |
+| `ALERT_BASELINE` / `JS_ALERT_BASELINE` | 4 / 7 | **0 / 0** | absolute rules — done |
+| axe moderate/minor | 12 | **0** | zero *on the 13 scanned pages*; P2 |
+| class-resolution allowlist | 67 | **18** | fold into surface work; P3 |
 
-Every ratchet is at its count, so *any* growth fails CI.
+Every ratchet sits exactly at its count, so any growth fails CI
+(`scripts/check-styles.sh`, wired into the `format-lint` job).
 
-**`JS_STYLE_DECISION_BASELINE` = 14 is a floor, not a queue.** What the
-count still sees is the sanctioned remainder — `app.js`'s runtime-computed
-popover geometry (8), `chickadee-ui.js`'s flash colour, collapse-animation
-overflow writes and a `--bar-h` custom-property assignment the crude grep
-cannot tell from styling (4), `workbench.js`'s `--wb-left-width`
-setProperty (1), and a `.style.fontSize` *read* in `jl-cell-perf-patch.js`
-(1). Converting any of these would be fixing the counter, not the code.
+`JS_STYLE_DECISION_BASELINE = 14` is a **floor, not a queue**: the count is
+`app.js` popover geometry (8, the sanctioned runtime-computed use),
+`chickadee-ui.js` flash/collapse behaviour plus a `--bar-h` custom-property
+assignment the crude grep cannot tell from styling (4), `workbench.js`'s
+`--wb-left-width` setProperty (1), and a `.style.fontSize` *read* (1).
+Do not spend effort here.
 
-**The 18-entry allowlist** is the non-editor tail: `content-item-*` (6),
-assorted row/anchor hooks (10), `inplace-error-banner`, and the
-`sortable-table` opt-in marker. Each is a rename of the same mechanical
-shape as the editor sweep — worth folding into whatever pass next touches
-its surface, not worth a pass of its own.
+---
 
-Reproduce:
+## P1 — Extract the inline `<script>` blocks (the headline)
+
+**Why this is the priority.** 1,317 lines of page JS live inside template
+`<script>` blocks where no tool can see them — ESLint cannot parse
+Leaf-interpolated JS, CodeQL skips it, nothing unit-tests it — and their
+existence is **the reason the CSP still allows inline script**. The end state
+worth aiming at: every page behaviour in a lintable `Public/*.js` file, pages
+carrying only data (via `data-*` attributes or a
+`<script type="application/json">` island), and then a CSP that drops the
+inline-script allowance. That last step is a deliberate, separate change —
+but every extraction is a prerequisite for it.
+
+**The order, by measured size and by what else the extraction buys:**
+
+| template | lines | notes |
+|---|---:|---|
+| `_assignment-edit-body.leaf` | 303 | do together with the next row |
+| `assignment-new.leaf` | 258 | the create page has repeatedly been the **stale fork** of the edit page's JS — leaf-decomposition-review found three live defects that way. Extraction here is de-duplication: one shared `Public/*.js` file, two thin data islands |
+| `admin.leaf` | 206 | admin dashboard |
+| `assignments.leaf` | 200 | instructor dashboard |
+| `instructor-brightspace.leaf` | 105 | |
+| `instructor-students.leaf` | 100 | |
+| `base.leaf` | 74 | **correct where it is** (bootstrap that must run before anything else); it is the last, hardest piece of any CSP flip — leave it for the CSP change itself |
+| `admin-runner.leaf` + `assignment-submissions.leaf` | 71 | small; fold into a nearby slice |
+
+**The extraction pattern** (established, do not invent a new one): the
+template serialises page data into `data-*` attributes or a JSON island; the
+new `Public/<page>.js` file reads it and owns all behaviour; the template
+keeps a single `<script src="/<page>.js?v=#appVersion()">` line. Look at how
+`suite-table.js` + `_suite-sections.leaf` or `global-inputs-editor.js` +
+the global-inputs block do it. While extracting, give any behaviour-only
+class hooks you touch the `js-` prefix (see P3) and add
+`node --test`-able coverage for logic worth pinning — the point of the move
+is that the code becomes testable.
+
+**Slice it one template (or one create/edit pair) per PR.** Each PR lowers
+`INLINE_SCRIPT_BASELINE` to the new count in the same commit.
+
+**What NOT to do here:** do not build a shared Leaf partial for the two
+authoring templates' *markup*. That has been litigated twice
+(leaf-decomposition-review.md): the genuinely shared markup (~70 lines) is
+already `_suite-sections.leaf`, and the rest differs structurally in ways a
+shared partial would get subtly wrong. The JS is the safe, valuable half.
+
+---
+
+## P2 — Give the authoring surface the coverage it doesn't have
+
+The previous pass discovered (the hard way — the prior handoff claimed
+otherwise) that **neither authoring page is in the visual-regression capture
+or the axe scan**. `Tools/visual-regression/pages.mjs` covers 13 pages, one
+per archetype; the assignment edit page, the create page, and the workbench —
+the most interaction-dense UI in the app, and the surface both prior passes
+restyled — have only render tests, which prove templates resolve and nothing
+else.
+
+Work items, in order:
+
+1. **Add an authoring-page capture to `pages.mjs`** (it feeds both the VR
+   harness and the axe scan — one module, so both gain at once). Use the
+   seeded instructor fixture; the page must render deterministically, so
+   capture the assignment-edit page for a seeded assignment whose suite has
+   at least one script row, one pattern family, and one notebook check (so
+   the suite table, cell inputs, and validity-cue classes all render).
+   Follow `seed.mjs`'s existing pattern. A page captured without a committed
+   baseline bootstraps loudly — commit the CI capture in the same PR
+   (CLAUDE.md, UI conventions).
+2. **Check the axe results for the new page and drive them to zero** like
+   S10 did for the original 13.
+3. **Audit keyboard access on the editor interactions.** Drag-reorder (suite
+   rows, sections), the Add Test modal (focus trap? Escape works — verify
+   focus return), and the validity cues (are they colour-only, or does the
+   title/text carry the information for a screen reader? — the cues set
+   `title`, verify that is enough). Treat "axe = 0" as *unmeasured* for
+   these interactions until this is done; axe cannot see drag-and-drop.
+4. If mouse-only reordering turns out to be the only path, file the gap as
+   an issue with a proposed keyboard affordance rather than bolting one on
+   inside this pass.
+
+**The one trap in this area** (it cost a day once): `run-visual.sh --update`
+rewrites more captures than your change explains — run-to-run variance, not
+real changes. After `--update`, `git status` the baselines and **revert every
+capture your diff cannot explain**, then re-run the plain comparison. Green
+with only the explainable captures updated is also your evidence the rest
+was pixel-neutral.
+
+---
+
+## P3 — Ride-along work (never its own PR)
+
+- **Page `<style>` blocks (689 lines).** No block dominates: `workbench.leaf`
+  120, `_notebook-body.leaf` 59, `admin-mcp.leaf` / `admin-course.leaf` 52
+  each, then a long tail. When a P1/P2 slice already has a template open,
+  hoist what matches an existing component (the vocabulary list in
+  `ui-design.md`) and lower `PAGE_STYLE_BASELINE` in the same PR. Do not
+  open a template just to shrink its style block.
+- **The 18-entry class-resolution allowlist.** All behaviour-only hooks on
+  non-editor surfaces: `content-item-*` (6), assorted row/anchor hooks (10),
+  `inplace-error-banner`, and the `sortable-table` opt-in marker. Rename to
+  `js-*` when you touch their surface; delete the allowlist entry in the
+  same PR (the guard fails on stale entries, so you cannot forget). Two
+  lessons from the editor sweep: **ids are not class hooks** — do not rename
+  `id="…"` values, and check every hit before a bulk rename (one token
+  appeared as both a class and an id); a hook that is assigned but never
+  queried anywhere is dead — delete it instead of renaming it.
+
+---
+
+## P4 — Deferred by design (do not start these; conditions to revisit)
+
+- **Styled `<dialog>` confirmations / converging the two overlay
+  implementations.** The `data-confirm` seam (app.js) and the S9 modal shell
+  make this a one-place change whenever the native `confirm()` look is
+  deemed not good enough. It is a product-taste call for the maintainer,
+  not a blocked task.
+- **S1b person typeahead** on the unified list filter. Deferred until the
+  filter shows real usage. Nothing has changed.
+- **The CSP inline-script flip itself.** Only after P1 reaches `base.leaf`.
+
+---
+
+## The contract (why the ratchets actually move — hold every slice to it)
+
+1. **Lower the ratchet in the PR that earns it.** Headroom left behind gets
+   spent by the next person adding a copy.
+2. **Close the idiom, not just the instances.** When a conversion reaches
+   zero, add the absolute guard (the editor pass removed the `el()` helpers'
+   style parameter so a new call site *cannot* pass a style string — that
+   shape, not just a lower number).
+3. **Run** `scripts/check-styles.sh`, `scripts/eslint.sh`,
+   `node --test Tests/BrowserRunnerJSTests/*.mjs`, and the render-test
+   suites for every template you touched, before pushing.
+4. **Watch your guard fail.** Add a violation, see the check go red, revert
+   it. A check never seen to fail is not a check — the repaint probe's
+   filter assertion once passed vacuously against a dead poll.
+5. **Do not quote markup in comments or docs the guards scan.** A scanner
+   cannot tell markup from prose about markup; this has bitten four times
+   (the Leaf lexer #1266, the S5 guard, the icon sprite comment, and Leaf
+   tag syntax in template comments). Describe the shape instead.
+
+## Stop doing
+
+- **Chasing `JS_STYLE_DECISION_BASELINE` below 14.** Floor. Converting the
+  popover math or the custom-property writes trades blessed idioms for a
+  rounder number.
+- **Proposing a shared markup partial for create/edit.** Re-litigated twice;
+  the answer is in leaf-decomposition-review.md.
+- **Standalone rename/cleanup PRs.** The tails are ride-alongs now.
+- **Adding new counters speculatively.** The guard set is dense and has its
+  own failure modes (guards matching their own documentation, event-gated
+  guards passing vacuously). Prefer an absolute rule when one is reachable;
+  add a counter only for a named surface it will ratchet down.
+
+---
+
+## Verification
 
 ```
 bash scripts/check-styles.sh
+bash scripts/eslint.sh
+node --test Tests/BrowserRunnerJSTests/*.mjs
 ```
+
+Per-template inline-script and page-style counts (re-measure before slicing):
+
+```
+for f in Resources/Views/*.leaf; do n=$(awk '/<script[^>]*src=/ { next } /<script>/ && /<\/script>/ { next } /<script/ { inscript = 1; next } /<\/script>/ { inscript = 0; next } inscript && NF > 0 { n++ } END { print n + 0 }' "$f"); [ "$n" -gt 0 ] && echo "$n $(basename $f)"; done | sort -rn
+```
+
+```
+for f in Resources/Views/*.leaf; do n=$(awk '/<style>/ { inblock = 1; next } /<\/style>/ { inblock = 0; next } inblock && NF > 0 { n++ } END { print n + 0 }' "$f"); [ "$n" -gt 0 ] && echo "$n $(basename $f)"; done | sort -rn
+```
+
+JS style decisions per file (should stay: app.js 8, chickadee-ui.js 4,
+workbench.js 1, jl-cell-perf-patch.js 1):
 
 ```
 for f in Public/*.js; do n=$( { grep -ho 'style="' "$f" || true; grep -hoE '\.style\.[a-zA-Z]+' "$f" | grep -v '\.style\.display' || true; grep -ho 'cssText' "$f" || true; } | wc -l); [ "$n" -gt 0 ] && echo "$n $f"; done | sort -rn
 ```
-
----
-
-## Where the remaining mass sits
-
-With the JS-styling ratchet at its floor, two ratchets hold everything
-left, and both are template-side:
-
-**`INLINE_SCRIPT_BASELINE` = 1317**, by template — the two authoring pages
-are 44%:
-
-| template | lines |
-|---|---:|
-| `_assignment-edit-body.leaf` | ~325 |
-| `assignment-new.leaf` | ~254 |
-| `admin.leaf` | 230 |
-| `assignments.leaf` | 223 |
-| `instructor-brightspace.leaf` | 116 |
-| `instructor-students.leaf` | 111 |
-| `base.leaf` | 77 — correct where it is |
-| `admin-runner` + `assignment-submissions` | 77 |
-
-The extraction pattern is established (data via `data-*`/JSON island, logic
-in a lintable `Public/*.js`), and the editor-surface pass demonstrated the
-adjacent cleanups pay for themselves: the create page's inline scripts were
-repeatedly found to be the stale fork of the edit page's
-(leaf-decomposition-review.md), so extraction is also de-duplication.
-
-**`PAGE_STYLE_BASELINE` = 689** — page-local `<style>` blocks. No single
-block dominates; shrink opportunistically when a page is already open.
-
----
-
-## The trap
-
-### Regenerating visual baselines rewrites more than you changed
-
-`run-visual.sh --update` rewrote **12** captures for a change touching five
-templates that cannot affect `login`, `student-submit`, `student-dashboard`
-or `submission-pending`. Those extra ones are this environment's run-to-run
-variance, not real changes, and committing them fails CI against the
-canonical set.
-
-**Rule:** after `--update`, `git status` the baselines and revert every page
-your diff cannot explain. Then re-run the plain comparison. If it is green
-with only the explainable captures updated, that is *also* your evidence the
-rest of the change was pixel-neutral.
-
----
-
-## What is deliberately not on the list
-
-- **The two authoring templates' markup.** They are 44% of the inline-script
-  ratchet and the biggest number on the board, but `leaf-decomposition-review.md`
-  is right that a shared partial getting the create-vs-edit differences subtly
-  wrong is worse than two honest copies. Extracting their inline *scripts*
-  to shared `Public/*.js` files is the safe half of that work — the review
-  found the create page's inline JS was the *stale fork* every time it
-  looked, and fixing three forks removed three live defects.
-- **Converting the sanctioned JS `.style` remainder.** The 14 counted
-  decisions left are popover geometry, custom-property writes and a read —
-  the patterns `ui-design.md` explicitly blesses. Rewriting them to appease
-  a grep would trade working idioms for a rounder number.
-- **S1b person typeahead.** Deferred until the unified filter has real usage.
-  Still the right call; nothing has changed.
-- **Styled `<dialog>` confirmations and converging the two overlays.** The
-  `data-confirm` seam makes this a one-place change whenever it is wanted.
-  No pressure to do it now.
-
----
-
-## Before you ship anything
-
-The contract every slice held to, and the reason the ratchets actually moved:
-
-1. **Lower the ratchet in the PR that earns it.** Headroom left behind gets
-   spent by the next person adding a copy.
-2. **Add the guard that closes the idiom**, not just the instances. Prefer an
-   absolute rule when the conversion reaches zero in one pass.
-3. **Run** `scripts/check-styles.sh`, the affected render tests, and the JS
-   gate (`scripts/eslint.sh`, `node --test Tests/BrowserRunnerJSTests/*.mjs`).
-4. **Watch your guard fail.** A check never seen to fail is not a check. The
-   repaint probe's own filter assertion was passing *vacuously* against a dead
-   poll until it was tested that way — it read as coverage while proving
-   nothing.
-5. **Do not quote markup in a comment.** A scanner cannot tell markup from
-   prose about markup. This has now bitten three separate times (#1266's Leaf
-   lexer, the S5 guard failing on its own documentation, and the icon sprite's
-   comment registering as a phantom call site). Describe the shape instead.
-
-`Tools/visual-regression/run-repaint-probe.sh` runs in CI as a step of the
-`visual` job and covers the seam where the shared filter, sort, poll and icon
-sprite meet — the interactions that fail silently and that a screenshot
-comparison cannot catch, because both sides would agree.

--- a/docs/ui-ratchet-handoff.md
+++ b/docs/ui-ratchet-handoff.md
@@ -1,12 +1,17 @@
 # UI ratchet — handoff for the next pass (2026-08)
 
 The widget-layer audit ([ui-consistency-audit.md](ui-consistency-audit.md))
-shipped as S0–S10 and is closed. This brief is for whoever continues the
-ratchet: where the remaining mass actually sits, which of it is mechanical,
-and the two traps that will cost you a day if you walk into them cold.
+shipped as S0–S10 and is closed. **The editor-surface pass that this brief
+originally queued as items 1–3 has since shipped too** (the pass that
+converted the pattern-family editor, suite table, inputs editors, Test
+Editor modal and both test renderers to the shared `.cell-*` / `.modal-*` /
+`.input-*` vocabulary, swept the editors' hooks to `js-` names, and salvaged
+then closed PR #1384). This brief is for whoever continues from there:
+where the remaining mass actually sits, and the trap that will cost you a
+day if you walk into it cold.
 
-Everything below is measured against `main` at the close of S10, not
-estimated. Re-measure before you act — the commands are given.
+Everything below is measured, not estimated. Re-measure before you act —
+the commands are given.
 
 ---
 
@@ -16,56 +21,29 @@ estimated. Re-measure before you act — the commands are given.
 |---|---:|---:|---|
 | `INLINE_SCRIPT_BASELINE` | 1968 | **1317** | none — sits at the count |
 | `PAGE_STYLE_BASELINE` | 913 | **689** | none |
-| `JS_STYLE_DECISION_BASELINE` | 122 | **118** | none |
+| `JS_STYLE_DECISION_BASELINE` | 122 | **14** | none — **at its floor** |
 | `ALERT_BASELINE` | 4 | **0** | absolute |
 | `JS_ALERT_BASELINE` | 7 | **0** | absolute |
 | axe moderate/minor | 12 | **0** | absolute in practice |
-| class-resolution allowlist | — | **67** | shrink-only |
+| class-resolution allowlist | 67 | **18** | shrink-only |
 
-Every ratchet is at its count, so *any* growth fails CI. Five guards were
-added by the audit; three are absolute rules rather than ratchets (icon
-geometry outside the sprite, native confirmation outside the seam, the
-retired button size modifiers).
+Every ratchet is at its count, so *any* growth fails CI.
 
----
+**`JS_STYLE_DECISION_BASELINE` = 14 is a floor, not a queue.** What the
+count still sees is the sanctioned remainder — `app.js`'s runtime-computed
+popover geometry (8), `chickadee-ui.js`'s flash colour, collapse-animation
+overflow writes and a `--bar-h` custom-property assignment the crude grep
+cannot tell from styling (4), `workbench.js`'s `--wb-left-width`
+setProperty (1), and a `.style.fontSize` *read* in `jl-cell-perf-patch.js`
+(1). Converting any of these would be fixing the counter, not the code.
 
-## The headline: one surface owns almost everything that is left
+**The 18-entry allowlist** is the non-editor tail: `content-item-*` (6),
+assorted row/anchor hooks (10), `inplace-error-banner`, and the
+`sortable-table` opt-in marker. Each is a rename of the same mechanical
+shape as the editor sweep — worth folding into whatever pass next touches
+its surface, not worth a pass of its own.
 
-The pattern-family / suite authoring surface is not merely *a* remaining
-target — it dominates three of the four open ratchets at once.
-
-**`JS_STYLE_DECISION_BASELINE` = 118**, by file:
-
-| file | count | share |
-|---|---:|---|
-| `pattern-family-editor.js` | 54 | 46% |
-| `suite-table.js` | 22 | 19% |
-| `test-editor-modal.js` | 12 | |
-| `inputs-editor-core.js` | 12 | |
-| `app.js` | 8 | |
-| everything else | 10 | |
-
-Two files are **64%** of it.
-
-**`INLINE_SCRIPT_BASELINE` = 1317**, by template — the two authoring pages
-are 44%:
-
-| template | lines |
-|---|---:|
-| `_assignment-edit-body.leaf` | 325 |
-| `assignment-new.leaf` | 254 |
-| `admin.leaf` | 230 |
-| `assignments.leaf` | 223 |
-| `instructor-brightspace.leaf` | 116 |
-| `instructor-students.leaf` | 111 |
-| `base.leaf` | 77 — correct where it is |
-| `admin-runner` + `assignment-submissions` | 77 |
-
-**The 67-entry class-resolution allowlist**, by owning surface: `pf-*` 13,
-`section-*` 11, `suite-*` 9, `global-input-*` 5, `am-*` 3, `ach-*` 2 —
-43 of 67 from the same editors.
-
-Reproduce all three:
+Reproduce:
 
 ```
 bash scripts/check-styles.sh
@@ -77,79 +55,39 @@ for f in Public/*.js; do n=$( { grep -ho 'style="' "$f" || true; grep -hoE '\.st
 
 ---
 
-## Low-hanging fruit, in the order I would take it
+## Where the remaining mass sits
 
-### 1. `pattern-family-editor.js` cell styling — the single best ratio
+With the JS-styling ratchet at its floor, two ratchets hold everything
+left, and both are template-side:
 
-54 of 118 JS style decisions, and they are **repeated literals**, not
-per-case logic. The same string recurs across the case-table builders:
+**`INLINE_SCRIPT_BASELINE` = 1317**, by template — the two authoring pages
+are 44%:
 
-```
-style="width:100%;padding:.2rem .4rem;font-size:.8rem;font-family:monospace"
-```
+| template | lines |
+|---|---:|
+| `_assignment-edit-body.leaf` | ~325 |
+| `assignment-new.leaf` | ~254 |
+| `admin.leaf` | 230 |
+| `assignments.leaf` | 223 |
+| `instructor-brightspace.leaf` | 116 |
+| `instructor-students.leaf` | 111 |
+| `base.leaf` | 77 — correct where it is |
+| `admin-runner` + `assignment-submissions` | 77 |
 
-Three or four shared classes absorb nearly all of it: a table-cell input, a
-narrow column, a muted inline note, a compact remove button.
+The extraction pattern is established (data via `data-*`/JSON island, logic
+in a lintable `Public/*.js`), and the editor-surface pass demonstrated the
+adjacent cleanups pay for themselves: the create page's inline scripts were
+repeatedly found to be the stale fork of the edit page's
+(leaf-decomposition-review.md), so extraction is also de-duplication.
 
-This is also a **token-layer** fix, not only a ratchet fix. Those literals
-bypass the scales the CSS guards enforce: `font-size:.7rem` is not a step
-(`--text-2xs` is `.72rem`), and bare `font-family:monospace` is exactly what
-`ui-design.md` forbids in favour of `--font-mono`. The guards cannot see any
-of it because it lives in a JS string.
-
-Note 25 of the 30 `borderColor`/`color` writes in the whole codebase are in
-this one file — validity cues that want toggled classes with dark-mode
-values, since a hardcoded colour here is invisible-on-dark waiting to happen.
-
-**Expected:** `JS_STYLE_DECISION_BASELINE` 118 → roughly 60. Low risk: it is
-one file, covered by frontend tests, and the visual harness captures the
-pages it renders.
-
-### 2. `suite-table.js` — the same job, 22 more
-
-Same shape, same fix, and it shares the `suite-*` allowlist entries. Doing it
-right after (1) means the classes from (1) already exist.
-
-### 3. The `js-` prefix sweep — mechanical, shrinks a third ratchet
-
-The 67 allowlist entries are behaviour-only hooks predating the convention.
-Renaming `pf-case-remove` → `js-pf-case-remove` (and its JS selector) removes
-an entry with no styling risk. 43 belong to the two files above, so fold this
-into (1) and (2) rather than doing it as its own pass.
-
-**Do not** add allowlist entries. It is shrink-only by contract.
+**`PAGE_STYLE_BASELINE` = 689** — page-local `<style>` blocks. No single
+block dominates; shrink opportunistically when a page is already open.
 
 ---
 
-## The two traps
+## The trap
 
-### Trap 1: PR #1384 is stale and half-superseded. Do not just rebase it.
-
-`claude/ui-rendering-rules-al968b`, open draft, based on `ad9e84b` — which
-predates the entire S0–S10 series. Its **CSS-vocabulary half was independently
-redone** by S7/S7b, in some cases differently:
-
-| #1384 proposed | status now |
-|---|---|
-| `.bs-*` → global vocabulary | **done in S7b** (`.bs-status` → `.detail-grid`; the green/red pairs → `.chip-ok`/`.chip-err`) |
-| `.storage-bar` → `.page-titlebar--baseline` | **done in S7b** |
-| `.titlebar-subtitle` | **done in S7** |
-| `.popover-panel` | **done in S7** |
-| VR determinism / relative-time pinning | **done differently** — `capture.mjs` freezes the masked text |
-| `.editor-modal-*`, `.input-expression` / `-attention` / `-invalid`, `.editor-stack`, `.editor-cm-mount`, `.input-mono` | **still unique — this is the valuable part** |
-
-Its ratchet numbers are also wrong now: it claims 913 → 811 and 122 → 100,
-against actual 689 and 118.
-
-**Recommendation:** do not rebase it wholesale. Salvage the JS-styling half
-(which overlaps items 1–2 above and is the same work), and close it with a
-note rather than fighting the conflicts. Verify before trusting this table:
-
-```
-for c in editor-modal input-expression editor-cm-mount input-mono titlebar-subtitle popover-panel chip-ok; do grep -q "\.$c" Public/styles.css && echo "$c PRESENT" || echo "$c absent"; done
-```
-
-### Trap 2: regenerating visual baselines rewrites more than you changed
+### Regenerating visual baselines rewrites more than you changed
 
 `run-visual.sh --update` rewrote **12** captures for a change touching five
 templates that cannot affect `login`, `student-submit`, `student-dashboard`
@@ -169,10 +107,14 @@ rest of the change was pixel-neutral.
 - **The two authoring templates' markup.** They are 44% of the inline-script
   ratchet and the biggest number on the board, but `leaf-decomposition-review.md`
   is right that a shared partial getting the create-vs-edit differences subtly
-  wrong is worse than two honest copies. **Their JS is a different question
-  from their markup** — that review found the create page was the *stale fork*
-  every time it looked, and fixing three forks removed three live defects.
-  Start with the JS.
+  wrong is worse than two honest copies. Extracting their inline *scripts*
+  to shared `Public/*.js` files is the safe half of that work — the review
+  found the create page's inline JS was the *stale fork* every time it
+  looked, and fixing three forks removed three live defects.
+- **Converting the sanctioned JS `.style` remainder.** The 14 counted
+  decisions left are popover geometry, custom-property writes and a read —
+  the patterns `ui-design.md` explicitly blesses. Rewriting them to appease
+  a grep would trade working idioms for a rounder number.
 - **S1b person typeahead.** Deferred until the unified filter has real usage.
   Still the right call; nothing has changed.
 - **Styled `<dialog>` confirmations and converging the two overlays.** The

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -141,7 +141,13 @@ fi
 # (docs/ui-design.md): JS toggles classes or sets a custom property
 # (workbench.js's --wb-left-width is the pattern); it does not decide
 # styling.
-JS_STYLE_DECISION_BASELINE=118
+# At the floor as of the editor-surface conversion: what remains is app.js's
+# runtime-computed popover geometry (the one sanctioned direct-write use),
+# chickadee-ui.js's flash colour + collapse-animation overflow writes and a
+# --bar-h custom-property assignment (the sanctioned pattern, counted
+# crudely), workbench.js's --wb-left-width setProperty (same), and a
+# .style.fontSize READ in jl-cell-perf-patch.js.
+JS_STYLE_DECISION_BASELINE=14
 js_style_count="$(
   {
     grep -ho 'style="' Public/*.js || true

--- a/scripts/class-resolution-allowlist.txt
+++ b/scripts/class-resolution-allowlist.txt
@@ -5,60 +5,11 @@
 # js-* or gains a stylesheet rule (check-class-resolution.sh fails on stale
 # entries); never add one for new code — new behaviour hooks take the js-
 # prefix instead.
-
-
-# Achievements editor (achievements-editor.js)
-ach-edit
-ach-remove
-am-cond-comparator
-am-conditions-wrap
-am-scope-field
-
-# Pattern-family editor (pattern-family-editor.js)
-pf-case-arg
-pf-case-args
-pf-case-expected
-pf-case-expected-col
-pf-case-hint
-pf-case-label
-pf-case-num
-pf-case-remove
-pf-var-name
-pf-var-remove
-pf-var-row-valid
-pf-var-section-row
-pf-var-value
-
-# Suite table + sections (suite-table.js, section-items-dnd.js)
-assignments-body
-section-add-test-btn
-section-delete-btn
-section-edit-cancel
-section-edit-toggle
-section-var-add
-section-var-name
-section-var-remove
-section-var-row
-section-var-row-valid
-section-var-value
-section-vars-body
-suite-check-points
-suite-check-tier
-suite-delete-btn
-suite-display-name
-suite-edit-btn
-suite-family-points
-suite-family-tier
-suite-points
-suite-tier
-
-# Inputs editors (inputs-editor-core.js)
-global-input-name
-global-input-remove
-global-input-row
-global-input-row-valid
-global-input-value
-global-inputs-body
+#
+# The assignment-editor surface (pattern-family editor, suite table, inputs
+# editors, achievements editor) was swept to js- names in the ratchet
+# follow-up pass; what remains below is the smaller tail of hooks on other
+# surfaces.
 
 # Content items (course content editor)
 content-item-add
@@ -70,10 +21,6 @@ content-item-row
 
 # Row/anchor hooks in tables and panels
 bs-grade-id-hidden
-check-delete-btn
-check-edit-btn
-family-delete-btn
-family-edit-btn
 nb-fallback
 publish-due-date
 role-cell
@@ -89,5 +36,3 @@ inplace-error-banner
 
 # Sortable-table opt-in marker (sortable-table.js)
 sortable-table
-
-# Ungrouped


### PR DESCRIPTION
Continues the UI ratchet from [docs/ui-ratchet-handoff.md](docs/ui-ratchet-handoff.md): items 1–3 of its queue (pattern-family editor, suite table, the `js-` sweep) plus the salvageable JS-styling half of stale PR #1384, which turned out to be the same work on the neighbouring files.

## JS styling ratchet: 118 → 14 (its floor)

The pattern-family editor, suite table, inputs editors, Test Editor modal and both test renderers now assign classes from a shared editor-table vocabulary in `styles.css` — `.cell-input` (+ width modifiers), `.cell-name`/`.cell-check`/`.cell-remove`/`.cell-num`, `.cell-stack`/`.cell-title`, locked-row `.cell-tight`/`.cell-code`/`.cell-preview`/`.cell-shadowed`, JS-rebuilt header `.th-code`/`.th-note`, the `.modal-head/-title/-close/-body/-foot` internals of the S9 modal shell, `.editor-stack`, `.editor-cm-mount`, and the `.input-*` value-state cues — instead of writing style strings.

What the count still sees is the sanctioned remainder (app.js popover geometry, two custom-property writes the grep cannot tell from styling, chickadee-ui's flash/collapse behaviour, one `.style` read), so the baseline is now documented as a floor, not headroom.

Notable correctness effects, not just accounting:

- **Validity cues get dark-mode values.** Invalid names, the per-student `=` tint, `$name` resolution and auto-computed values were inline `borderColor`/`color`/`rgba()` writes with no dark-mode story; they are now toggled classes on palette colours. The `rgba(45,143,71,.07)` tint became `color-mix` on `--green`/`--surface`.
- **A live JS/server drift is gone.** The section-inputs table ran `.78rem` in JS-added rows and `.8rem` in server-rendered rows of the same table. Both now share one set of classes, and the global-inputs rows join the same dense-table size.
- **The off-scale literals are gone** — `font-size:.7rem`/`.78rem`/`.82rem`/`.85rem` and bare `font-family:monospace` all sit on the `--text-*` scale and `--font-mono` now.
- **The `el()` helpers lose their `style` parameter**, so a new renderer call site cannot smuggle a style string past the CSS guards.

## Class-resolution allowlist: 67 → 18

Every behaviour-only hook on the editor surface takes the `js-` prefix (`pf-case-remove` → `js-pf-case-remove`, the suite/section/global-input/achievements families likewise), across JS, templates, and the frontend tests. Three dead identifiers found on the way (`pf-case-expected-col`, `am-conditions-wrap`, the `assignments-body` tbody class — assigned, never queried, never styled) are deleted rather than renamed.

`suite-table.js`'s focus restore previously keyed on the first non-`form-` class, which after this change could be a styling class shared by several controls in a row; it now prefers the `js-` hook.

## PR #1384

Its CSS-vocabulary half was already redone by S7/S7b; this PR lands the still-unique JS-styling half with the current stylesheet's names (`.modal-*` extends the S9 shell rather than adding a parallel `.editor-modal-*` family). #1384 can be closed once this merges — a note is posted there.

## Validation

- `scripts/check-styles.sh` green with both ratchets lowered in this PR (JS-style baseline 118 → 14, allowlist 67 → 18); the ratchet was watched to **fail** on a probe style write before trusting it.
- ESLint clean; all 363 frontend tests pass (the swept hook names are pinned by `pattern-family-editor.test.mjs`, `section-inputs-adoption.test.mjs`, `section-reorder-url.test.mjs`).
- Render-test suites for the touched templates (`AssignmentRoutesEditorTests`, `InstructorWorkbenchRoutesTests`, `AssignmentRoutesDashboardTests`, `DraftSuiteSectionRoutesTests`, `SectionInputsTests`, `TestEditorCatalogCoverageTests`, `PatternFamilyApplyTests`, `StatusClassStylesheetTests`) run locally.
- No captured visual-regression page uses any changed rule (the editors render on uncaptured pages; `instructor-assignments` only had unstyled hook renames), so baselines are untouched.
- `docs/ui-design.md` gains the new vocabulary entries; `docs/ui-ratchet-handoff.md` is updated so the next pass inherits accurate numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVCUz26gA3ZGmAxKBpfWcN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVCUz26gA3ZGmAxKBpfWcN)_