### PR TITLE
fix(ui): relative timestamps keep ticking instead of freezing at page load

### DIFF
--- a/Public/relative-time.js
+++ b/Public/relative-time.js
@@ -1,9 +1,28 @@
 // Shared relative-time rendering for `.js-relative-time[data-iso]` nodes.
 //
 // Replaces six copy-pasted (and drifted) per-template implementations
-// (June 2026 audit). Applies once on load automatically; pages that
-// re-render rows from a poll call
-// `ChickadeeRelativeTime.applyRelativeTimes(scopeEl)` afterwards.
+// (June 2026 audit). Applies on load, then keeps ticking; pages that re-render
+// rows from a poll call `ChickadeeRelativeTime.applyRelativeTimes(scopeEl)`
+// afterwards to catch the new nodes immediately.
+//
+// THE TICK IS THE POINT. This used to apply exactly once per page load, so a
+// timestamp was live only where something else happened to repaint it — the
+// three tables `table-poll.js` refreshes every five seconds. Everywhere else
+// (the runner dashboard, MCP agents, alerts, the activity log) "2 minutes ago"
+// meant "2 minutes before you opened this tab", for as long as the tab stayed
+// open. A component that does its job on the pages where a neighbour drives it
+// and silently stops on the rest is the same defect the list filter had with
+// its empty state, and it wants the same answer: the component owns it.
+//
+// The cadence follows the freshest timestamp on the page, because that is what
+// decides when the text next changes: seconds-old stamps need a 15s tick,
+// minutes-old ones a minute, and a page whose newest stamp is hours old can
+// tick every five without ever showing a stale string. Ticking stops while the
+// tab is hidden and catches up on the way back, so a tab left open overnight
+// re-renders on focus rather than after one more interval.
+//
+// Text is written only when it changes, so a quiet page costs a formatter call
+// per node and no DOM mutation at all.
 (function (global) {
     'use strict';
 
@@ -31,17 +50,45 @@
         return relativeFormatter.format(years, 'year');
     }
 
+    // How long until the freshest stamp's TEXT could change. Under a minute the
+    // string moves every few seconds; past an hour it moves once an hour. These
+    // are the same thresholds formatRelative switches on, so the tick can never
+    // be slower than the text it renders.
+    var TICK_SECONDS = 15;
+    var TICK_MINUTES = 60;
+    var TICK_SLOW = 300;
+
+    function tickSecondsFor(youngestAgeSeconds) {
+        if (youngestAgeSeconds === null) return null;      // nothing to tick
+        if (youngestAgeSeconds < 60) return TICK_SECONDS;
+        if (youngestAgeSeconds < 3600) return TICK_MINUTES;
+        return TICK_SLOW;
+    }
+
+    /// Render every `.js-relative-time[data-iso]` under `root`, and report the
+    /// age in seconds of the freshest one (null if there are none) so the
+    /// caller can pace itself.
     function applyRelativeTimes(root) {
         var scope = root || document;
         var nodes = scope.querySelectorAll('.js-relative-time[data-iso]');
+        var youngest = null;
+        var now = Date.now();
         nodes.forEach(function (el) {
             var iso = el.getAttribute('data-iso');
             if (!iso) return;
             var date = new Date(iso);
-            if (Number.isNaN(date.getTime())) return;
-            el.textContent = formatRelative(iso);
-            el.title = date.toLocaleString();
+            var time = date.getTime();
+            if (Number.isNaN(time)) return;
+            var age = Math.abs(now - time) / 1000;
+            if (youngest === null || age < youngest) youngest = age;
+            // Write only on change: a page of hour-old stamps re-renders its
+            // strings every tick and mutates nothing.
+            var text = formatRelative(iso);
+            if (el.textContent !== text) el.textContent = text;
+            var title = date.toLocaleString();
+            if (el.title !== title) el.title = title;
         });
+        return youngest;
     }
 
     // "Has this thing gone quiet?" — the client half of the server's
@@ -58,15 +105,63 @@
         return (Date.now() - t) > (thresholdMs || STALE_AFTER_MS);
     }
 
