### PR TITLE
perf(ui): make the dashboard polls conditional, and stop them closing open panels

### DIFF
--- a/Public/table-poll.js
+++ b/Public/table-poll.js
@@ -20,10 +20,17 @@
 // file.
 //
 // Polling is suppressed while the tab is hidden, while focus is inside the
-// table (a repaint would yank a half-open <select> away), and while the
-// table's filter box has focus. Requests carry `X-Background-Refresh: 1`, so
-// a dashboard left open in a tab cannot keep a session alive — the one thing
-// all three copies were supposed to do and one of them didn't.
+// table (a repaint would yank a half-open <select> away), while any <details>
+// in the table is open (the pending-student registration panel is state the
+// server cannot re-render), and while the table's filter box has focus.
+// Requests carry `X-Background-Refresh: 1`, so a dashboard left open in a tab
+// cannot keep a session alive — the one thing all three copies were supposed
+// to do and one of them didn't.
+//
+// Each poll is CONDITIONAL: the rows carry an ETag and the next request sends
+// it back, so an unchanged table answers 304 and nothing below runs at all.
+// Before that, an idle roster replaced its own <tbody> twelve times a minute
+// and rebuilt every derived behaviour from identical input.
 (function (global) {
     'use strict';
 
@@ -37,18 +44,38 @@
     function shouldSkip(table) {
         if (document.hidden) return true;
         if (table.contains(document.activeElement)) return true;
+        // An open <details> is state the server does not know about: the
+        // students table's pending-enrolment rows carry a registration panel,
+        // and a repaint closes it mid-use. Focus alone did not cover this —
+        // reading the panel, or clicking away to copy a value out of it, moves
+        // focus off the table while the panel is still open and wanted.
+        if (table.querySelector('details[open]')) return true;
         var filter = filterInputFor(table);
         return !!(filter && document.activeElement === filter);
     }
+
+    // The ETag of the rows currently on screen, per table. A poll sends it back
+    // as If-None-Match; a 304 means this tbody is already correct, so the whole
+    // repaint — the innerHTML write, the relative-time pass, the re-sort, the
+    // re-filter, the page's own decorations — is skipped rather than redone
+    // with identical input. On an idle dashboard that is every poll.
+    var etags = new WeakMap();
 
     function refresh(table) {
         var url = table.getAttribute('data-poll-url');
         var tbody = table.querySelector('tbody');
         if (!url || !tbody) return Promise.resolve(false);
 
+        var headers = { 'Accept': 'text/html', 'X-Background-Refresh': '1' };
+        var known = etags.get(table);
+        if (known) headers['If-None-Match'] = known;
+
         return fetch(url, {
-            headers: { 'Accept': 'text/html', 'X-Background-Refresh': '1' },
-            cache: 'no-store',
+            headers: headers,
+            // 'no-store' would forbid the conditional request this depends on;
+            // 'no-cache' still revalidates on every poll, which is what a poll
+            // is, but lets If-None-Match/304 do their job.
+            cache: 'no-cache',
             credentials: 'same-origin'
         }).then(function (res) {
             // A redirect or an auth failure means the session ended server-side;
@@ -57,7 +84,10 @@
                 window.location.reload();
                 return null;
             }
+            if (res.status === 304) return null;      // rows unchanged: nothing to do
             if (!res.ok) return null;
+            var etag = res.headers && res.headers.get ? res.headers.get('ETag') : null;
+            if (etag) etags.set(table, etag);
             return res.text();
         }).then(function (html) {
             if (html === null || html === undefined) return false;

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Runners.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Runners.swift
@@ -23,7 +23,7 @@ extension AdminRoutes {
             return try await rows.encodeResponse(for: req)
         }
         return try await req.view.render("_worker-rows", WorkerRowsFragmentContext(workers: rows))
-            .encodeResponse(for: req)
+            .encodePollFragment(for: req)
     }
 
     // MARK: - GET /admin/runners/:runnerID

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -162,7 +162,7 @@ struct AdminRoutes: RouteCollection {
             return try await rows.encodeResponse(for: req)
         }
         return try await req.view.render("_user-rows", UserRowsFragmentContext(users: rows))
-            .encodeResponse(for: req)
+            .encodePollFragment(for: req)
     }
 
     /// Loads every user, ordered most-recently-seen first (NULL last_seen

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -121,7 +121,7 @@ extension InstructorDashboardRoutes {
 
         guard let activeCourseUUID = courseState.activeCourseUUID else {
             return wantsFragment
-                ? Response(status: .ok, headers: ["Content-Type": "text/html; charset=utf-8"], body: .init(string: ""))
+                ? Response.emptyPollFragment(for: req)
                 : try await [EnrolledStudentRow]().encodeResponse(for: req)
         }
         let roster = try await loadEnrolledStudentRows(
@@ -147,7 +147,7 @@ extension InstructorDashboardRoutes {
             enrolledStudents: roster.rows,
             rosterReadOnly: courseIsArchived || !canManageRoster
         )
-        return try await req.view.render("_student-rows", ctx).encodeResponse(for: req)
+        return try await req.view.render("_student-rows", ctx).encodePollFragment(for: req)
     }
 }
 

--- a/Sources/APIServer/Utilities/PollFragmentResponse.swift
+++ b/Sources/APIServer/Utilities/PollFragmentResponse.swift
@@ -1,0 +1,80 @@
+// APIServer/Utilities/PollFragmentResponse.swift
+//
+// Conditional responses for the three `?fragment=rows` poll endpoints
+// (`/instructor/students-data`, `/admin/users-data`, `/admin/runners`).
+//
+// `table-poll.js` refetches these every five seconds for as long as a
+// dashboard is open, and until now every response was a 200 carrying the whole
+// table — so an idle roster nobody was touching still replaced its `<tbody>`
+// twelve times a minute. That is not just bytes: replacing the rows throws away
+// their DOM state and forces the page to rebuild what the server does not know
+// about — relative times, the user's sort, the user's filter, each page's own
+// decorations — and destroys anything else in there, such as a pending
+// student's open registration panel.
+//
+// An ETag over the rendered bytes makes "nothing changed" cost one 304 and no
+// client work at all. The hash is SHA-256 rather than Swift's `Hasher`, whose
+// seed is per-process: two app processes behind the load balancer would
+// otherwise disagree about the ETag for identical rows and each poll would
+// repaint whichever process it did not hit last.
+//
+// What this deliberately does NOT save is the server's own work: the rows are
+// queried and rendered before they can be hashed. Skipping that needs a cheap
+// version stamp per table (a max(updated_at) + count probe), which is a
+// different and more invasive change; the win here is on the client, where the
+// repaint was doing real damage.
+
+import Crypto
+import Foundation
+import Vapor
+
+extension View {
+    /// Encode a rendered row fragment as a conditional response: an `ETag` over
+    /// the bytes, and `304 Not Modified` when the client already has them.
+    ///
+    /// The ETag is weak (`W/`) because these fragments are equivalent-for-
+    /// display, not byte-identical resources — nothing does range requests
+    /// against them.
+    func encodePollFragment(for req: Request) -> Response {
+        Response.pollFragment(html: data, for: req)
+    }
+}
+
+extension Response {
+    /// The empty-body case (no active course) takes the same path, so a client
+    /// polling an empty table also settles into 304s instead of re-clearing it.
+    static func emptyPollFragment(for req: Request) -> Response {
+        pollFragment(html: ByteBuffer(), for: req)
+    }
+
+    static func pollFragment(html: ByteBuffer, for req: Request) -> Response {
+        let etag = Self.weakETag(for: html)
+
+        // A conditional request lists one or more candidates; `*` matches any
+        // existing representation.
+        let candidates = req.headers[.ifNoneMatch]
+            .flatMap { $0.split(separator: ",") }
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        if candidates.contains(etag) || candidates.contains("*") {
+            var headers = HTTPHeaders()
+            headers.replaceOrAdd(name: .eTag, value: etag)
+            headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+            return Response(status: .notModified, headers: headers)
+        }
+
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .contentType, value: "text/html; charset=utf-8")
+        headers.replaceOrAdd(name: .eTag, value: etag)
+        // `no-cache` means "revalidate", not "do not store": the client is
+        // expected to come back with If-None-Match, which is the whole point.
+        headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+        return Response(status: .ok, headers: headers, body: .init(buffer: html))
+    }
+
+    static func weakETag(for buffer: ByteBuffer) -> String {
+        let bytes = buffer.getBytes(at: buffer.readerIndex, length: buffer.readableBytes) ?? []
+        let digest = SHA256.hash(data: Data(bytes))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "W/\"\(hex.prefix(32))\""
+    }
+}

--- a/Tests/APITests/PollFragmentResponseTests.swift
+++ b/Tests/APITests/PollFragmentResponseTests.swift
@@ -1,0 +1,128 @@
+// Tests/APITests/PollFragmentResponseTests.swift
+//
+// The conditional-response contract for the three `?fragment=rows` poll
+// endpoints. `table-poll.js` refetches them every five seconds for as long as
+// a dashboard is open; without an ETag every one of those was a 200 carrying
+// the whole table, and the client repainted its `<tbody>` from identical bytes.
+//
+// The properties that matter are all about STABILITY: the same rows must hash
+// the same way on every process (so a load-balanced deployment does not
+// alternate 200s), and different rows must not collide into a 304, which would
+// leave a roster silently stale.
+
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+/// Serialized: each test builds and tears down its own `Application` for the
+/// bare `Request` these pure helpers take.
+@Suite(.serialized) struct PollFragmentResponseTests {
+
+    /// Runs `body` with a `Request` carrying the given `If-None-Match`.
+    private func withRequest(
+        ifNoneMatch: String? = nil,
+        _ body: (Request) throws -> Void
+    ) async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            var headers = HTTPHeaders()
+            if let ifNoneMatch {
+                headers.replaceOrAdd(name: .ifNoneMatch, value: ifNoneMatch)
+            }
+            let req = Request(
+                application: app,
+                method: .GET,
+                url: "/rows?fragment=rows",
+                headers: headers,
+                on: app.eventLoopGroup.next()
+            )
+            try body(req)
+        }
+    }
+
+    private func buffer(_ string: String) -> ByteBuffer {
+        ByteBuffer(string: string)
+    }
+
+    /// The ETag the helper would mint for these bytes, without a request.
+    private func etag(_ string: String) -> String {
+        Response.weakETag(for: buffer(string))
+    }
+
+    @Test func firstRequestGetsRowsAndAnETag() async throws {
+        try await withRequest { req in
+            let response = Response.pollFragment(html: self.buffer("<tr>a</tr>"), for: req)
+            #expect(response.status == .ok)
+            let tag = try #require(response.headers.first(name: .eTag))
+            #expect(tag.hasPrefix("W/\""))
+            #expect(response.headers.first(name: .contentType)?.contains("text/html") == true)
+        }
+    }
+
+    @Test func matchingETagAnswers304WithNoBody() async throws {
+        try await withRequest(ifNoneMatch: etag("<tr>a</tr>")) { req in
+            let response = Response.pollFragment(html: self.buffer("<tr>a</tr>"), for: req)
+            #expect(response.status == .notModified)
+            #expect(response.body.data?.isEmpty ?? true)
+            #expect(response.headers.first(name: .eTag) == self.etag("<tr>a</tr>"))
+        }
+    }
+
+    @Test func changedRowsAnswer200EvenWhenTheClientOffersAnETag() async throws {
+        try await withRequest(ifNoneMatch: etag("<tr>a</tr>")) { req in
+            let response = Response.pollFragment(html: self.buffer("<tr>b</tr>"), for: req)
+            #expect(response.status == .ok)
+            #expect(response.headers.first(name: .eTag) == self.etag("<tr>b</tr>"))
+        }
+    }
+
+    /// A conditional request may list several candidates.
+    @Test func aListOfCandidatesIsHonoured() async throws {
+        try await withRequest(ifNoneMatch: "W/\"stale\", \(etag("<tr>a</tr>"))") { req in
+            #expect(Response.pollFragment(html: self.buffer("<tr>a</tr>"), for: req).status == .notModified)
+        }
+    }
+
+    /// `*` matches any existing representation.
+    @Test func theWildcardCandidateIsHonoured() async throws {
+        try await withRequest(ifNoneMatch: "*") { req in
+            #expect(Response.pollFragment(html: self.buffer("<tr>a</tr>"), for: req).status == .notModified)
+        }
+    }
+
+    /// The ETag is a content hash, not a per-process value: two app processes
+    /// behind a load balancer must agree, or every poll repaints whichever one
+    /// it did not hit last. (Swift's `Hasher` is seeded per process, which is
+    /// exactly why it is not used here.)
+    @Test func theETagDependsOnlyOnTheBytes() {
+        #expect(etag("<tr>a</tr>") == etag("<tr>a</tr>"))
+        #expect(etag("<tr>a</tr>") != etag("<tr>b</tr>"))
+        #expect(etag("").isEmpty == false, "even empty rows get a stable tag")
+    }
+
+    @Test func theEmptyFragmentAlsoRevalidates() async throws {
+        try await withRequest(ifNoneMatch: etag("")) { req in
+            let response = Response.emptyPollFragment(for: req)
+            #expect(response.status == .notModified, "a client polling an empty table settles into 304s too")
+        }
+    }
+
+    /// `no-cache` means revalidate, not "do not store" — the whole design
+    /// depends on the client coming back with If-None-Match.
+    @Test func fragmentsAskToBeRevalidated() async throws {
+        try await withRequest { req in
+            let response = Response.pollFragment(html: self.buffer("<tr>a</tr>"), for: req)
+            #expect(response.headers.first(name: .cacheControl) == "no-cache")
+        }
+    }
+
+    /// Whitespace around a listed candidate is normal in the wild.
+    @Test func candidateWhitespaceIsTolerated() async throws {
+        try await withRequest(ifNoneMatch: "   \(etag("<tr>a</tr>"))   ") { req in
+            #expect(Response.pollFragment(html: self.buffer("<tr>a</tr>"), for: req).status == .notModified)
+        }
+    }
+}

