### PR TITLE
refactor(ui): close the class-resolution allowlist tail; epic closure record

### DIFF
--- a/Public/assignment-submissions.js
+++ b/Public/assignment-submissions.js
@@ -9,7 +9,7 @@
 
     var card = document.querySelector('[data-subm-trend]');
     if (!card) return;
-    var sparks = Array.prototype.slice.call(card.querySelectorAll('.subm-trend-spark'));
+    var sparks = Array.prototype.slice.call(card.querySelectorAll('.js-subm-trend-spark'));
     if (sparks.length < 2) return;
     var chip = card.querySelector('[data-subm-chip]');
     var valueEl = card.querySelector('[data-subm-value]');

--- a/Public/assignments.js
+++ b/Public/assignments.js
@@ -226,7 +226,7 @@
     // ── UWaterloo important-date proximity warning ────────────────────────────
     // Shared implementation (Public/chickadee-ui.js, loaded from base.leaf).
     // The compact publish form keeps its shorter label.
-    document.querySelectorAll('.publish-due-date').forEach(function (input) {
+    document.querySelectorAll('.js-publish-due-date').forEach(function (input) {
         var warning = input.closest('form')?.querySelector('.publish-uw-warning');
         if (!warning) return;
         input.addEventListener('change', function () {

--- a/Public/inplace-forms.js
+++ b/Public/inplace-forms.js
@@ -39,10 +39,10 @@
     // same reason: a native dialog inside a pane is a modal over one third of
     // the screen with no indication of which half raised it.
     function showError(form, msg) {
-        var banner = form.querySelector('.inplace-error-banner');
+        var banner = form.querySelector('.js-inplace-error-banner');
         if (!banner) {
             banner = document.createElement('div');
-            banner.className = 'form-error inplace-error-banner';
+            banner.className = 'form-error js-inplace-error-banner';
             banner.setAttribute('role', 'alert');
             form.insertBefore(banner, form.firstChild);
         }
@@ -51,7 +51,7 @@
     }
 
     function clearError(form) {
-        var banner = form.querySelector('.inplace-error-banner');
+        var banner = form.querySelector('.js-inplace-error-banner');
         if (banner) banner.remove();
     }
 

--- a/Public/instructor-brightspace.js
+++ b/Public/instructor-brightspace.js
@@ -56,7 +56,7 @@
     function wireForms(byId, byName) {
         document.querySelectorAll('.bs-grade-form').forEach(function (form) {
             var visibleInput = form.querySelector('.bs-grade-input');
-            var hiddenInput = form.querySelector('.bs-grade-id-hidden');
+            var hiddenInput = form.querySelector('.js-bs-grade-id-hidden');
             if (!visibleInput || !hiddenInput) return;
             var rawId = visibleInput.dataset.rawId || '';
             if (rawId && byId[rawId]) {

--- a/Public/notebook-preflight.js
+++ b/Public/notebook-preflight.js
@@ -9,7 +9,7 @@
 //   2. watchdog_timeout — the iframe loaded but the JupyterLite kernel
 //                          didn't become ready within the watchdog window.
 //
-// On either failure: hide the iframe, reveal the #nb-fallback section
+// On either failure: hide the iframe, reveal the #js-nb-fallback section
 // containing a direct .ipynb upload picker, and POST a record to
 // /api/v1/client-diagnostics so the instructor dashboard can surface the
 // affected student.
@@ -106,8 +106,8 @@
         _failureShown = true;
 
         const frame    = document.getElementById('jl-frame');
-        const fallback = document.getElementById('nb-fallback');
-        const details  = document.getElementById('nb-fallback-details');
+        const fallback = document.getElementById('js-nb-fallback');
+        const details  = document.getElementById('js-nb-fallback-details');
         const submit   = document.getElementById('nb-submit');
 
         if (frame)    frame.style.display = 'none';
@@ -119,8 +119,8 @@
         // same fallback panel (which already offers .ipynb upload + reset link),
         // instead of the generic "Editor didn't load" message.
         if (info.variant === 'memory' && fallback) {
-            const titleEl = fallback.querySelector('.nb-fallback-title');
-            const textEl  = fallback.querySelector('.nb-fallback-text');
+            const titleEl = fallback.querySelector('.js-nb-fallback-title');
+            const textEl  = fallback.querySelector('.js-nb-fallback-text');
             if (titleEl) titleEl.textContent = 'Your browser ran low on memory';
             if (textEl) {
                 textEl.textContent =
@@ -311,10 +311,10 @@
         if (_slowNoticeShown || _failureShown) return;
         _slowNoticeShown = true;
 
-        const fallback = document.getElementById('nb-fallback');
+        const fallback = document.getElementById('js-nb-fallback');
         if (fallback) {
-            const titleEl = fallback.querySelector('.nb-fallback-title');
-            const textEl  = fallback.querySelector('.nb-fallback-text');
+            const titleEl = fallback.querySelector('.js-nb-fallback-title');
+            const textEl  = fallback.querySelector('.js-nb-fallback-text');
             if (titleEl) titleEl.textContent = 'The editor is taking a while to load';
             if (textEl) {
                 textEl.textContent =

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -2217,8 +2217,8 @@
                      || document.getElementById('suite-config-body');
         if (suiteBody) {
             suiteBody.addEventListener('click', function (e) {
-                var editBtn = e.target && e.target.closest('.family-edit-btn');
-                var delBtn  = e.target && e.target.closest('.family-delete-btn');
+                var editBtn = e.target && e.target.closest('.js-family-edit-btn');
+                var delBtn  = e.target && e.target.closest('.js-family-delete-btn');
                 if (editBtn) {
                     var fid = editBtn.getAttribute('data-family-id');
                     var idx = familiesState.findIndex(function (f) { return f.id === fid; });

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -394,8 +394,8 @@
                 + '<td><input type="number" class="form-input cell-input points-input js-suite-family-points" min="0" max="100" value="' + defaultPoints + '" title="Points per case — applied to every generated test"></td>'
                 + '<td class="time"><div class="cell-actions">'
                 +   ChickadeeUI.accordion.CARET_HTML
-                +   '<button class="btn action-btn action-btn-icon family-edit-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Edit family" aria-label="Edit family"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
-                +   '<button class="btn action-btn action-btn-icon action-danger family-delete-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Delete family" aria-label="Delete family"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon js-family-edit-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Edit family" aria-label="Edit family"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon action-danger js-family-delete-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Delete family" aria-label="Delete family"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
                 + '</div></td>'
                 + '</tr>';
         }
@@ -425,8 +425,8 @@
                 + '<td><input type="number" class="form-input cell-input points-input js-suite-check-points" min="0" max="100" value="' + points + '"></td>'
                 + '<td class="time"><div class="cell-actions">'
                 +   ChickadeeUI.accordion.CARET_HTML
-                +   '<button class="btn action-btn action-btn-icon check-edit-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Edit notebook check" aria-label="Edit notebook check"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
-                +   '<button class="btn action-btn action-btn-icon action-danger check-delete-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Delete notebook check" aria-label="Delete notebook check"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon js-check-edit-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Edit notebook check" aria-label="Edit notebook check"><svg class="icon" aria-hidden="true"><use href="#i-pencil"/></svg></button>'
+                +   '<button class="btn action-btn action-btn-icon action-danger js-check-delete-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Delete notebook check" aria-label="Delete notebook check"><svg class="icon" aria-hidden="true"><use href="#i-trash"/></svg></button>'
                 + '</div></td>'
                 + '</tr>';
         }
@@ -1187,7 +1187,7 @@
         // pre-populated; Delete drops the check and re-saves the list via the
         // single PUT /suite write path.
         container.addEventListener('click', function (e) {
-            var editBtn = e.target.closest && e.target.closest('.check-edit-btn');
+            var editBtn = e.target.closest && e.target.closest('.js-check-edit-btn');
             if (editBtn) {
                 let row = editBtn.closest('tr[data-kind="check"]');
                 if (!row) return;
@@ -1202,7 +1202,7 @@
                 });
                 return;
             }
-            var delBtn = e.target.closest && e.target.closest('.check-delete-btn');
+            var delBtn = e.target.closest && e.target.closest('.js-check-delete-btn');
             if (delBtn) {
                 var row2 = delBtn.closest('tr[data-kind="check"]');
                 if (!row2) return;

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -17,7 +17,7 @@
 //
 // Expects the shared markup ids: #add-support-file-btn,
 // #support-file-upload-input, #support-file-upload-status, and per-row
-// .support-file-delete-btn[data-filename] buttons.
+// .js-support-file-delete-btn[data-filename] buttons.
 (function () {
     'use strict';
 
@@ -82,7 +82,7 @@
         }
 
         document.body.addEventListener('click', async function (ev) {
-            var btn = ev.target.closest && ev.target.closest('.support-file-delete-btn');
+            var btn = ev.target.closest && ev.target.closest('.js-support-file-delete-btn');
             if (!btn) return;
             var filename = btn.getAttribute('data-filename');
             if (!filename) return;

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -167,7 +167,7 @@
                         <a href="#(supportFile.url)"><code>#(supportFile.name)</code></a>
                     </td>
                     <td class="time">
-                        <button class="btn action-btn action-danger support-file-delete-btn" type="button"
+                        <button class="btn action-btn action-danger js-support-file-delete-btn" type="button"
                                 data-filename="#(supportFile.name)">Remove</button>
                     </td>
                 </tr>

--- a/Resources/Views/_course-item-row.leaf
+++ b/Resources/Views/_course-item-row.leaf
@@ -10,7 +10,7 @@
      section - which is every assignment on a course that has never created a
      section - rendered without them. -->
 #if(item.isContent):
-    <tr class="content-item-row" data-content-item-id="#(item.content.id)">
+    <tr data-content-item-id="#(item.content.id)">
         <td>
             <span class="assignment-name-cell">
                 <span class="assignment-drag-handle" title="Drag to reorder or move between sections" aria-hidden="true">⋮⋮</span>
@@ -23,10 +23,10 @@
         <td colspan="3" class="col-hide-phone content-item-links">#for(link in item.content.links):<a href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor#for(att in item.content.attachments):<a href="#(att.downloadURL)">#(att.displayName)</a>#endfor</td>
         <td class="col-hide-phone">#if(item.content.updatedLabel):#(item.content.updatedLabel)#else:<span class="text-muted">—</span>#endif</td>
         <td class="content-item-actions">
-            <details class="popup-anchor content-item-edit-details">
+            <details class="popup-anchor">
                 <summary class="btn action-btn summary-btn">Edit</summary>
                 <div class="add-section-popup card">
-                    <form method="post" action="/instructor/content-items/#(item.content.id)/edit" enctype="multipart/form-data" class="form popup-form content-item-form">
+                    <form method="post" action="/instructor/content-items/#(item.content.id)/edit" enctype="multipart/form-data" class="form popup-form">
                         #csrfFormField()
                         <label class="form-label">Title
                             <input class="form-input editor-input" type="text" name="title" value="#(item.content.title)" required>
@@ -86,7 +86,7 @@
                     #endif
                 </div>
             </details>
-            <form method="post" action="/instructor/content-items/#(item.content.id)/delete" class="content-item-delete-form" data-confirm="Delete this material?">
+            <form method="post" action="/instructor/content-items/#(item.content.id)/delete" data-confirm="Delete this material?">
                 #csrfFormField()
                 <button class="btn action-btn action-danger" type="submit">Delete</button>
             </form>
@@ -179,7 +179,7 @@
                     </label>
                     <label class="form-label publish-label">
                         Due date (optional)
-                        <input class="form-input publish-due-date editor-input" type="datetime-local" name="dueAt">
+                        <input class="form-input js-publish-due-date editor-input" type="datetime-local" name="dueAt">
                     </label>
                     <div class="publish-uw-warning card-meta" style="display:none"></div>
                     <button class="btn btn-primary btn-compact" type="submit">Create draft</button>

--- a/Resources/Views/_diagnostic-cards.leaf
+++ b/Resources/Views/_diagnostic-cards.leaf
@@ -29,7 +29,7 @@
         <div class="diagnostic-label"><span class="diagnostic-window-chip" data-subm-chip>#(metric.windowChip)</span> #(metric.label)</div>
         <div class="diagnostic-value" data-subm-value>#(metric.value)</div>
         #for(win in metric.windows):
-        <div class="diagnostic-spark subm-trend-spark" data-subm-window="#(win.key)" data-subm-headline="#(win.headline)" aria-hidden="true"#if(win.initiallyHidden): hidden#endif>
+        <div class="diagnostic-spark js-subm-trend-spark" data-subm-window="#(win.key)" data-subm-headline="#(win.headline)" aria-hidden="true"#if(win.initiallyHidden): hidden#endif>
             #for(bar in win.bars):
             <div class="spark-slot" title="#(bar.title)"><span class="spark-fill#if(bar.isEmpty): spark-fill-empty#endif" style="--bar-h:#(bar.heightPercent)%"></span></div>
             #endfor

--- a/Resources/Views/_notebook-body.leaf
+++ b/Resources/Views/_notebook-body.leaf
@@ -16,10 +16,10 @@
 .nb-closed-notice { color: var(--gray-600); font-size: var(--text-base); }
 .nb-notice-title { margin: .2rem 0 .5rem; }
 .nb-notice-text { margin: 0; color: var(--gray-700); }
-.nb-fallback-title { margin: .2rem 0; }
-.nb-fallback-text { margin: .4rem 0; }
-.nb-fallback-diagnostic { margin-top: .6rem; }
-.nb-fallback-pre { white-space: pre-wrap; font-size: .85em; margin: .4rem 0; }
+.js-nb-fallback-title { margin: .2rem 0; }
+.js-nb-fallback-text { margin: .4rem 0; }
+.js-nb-fallback-diagnostic { margin-top: .6rem; }
+.js-nb-fallback-pre { white-space: pre-wrap; font-size: .85em; margin: .4rem 0; }
 
 /* Proactive low-memory hint (revealed by notebook-preflight.js on a low-RAM
    device). Non-blocking and dismissible — the editor still loads beneath it. */
@@ -53,7 +53,7 @@
 @media (max-width: 640px) {
     .notebook-header,
     #jl-frame,
-    #nb-fallback,
+    #js-nb-fallback,
     #nb-device-warning,
     #nb-browser-support-warning,
     #nb-results,
@@ -158,24 +158,24 @@
     src="about:blank"
     loading="eager">
 </iframe>
-<section id="nb-fallback" class="nb-fallback" role="alert" hidden>
-    <h2 class="nb-fallback-title">Editor didn&rsquo;t load</h2>
-    <p class="nb-fallback-text">
+<section id="js-nb-fallback" class="js-nb-fallback" role="alert" hidden>
+    <h2 class="js-nb-fallback-title">Editor didn&rsquo;t load</h2>
+    <p class="js-nb-fallback-text">
         The in-browser notebook editor didn&rsquo;t start in your browser.
         You can still submit your assignment by uploading your <code>.ipynb</code> file directly.
     </p>
-    <p class="nb-fallback-text">
+    <p class="js-nb-fallback-text">
         <input type="file" id="nb-upload-file" accept=".ipynb,application/json">
     </p>
-    <p class="nb-fallback-text">
+    <p class="js-nb-fallback-text">
         Still stuck? You can
         <a id="nb-reset-editor-link" href="/reset-editor">reset the notebook editor</a>
         &mdash; this clears cached editor data in your browser (your submitted
         work is safe) so the kernel can start fresh.
     </p>
-    <details class="nb-fallback-diagnostic">
+    <details class="js-nb-fallback-diagnostic">
         <summary>Diagnostic details</summary>
-        <pre id="nb-fallback-details" class="nb-fallback-pre"></pre>
+        <pre id="js-nb-fallback-details" class="js-nb-fallback-pre"></pre>
     </details>
 </section>
 <div id="nb-results" class="nb-results" hidden></div>

--- a/Resources/Views/_student-rows.leaf
+++ b/Resources/Views/_student-rows.leaf
@@ -17,7 +17,7 @@
                 <a href="#(student.submissionsURL)"><code>#(student.username)</code></a>
                 #endif
             </td>
-            <td class="role-cell">
+            <td>
                 #if(student.isPending):
                 <span class="students-pending-role">(pending)</span>
                 #elseif(rosterReadOnly):

--- a/Resources/Views/_user-rows.leaf
+++ b/Resources/Views/_user-rows.leaf
@@ -10,7 +10,7 @@
                 <td><code>#(user.username)</code></td>
                 <td>
                     #if(user.role == "mcp"):
-                    <code class="role-fixed">mcp</code>
+                    <code>mcp</code>
                     #else:
                     <form method="post" action="/admin/users/#(user.id)/role"
                           class="role-form">

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -167,7 +167,7 @@ Create Assignment
                         <a href="#(supportFile.url)"><code>#(supportFile.name)</code></a>
                     </td>
                     <td class="time">
-                        <button class="btn action-btn action-danger support-file-delete-btn" type="button"
+                        <button class="btn action-btn action-danger js-support-file-delete-btn" type="button"
                                 data-filename="#(supportFile.name)">Remove</button>
                     </td>
                 </tr>

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -109,10 +109,10 @@
     <!-- Toolbar: add ungraded reference material to this section (interleaved
          with the assignments in the drag-orderable table below). -->
     <div class="content-lane">
-        <details class="add-section-details popup-anchor content-item-add">
+        <details class="add-section-details popup-anchor">
             <summary class="btn action-btn summary-btn">+ Add material</summary>
             <div class="add-section-popup card">
-                <form method="post" action="/instructor/content-items" enctype="multipart/form-data" class="form popup-form content-item-form">
+                <form method="post" action="/instructor/content-items" enctype="multipart/form-data" class="form popup-form">
                     #csrfFormField()
                     <input type="hidden" name="sectionID" value="#(section.sectionID)">
                     <label class="form-label">Title
@@ -198,10 +198,10 @@
     <!-- Toolbar: add ungraded reference material with no section (interleaved
          with the ungrouped assignments in the drag-orderable table below). -->
     <div class="content-lane">
-        <details class="add-section-details popup-anchor content-item-add">
+        <details class="add-section-details popup-anchor">
             <summary class="btn action-btn summary-btn">+ Add material</summary>
             <div class="add-section-popup card">
-                <form method="post" action="/instructor/content-items" enctype="multipart/form-data" class="form popup-form content-item-form">
+                <form method="post" action="/instructor/content-items" enctype="multipart/form-data" class="form popup-form">
                     #csrfFormField()
                     <input type="hidden" name="sectionID" value="">
                     <label class="form-label">Title

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -9,7 +9,7 @@
 <h1>Assignments</h1>
 #endif
 #if(slipDaySummary):
-<p class="text-muted slip-day-summary">#(slipDaySummary)</p>
+<p class="text-muted">#(slipDaySummary)</p>
 #endif
 #if(!hasAny):
 #if(currentUser.activeCourse):
@@ -29,7 +29,7 @@
     <tbody>
     #for(item in group.items):
     #if(item.isContent):
-        <tr class="content-item-row">
+        <tr>
             <td>
                 <span class="content-item-kind">#(item.content.kindLabel)</span>
                 <span class="content-item-title">#(item.content.title)</span>
@@ -37,8 +37,8 @@
                 #if(item.content.itemDescription):<div class="content-item-desc text-muted">#(item.content.itemDescription)</div>#endif
             </td>
             <td colspan="4" class="col-hide-phone content-item-links">
-                #for(link in item.content.links):<a class="content-item-link" href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor
-                #for(att in item.content.attachments):<a class="content-item-link" href="#(att.downloadURL)">#(att.displayName)</a>#endfor
+                #for(link in item.content.links):<a href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor
+                #for(att in item.content.attachments):<a href="#(att.downloadURL)">#(att.displayName)</a>#endfor
             </td>
             <td class="col-hide-phone">#if(item.content.updatedLabel):#(item.content.updatedLabel)#else:<span class="text-muted">—</span>#endif</td>
         </tr>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -130,7 +130,7 @@ LEARN
                           class="bs-grade-form" data-assignment-id="#(row.assignmentID)">
                         #csrfFormField()
                         <input type="hidden" name="returnTo" value="brightspace">
-                        <input type="hidden" name="gradeObjectID" class="bs-grade-id-hidden">
+                        <input type="hidden" name="gradeObjectID" class="js-bs-grade-id-hidden">
                         <label class="visually-hidden" for="bs-go-#(row.assignmentID)">LEARN Assessment for #(row.title)</label>
                         <input class="form-input bs-grade-input" type="text"
                                id="bs-go-#(row.assignmentID)" list="bs-grade-objects"

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -24,7 +24,7 @@ Submission #(submissionID)
 <div class="submission-header">
     <div class="submission-header-row">
         <h1>Submission</h1>
-        <div class="submission-actions">
+        <div>
             <a class="btn action-btn" href="/api/v1/submissions/#(submissionID)/download">#if(submissionFilename):Download #(submissionFilename)#else:Download submission#endif</a>
             #if(openInNotebookURL):
             <a class="btn action-btn" href="#(openInNotebookURL)">Open in notebook</a>
@@ -180,7 +180,7 @@ Submission #(submissionID)
     #endif
     #if(sec.secretSummary):
     <div class="tier-summary-row tier-summary-secret">
-        <span class="tier tier-secret-badge">secret</span>
+        <span class="tier">secret</span>
         <span class="tier-summary-counts">#(sec.secretSummary.passCount) passed, #(sec.secretSummary.failCount) failed#if(sec.secretSummary.errorCount): , #(sec.secretSummary.errorCount) error(s)#endif</span>
         <span class="tier-summary-note">— hidden tests in this section; they count toward your grade, but individual tests aren't shown</span>
     </div>

--- a/Tools/visual-regression/README.md
+++ b/Tools/visual-regression/README.md
@@ -82,3 +82,26 @@ together. Baselines are
 **CI-canonical**: regenerate them in the CI image (or trust the bootstrap
 artifact) rather than committing captures from a host with different font
 rendering.
+
+## Running in a Claude remote container
+
+The remote-execution image pre-installs Playwright browsers at
+`/opt/pw-browsers` (with `PLAYWRIGHT_BROWSERS_PATH` pointing there and
+downloads disabled), but the browser build there tracks the image, not this
+package's lockfile — so a newer `playwright` from `npm ci` will look for a
+`chromium_headless_shell-<rev>` directory the image does not have and fail
+with "Executable doesn't exist". Do not run `npx playwright install`
+(downloads are disabled by policy). Bridge the layout instead — symlink the
+expected revision directory to the installed binary:
+
+```
+ls /opt/pw-browsers
+mkdir -p /opt/pw-browsers/chromium_headless_shell-REV/chrome-headless-shell-linux64
+ln -sf /opt/pw-browsers/chromium_headless_shell-OLDREV/chrome-linux/headless_shell /opt/pw-browsers/chromium_headless_shell-REV/chrome-headless-shell-linux64/chrome-headless-shell
+```
+
+with REV taken from the error message and OLDREV from the `ls`. The compare
+then runs against a slightly different Chromium than CI captured the
+baselines on; the anti-aliasing budget absorbs it in practice, but treat a
+borderline diff on text-heavy pages as suspect and let the CI `visual` job
+arbitrate.

--- a/changelog.d/ui-ratchet-tail.md
+++ b/changelog.d/ui-ratchet-tail.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **The UI-maintainability ratchet closes out.** The last 21 removable
+  entries leave the class-resolution allowlist: ten behaviour hooks that
+  scripts genuinely read take the `js-` prefix (suite/family/check row
+  actions, support-file delete, the publish due-date field, the notebook
+  fallback notice, the submissions sparkline, the BrightSpace hidden-id
+  field, the in-place error banner), and eleven class tokens that nothing
+  read or styled — leftovers of earlier eras — are removed outright. The
+  allowlist's one remaining entry, the sort component's `sortable-table`
+  opt-in marker, is kept as a documented exception. The ratchet handoff
+  document becomes the epic's closure record, with the standing rules for
+  per-page revision work, and the visual-regression README documents how
+  to run the harness in a remote container whose pre-installed browsers
+  trail the lockfile.

--- a/docs/ui-ratchet-handoff.md
+++ b/docs/ui-ratchet-handoff.md
@@ -1,13 +1,16 @@
-# UI ratchet — handoff for the next pass (2026-08)
+# UI ratchet — the maintainability epic, closed (2026-08)
 
-The widget-layer audit ([ui-consistency-audit.md](ui-consistency-audit.md))
-shipped as S0–S10 and is closed. This brief is for whoever continues the
-ratchet: where the remaining mass actually sits, which of it is mechanical,
-and the traps that will cost you a day if you walk into them cold.
+**This epic is complete.** The widget-layer audit
+([ui-consistency-audit.md](ui-consistency-audit.md)) shipped as S0–S10; the
+editor-conversion pass and the inline-script pass (both 2026-08-14) closed
+the two big tracks it left open; the tail pass closed the allowlist. This
+document is now the closure record plus the standing rules for what comes
+next. Nothing here is a work list any more — per-page revision work starts
+from ["For the per-page revision work"](#for-the-per-page-revision-work) at
+the bottom.
 
-**Updated after the editor-conversion pass (2026-08-14),** which took the
-brief's items 1–3 and the #1384 salvage in one PR. Everything below is
-measured, not estimated. Re-measure before you act — the commands are given.
+Everything below is measured, not estimated. Re-measure before trusting a
+number that gates a decision — the commands are given.
 
 > **Update (2026-08, the inline-script pass): the inline-script track is
 > complete.** Every template's multi-line `<script>` body moved into a
@@ -37,7 +40,7 @@ measured, not estimated. Re-measure before you act — the commands are given.
 | `ALERT_BASELINE` | 4 | **0** | absolute |
 | `JS_ALERT_BASELINE` | 7 | **0** | absolute |
 | axe moderate/minor | 12 | **0** | absolute in practice |
-| class-resolution allowlist | 67 | **22** | shrink-only |
+| class-resolution allowlist | 67 | **1** | `sortable-table`, the documented exception |
 
 Every ratchet is at its count, so *any* growth fails CI. The audit's three
 absolute rules (icon geometry outside the sprite, native confirmation
@@ -98,25 +101,29 @@ for f in Public/*.js; do n=$( { grep -ho 'style="' "$f" || true; grep -hoE '\.st
 
 ---
 
-## What is actually left, in the order I would take it
+## The tail pass (closed the epic)
 
-Both big tracks are now closed — the JS-styling track by the editor pass,
-the inline-script track by the externalization pass. What remains is small:
+The last 21 removable allowlist entries went in the final pass, each by
+what it actually was rather than by blanket rename:
 
-### 1. The 22 remaining allowlist entries
+- **10 hooks JS genuinely reads** took the `js-` prefix
+  (`js-check-edit-btn`/`-delete-btn`, `js-family-edit-btn`/`-delete-btn`,
+  `js-support-file-delete-btn`, `js-publish-due-date`, `js-nb-fallback`,
+  `js-subm-trend-spark`, `js-bs-grade-id-hidden`,
+  `js-inplace-error-banner`), renamed at every assignment and query site.
+- **11 tokens nothing read or styled were dropped outright** — the
+  `content-item-*` six, `role-cell`, `role-fixed`, `slip-day-summary`,
+  `submission-actions`, `tier-secret-badge`. Each was verified unread
+  (including dynamically-built selectors) and unstyled before removal;
+  they were leftovers of earlier eras doing literally nothing.
+- **`sortable-table` stays, deliberately**, as the allowlist's single
+  documented entry: it is the sort component's opt-in marker, renaming it
+  would churn every sortable table for zero drift risk, and a stylesheet
+  rule for it would be a lie (it opts into behaviour, not appearance).
 
-`content-item-*` (6, course-content editor), the cross-page row/anchor
-hooks (14), `inplace-error-banner`, and `sortable-table`. All are the same
-mechanical rename — the reason they are second is only that they spread
-across more templates per name than the editor hooks did. `sortable-table`
-is the one to leave: it is the opt-in marker the sort component documents,
-so renaming it would churn every sortable table for zero drift risk.
-
-### 2. `PAGE_STYLE_BASELINE` = 689
-
-No slice plan ever existed for this one; it shrinks opportunistically when
-a page block's pattern is promoted into the component vocabulary. Not worth
-a dedicated pass.
+`PAGE_STYLE_BASELINE` (689) never had a slice plan and does not need one:
+it shrinks opportunistically when a page block's pattern is promoted into
+the component vocabulary during page revisions.
 
 ### Historical: where the inline-script mass sat
 
@@ -203,3 +210,35 @@ The contract every slice held to, and the reason the ratchets actually moved:
 `visual` job and covers the seam where the shared filter, sort, poll and icon
 sprite meet — the interactions that fail silently and that a screenshot
 comparison cannot catch, because both sides would agree.
+
+---
+
+## For the per-page revision work
+
+The epic's end state is the starting contract for revising individual
+pages. In practice it means:
+
+- **The rulebook is [ui-design.md](ui-design.md)**, and it is enforced, not
+  aspirational: tokens (palette/type/radius/spacing), the component
+  vocabulary, the page archetypes, `js-` hooks, class resolution, and the
+  absolute rules (no alerts, no raw confirm, no icon geometry outside the
+  sprite, no inline template script, no JS-written colour/typography, no
+  non-custom-prop `style=` anywhere). A revision that fights the guards is
+  wrong by definition — extend the vocabulary instead, in `styles.css`,
+  with the ui-design.md catalog updated in the same PR.
+- **Every page's behaviour lives in a lintable, testable wiring file**
+  (`Public/<page>.js`), and its styling in named classes. Redesigning a
+  page means editing exactly those two layers plus the template's markup —
+  there is no third place for logic or appearance to hide any more.
+- **Budgets are spent, not banked.** Ratchets sit at their counts; a page
+  revision that adds a page-local `<style>` line must remove one somewhere
+  (or promote the pattern to the global sheet). That is intentional
+  pressure toward the vocabulary.
+- **Evidence over eyeballs:** a page revision changes pixels on purpose, so
+  its PR regenerates the affected visual baselines (Trap 2's rule: revert
+  every capture the diff cannot explain) and keeps axe at zero. New
+  interactive seams deserve a repaint-probe assertion, not just a
+  screenshot.
+- **The per-page fine-tuning epic should keep this file closed.** New
+  systemic debt goes in a new document against a new audit — this one
+  records where the maintainability line was drawn and why.

--- a/scripts/class-resolution-allowlist.txt
+++ b/scripts/class-resolution-allowlist.txt
@@ -1,43 +1,17 @@
 # Behaviour-only class hooks that predate the js- prefix convention
-# (docs/ui-design.md, "Class names must resolve").  Every name here is
-# assigned in a template or Public/*.js as a JS hook — selected by script,
-# never styled.  SHRINK-ONLY: remove an entry when the hook is renamed to
-# js-* or gains a stylesheet rule (check-class-resolution.sh fails on stale
-# entries); never add one for new code — new behaviour hooks take the js-
-# prefix instead.
+# (docs/ui-design.md, "Class names must resolve").  SHRINK-ONLY: remove an
+# entry when the hook is renamed to js-* or gains a stylesheet rule
+# (check-class-resolution.sh fails on stale entries); never add one for new
+# code — new behaviour hooks take the js- prefix instead.
 #
-# The pattern-family, suite/section, inputs and achievements editors' hooks
-# were renamed to js-* (or styled, for the ones that carried real styling)
-# in the 2026-08 ratchet pass; what remains is the cross-page row/anchor
-# hooks and the course-content editor.
+# The 2026-08 ratchet passes renamed every editor- and page-owned hook to
+# js-* and dropped the tokens that nothing read or styled.  ONE deliberate
+# survivor remains:
+#
+# sortable-table — the opt-in marker the column-sort component documents
+# (`.sortable-table` + th > button.sort-header, ui-design.md).  Renaming it
+# would churn every sortable table in the app for zero drift risk, and
+# giving it a stylesheet rule would style tables that opted into behaviour,
+# not appearance.  It stays a named, documented exception.
 
-
-# Content items (course content editor)
-content-item-add
-content-item-delete-form
-content-item-edit-details
-content-item-form
-content-item-link
-content-item-row
-
-# Row/anchor hooks in tables and panels
-bs-grade-id-hidden
-check-delete-btn
-check-edit-btn
-family-delete-btn
-family-edit-btn
-nb-fallback
-publish-due-date
-role-cell
-role-fixed
-slip-day-summary
-subm-trend-spark
-submission-actions
-support-file-delete-btn
-tier-secret-badge
-
-# Error-banner anchors (inplace-forms.js)
-inplace-error-banner
-
-# Sortable-table opt-in marker (sortable-table.js)
 sortable-table


### PR DESCRIPTION
Closes out the UI-maintainability epic's mechanical tail — the last work item in [docs/ui-ratchet-handoff.md](https://github.com/JimWallace/Chickadee/blob/main/docs/ui-ratchet-handoff.md).

## What moved

**Class-resolution allowlist 22 → 1.** The 21 removable entries went by what each actually was, not by blanket rename:

- **10 hooks JS genuinely reads** take the `js-` prefix, renamed at every assignment and query site: `js-check-edit-btn`/`-delete-btn` and `js-family-edit-btn`/`-delete-btn` (suite rows), `js-support-file-delete-btn`, `js-publish-due-date`, `js-nb-fallback` (notebook preflight), `js-subm-trend-spark` (submissions sparkline), `js-bs-grade-id-hidden` (BrightSpace binding), `js-inplace-error-banner`.
- **11 tokens nothing read or styled are dropped outright** — the `content-item-*` six, `role-cell`, `role-fixed`, `slip-day-summary`, `submission-actions`, `tier-secret-badge`. Each was verified unread (including dynamically-built selectors, Swift, tests, and tooling) and unstyled before removal; they were dead weight from earlier eras. (`tier-secret-badge` was checked against the `.tier-*` variant family first — it never was a colour variant; the chip's styling is `.tier` alone.)
- **`sortable-table` stays**, as the allowlist's single documented exception: it's the sort component's opt-in marker, renaming it would churn every sortable table for zero drift risk, and giving it a stylesheet rule would style tables that opted into behaviour, not appearance.

**The handoff doc becomes the epic's closure record.** Status table final (allowlist 67 → 1 across the epic), the tail pass documented, and a new "For the per-page revision work" section states the standing rules the next epic works under — the enforced rulebook, the two-layer page structure (wiring file + named classes), spend-don't-bank budgets, and evidence-over-eyeballs verification.

**One papercut fixed for future agents:** `Tools/visual-regression/README.md` now documents the browser-layout bridge for running the harness in a remote container whose pre-installed Playwright browsers trail the lockfile (the "Executable doesn't exist" failure), and warns that CI's `visual` job arbitrates borderline diffs.

## Verification

- `scripts/check-styles.sh` green with the single-entry allowlist (hygiene check validates the survivor is still referenced).
- ESLint clean; frontend suite 0 failures.
- Repo-wide straggler scans: zero references to any old hook name in JS, CSS, templates, tests, tooling, or Swift.
- The dropped tokens are pixel-neutral by construction (unstyled), so no visual baselines change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkXj6gcccWEtB1DdXW7qgn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkXj6gcccWEtB1DdXW7qgn)_