+    // ── The tick ─────────────────────────────────────────────────────────────
+    //
+    // One timer for the whole page, re-armed after each pass at the cadence the
+    // freshest stamp needs. setTimeout rather than setInterval so the cadence
+    // can change as the page ages, and so a slow pass can never stack.
+    var timer = null;
+
+    function clearTimer() {
+        if (timer === null) return;
+        clearTimeout(timer);
+        timer = null;
+    }
+
+    function tick() {
+        timer = null;
+        if (typeof document !== 'undefined' && document.hidden) return;  // resumes on visibilitychange
+        var youngest = applyRelativeTimes(document);
+        var seconds = tickSecondsFor(youngest);
+        if (seconds === null) return;   // no timestamps on this page
+        timer = setTimeout(tick, seconds * 1000);
+    }
+
+    /// Render now and re-arm. Safe to call repeatedly — a page that adds
+    /// timestamp nodes (a poll repaint) calls applyRelativeTimes for the
+    /// immediate paint; this is what keeps the cadence honest afterwards.
+    function start() {
+        clearTimer();
+        tick();
+    }
+
     global.ChickadeeRelativeTime = {
         formatRelative: formatRelative,
         applyRelativeTimes: applyRelativeTimes,
-        isStale: isStale
+        isStale: isStale,
+        tickSecondsFor: tickSecondsFor,
+        start: start,
+        stop: clearTimer
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function () { applyRelativeTimes(document); });
-    } else {
-        applyRelativeTimes(document);
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', start);
+        } else {
+            start();
+        }
+        // A tab restored after an hour must not show its load-time strings
+        // until one more interval elapses.
+        document.addEventListener('visibilitychange', function () {
+            if (document.hidden) clearTimer();
+            else start();
+        });
+    }
+
+    // Node export for the .mjs unit tests (Tests/BrowserRunnerJSTests);
+    // browsers take the global above. Its absence is part of why this file
+    // went untested while every other shared component had a suite.
+    if (typeof module === 'object' && module.exports) {
+        module.exports = global.ChickadeeRelativeTime;
     }
 })(typeof self !== 'undefined' ? self : this);