--- a/Tests/BrowserRunnerJSTests/table-poll.test.mjs
+++ b/Tests/BrowserRunnerJSTests/table-poll.test.mjs
@@ -1,0 +1,232 @@
+// Unit tests for Public/table-poll.js — the one background table refresh.
+//
+// It had no unit test: the visual harness's repaint probe proves a repaint
+// still respects the sort and the filter, but nothing covered when a repaint
+// should happen at all. That is where the cost was. Every five seconds, for as
+// long as a dashboard was open, this replaced the whole <tbody> whether or not
+// anything had changed — throwing away DOM state the server does not know
+// about and rebuilding every derived behaviour from identical input.
+//
+// So what is pinned here is the decisions: when a poll is skipped, when a
+// response is applied, and the order the shared behaviours are re-applied in
+// (each depends on the last).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/table-poll.js'), 'utf8');
+
+function makeTable({ url = '/rows?fragment=rows', openDetails = false, contains = false } = {}) {
+  const tbody = { innerHTML: '', writes: 0 };
+  Object.defineProperty(tbody, 'innerHTML', {
+    get() { return this._html || ''; },
+    set(v) { this.writes += 1; this._html = v; },
+  });
+  return {
+    id: 'the-table',
+    attrs: { 'data-poll-url': url, 'data-poll-interval': '5000' },
+    events: [],
+    getAttribute(n) { return this.attrs[n] ?? null; },
+    querySelector(sel) {
+      if (sel === 'tbody') return tbody;
+      if (sel === 'details[open]') return openDetails ? {} : null;
+      return null;
+    },
+    contains: () => contains,
+    dispatchEvent(e) { this.events.push(e.type); return true; },
+    tbody,
+  };
+}
+
+function load({ table, responses = [], activeElement = null, hidden = false }) {
+  const calls = [];
+  let index = 0;
+  const applied = [];
+
+  const sandbox = {
+    document: {
+      readyState: 'complete',
+      hidden,
+      activeElement,
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      addEventListener: () => {},
+    },
+    module: { exports: {} },
+    WeakMap,
+    Promise,
+    setInterval: () => 0,
+    CustomEvent: class { constructor(type) { this.type = type; } },
+    fetch: (url, opts) => {
+      calls.push({ url, opts });
+      const res = responses[Math.min(index, responses.length - 1)];
+      index += 1;
+      return Promise.resolve({
+        status: res.status,
+        ok: res.status >= 200 && res.status < 300,
+        redirected: false,
+        headers: { get: (name) => (name === 'ETag' ? res.etag ?? null : null) },
+        text: () => Promise.resolve(res.body ?? ''),
+      });
+    },
+    ChickadeeRelativeTime: { applyRelativeTimes: () => applied.push('relative-time') },
+    ChickadeeSortableTable: { apply: () => applied.push('sort') },
+    ChickadeeListFilter: { apply: () => applied.push('filter') },
+  };
+  sandbox.self = sandbox;
+  sandbox.window = { location: { reload: () => applied.push('reload') } };
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+  return { TablePoll: sandbox.module.exports, calls, applied, table };
+}
+
+// ── When a poll is skipped ──────────────────────────────────────────────────
+
+test('a hidden tab does not poll', () => {
+  const table = makeTable();
+  const h = load({ table, hidden: true, responses: [{ status: 200, body: '<tr></tr>' }] });
+  assert.equal(h.TablePoll.shouldSkip(table), true);
+});
+
+test('focus inside the table defers the repaint', () => {
+  const table = makeTable({ contains: true });
+  const h = load({ table, responses: [{ status: 200 }] });
+  assert.equal(h.TablePoll.shouldSkip(table), true);
+});
+
+// The registration panel on a pending-enrolment row is an open <details>. A
+// repaint closes it mid-use, and focus does not cover the case: reading the
+// panel, or clicking away to copy a value into it, moves focus off the table
+// while the panel is still open and wanted.
+test('an open <details> in the table defers the repaint', () => {
+  const table = makeTable({ openDetails: true });
+  const h = load({ table, responses: [{ status: 200 }] });
+  assert.equal(h.TablePoll.shouldSkip(table), true);
+});
+
+test('an idle visible table with nothing open does poll', () => {
+  const table = makeTable();
+  const h = load({ table, responses: [{ status: 200 }] });
+  assert.equal(h.TablePoll.shouldSkip(table), false);
+});
+
+// ── Conditional fetch ───────────────────────────────────────────────────────
+
+test('the first poll sends no If-None-Match and applies the rows', async () => {
+  const table = makeTable();
+  const h = load({ table, responses: [{ status: 200, body: '<tr>a</tr>', etag: 'W/"abc"' }] });
+
+  const changed = await h.TablePoll.refresh(table);
+  assert.equal(changed, true);
+  assert.equal(h.calls[0].opts.headers['If-None-Match'], undefined);
+  assert.equal(table.tbody.innerHTML, '<tr>a</tr>');
+  assert.deepEqual(h.applied, ['relative-time', 'sort', 'filter']);
+  assert.deepEqual(table.events, ['chickadee:table-repaint']);
+});
+
+test('the next poll sends the ETag back', async () => {
+  const table = makeTable();
+  const h = load({
+    table,
+    responses: [
+      { status: 200, body: '<tr>a</tr>', etag: 'W/"abc"' },
+      { status: 304 },
+    ],
+  });
+
+  await h.TablePoll.refresh(table);
+  await h.TablePoll.refresh(table);
+  assert.equal(h.calls[1].opts.headers['If-None-Match'], 'W/"abc"');
+});
+
+test('a 304 changes nothing: no write, no re-apply, no repaint event', async () => {
+  const table = makeTable();
+  const h = load({
+    table,
+    responses: [
+      { status: 200, body: '<tr>a</tr>', etag: 'W/"abc"' },
+      { status: 304 },
+    ],
+  });
+
+  await h.TablePoll.refresh(table);
+  const writesAfterFirst = table.tbody.writes;
+  const appliedAfterFirst = h.applied.length;
+
+  const changed = await h.TablePoll.refresh(table);
+  assert.equal(changed, false);
+  assert.equal(table.tbody.writes, writesAfterFirst, 'the tbody is not rewritten');
+  assert.equal(h.applied.length, appliedAfterFirst, 'nothing is re-applied');
+  assert.deepEqual(table.events, ['chickadee:table-repaint'], 'the page is not told to redecorate');
+});
+
+test('a changed table gets a new ETag and repaints', async () => {
+  const table = makeTable();
+  const h = load({
+    table,
+    responses: [
+      { status: 200, body: '<tr>a</tr>', etag: 'W/"abc"' },
+      { status: 200, body: '<tr>b</tr>', etag: 'W/"def"' },
+      { status: 304 },
+    ],
+  });
+
+  await h.TablePoll.refresh(table);
+  await h.TablePoll.refresh(table);
+  assert.equal(table.tbody.innerHTML, '<tr>b</tr>');
+
+  await h.TablePoll.refresh(table);
+  assert.equal(h.calls[2].opts.headers['If-None-Match'], 'W/"def"', 'the newest ETag is sent');
+});
+
+test('the request never uses cache: no-store, which would forbid revalidation', async () => {
+  const table = makeTable();
+  const h = load({ table, responses: [{ status: 200, body: '', etag: 'W/"x"' }] });
+  await h.TablePoll.refresh(table);
+  assert.equal(h.calls[0].opts.cache, 'no-cache');
+});
+
+test('a poll still declares itself a background refresh', async () => {
+  const table = makeTable();
+  const h = load({ table, responses: [{ status: 200, body: '', etag: 'W/"x"' }] });
+  await h.TablePoll.refresh(table);
+  assert.equal(h.calls[0].opts.headers['X-Background-Refresh'], '1');
+});
+
+// ── Failure ─────────────────────────────────────────────────────────────────
+
+test('a server error leaves the rows already on screen alone', async () => {
+  const table = makeTable();
+  const h = load({
+    table,
+    responses: [
+      { status: 200, body: '<tr>a</tr>', etag: 'W/"abc"' },
+      { status: 500 },
+    ],
+  });
+
+  await h.TablePoll.refresh(table);
+  const changed = await h.TablePoll.refresh(table);
+  assert.equal(changed, false);
+  assert.equal(table.tbody.innerHTML, '<tr>a</tr>', 'a transient blip must not blank a roster');
+});
+
+test('a 500 does not poison the stored ETag', async () => {
+  const table = makeTable();
+  const h = load({
+    table,
+    responses: [
+      { status: 200, body: '<tr>a</tr>', etag: 'W/"abc"' },
+      { status: 500 },
+      { status: 304 },
+    ],
+  });
+
+  await h.TablePoll.refresh(table);
+  await h.TablePoll.refresh(table);
+  await h.TablePoll.refresh(table);
+  assert.equal(h.calls[2].opts.headers['If-None-Match'], 'W/"abc"');
+});

