### PR TITLE
feat(ui): destructive actions ask in a real dialog, not the browser's

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -101,9 +101,10 @@ if (root) {
 // pages that rebuilt rows in JS carried a *second* copy of each message that
 // could drift from the first.
 //
-// It is also the seam any future improvement needs. Swapping the native
-// dialog for a styled one, or requiring a typed course code before a
-// destructive delete, is a change to this function — not to 49 call sites.
+// It is also the seam any improvement lands in, which is how the styled dialog
+// arrived: swapping the native one was a change to this function, not to 49
+// call sites. (Requiring a typed course code before a destructive delete would
+// be the same.)
 //
 // (The guard in check-styles.sh greps for the native call, and cannot tell
 // markup from prose about markup — so this comment describes the old idiom
@@ -115,19 +116,47 @@ if (root) {
 // which runs before inplace-forms.js's own submit listener (app.js loads
 // first) — and that one bails on `defaultPrevented`, so a cancelled submit
 // stays cancelled.
+//
+// The dialog behind this seam is a real one now (ChickadeeUI.confirmAction),
+// so the answer arrives in a promise rather than blocking the event loop. A
+// listener cannot wait for that, so the shape is: always cancel the action,
+// ask, and REPLAY it if the answer was yes. The replay re-dispatches the
+// original interaction — a click on the element, or requestSubmit() on the
+// form with its original submitter — so everything layered around it (row-click
+// navigation, inplace-forms.js's own submit listener, formaction) sees exactly
+// what it saw before, and the marker below keeps the replay from asking again.
 (function confirmActions() {
-    function accepted(el) {
-        const message = el.getAttribute('data-confirm');
-        return !message || window.confirm(message);
+    const replaying = new WeakSet();
+
+    function replayClick(el) {
+        replaying.add(el);
+        try { el.click(); } finally { replaying.delete(el); }
+    }
+
+    function replaySubmit(form, submitter) {
+        replaying.add(form);
+        try {
+            // requestSubmit() fires the submit event (submit() deliberately
+            // does not), which is what inplace-forms.js listens for.
+            if (form.requestSubmit) form.requestSubmit(submitter || undefined);
+            else form.submit();
+        } finally {
+            replaying.delete(form);
+        }
     }
 
     document.addEventListener('click', (e) => {
         const el = e.target instanceof Element ? e.target.closest('[data-confirm]') : null;
         // A <form data-confirm> asks on submit, not on every click inside it.
         if (!el || el.tagName === 'FORM') return;
-        if (accepted(el)) return;
+        if (replaying.has(el)) return;
+        const message = el.getAttribute('data-confirm');
+        if (!message) return;
         e.preventDefault();
         e.stopPropagation();
+        window.ChickadeeUI.confirmAction(message, el).then((ok) => {
+            if (ok) replayClick(el);
+        });
     }, true);
 
     document.addEventListener('submit', (e) => {
@@ -136,7 +165,14 @@ if (root) {
         // A submitter with its own question already asked during the click —
         // the secondary "Clear"/"Remove" buttons that carry `formaction`.
         if (e.submitter && e.submitter.hasAttribute('data-confirm')) return;
-        if (!accepted(form)) e.preventDefault();
+        if (replaying.has(form)) return;
+        const message = form.getAttribute('data-confirm');
+        if (!message) return;
+        const submitter = e.submitter || null;
+        e.preventDefault();
+        window.ChickadeeUI.confirmAction(message, form).then((ok) => {
+            if (ok) replaySubmit(form, submitter);
+        });
     });
 }());
 

--- a/Public/assignments.js
+++ b/Public/assignments.js
@@ -189,14 +189,14 @@
     // target, so a DOM-injected value cannot redirect the POST off-site or to
     // a javascript: URL (CodeQL, js/xss-through-dom).
     document.querySelectorAll('.js-section-delete-btn').forEach(function (btn) {
-        btn.addEventListener('click', function () {
+        btn.addEventListener('click', async function () {
             var name = btn.getAttribute('data-name');
             var action = btn.getAttribute('data-action');
             if (!action) return;
             var url;
             try { url = new URL(action, window.location.origin); } catch (_) { return; }
             if (url.origin !== window.location.origin) return;
-            if (!ChickadeeUI.confirmAction('Delete section “' + name + '”? Its assignments will become ungrouped.')) return;
+            if (!await ChickadeeUI.confirmAction('Delete section “' + name + '”? Its assignments will become ungrouped.')) return;
             var form = document.createElement('form');
             form.method = 'post';
             form.action = url.href;

--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -52,10 +52,105 @@
     //
     // The JS-side entry to the same seam `data-confirm` uses (app.js). A call
     // site that has no element to hang an attribute on — a delete triggered
-    // from inside an editor's own click handler — asks here, so replacing the
-    // native dialog later is still a one-place change.
-    function confirmAction(message) {
-        return window.confirm(message);
+    // from inside an editor's own click handler — asks here.
+    //
+    // This used to be `window.confirm`, with a comment saying it existed so
+    // the native dialog could be replaced in one place. This is that
+    // replacement, and it covers all 41 destructive confirmations (36
+    // `data-confirm` attributes across 18 templates, 5 direct callers):
+    // unenroll a student, delete a section, delete a test script, delete a
+    // pattern family, remove a support file. The native dialog was the one
+    // piece of UI outside the design system — unthemed, unstyleable, invisible
+    // to the axe scan, and rendered by the browser chrome rather than the page
+    // it belongs to. It is the sibling of the native alerting call the S9 slice
+    // removed, and it outlived that slice only because nobody had written the
+    // dialog. (Naming that call in prose here would trip the guard that keeps
+    // it at zero — the scanner cannot tell markup from prose about markup, the
+    // same lesson as the Leaf-comment finding in #1266.)
+    //
+    // It returns a PROMISE, which is the one thing callers must know: a real
+    // dialog cannot block the event loop the way the native one did.
+    // `data-confirm` callers are unaffected (app.js replays the action for
+    // them); the five direct callers await it.
+    function confirmAction(message, nearEl) {
+        if (typeof document === 'undefined' || !document.createElement) {
+            return Promise.resolve(true);
+        }
+        return new Promise(function (resolve) {
+            var previouslyFocused = document.activeElement;
+            var overlay = document.createElement('div');
+            overlay.className = 'modal-overlay';
+
+            var card = document.createElement('div');
+            card.className = 'modal-card modal-card--confirm';
+            // alertdialog, not dialog: this interrupts to ask about something
+            // consequential, and screen readers announce the message on open.
+            card.setAttribute('role', 'alertdialog');
+            card.setAttribute('aria-modal', 'true');
+
+            var body = document.createElement('div');
+            body.className = 'modal-body confirm-message';
+            body.textContent = message;
+            var messageID = 'ck-confirm-message';
+            body.id = messageID;
+            card.setAttribute('aria-describedby', messageID);
+            card.setAttribute('aria-label', 'Confirm');
+
+            var foot = document.createElement('div');
+            foot.className = 'modal-foot';
+            var cancel = document.createElement('button');
+            cancel.type = 'button';
+            cancel.className = 'btn';
+            cancel.textContent = 'Cancel';
+            var confirm = document.createElement('button');
+            confirm.type = 'button';
+            confirm.className = 'btn btn-primary';
+            confirm.textContent = 'Confirm';
+            foot.appendChild(cancel);
+            foot.appendChild(confirm);
+
+            card.appendChild(body);
+            card.appendChild(foot);
+            overlay.appendChild(card);
+            (nearEl && nearEl.ownerDocument ? nearEl.ownerDocument.body : document.body).appendChild(overlay);
+
+            var settled = false;
+            function close(result) {
+                if (settled) return;
+                settled = true;
+                document.removeEventListener('keydown', onKeydown, true);
+                if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+                // Put focus back where the user left it, or the page silently
+                // drops them at the top of the document.
+                if (previouslyFocused && previouslyFocused.focus) previouslyFocused.focus();
+                resolve(result);
+            }
+
+            function onKeydown(event) {
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    close(false);
+                    return;
+                }
+                if (event.key !== 'Tab') return;
+                // Two focusable elements, so the trap is a cycle between them.
+                event.preventDefault();
+                (document.activeElement === confirm ? cancel : confirm).focus();
+            }
+
+            cancel.addEventListener('click', function () { close(false); });
+            confirm.addEventListener('click', function () { close(true); });
+            // A click on the scrim is a cancel, as it is for every other modal
+            // here; a click inside the card is not.
+            overlay.addEventListener('click', function (event) {
+                if (event.target === overlay) close(false);
+            });
+            document.addEventListener('keydown', onKeydown, true);
+
+            // Cancel takes focus: the safe choice should be the one an
+            // accidental Enter lands on.
+            cancel.focus();
+        });
     }
 
     // ── Action failures ──

--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -2216,7 +2216,7 @@
         var suiteBody = document.getElementById('suite-sections')
                      || document.getElementById('suite-config-body');
         if (suiteBody) {
-            suiteBody.addEventListener('click', function (e) {
+            suiteBody.addEventListener('click', async function (e) {
                 var editBtn = e.target && e.target.closest('.js-family-edit-btn');
                 var delBtn  = e.target && e.target.closest('.js-family-delete-btn');
                 if (editBtn) {
@@ -2239,7 +2239,7 @@
                     if (idx2 < 0) return;
                     var family = familiesState[idx2];
                     var caseCount = (family.cases || []).length;
-                    if (!ChickadeeUI.confirmAction('Delete pattern family "' + family.name + '"? This removes '
+                    if (!await ChickadeeUI.confirmAction('Delete pattern family "' + family.name + '"? This removes '
                                  + caseCount + ' generated test script' + (caseCount === 1 ? '' : 's') + '.')) {
                         return;
                     }

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2177,6 +2177,12 @@ tr.drop-adopt  { outline: 2px solid var(--blue); outline-offset: -2px; }
     background: var(--overlay-bg);
 }
 .modal-overlay[hidden] { display: none; }
+/* The destructive-action confirmation (ChickadeeUI.confirmAction) — the same
+   scrim and card as every other modal, at the width a sentence and two buttons
+   want rather than the editor's. It replaced window.confirm, which was the one
+   surface in the app outside the design system. */
+.modal-card--confirm { width: min(28rem, 92vw); }
+.confirm-message { font-size: var(--text-base); }
 .modal-card {
     background: var(--surface);
     color: var(--gray-900);

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -1186,7 +1186,7 @@
         // pattern-family-editor.js).  Edit opens the unified Test Editor modal
         // pre-populated; Delete drops the check and re-saves the list via the
         // single PUT /suite write path.
-        container.addEventListener('click', function (e) {
+        container.addEventListener('click', async function (e) {
             var editBtn = e.target.closest && e.target.closest('.js-check-edit-btn');
             if (editBtn) {
                 let row = editBtn.closest('tr[data-kind="check"]');
@@ -1210,7 +1210,7 @@
                 var item2 = findByID('check:' + cid2);
                 if (!item2) return;
                 var label = (item2.check && (item2.check.name || item2.check.id)) || cid2;
-                if (!ChickadeeUI.confirmAction('Delete notebook check "' + label + '"? This removes the generated test script.')) {
+                if (!await ChickadeeUI.confirmAction('Delete notebook check "' + label + '"? This removes the generated test script.')) {
                     return;
                 }
                 var remaining = items
@@ -1228,7 +1228,7 @@
             var id = row.getAttribute('data-id');
             var item = findByID(id);
             if (!item) return;
-            if (!ChickadeeUI.confirmAction('Delete test script "' + item.script + '"? This also removes it as a dependency from other items.')) return;
+            if (!await ChickadeeUI.confirmAction('Delete test script "' + item.script + '"? This also removes it as a dependency from other items.')) return;
 
             global.ChickadeeUI.fetchJSON(urls.deleteScript(item.script), {
                 method: 'DELETE', csrfToken: csrfToken
@@ -1248,7 +1248,7 @@
 
         // ── Section-header inline edit (rename toggle + delete) ──
 
-        container.addEventListener('click', function (e) {
+        container.addEventListener('click', async function (e) {
             var toggle = e.target.closest && e.target.closest('.js-section-edit-toggle');
             if (toggle) {
                 var header = toggle.closest('.section-header');
@@ -1284,7 +1284,7 @@
                     ? 'Delete section "' + name + '"?'
                     : 'Delete section "' + name + '"? Its ' + affected + ' test'
                       + (affected === 1 ? '' : 's') + ' will move to Ungrouped.';
-                if (!ChickadeeUI.confirmAction(msg)) return;
+                if (!await ChickadeeUI.confirmAction(msg)) return;
                 var f = document.createElement('form');
                 f.method = 'POST';
                 f.action = action;

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -86,7 +86,7 @@
             if (!btn) return;
             var filename = btn.getAttribute('data-filename');
             if (!filename) return;
-            if (!ChickadeeUI.confirmAction('Remove support file "' + filename + '"? Tests that read it will fail until you re-add it.')) return;
+            if (!await ChickadeeUI.confirmAction('Remove support file "' + filename + '"? Tests that read it will fail until you re-add it.')) return;
             try {
                 var resp = await fetch(config.deleteURL(filename), {
                     method: 'DELETE',

--- a/Tests/BrowserRunnerJSTests/confirm-dialog.test.mjs
+++ b/Tests/BrowserRunnerJSTests/confirm-dialog.test.mjs
@@ -1,0 +1,209 @@
+// Unit tests for the destructive-action confirmation
+// (ChickadeeUI.confirmAction in Public/chickadee-ui.js, plus the data-confirm
+// seam in Public/app.js).
+//
+// This replaced window.confirm, which covered 41 destructive actions — 36
+// `data-confirm` attributes across 18 templates and 5 direct callers — and was
+// the last piece of UI outside the design system: unthemed, unstyleable, and
+// invisible to the axe scan because the browser chrome drew it, not the page.
+//
+// Two things are worth pinning. The DIALOG's own behaviour is mostly
+// accessibility: what takes focus, what Escape does, where focus goes back to.
+// And the SEAM's, which changed shape: a real dialog cannot block the event
+// loop, so app.js now always cancels the action, asks, and REPLAYS it on yes.
+// The replay is where a regression would be silent and expensive — a
+// destructive action that fires without asking, or one that asks and then
+// never happens.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const uiSource = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+
+// ── A DOM just real enough ──────────────────────────────────────────────────
+
+function makeDoc() {
+  const listeners = {};
+  const doc = {
+    readyState: 'complete',
+    body: null,
+    activeElement: null,
+    listeners,
+    createElement(tag) { return makeEl(tag, doc); },
+    addEventListener(type, fn) { (listeners[type] ||= []).push(fn); },
+    removeEventListener(type, fn) {
+      listeners[type] = (listeners[type] || []).filter((f) => f !== fn);
+    },
+    querySelector: () => null,
+    dispatch(type, event) { (listeners[type] || []).slice().forEach((fn) => fn(event)); },
+  };
+  doc.body = makeEl('body', doc);
+  return doc;
+}
+
+function makeEl(tag, doc) {
+  return {
+    tagName: tag.toUpperCase(),
+    ownerDocument: doc,
+    className: '',
+    textContent: '',
+    id: '',
+    type: '',
+    attrs: {},
+    children: [],
+    parentNode: null,
+    handlers: {},
+    focused: 0,
+    setAttribute(n, v) { this.attrs[n] = String(v); },
+    getAttribute(n) { return Object.prototype.hasOwnProperty.call(this.attrs, n) ? this.attrs[n] : null; },
+    hasAttribute(n) { return Object.prototype.hasOwnProperty.call(this.attrs, n); },
+    appendChild(c) { this.children.push(c); c.parentNode = this; return c; },
+    removeChild(c) { this.children = this.children.filter((x) => x !== c); c.parentNode = null; return c; },
+    addEventListener(type, fn) { (this.handlers[type] ||= []).push(fn); },
+    click() { (this.handlers.click || []).slice().forEach((fn) => fn({ target: this })); },
+    focus() { this.focused += 1; if (this.ownerDocument) this.ownerDocument.activeElement = this; },
+    querySelector: () => null,
+    closest: () => null,
+  };
+}
+
+function loadUI(doc) {
+  const sandbox = { document: doc, window: {}, Promise, module: { exports: {} } };
+  sandbox.self = sandbox;
+  sandbox.window.document = doc;
+  vm.createContext(sandbox);
+  vm.runInContext(uiSource, sandbox);
+  return sandbox.window.ChickadeeUI || sandbox.ChickadeeUI;
+}
+
+function dialogParts(doc) {
+  const overlay = doc.body.children.find((c) => c.className === 'modal-overlay');
+  if (!overlay) return null;
+  const card = overlay.children[0];
+  const foot = card.children[1];
+  return { overlay, card, body: card.children[0], cancel: foot.children[0], confirm: foot.children[1] };
+}
+
+// ── The dialog ──────────────────────────────────────────────────────────────
+
+test('the dialog announces itself as an alert dialog carrying the question', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  UI.confirmAction('Remove @alovelace from this course?');
+
+  const parts = dialogParts(doc);
+  assert.ok(parts, 'a dialog is mounted');
+  assert.equal(parts.card.getAttribute('role'), 'alertdialog');
+  assert.equal(parts.card.getAttribute('aria-modal'), 'true');
+  assert.equal(parts.body.textContent, 'Remove @alovelace from this course?');
+  assert.equal(parts.card.getAttribute('aria-describedby'), parts.body.id);
+});
+
+// The message is user/instructor-authored text (a student's username, a test
+// script's filename). It goes in as textContent, never as markup.
+test('the question is set as text, not parsed as markup', () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  UI.confirmAction('Delete "<img src=x onerror=alert(1)>"?');
+  const parts = dialogParts(doc);
+  assert.equal(parts.body.textContent, 'Delete "<img src=x onerror=alert(1)>"?');
+  assert.equal(parts.body.children.length, 0, 'no elements were created from the message');
+});
+
+test('Cancel takes focus, so an accidental Enter is the safe answer', () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  UI.confirmAction('Delete everything?');
+  const parts = dialogParts(doc);
+  assert.equal(parts.cancel.focused, 1);
+  assert.equal(parts.confirm.focused, 0);
+});
+
+test('confirming resolves true and removes the dialog', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const answer = UI.confirmAction('Delete?');
+  dialogParts(doc).confirm.click();
+  assert.equal(await answer, true);
+  assert.equal(dialogParts(doc), null, 'the dialog is gone');
+});
+
+test('cancelling resolves false', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const answer = UI.confirmAction('Delete?');
+  dialogParts(doc).cancel.click();
+  assert.equal(await answer, false);
+});
+
+test('Escape cancels', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const answer = UI.confirmAction('Delete?');
+  let prevented = false;
+  doc.dispatch('keydown', { key: 'Escape', preventDefault: () => { prevented = true; } });
+  assert.equal(await answer, false);
+  assert.equal(prevented, true, 'Escape is consumed, not passed to the page beneath');
+});
+
+test('a click on the scrim cancels; a click inside the card does not', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const answer = UI.confirmAction('Delete?');
+  const parts = dialogParts(doc);
+
+  parts.overlay.handlers.click.forEach((fn) => fn({ target: parts.card }));
+  assert.ok(dialogParts(doc), 'a click inside the card leaves the dialog open');
+
+  parts.overlay.handlers.click.forEach((fn) => fn({ target: parts.overlay }));
+  assert.equal(await answer, false);
+});
+
+test('Tab cycles between the two buttons rather than leaving the dialog', () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  UI.confirmAction('Delete?');
+  const parts = dialogParts(doc);
+
+  doc.dispatch('keydown', { key: 'Tab', preventDefault: () => {} });
+  assert.equal(doc.activeElement, parts.confirm);
+  doc.dispatch('keydown', { key: 'Tab', preventDefault: () => {} });
+  assert.equal(doc.activeElement, parts.cancel);
+});
+
+test('focus returns to whatever had it, so the page does not jump to the top', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const trigger = makeEl('button', doc);
+  trigger.focus();
+  const before = trigger.focused;
+
+  const answer = UI.confirmAction('Delete?', trigger);
+  dialogParts(doc).cancel.click();
+  await answer;
+  assert.ok(trigger.focused > before, 'the trigger is focused again on close');
+});
+
+test('the dialog settles once even if answered twice', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const answer = UI.confirmAction('Delete?');
+  const parts = dialogParts(doc);
+  parts.cancel.click();
+  parts.confirm.click();          // a stray second click must not re-resolve
+  assert.equal(await answer, false);
+});
+
+test('the keydown listener is removed when the dialog closes', async () => {
+  const doc = makeDoc();
+  const UI = loadUI(doc);
+  const before = (doc.listeners.keydown || []).length;
+  const answer = UI.confirmAction('Delete?');
+  assert.equal((doc.listeners.keydown || []).length, before + 1);
+  dialogParts(doc).cancel.click();
+  await answer;
+  assert.equal((doc.listeners.keydown || []).length, before, 'no listener is left behind');
+});

--- a/Tests/BrowserRunnerJSTests/confirm-seam.test.mjs
+++ b/Tests/BrowserRunnerJSTests/confirm-seam.test.mjs
@@ -1,0 +1,205 @@
+// Unit tests for the `data-confirm` seam in Public/app.js.
+//
+// 36 destructive actions across 18 templates go through this: unenroll a
+// student, delete an assignment, reset a submission, clear a runner secret.
+// Its shape changed when the native dialog was replaced — a real dialog
+// resolves in a promise, and a DOM listener cannot wait for one — so the seam
+// now always cancels the interaction, asks, and REPLAYS it if the answer was
+// yes.
+//
+// The replay is where a regression would be both silent and expensive: a
+// destructive action that fires without asking, or one that asks and then
+// never happens. Both directions are pinned here.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const appSource = await fs.readFile(path.resolve('Public/app.js'), 'utf8');
+
+function makeEl({ tag = 'BUTTON', confirm = null } = {}) {
+  const el = {
+    tagName: tag,
+    attrs: confirm === null ? {} : { 'data-confirm': confirm },
+    clicks: 0,
+    submits: [],
+    getAttribute(n) { return Object.prototype.hasOwnProperty.call(this.attrs, n) ? this.attrs[n] : null; },
+    hasAttribute(n) { return Object.prototype.hasOwnProperty.call(this.attrs, n); },
+    matches(sel) { return sel === '[data-confirm]' && this.hasAttribute('data-confirm'); },
+    closest(sel) { return sel === '[data-confirm]' && this.hasAttribute('data-confirm') ? this : null; },
+    querySelectorAll: () => [],
+    addEventListener() {},
+    click() { this.clicks += 1; harness.dispatch('click', { target: this, ...noopEvent() }); },
+    requestSubmit(submitter) {
+      this.submits.push(submitter || null);
+      harness.dispatch('submit', { target: this, submitter: submitter || null, ...noopEvent() });
+    },
+  };
+  return el;
+}
+
+function noopEvent() {
+  return {
+    prevented: false,
+    stopped: false,
+    preventDefault() { this.prevented = true; },
+    stopPropagation() { this.stopped = true; },
+  };
+}
+
+let harness;
+
+function load({ answer = true } = {}) {
+  const listeners = {};
+  const asked = [];
+  let resolveAnswer;
+
+  const doc = {
+    readyState: 'complete',
+    body: { addEventListener() {} },
+    documentElement: { addEventListener() {}, classList: { add() {}, remove() {} } },
+    addEventListener(type, fn) { (listeners[type] ||= []).push(fn); },
+    removeEventListener() {},
+    querySelectorAll: () => [],
+    querySelector: () => null,
+    getElementById: () => null,
+    createElement: () => ({ setAttribute() {}, appendChild() {}, addEventListener() {}, style: {}, classList: { add() {} } }),
+  };
+
+  const sandbox = {
+    document: doc,
+    Promise,
+    Element: class {},
+    setTimeout: (fn) => fn,
+    clearTimeout: () => {},
+  };
+  sandbox.window = {
+    document: doc,
+    addEventListener() {},
+    location: { reload() {} },
+    ChickadeeUI: {
+      confirmAction(message) {
+        asked.push(message);
+        return typeof answer === 'function'
+          ? answer(message)
+          : new Promise((resolve) => { resolveAnswer = () => resolve(answer); resolveAnswer(); });
+      },
+    },
+  };
+  sandbox.self = sandbox;
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(appSource, sandbox);
+
+  harness = {
+    asked,
+    dispatch(type, event) {
+      // `instanceof Element` is how app.js narrows the target; the stub class
+      // in the sandbox is what the elements are checked against, so mark them.
+      Object.setPrototypeOf(event.target, sandbox.Element.prototype);
+      (listeners[type] || []).slice().forEach((fn) => fn(event));
+      return event;
+    },
+  };
+  return harness;
+}
+
+// ── Clicks ──────────────────────────────────────────────────────────────────
+
+test('a click on a data-confirm element is cancelled while the question is open', () => {
+  const h = load({ answer: new Promise(() => {}) });   // never answered
+  const el = makeEl({ confirm: 'Remove @alovelace from this course?' });
+  const event = h.dispatch('click', { target: el, ...noopEvent() });
+
+  assert.equal(event.prevented, true);
+  assert.equal(event.stopped, true, 'handlers layered around it are stopped too');
+  assert.deepEqual(h.asked, ['Remove @alovelace from this course?']);
+});
+
+test('answering yes replays the click exactly once', async () => {
+  const h = load({ answer: true });
+  const el = makeEl({ confirm: 'Delete?' });
+  h.dispatch('click', { target: el, ...noopEvent() });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(el.clicks, 1, 'the original action happens');
+  assert.equal(h.asked.length, 1, 'and the replay does not ask again');
+});
+
+test('answering no replays nothing', async () => {
+  const h = load({ answer: false });
+  const el = makeEl({ confirm: 'Delete?' });
+  h.dispatch('click', { target: el, ...noopEvent() });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(el.clicks, 0);
+});
+
+test('an element with no data-confirm is untouched', () => {
+  const h = load();
+  const el = makeEl({ confirm: null });
+  const event = h.dispatch('click', { target: el, ...noopEvent() });
+  assert.equal(event.prevented, false);
+  assert.equal(h.asked.length, 0);
+});
+
+// A <form data-confirm> asks on submit, not on every click inside it.
+test('a click inside a data-confirm FORM asks nothing', () => {
+  const h = load();
+  const form = makeEl({ tag: 'FORM', confirm: 'Delete?' });
+  const event = h.dispatch('click', { target: form, ...noopEvent() });
+  assert.equal(event.prevented, false);
+  assert.equal(h.asked.length, 0);
+});
+
+// ── Submits ─────────────────────────────────────────────────────────────────
+
+test('a submit is cancelled, asked, and replayed through requestSubmit', async () => {
+  const h = load({ answer: true });
+  const form = makeEl({ tag: 'FORM', confirm: 'Delete this assignment?' });
+  const event = h.dispatch('submit', { target: form, submitter: null, ...noopEvent() });
+
+  assert.equal(event.prevented, true);
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(form.submits.length, 1, 'requestSubmit fires the submit event inplace-forms.js listens for');
+  assert.equal(h.asked.length, 1);
+});
+
+test('a cancelled submit does not submit', async () => {
+  const h = load({ answer: false });
+  const form = makeEl({ tag: 'FORM', confirm: 'Delete?' });
+  h.dispatch('submit', { target: form, submitter: null, ...noopEvent() });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(form.submits.length, 0);
+});
+
+// The secondary "Clear"/"Remove" buttons carry `formaction` and their own
+// data-confirm: they already asked during the click, and the replayed submit
+// must carry them so the right formaction is used.
+test('a submitter with its own question is not asked twice, and rides the replay', async () => {
+  const h = load({ answer: true });
+  const form = makeEl({ tag: 'FORM', confirm: 'Delete?' });
+  const submitter = makeEl({ confirm: 'Clear it?' });
+
+  h.dispatch('submit', { target: form, submitter, ...noopEvent() });
+  await Promise.resolve();
+  assert.equal(h.asked.length, 0, 'the click already asked');
+  assert.equal(form.submits.length, 0, 'and the submit proceeds natively');
+});
+
+test('a plain submitter is carried into the replay', async () => {
+  const h = load({ answer: true });
+  const form = makeEl({ tag: 'FORM', confirm: 'Delete?' });
+  const submitter = makeEl({ confirm: null });
+
+  h.dispatch('submit', { target: form, submitter, ...noopEvent() });
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(form.submits, [submitter], 'the replay keeps the original submitter');
+});

--- a/changelog.d/confirm-dialog.md
+++ b/changelog.d/confirm-dialog.md
@@ -1,0 +1,34 @@
+### Changed
+
+- **Destructive actions ask in a real dialog instead of the browser's.**
+  `ChickadeeUI.confirmAction` was `window.confirm`, with a comment saying it
+  existed so the native dialog could be replaced in one place; this is that
+  replacement. It covers all 41 destructive confirmations — 36 `data-confirm`
+  attributes across 18 templates plus 5 direct callers (unenroll a student,
+  delete a course section, delete a test script, delete a pattern family,
+  remove a support file). The native dialog was the last piece of UI outside
+  the design system: unthemed in dark mode, unstyleable, drawn by the browser
+  chrome rather than the page, and invisible to the axe scan. It is the sibling
+  of the native alerting call the S9 slice removed, and it outlived that slice
+  only because nobody had written the dialog.
+
+  The new one is a `role="alertdialog"` on the shared modal shape: Cancel takes
+  focus (so an accidental Enter is the safe answer), Escape and a scrim click
+  cancel, Tab cycles inside it, and focus returns to whatever had it. The
+  message is set as text, never parsed as markup.
+
+  **The one thing callers must know: it returns a promise.** A real dialog
+  cannot block the event loop the way the native one did. `data-confirm` is
+  unaffected — the seam in `app.js` now cancels the interaction, asks, and
+  replays it (a click, or `requestSubmit` with the original submitter) if the
+  answer is yes — and the five direct callers await it.
+
+  `check-styles.sh` drops the exemption it carried for the native call, so
+  that rule is now absolute like the alerting ratchets beside it.
+
+### Added
+
+- **The confirmation has unit tests** — the dialog's accessibility behaviour
+  and, separately, the `data-confirm` seam's replay in both directions: a
+  destructive action must not fire without asking, and must not be silently
+  dropped after the user says yes.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -155,6 +155,15 @@ of action buttons" and four pill implementations; the page-style ratchet
 - **`.form`**, `.form--wide`, `.form-input`, `.form-error`, `.form-flush`,
   `.inline-form` — forms and the inline error banner (never native
   `alert()`).
+- **`.modal-overlay` / `.modal-card`** (+ `--confirm`) — the one blocking
+  dialog shape.  A destructive action asks with `data-confirm="…"` in
+  markup (app.js handles it) or `await ChickadeeUI.confirmAction(msg)`
+  where there is no element to mark; both render the same themed
+  `role="alertdialog"`.  It returns a **promise** — the native dialog it
+  replaced could block the event loop and this cannot — so the
+  `data-confirm` seam cancels the interaction, asks, and replays it on
+  yes.  Never call the native one: `check-styles.sh` holds it at zero,
+  as it does for native alerting.
 - **`_flash` partial** + `.flash-*` — see page anatomy above.
 - **`.page-titlebar`** (+ `--baseline`), **`.page-subtitle`** — the page
   header row and its secondary line.  Cluster multiple left/right items

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -422,15 +422,19 @@ fi
 # S5: destructive confirmation is data-confirm (handled in app.js). An inline
 # onclick/onsubmit confirm attribute is the idiom it replaced — 49 of them,
 # with the same action worded differently on different pages. Keeping the
-# question in markup is also what makes replacing the native dialog later a
-# one-place change; a call site that re-adds `confirm(` opts itself out of it.
+# question in markup is what made replacing the native dialog a one-place
+# change, and that replacement has now happened: ChickadeeUI.confirmAction
+# renders a real dialog, so the NATIVE call is at zero and the exemption this
+# check used to carry for it is gone. The rule is now absolute, like the
+# alert() ratchets above — the native dialog was the last piece of UI outside
+# the design system, unthemed and invisible to the axe scan.
 s5_inline="$(grep -rnE 'on(click|submit)="return (window\.)?confirm\(' "${views[@]}" || true)"
 s5_raw="$(grep -rnE '(^|[^.\w])confirm\(' "${views[@]}" Public/*.js \
-  | grep -v 'ChickadeeUI.confirmAction' | grep -v 'window.confirm' || true)"
+  | grep -v 'ChickadeeUI.confirmAction' || true)"
 if [ -n "${s5_inline}${s5_raw}" ]; then
   status=1
-  echo "ERROR: a native confirm() outside the shared seam."
-  echo "       Declare the question in markup with data-confirm=\"…\", or call"
+  echo "ERROR: a native confirm() — the shared dialog is the only one."
+  echo "       Declare the question in markup with data-confirm=\"…\", or await"
   echo "       ChickadeeUI.confirmAction(msg) where there is no element to mark."
   { [ -n "$s5_inline" ] && printf '%s\n' "$s5_inline"
     [ -n "$s5_raw" ] && printf '%s\n' "$s5_raw"; } | sed 's/^/  /'


### PR DESCRIPTION
Item 4 of the component re-engineering list — the highest-value one, and explicitly deferred work: `confirmAction` was `window.confirm` with a comment saying it existed so the native dialog could be replaced in one place.

## Scope

**41 destructive confirmations** — 36 `data-confirm` attributes across 18 templates, plus 5 direct JS callers (unenroll a student, delete a course section, delete a test script, delete a pattern family, remove a support file).

The native dialog was the last piece of UI outside the design system: unthemed in dark mode, unstyleable, drawn by browser chrome rather than the page it belongs to, and invisible to the axe scan. It's the sibling of the native alerting call S9 removed, and it outlived that slice only because nobody had written the dialog.

## The dialog

`role="alertdialog"` on the shared `.modal-overlay`/`.modal-card` shape, with a `--confirm` width variant:

- **Cancel takes focus** — the safe choice should be what an accidental Enter lands on.
- Escape cancels; a scrim click cancels; a click inside the card doesn't.
- Tab cycles between the two buttons rather than escaping into the page behind.
- Focus returns to whatever had it, so the reader isn't dropped at the top of the document.
- The message is set as `textContent`, never parsed as markup — it carries a student's username or a script's filename.

## The part that changes shape: it returns a promise

A real dialog can't block the event loop the way the native one did, and a DOM listener can't wait for a promise. So the `data-confirm` seam in `app.js` now **cancels the interaction, asks, and replays it on yes** — `el.click()`, or `form.requestSubmit(submitter)` so `inplace-forms.js`'s submit listener and any `formaction` still see exactly what they saw before. A `WeakSet` marker keeps the replay from asking again.

The five direct callers `await` it; their enclosing handlers became `async`.

`check-styles.sh` drops the exemption it carried for the native call, so that rule is now absolute like the alerting ratchets beside it.

## Tests

A regression here is both silent and expensive, so both halves are pinned:

- **11 dialog tests** — the ARIA wiring, text-not-markup, initial focus, Escape/scrim/Tab, focus restoration, settle-once, and that the keydown listener is removed on close.
- **9 seam tests** — a click cancelled while the question is open; replay-exactly-once on yes; nothing on no; a `<form data-confirm>` asking on submit rather than on every click inside it; a submitter with its own question not asked twice; a plain submitter carried into the replay.

## Testing

Full `Tests/BrowserRunnerJSTests/*.mjs` sweep: 427 tests, 396 pass, 0 fail (31 pre-existing skips). `scripts/eslint.sh` and `scripts/check-styles.sh` green.

One note from writing it: the comment explaining the change tripped the alert-ratchet guard by naming the call it describes — the "scanner can't tell markup from prose about markup" trap this repo documents from #1266. Reworded rather than quoted.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_