--- a/Tests/BrowserRunnerJSTests/relative-time.test.mjs
+++ b/Tests/BrowserRunnerJSTests/relative-time.test.mjs
@@ -1,0 +1,212 @@
+// Unit tests for Public/relative-time.js — the one relative-timestamp
+// renderer, loaded on every page from base.leaf.
+//
+// It had no tests, which is how it kept applying exactly ONCE per page load.
+// That made a timestamp live only where something else repainted it — the
+// three tables table-poll.js refreshes — and frozen at load time on the runner
+// dashboard, the MCP agent list, alerts and the activity log. The tick, its
+// cadence, and the fact that it stops while the tab is hidden are the things
+// worth pinning; the formatting is pinned alongside because six drifted copies
+// of it is why this file exists.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/relative-time.js'), 'utf8');
+
+function makeNode(iso) {
+  return {
+    iso,
+    textContent: '(unrendered)',
+    title: '',
+    writes: 0,
+    getAttribute(name) { return name === 'data-iso' ? this.iso : null; },
+    set text(v) { this.textContent = v; },
+  };
+}
+
+// Counts textContent writes so "write only on change" can be asserted.
+function instrument(node) {
+  let value = node.textContent;
+  Object.defineProperty(node, 'textContent', {
+    get() { return value; },
+    set(v) { node.writes += 1; value = v; },
+  });
+  return node;
+}
+
+function load({ nodes = [], hidden = false, now = Date.parse('2026-08-14T12:00:00Z') } = {}) {
+  const timers = [];
+  let clock = now;
+  const listeners = {};
+
+  const documentStub = {
+    readyState: 'complete',
+    hidden,
+    querySelectorAll: () => nodes,
+    addEventListener: (type, fn) => { (listeners[type] ||= []).push(fn); },
+  };
+
+  const sandbox = {
+    document: documentStub,
+    module: { exports: {} },
+    Intl,
+    Number,
+    Math,
+    String,
+    Date: class extends Date {
+      constructor(...args) { super(...(args.length ? args : [clock])); }
+      static now() { return clock; }
+    },
+    setTimeout: (fn, ms) => { timers.push({ fn, ms }); return timers.length; },
+    clearTimeout: (id) => { if (timers[id - 1]) timers[id - 1].cleared = true; },
+  };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  return {
+    RelativeTime: sandbox.module.exports,
+    timers,
+    pending: () => timers.filter((t) => !t.cleared && !t.fired).slice(-1)[0] || null,
+    // Firing consumes the timer, as a real one does — otherwise a tick that
+    // deliberately does NOT re-arm looks identical to one that did.
+    fire: () => {
+      const t = timers.filter((x) => !x.cleared && !x.fired).slice(-1)[0];
+      if (!t) return;
+      t.fired = true;
+      t.fn();
+    },
+    advance: (seconds) => { clock += seconds * 1000; },
+    emit: (type) => (listeners[type] || []).forEach((fn) => fn()),
+    setHidden: (v) => { documentStub.hidden = v; },
+  };
+}
+
+// ── Cadence ─────────────────────────────────────────────────────────────────
+
+test('the cadence follows the freshest timestamp on the page', () => {
+  const { RelativeTime } = load();
+  assert.equal(RelativeTime.tickSecondsFor(5), 15, 'seconds-old stamps tick every 15s');
+  assert.equal(RelativeTime.tickSecondsFor(59), 15);
+  assert.equal(RelativeTime.tickSecondsFor(60), 60, 'minutes-old stamps tick every minute');
+  assert.equal(RelativeTime.tickSecondsFor(3599), 60);
+  assert.equal(RelativeTime.tickSecondsFor(3600), 300, 'hours-old stamps tick every 5 minutes');
+  assert.equal(RelativeTime.tickSecondsFor(null), null, 'a page with no timestamps does not tick');
+});
+
+test('a page with no timestamps arms no timer at all', () => {
+  const h = load({ nodes: [] });
+  assert.equal(h.pending(), null);
+});
+
+test('a page of fresh stamps arms the fast tick; an old page the slow one', () => {
+  const fresh = load({ nodes: [makeNode('2026-08-14T11:59:50Z')] });
+  assert.equal(fresh.pending().ms, 15000);
+
+  const old = load({ nodes: [makeNode('2026-08-14T06:00:00Z')] });
+  assert.equal(old.pending().ms, 300000);
+});
+
+test('the freshest stamp sets the pace, not the average', () => {
+  const h = load({
+    nodes: [
+      makeNode('2026-08-10T12:00:00Z'),   // days old
+      makeNode('2026-08-14T11:59:55Z'),   // seconds old
+      makeNode('2026-08-13T12:00:00Z'),   // a day old
+    ],
+  });
+  assert.equal(h.pending().ms, 15000);
+});
+
+// ── The tick itself ─────────────────────────────────────────────────────────
+
+test('the text keeps up as time passes', () => {
+  const node = makeNode('2026-08-14T11:59:00Z');
+  const h = load({ nodes: [node] });
+  assert.equal(node.textContent, '1 minute ago');
+
+  h.advance(3600);
+  h.fire();
+  assert.equal(node.textContent, '1 hour ago', 'the tick re-renders rather than freezing at load');
+});
+
+test('the tick re-arms itself, and slows as the page ages', () => {
+  const node = makeNode('2026-08-14T11:59:30Z');   // 30s old
+  const h = load({ nodes: [node] });
+  assert.equal(h.pending().ms, 15000);
+
+  h.advance(120);      // now 2.5 minutes old
+  h.fire();
+  assert.equal(h.pending().ms, 60000, 'a re-armed tick uses the cadence for the NEW age');
+});
+
+test('text is written only when it changes', () => {
+  const node = instrument(makeNode('2026-08-14T06:00:00Z'));   // 6 hours old
+  const h = load({ nodes: [node] });
+  const afterFirstPaint = node.writes;
+  assert.equal(afterFirstPaint, 1, 'one write to render it');
+
+  h.advance(60);
+  h.fire();
+  assert.equal(node.writes, afterFirstPaint, 'a minute later "6 hours ago" is unchanged: no write');
+
+  h.advance(3600);
+  h.fire();
+  assert.equal(node.writes, afterFirstPaint + 1, 'when the string changes, it is written');
+});
+
+// ── Hidden tabs ─────────────────────────────────────────────────────────────
+
+test('a hidden tab stops ticking and catches up when it comes back', () => {
+  const node = makeNode('2026-08-14T11:59:00Z');
+  const h = load({ nodes: [node] });
+  assert.equal(node.textContent, '1 minute ago');
+
+  h.setHidden(true);
+  h.emit('visibilitychange');
+  assert.equal(h.pending(), null, 'no timer while hidden');
+
+  h.advance(7200);
+  h.setHidden(false);
+  h.emit('visibilitychange');
+  assert.equal(node.textContent, '2 hours ago', 'restored tab re-renders immediately');
+  assert.ok(h.pending(), 'and starts ticking again');
+});
+
+test('a tick that fires while hidden renders nothing and does not re-arm', () => {
+  const node = instrument(makeNode('2026-08-14T11:59:50Z'));
+  const h = load({ nodes: [node] });
+  const writes = node.writes;
+
+  h.setHidden(true);
+  h.fire();                       // a timer already in flight when the tab hid
+  assert.equal(node.writes, writes, 'no work while hidden');
+  assert.equal(h.pending(), null, 'and no re-arm — visibilitychange restarts it');
+});
+
+// ── Formatting (six drifted copies is why this file exists) ─────────────────
+
+test('formatting spans seconds to years, in both directions', () => {
+  const { RelativeTime } = load();
+  assert.equal(RelativeTime.formatRelative('2026-08-14T11:59:30Z'), '30 seconds ago');
+  assert.equal(RelativeTime.formatRelative('2026-08-14T11:00:00Z'), '1 hour ago');
+  assert.equal(RelativeTime.formatRelative('2026-08-07T12:00:00Z'), 'last week');
+  assert.equal(RelativeTime.formatRelative('2026-08-15T12:00:00Z'), 'tomorrow');
+  assert.equal(RelativeTime.formatRelative('2027-08-14T12:00:00Z'), 'next year');
+});
+
+test('an unparseable timestamp renders as itself rather than "Invalid Date"', () => {
+  const { RelativeTime } = load();
+  assert.equal(RelativeTime.formatRelative('not-a-date'), 'not-a-date');
+});
+
+test('isStale is the client half of the 5-minute runner rule', () => {
+  const { RelativeTime } = load();
+  assert.equal(RelativeTime.isStale('2026-08-14T11:59:00Z'), false, '1 minute is fresh');
+  assert.equal(RelativeTime.isStale('2026-08-14T11:50:00Z'), true, '10 minutes is stale');
+  assert.equal(RelativeTime.isStale(''), false, 'no timestamp is not a staleness claim');
+});