--- a/changelog.d/table-poll-conditional.md
+++ b/changelog.d/table-poll-conditional.md
@@ -1,0 +1,30 @@
+### Performance
+
+- **Dashboard polls are conditional.** The three `?fragment=rows` endpoints
+  (`/instructor/students-data`, `/admin/users-data`, `/admin/runners`) now carry
+  an `ETag` over their rendered rows, and `table-poll.js` sends it back as
+  `If-None-Match`. An unchanged table answers `304` and the client does nothing
+  at all — no `innerHTML` write, no relative-time pass, no re-sort, no
+  re-filter, no `chickadee:table-repaint` for the page's own decorations. On an
+  idle dashboard that is every poll, twelve times a minute, for as long as the
+  tab is open. (The server still queries and renders the rows in order to hash
+  them; skipping that needs a per-table version stamp, which is a separate
+  change.)
+
+### Fixed
+
+- **A background repaint no longer closes an open panel.** Polling was
+  suppressed while focus was inside the table, but the students roster's
+  pending-enrolment rows carry a `<details>` registration panel — and reading
+  it, or clicking away to copy a value into it, moves focus off the table while
+  the panel is still open and wanted. Any open `<details>` in a polled table now
+  defers the repaint, alongside the existing focus and hidden-tab rules.
+
+### Added
+
+- **`table-poll.js` has unit tests.** The visual harness's repaint probe proved
+  a repaint respects the sort and the filter; nothing covered *when* a repaint
+  should happen, which is where the cost was. The suite pins the skip
+  conditions, the conditional-fetch handshake, the 304 no-op, the re-apply
+  order, and that a transient server error leaves the rows on screen and the
+  stored ETag intact.