--- a/changelog.d/relative-time-ticks.md
+++ b/changelog.d/relative-time-ticks.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **Relative timestamps keep up with the clock instead of freezing at page
+  load.** `relative-time.js` applied exactly once per load, so a timestamp was
+  live only where something else happened to repaint it — the three tables
+  `table-poll.js` refreshes every five seconds. Everywhere else (the runner
+  dashboard, the MCP agent lists, alerts, the activity log) "2 minutes ago"
+  meant "2 minutes before you opened this tab", for as long as the tab stayed
+  open. It now ticks at a cadence set by the freshest stamp on the page — 15 s
+  while something is seconds old, a minute while something is minutes old, five
+  minutes otherwise — writing text only when the rendered string actually
+  changes, so a quiet page mutates no DOM. Ticking stops while the tab is
+  hidden and catches up on return, so a tab left open overnight re-renders when
+  you come back to it rather than one interval later.
+
+### Added
+
+- **`relative-time.js` has unit tests.** It is loaded on every page and had
+  none — it also had no Node export block, which is part of why. The suite
+  pins the cadence, the re-arm, the write-only-on-change rule, the hidden-tab
+  behaviour, and the formatting the six drifted copies it replaced disagreed
+  about.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -235,7 +235,10 @@ Two renderings, chosen by what the reader is asking (UI audit S8):
   `Public/relative-time.js` (loaded from `base.leaf`) rewrites to "3 hours
   ago" and gives an absolute `title`.  The reader wants recency, and a
   relative value answers that at a glance.  A **countdown** (a token's
-  expiry) is the same case: "in 3 days" beats a date.
+  expiry) is the same case: "in 3 days" beats a date.  The component
+  **keeps ticking** — at a cadence set by the freshest stamp on the page,
+  paused while the tab is hidden and caught up on return — so a page needs
+  no timer of its own and a stamp is never older than the tab.
 - **Forensic or compliance** times — the audit log, retention dates —
   render **absolute**, in `--font-mono`, deliberately.  Here the exact
   instant *is* the content, and "2 months ago" would destroy it.


### PR DESCRIPTION
Item 2 of the component re-engineering list.

## The defect

`relative-time.js` applied exactly **once** per page load. So a timestamp was live only where something else happened to repaint it — the three tables `table-poll.js` refreshes every five seconds. `js-relative-time` appears in 8 templates; 3 of them poll. On the other five (runner dashboard, MCP agent lists, connected agents, alerts, activity log) "2 minutes ago" meant "2 minutes before you opened this tab", for as long as the tab stayed open.

That's the same shape the list filter had with its empty state: a component that does its job on the pages where a neighbour drives it, and silently stops on the rest. Same answer — the component owns it.

## The tick

Cadence follows the **freshest** stamp on the page, since that's what decides when the text next changes:

| freshest stamp | tick |
|---|---|
| < 1 minute old | 15 s |
| < 1 hour old | 60 s |
| older | 5 min |

A page with no timestamps arms no timer at all. Text is written only when the rendered string changes, so a page of hour-old stamps re-renders its strings each tick and mutates no DOM. Ticking stops while the tab is hidden and catches up on `visibilitychange`, so a tab left open overnight re-renders when you come back to it rather than one interval later.

`setTimeout` rather than `setInterval`, so the cadence can change as the page ages and a slow pass can't stack.

## Tests

It had none — and no Node export block, which is part of why. Both now exist. The suite pins the cadence thresholds, the re-arm at the *new* age, write-only-on-change, the hidden-tab stop/catch-up, and the formatting the six drifted copies it replaced disagreed about.

One test failure during development was the harness's fault, not the code's: a fired timer wasn't marked consumed, so "a tick that deliberately does not re-arm" looked identical to one that did. Fixed in the stub.

## Testing

`node --test relative-time.test.mjs` 12/12; full `Tests/BrowserRunnerJSTests/*.mjs` sweep green; `scripts/eslint.sh` and `scripts/check-styles.sh` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_