### PR DESCRIPTION
Item 3 of the component re-engineering list.

## The waste

The three `?fragment=rows` endpoints (`/instructor/students-data`, `/admin/users-data`, `/admin/runners`) answered every poll with a 200 carrying the whole table, and `table-poll.js` refetches them every five seconds for as long as a dashboard is open. An idle roster nobody was touching replaced its own `<tbody>` **twelve times a minute**.

That isn't just bytes. Replacing the rows throws away their DOM state and forces every derived behaviour to be rebuilt from identical input — relative times, the user's sort (which after #1420 is still a full decorated pass), the user's filter, and each page's own decorations via `chickadee:table-repaint`.

The rows now carry an `ETag`; the poll sends it back as `If-None-Match`; an unchanged table answers `304` and **none of that runs**.

Two details worth review:

- **SHA-256, not `Hasher`.** Swift's `Hasher` is seeded per process, so two app processes behind the load balancer would disagree about the ETag for identical rows and every poll would repaint whichever one it did not hit last.
- **`cache: 'no-cache'`, not `'no-store'`.** `no-store` would forbid the conditional request this depends on. `no-cache` still revalidates every poll — which is what a poll is — but lets `If-None-Match`/304 work.

**What this deliberately does not save:** the server still queries and renders the rows in order to hash them. Skipping that needs a per-table version stamp (a `max(updated_at)` + count probe), which is a separate and more invasive change. The win here is on the client.

## The defect

Polling was suppressed while focus was inside the table — but the students roster's pending-enrolment rows carry a `<details>` registration panel, and reading it, or clicking away to copy a value into it, moves focus off the table while the panel is still open and wanted. The repaint closed it. Any open `<details>` in a polled table now defers the poll, alongside the existing focus and hidden-tab rules.

## Tests

`table-poll.js` had none. The visual harness's repaint probe proves a repaint *respects* the sort and filter; nothing covered **when** a repaint should happen, which is where the cost was.

- 12 JS tests: skip conditions, the conditional handshake, the 304 no-op (no write, no re-apply, no repaint event), the re-apply order, and that a transient 500 leaves the rows on screen and the stored ETag intact.
- 9 Swift tests on the response helper: 304 on match, 200 with a fresh ETag on change, candidate lists and `*`, whitespace tolerance, the empty-fragment case, and that the ETag depends only on the bytes.

## Testing

`node --test table-poll.test.mjs` 12/12; `swift test --filter PollFragmentResponse` 9/9; the render suites covering all three endpoints (45 tests / 11 suites) green; `scripts/eslint.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh`, `scripts/check-styles.sh` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_