### PR TITLE
test(ui): cover the four remaining untested authoring widgets

### DIFF
--- a/Tests/BrowserRunnerJSTests/section-inputs-editor.test.mjs
+++ b/Tests/BrowserRunnerJSTests/section-inputs-editor.test.mjs
@@ -1,0 +1,237 @@
+// Unit tests for Public/section-inputs-editor.js — the per-section inputs
+// panels on the assignment edit page.
+//
+// Most of its mechanics live in the shared core (inputs-editor-core.js, which
+// has its own suite). What is only here is the wiring, and the wiring is where
+// an author's work can be lost:
+//
+//   * the panel auto-saves on a debounce, so the assignment's main Save must
+//     flush it first — and flush EVERY section's form, not just one. A miss
+//     means the author's last edit to that section never reaches the server,
+//     with a successful-looking save on screen.
+//   * the section form must never navigate on submit; it is not the page's
+//     form.
+//   * a failed save must not announce success to the workbench pane, which
+//     would tell a notebook to re-render values the server never took.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/section-inputs-editor.js'), 'utf8');
+
+function makeForm(sectionID, { action = '/instructor/x/suite-sections/' + sectionID + '/variables' } = {}) {
+  const tbody = { rows: [], id: 'tbody-' + sectionID };
+  const form = {
+    action,
+    attrs: { 'data-section-id': sectionID },
+    handlers: {},
+    tbody,
+    getAttribute: (n) => form.attrs[n] ?? null,
+    querySelector: (sel) => (sel === 'tbody.js-section-vars-body' ? tbody : null),
+    addEventListener(type, fn) { (form.handlers[type] ||= []).push(fn); },
+    fire(type, event) { (form.handlers[type] || []).slice().forEach((fn) => fn(event)); },
+    contains: () => true,
+  };
+  return form;
+}
+
+function load({ forms, payload = { variables: [{ name: 'n', value: '1' }] }, response = { ok: true } } = {}) {
+  const fetches = [];
+  const notified = [];
+  const errors = [];
+  const scheduled = [];
+  let flushImpl;
+
+  const doc = {
+    readyState: 'complete',
+    querySelectorAll: (sel) => {
+      if (sel === 'form.section-vars-form') return forms;
+      if (sel === 'button.js-section-var-add') return [];
+      return [];
+    },
+    querySelector: () => null,
+    addEventListener() {},
+  };
+
+  const sandbox = {
+    document: doc,
+    Promise,
+    JSON,
+    Array,
+    Error,
+    console: { error: (...a) => errors.push(a.join(' ')) },
+    fetch: (url, opts) => {
+      fetches.push({ url, opts, body: JSON.parse(opts.body) });
+      return Promise.resolve({
+        ok: response.ok !== false,
+        status: response.status || 200,
+        type: response.type || 'basic',
+        text: () => Promise.resolve(response.body || ''),
+      });
+    },
+  };
+  // The shared core, stubbed: its own behaviour is covered by
+  // inputs-editor-core.test.mjs, so this file only needs its seams.
+  sandbox.ChickadeeInputsCore = {
+    createEditor: () => ({
+      buildPayload: () => payload,
+      refreshAllRows: () => {},
+      addEmptyRow: () => {},
+    }),
+    // A saver that records scheduling and lets the test drive the flush,
+    // so the debounce timer is not what these assertions depend on.
+    makeDebouncedSaver: (doPost) => {
+      flushImpl = doPost;
+      return {
+        schedule: () => scheduled.push('scheduled'),
+        flush: () => doPost(),
+      };
+    },
+  };
+  sandbox.ChickadeeUI = {
+    getCsrfToken: () => 'csrf-token-value',
+    notifyWorkbench: (what) => notified.push(what),
+  };
+  sandbox.window = { ChickadeeUI: sandbox.ChickadeeUI };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  return { fetches, notified, errors, scheduled, sandbox, flushImpl: () => flushImpl };
+}
+
+async function settle() {
+  for (let i = 0; i < 6; i += 1) await Promise.resolve();
+}
+
+// ── The flush contract ──────────────────────────────────────────────────────
+
+test('the page-level flush covers EVERY section form, not just one', async () => {
+  const forms = [makeForm('sec-a'), makeForm('sec-b'), makeForm('sec-c')];
+  const h = load({ forms });
+
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  await settle();
+
+  assert.deepEqual(h.fetches.map((f) => f.url), [
+    '/instructor/x/suite-sections/sec-a/variables',
+    '/instructor/x/suite-sections/sec-b/variables',
+    '/instructor/x/suite-sections/sec-c/variables',
+  ], 'a missed form is an edit silently dropped behind a successful-looking save');
+});
+
+test('the flush is awaitable, so the assignment save can wait on it', async () => {
+  const h = load({ forms: [makeForm('sec-a')] });
+  const result = h.sandbox.window.chickadeeFlushSectionVars();
+  assert.ok(result && typeof result.then === 'function');
+  await result;
+});
+
+test('a page with no section panels still exposes a flush that resolves', async () => {
+  const h = load({ forms: [] });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  assert.deepEqual(h.fetches, []);
+});
+
+test('a form with no rows body flushes to a no-op rather than throwing', async () => {
+  const form = makeForm('sec-a');
+  form.querySelector = () => null;
+  const h = load({ forms: [form] });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  assert.deepEqual(h.fetches, []);
+});
+
+test('nothing is posted when the editor has no payload to send', async () => {
+  const h = load({ forms: [makeForm('sec-a')], payload: null });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  assert.deepEqual(h.fetches, []);
+});
+
+// ── The request ─────────────────────────────────────────────────────────────
+
+test('the save posts JSON to the form action with the CSRF header', async () => {
+  const h = load({ forms: [makeForm('sec-a')] });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+
+  const sent = h.fetches[0];
+  assert.equal(sent.opts.method, 'POST');
+  assert.equal(sent.opts.headers['Content-Type'], 'application/json');
+  assert.equal(sent.opts.headers['x-csrf-token'], 'csrf-token-value');
+  assert.deepEqual(sent.body, { variables: [{ name: 'n', value: '1' }] });
+});
+
+test('a successful save tells the workbench its values are stale', async () => {
+  const h = load({ forms: [makeForm('sec-a')] });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  await settle();
+  assert.deepEqual(h.notified, ['inputs-changed']);
+});
+
+test('a failed save is reported and does NOT announce success', async () => {
+  const h = load({
+    forms: [makeForm('sec-a')],
+    response: { ok: false, status: 422, body: 'bad name' },
+  });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  await settle();
+
+  assert.deepEqual(h.notified, [], 'a notebook must not re-render values the server rejected');
+  assert.equal(h.errors.length, 1);
+  assert.match(h.errors[0], /422/);
+});
+
+// A same-origin redirect answer is how the endpoint replies to a normal form
+// post; with redirect: 'manual' that surfaces as an opaque response, which is
+// success, not failure.
+test('an opaque redirect counts as a successful save', async () => {
+  const h = load({
+    forms: [makeForm('sec-a')],
+    response: { ok: false, status: 0, type: 'opaqueredirect' },
+  });
+  await h.sandbox.window.chickadeeFlushSectionVars();
+  await settle();
+
+  assert.deepEqual(h.notified, ['inputs-changed']);
+  assert.deepEqual(h.errors, []);
+});
+
+// ── Form behaviour ──────────────────────────────────────────────────────────
+
+test('submitting a section form saves in place rather than navigating', async () => {
+  const forms = [makeForm('sec-a')];
+  const h = load({ forms });
+  let prevented = false;
+
+  forms[0].fire('submit', { preventDefault: () => { prevented = true; } });
+  await settle();
+
+  assert.equal(prevented, true, 'the section panel is not the page form');
+  assert.equal(h.fetches.length, 1, 'and the edit is saved rather than dropped');
+});
+
+test('editing a row schedules a save; editing elsewhere does not', () => {
+  const forms = [makeForm('sec-a')];
+  const h = load({ forms });
+
+  forms[0].fire('input', { target: { closest: (sel) => (sel === 'tr.js-section-var-row' ? {} : null) } });
+  assert.equal(h.scheduled.length, 1);
+
+  forms[0].fire('input', { target: { closest: () => null } });
+  assert.equal(h.scheduled.length, 1, 'an unrelated input must not schedule a section save');
+});
+
+test('removing a row drops it and schedules a save', () => {
+  const forms = [makeForm('sec-a')];
+  const h = load({ forms });
+  let removed = false;
+  const tr = { remove: () => { removed = true; } };
+  const btn = { closest: (sel) => (sel === 'tr.js-section-var-row' ? tr : null) };
+
+  forms[0].fire('click', { target: { closest: (sel) => (sel === '.js-section-var-remove' ? btn : null) } });
+
+  assert.equal(removed, true);
+  assert.equal(h.scheduled.length, 1);
+});

--- a/Tests/BrowserRunnerJSTests/section-items-dnd.test.mjs
+++ b/Tests/BrowserRunnerJSTests/section-items-dnd.test.mjs
@@ -1,0 +1,302 @@
+// Unit tests for Public/section-items-dnd.js — drag-ordering of the
+// instructor dashboard's section item list.
+//
+// It had none. What it decides is which of three things a finished drag means:
+// nothing happened, the order changed within a section, or the item moved to
+// another section. Getting that wrong is not a visual bug — it writes the wrong
+// order to the server, or writes one when the author only picked a row up and
+// put it back.
+//
+// The mixed-type list is the other reason to pin it: assignments and content
+// items interleave, they have DIFFERENT move endpoints, and the reorder body
+// must carry the whole tbody in order — both types — or the section's numbering
+// comes out wrong for whichever type was omitted.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/section-items-dnd.js'), 'utf8');
+
+// ── A DOM with just enough tree to move rows between tbodies ────────────────
+
+function makeNode(tag, attrs = {}) {
+  const node = {
+    tagName: tag.toUpperCase(),
+    attrs,
+    children: [],
+    parentElement: null,
+    classes: new Set(),
+    classList: {
+      add: (...c) => c.forEach((x) => node.classes.add(x)),
+      remove: (...c) => c.forEach((x) => node.classes.delete(x)),
+      contains: (c) => node.classes.has(c),
+    },
+    style: {},
+    getAttribute: (n) => (Object.prototype.hasOwnProperty.call(attrs, n) ? attrs[n] : null),
+    setAttribute: (n, v) => { attrs[n] = String(v); },
+    getBoundingClientRect: () => ({ top: 0, height: 20 }),
+    append(child) {
+      if (child.parentElement) child.parentElement.remove(child);
+      child.parentElement = node;
+      node.children.push(child);
+      return child;
+    },
+    remove(child) { node.children = node.children.filter((c) => c !== child); },
+    appendChild(child) { return node.append(child); },
+    insertBefore(child, ref) {
+      if (child.parentElement) child.parentElement.remove(child);
+      child.parentElement = node;
+      const at = ref ? node.children.indexOf(ref) : -1;
+      if (at < 0) node.children.push(child);
+      else node.children.splice(at, 0, child);
+      return child;
+    },
+    get nextSibling() {
+      if (!node.parentElement) return null;
+      const sibs = node.parentElement.children;
+      return sibs[sibs.indexOf(node) + 1] || null;
+    },
+    querySelectorAll(sel) { return descendants(node).filter((n) => matches(n, sel)); },
+    querySelector(sel) { return node.querySelectorAll(sel)[0] || null; },
+    closest(sel) {
+      let cur = node;
+      while (cur) {
+        if (matches(cur, sel)) return cur;
+        cur = cur.parentElement;
+      }
+      return null;
+    },
+  };
+  return node;
+}
+
+function descendants(node) {
+  return node.children.flatMap((c) => [c, ...descendants(c)]);
+}
+
+// Only the selectors this module actually uses.
+function matches(node, selector) {
+  return selector.split(',').map((s) => s.trim()).some((sel) => {
+    if (sel === 'tr[data-assignment-id]') return node.tagName === 'TR' && node.getAttribute('data-assignment-id');
+    if (sel === 'tr[data-content-item-id]') return node.tagName === 'TR' && node.getAttribute('data-content-item-id');
+    if (sel === 'tbody[data-section-id]') return node.tagName === 'TBODY' && node.getAttribute('data-section-id') !== null;
+    if (sel === 'tr.section-empty-row') return node.tagName === 'TR' && node.classes.has('section-empty-row');
+    if (sel === '.section-block[data-section-id]') return node.classes.has('section-block') && node.getAttribute('data-section-id') !== null;
+    if (sel === 'a, img' || sel === 'a' || sel === 'img') return node.tagName === 'A' || node.tagName === 'IMG';
+    return false;
+  });
+}
+
+function row(kind, id) {
+  const tr = makeNode('tr', kind === 'assignment'
+    ? { 'data-assignment-id': id }
+    : { 'data-content-item-id': id });
+  return tr;
+}
+
+/// Two sections, each a .section-block containing a tbody of rows.
+function load({ sections }) {
+  const fetches = [];
+  const reloads = [];
+  const listeners = {};
+
+  const root = makeNode('div');
+  const tbodies = {};
+  for (const [sectionID, rows] of Object.entries(sections)) {
+    const block = makeNode('div', { 'data-section-id': sectionID });
+    block.classes.add('section-block');
+    const tbody = makeNode('tbody', { 'data-section-id': sectionID });
+    rows.forEach((r) => tbody.append(r));
+    block.append(tbody);
+    root.append(block);
+    tbodies[sectionID] = tbody;
+  }
+
+  const doc = {
+    readyState: 'complete',
+    addEventListener(type, fn) { (listeners[type] ||= []).push(fn); },
+    querySelectorAll: (sel) => root.querySelectorAll(sel),
+    querySelector: (sel) => root.querySelector(sel),
+  };
+
+  const sandbox = {
+    document: doc,
+    Promise,
+    JSON,
+    Array,
+    Element: class {},
+    fetch: (url, opts) => {
+      fetches.push({ url, opts, body: JSON.parse(opts.body) });
+      return Promise.resolve({ ok: true, status: 200 });
+    },
+  };
+  sandbox.window = {
+    ChickadeeUI: { getCsrfToken: () => 'csrf-token-value' },
+    location: { reload: () => reloads.push('reload') },
+  };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  function fire(type, event) {
+    if (event && event.target) Object.setPrototypeOf(event.target, sandbox.Element.prototype);
+    (listeners[type] || []).slice().forEach((fn) => fn(event || {}));
+  }
+
+  return { fetches, reloads, tbodies, root, fire };
+}
+
+const noopEvent = () => ({ preventDefault() {}, dataTransfer: { setData() {} } });
+
+async function settle() {
+  for (let i = 0; i < 6; i += 1) await Promise.resolve();
+}
+
+// ── What a finished drag means ──────────────────────────────────────────────
+
+test('a drag that ends where it started posts nothing', async () => {
+  const a = row('assignment', 'a1');
+  const b = row('assignment', 'a2');
+  const h = load({ sections: { labs: [a, b] } });
+
+  h.fire('dragstart', { target: a, ...noopEvent() });
+  h.fire('dragend', {});
+  await settle();
+
+  assert.deepEqual(h.fetches, [], 'picking a row up and putting it back is not a change');
+  assert.deepEqual(h.reloads, []);
+});
+
+test('a reorder inside one section posts the whole tbody in its new order', async () => {
+  const a = row('assignment', 'a1');
+  const c = row('content', 'c1');
+  const b = row('assignment', 'a2');
+  const h = load({ sections: { labs: [a, c, b] } });
+
+  h.fire('dragstart', { target: b, ...noopEvent() });
+  // Drop b above a: dragover the top half of a.
+  h.fire('dragover', { target: a, clientY: 1, preventDefault() {} });
+  h.fire('dragend', {});
+  await settle();
+
+  assert.equal(h.fetches.length, 1);
+  assert.equal(h.fetches[0].url, '/instructor/section-items/reorder');
+  assert.equal(h.fetches[0].opts.headers['x-csrf-token'], 'csrf-token-value');
+  assert.deepEqual(h.fetches[0].body, {
+    sectionID: 'labs',
+    items: [
+      { type: 'assignment', id: 'a2' },
+      { type: 'assignment', id: 'a1' },
+      { type: 'content', id: 'c1' },
+    ],
+  }, 'both row types ride the reorder, in the order they now appear');
+});
+
+test('dropping below a row places it after, not before', async () => {
+  const a = row('assignment', 'a1');
+  const b = row('assignment', 'a2');
+  const h = load({ sections: { labs: [a, b] } });
+
+  h.fire('dragstart', { target: b, ...noopEvent() });
+  h.fire('dragover', { target: a, clientY: 19, preventDefault() {} });   // bottom half
+  h.fire('dragend', {});
+  await settle();
+
+  assert.deepEqual(h.fetches, [], 'a2 is already after a1 — no change, so no post');
+});
+
+// ── Cross-section moves ─────────────────────────────────────────────────────
+
+test('moving an assignment to another section uses the assignment endpoint, then reorders, then reloads', async () => {
+  const a = row('assignment', 'a1');
+  const other = row('assignment', 'a9');
+  const h = load({ sections: { labs: [a], exams: [other] } });
+
+  h.fire('dragstart', { target: a, ...noopEvent() });
+  h.fire('dragover', { target: h.tbodies.exams, preventDefault() {} });
+  h.fire('dragend', {});
+  await settle();
+
+  assert.deepEqual(h.fetches.map((f) => f.url), [
+    '/instructor/a1/section',
+    '/instructor/section-items/reorder',
+  ]);
+  assert.deepEqual(h.fetches[0].body, { sectionID: 'exams' });
+  assert.deepEqual(h.fetches[1].body.items, [
+    { type: 'assignment', id: 'a9' },
+    { type: 'assignment', id: 'a1' },
+  ]);
+  assert.deepEqual(h.reloads, ['reload']);
+});
+
+// The two types have different move endpoints; sending a content item to the
+// assignment one would 404 and lose the move.
+test('moving a content item uses the content endpoint', async () => {
+  const c = row('content', 'c1');
+  const other = row('assignment', 'a9');
+  const h = load({ sections: { labs: [c], exams: [other] } });
+
+  h.fire('dragstart', { target: c, ...noopEvent() });
+  h.fire('dragover', { target: h.tbodies.exams, preventDefault() {} });
+  h.fire('dragend', {});
+  await settle();
+
+  assert.equal(h.fetches[0].url, '/instructor/content-items/c1/section');
+  assert.deepEqual(h.fetches[0].body, { sectionID: 'exams' });
+});
+
+test('moving into an empty section hides its placeholder and lands there', async () => {
+  const a = row('assignment', 'a1');
+  const empty = makeNode('tr');
+  empty.classes.add('section-empty-row');
+  const h = load({ sections: { labs: [a], exams: [empty] } });
+
+  h.fire('dragstart', { target: a, ...noopEvent() });
+  h.fire('dragover', { target: empty, preventDefault() {} });
+  h.fire('dragend', {});
+  await settle();
+
+  assert.equal(empty.style.display, 'none', 'the "no items" row gets out of the way');
+  assert.equal(a.parentElement, h.tbodies.exams);
+  assert.equal(h.fetches[0].url, '/instructor/a1/section');
+});
+
+test('a section with no id at all is the ungrouped section, sent as ""', async () => {
+  const a = row('assignment', 'a1');
+  const other = row('assignment', 'a9');
+  const h = load({ sections: { '': [other], labs: [a] } });
+
+  h.fire('dragstart', { target: a, ...noopEvent() });
+  h.fire('dragover', { target: h.tbodies[''], preventDefault() {} });
+  h.fire('dragend', {});
+  await settle();
+
+  assert.deepEqual(h.fetches[0].body, { sectionID: '' });
+});
+
+// ── Setup ───────────────────────────────────────────────────────────────────
+
+test('rows are made draggable and their links are not', () => {
+  const a = row('assignment', 'a1');
+  const link = makeNode('a');
+  a.append(link);
+  load({ sections: { labs: [a] } });
+
+  assert.equal(a.getAttribute('draggable'), 'true');
+  assert.ok(a.classes.has('assignment-draggable'));
+  assert.equal(link.getAttribute('draggable'), 'false',
+    'native link drag must not hijack the row drag');
+});
+
+test('a drag that never started ignores dragover and dragend', async () => {
+  const a = row('assignment', 'a1');
+  const h = load({ sections: { labs: [a] } });
+
+  h.fire('dragover', { target: a, clientY: 1, preventDefault() {} });
+  h.fire('dragend', {});
+  await settle();
+  assert.deepEqual(h.fetches, []);
+});

--- a/Tests/BrowserRunnerJSTests/support-files.test.mjs
+++ b/Tests/BrowserRunnerJSTests/support-files.test.mjs
@@ -1,0 +1,249 @@
+// Unit tests for Public/support-files.js — the support-file upload/delete
+// widget shared by the two assignment authoring pages.
+//
+// It had none, and its history is the reason to care: the two pages carried
+// near-identical inline copies, the create page's being the stale fork of the
+// pair. This file exists to make that one implementation; nothing was checking
+// that it stays correct.
+//
+// Two things here are easy to get wrong in ways no page would show you. An
+// upload posts `tier: "support", isTest: false` — get that wrong and the file
+// is stored as a TEST and starts being graded. And a failed upload mid-batch
+// must not report success, or the author is told a file landed that did not.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/support-files.js'), 'utf8');
+
+function makeEl(id) {
+  return {
+    id,
+    handlers: {},
+    files: null,
+    value: 'unset',
+    addEventListener(type, fn) { (this.handlers[type] ||= []).push(fn); },
+    fire(type, event) { (this.handlers[type] || []).slice().forEach((fn) => fn(event || {})); },
+    click() { this.clicked = (this.clicked || 0) + 1; },
+    getAttribute() { return null; },
+    closest() { return null; },
+  };
+}
+
+function load({ responses = [], confirmAnswer = true, readFails = false } = {}) {
+  const fetches = [];
+  const statuses = [];
+  const bodyHandlers = {};
+  let index = 0;
+
+  const elements = {
+    'add-support-file-btn': makeEl('add-support-file-btn'),
+    'support-file-upload-input': makeEl('support-file-upload-input'),
+    'support-file-upload-status': makeEl('support-file-upload-status'),
+  };
+
+  const doc = {
+    readyState: 'complete',
+    getElementById: (id) => elements[id] || null,
+    body: {
+      addEventListener(type, fn) { (bodyHandlers[type] ||= []).push(fn); },
+    },
+    addEventListener() {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+
+  const sandbox = {
+    document: doc,
+    Promise,
+    JSON,
+    Error,
+    // A FileReader that resolves with the file's own text, or fails on demand.
+    FileReader: class {
+      readAsText(file) {
+        if (readFails) {
+          setTimeout(() => this.onerror && this.onerror(), 0);
+          return;
+        }
+        this.result = file.text;
+        setTimeout(() => this.onload && this.onload(), 0);
+      }
+    },
+    setTimeout: (fn) => { fn(); return 1; },
+    fetch: (url, opts) => {
+      fetches.push({ url, opts, body: opts && opts.body ? JSON.parse(opts.body) : null });
+      const res = responses[Math.min(index, responses.length - 1)] || { ok: true, status: 200 };
+      index += 1;
+      return Promise.resolve({
+        ok: res.ok !== false,
+        status: res.status || 200,
+        text: () => Promise.resolve(res.body || ''),
+      });
+    },
+  };
+  sandbox.ChickadeeUI = {
+    setStatus: (_el, msg, kind) => statuses.push({ msg, kind }),
+    confirmAction: () => Promise.resolve(confirmAnswer),
+    showActionError: (msg) => statuses.push({ msg, kind: 'error' }),
+  };
+  sandbox.window = { ChickadeeUI: sandbox.ChickadeeUI };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  const changed = [];
+  sandbox.window.initSupportFiles({
+    csrfToken: 'csrf-token-value',
+    uploadURL: () => '/instructor/abc/support-files',
+    deleteURL: (name) => '/instructor/abc/support-files/' + name,
+    onChange: () => changed.push('changed'),
+  });
+
+  return { fetches, statuses, changed, elements, bodyHandlers, sandbox };
+}
+
+function file(name, text) { return { name, text }; }
+
+function deleteClick(h, filename) {
+  const btn = {
+    getAttribute: (n) => (n === 'data-filename' ? filename : null),
+    closest: (sel) => (sel === '.js-support-file-delete-btn' ? btn : null),
+  };
+  const event = { target: { closest: (sel) => (sel === '.js-support-file-delete-btn' ? btn : null) } };
+  return Promise.all((h.bodyHandlers.click || []).map((fn) => fn(event)));
+}
+
+// The FileReader stub resolves on a real timer (its `setTimeout` binds to the
+// host's, not the sandbox's), so settling needs macrotasks, not just
+// microtasks — draining only the microtask queue made every upload test see
+// zero fetches and look like a code failure.
+async function settle() {
+  for (let i = 0; i < 4; i += 1) await new Promise((r) => setTimeout(r, 0));
+}
+
+// ── Upload ──────────────────────────────────────────────────────────────────
+
+test('an upload posts the file as a SUPPORT entry, not a test', async () => {
+  const h = load();
+  h.elements['support-file-upload-input'].files = [file('data.csv', 'a,b\n1,2\n')];
+  h.elements['support-file-upload-input'].fire('change');
+  await settle();
+
+  assert.equal(h.fetches.length, 1);
+  const sent = h.fetches[0];
+  assert.equal(sent.url, '/instructor/abc/support-files');
+  assert.equal(sent.opts.method, 'POST');
+  assert.equal(sent.opts.headers['x-csrf-token'], 'csrf-token-value');
+  assert.equal(sent.opts.credentials, 'same-origin');
+  assert.deepEqual(sent.body, {
+    filename: 'data.csv',
+    content: 'a,b\n1,2\n',
+    tier: 'support',
+    isTest: false,
+  });
+});
+
+test('the Add button opens the file picker rather than posting anything', () => {
+  const h = load();
+  h.elements['add-support-file-btn'].fire('click');
+  assert.equal(h.elements['support-file-upload-input'].clicked, 1);
+  assert.equal(h.fetches.length, 0);
+});
+
+test('picking nothing does nothing', async () => {
+  const h = load();
+  h.elements['support-file-upload-input'].files = [];
+  h.elements['support-file-upload-input'].fire('change');
+  await settle();
+  assert.equal(h.fetches.length, 0);
+  assert.deepEqual(h.statuses, []);
+});
+
+test('every file in a batch is uploaded, and the surface is refreshed once', async () => {
+  const h = load();
+  h.elements['support-file-upload-input'].files = [
+    file('a.csv', 'a'), file('b.csv', 'b'), file('c.csv', 'c'),
+  ];
+  h.elements['support-file-upload-input'].fire('change');
+  await settle();
+
+  assert.deepEqual(h.fetches.map((f) => f.body.filename), ['a.csv', 'b.csv', 'c.csv']);
+  assert.deepEqual(h.changed, ['changed'], 'one refresh for the batch, not one per file');
+});
+
+test('a failed upload reports the failure and does NOT refresh', async () => {
+  const h = load({ responses: [{ ok: false, status: 413, body: 'File too large' }] });
+  h.elements['support-file-upload-input'].files = [file('big.csv', 'x')];
+  h.elements['support-file-upload-input'].fire('change');
+  await settle();
+
+  const last = h.statuses[h.statuses.length - 1];
+  assert.equal(last.kind, 'error');
+  assert.match(last.msg, /413/);
+  assert.deepEqual(h.changed, [], 'a failed upload must not look like a successful one');
+});
+
+test('a batch stops at the first failure rather than reporting success', async () => {
+  const h = load({ responses: [{ ok: true }, { ok: false, status: 500, body: 'boom' }, { ok: true }] });
+  h.elements['support-file-upload-input'].files = [file('a', '1'), file('b', '2'), file('c', '3')];
+  h.elements['support-file-upload-input'].fire('change');
+  await settle();
+
+  assert.equal(h.fetches.length, 2, 'the third file is not attempted after the second fails');
+  assert.equal(h.statuses[h.statuses.length - 1].kind, 'error');
+  assert.deepEqual(h.changed, []);
+});
+
+test('an unreadable file is reported, not swallowed', async () => {
+  const h = load({ readFails: true });
+  h.elements['support-file-upload-input'].files = [file('locked.csv', 'x')];
+  h.elements['support-file-upload-input'].fire('change');
+  await settle();
+
+  assert.equal(h.fetches.length, 0, 'nothing is posted when the read fails');
+  assert.equal(h.statuses[h.statuses.length - 1].kind, 'error');
+});
+
+test('the picker is cleared after a batch so the same file can be re-picked', async () => {
+  const h = load();
+  const input = h.elements['support-file-upload-input'];
+  input.files = [file('a.csv', 'a')];
+  input.fire('change');
+  await settle();
+  assert.equal(input.value, '');
+});
+
+// ── Delete ──────────────────────────────────────────────────────────────────
+
+test('deleting asks first, then DELETEs the named file', async () => {
+  const h = load();
+  await deleteClick(h, 'data.csv');
+  await settle();
+
+  assert.equal(h.fetches.length, 1);
+  assert.equal(h.fetches[0].url, '/instructor/abc/support-files/data.csv');
+  assert.equal(h.fetches[0].opts.method, 'DELETE');
+  assert.equal(h.fetches[0].opts.headers['x-csrf-token'], 'csrf-token-value');
+  assert.deepEqual(h.changed, ['changed']);
+});
+
+test('cancelling the question deletes nothing', async () => {
+  const h = load({ confirmAnswer: false });
+  await deleteClick(h, 'data.csv');
+  await settle();
+
+  assert.equal(h.fetches.length, 0);
+  assert.deepEqual(h.changed, []);
+});
+
+test('a failed delete reports it and does not refresh', async () => {
+  const h = load({ responses: [{ ok: false, status: 409, body: 'in use' }] });
+  await deleteClick(h, 'data.csv');
+  await settle();
+
+  assert.equal(h.statuses[h.statuses.length - 1].kind, 'error');
+  assert.deepEqual(h.changed, []);
+});

--- a/Tests/BrowserRunnerJSTests/test-editor-modal.test.mjs
+++ b/Tests/BrowserRunnerJSTests/test-editor-modal.test.mjs
@@ -1,0 +1,279 @@
+// Unit tests for Public/test-editor-modal.js — the one "+ Add Test" shell.
+//
+// It had none, and it carries a fix whose failure mode is a blank form. When
+// editing, the mechanism and kind are authoritative from the edit payload; the
+// hidden type dropdown's leftover value must not decide which renderer runs.
+// Before that, editing a check or a script resolved to whatever the dropdown
+// last showed (default `family`), so the shell called reset() instead of
+// populate() and the modal opened empty — the author's existing test appearing
+// to have lost its contents. That is pinned first here.
+//
+// The other invariant worth holding is cleanup(). A renderer owns a CodeMirror
+// instance or a kernel worker; the shell must tear the old one down when the
+// body morphs to another mechanism and when the modal closes, or those leak
+// for the life of the page.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/test-editor-modal.js'), 'utf8');
+
+function stubEl(id) {
+  const el = {
+    id,
+    textContent: '',
+    value: '',
+    hidden: false,
+    disabled: false,
+    style: {},
+    classes: new Set(),
+    classList: {
+      add(...c) { c.forEach((name) => el.classes.add(name)); },
+      remove(...c) { c.forEach((name) => el.classes.delete(name)); },
+      contains: (name) => el.classes.has(name),
+    },
+    children: [],
+    handlers: {},
+    innerHTML: '',
+    appendChild(c) { this.children.push(c); return c; },
+    addEventListener(type, fn) { (this.handlers[type] ||= []).push(fn); },
+    fire(type, e) { (this.handlers[type] || []).slice().forEach((fn) => fn(e || {})); },
+    setAttribute() {},
+    getAttribute() { return null; },
+    focus() {},
+    contains: () => false,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    closest: () => null,
+  };
+  return el;
+}
+
+function load({ renderers, language = {} } = {}) {
+  const els = {};
+  const docHandlers = {};
+  const bodyHandlers = {};
+  const created = [];
+
+  const idFor = (id) => (els[id] ||= stubEl(id));
+  // The shell builds its chrome with innerHTML then looks each part up by id.
+  ['test-editor-type', 'test-editor-type-row', 'test-editor-desc', 'test-editor-title',
+    'test-editor-body', 'test-editor-status', 'test-editor-save', 'test-editor-cancel',
+    'test-editor-close'].forEach(idFor);
+
+  const doc = {
+    readyState: 'complete',
+    body: {
+      appendChild(c) { created.push(c); return c; },
+      addEventListener(type, fn) { (bodyHandlers[type] ||= []).push(fn); },
+    },
+    createElement: (tag) => {
+      const el = stubEl(tag);
+      el.classList = { add: () => {}, remove: () => {}, contains: () => false };
+      return el;
+    },
+    getElementById: (id) => els[id] || null,
+    addEventListener(type, fn) { (docHandlers[type] ||= []).push(fn); },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+
+  const sandbox = {
+    document: doc,
+    Promise,
+    JSON,
+    Object,
+    Error,
+    setTimeout: (fn) => { fn(); return 1; },
+    console: { error() {} },
+  };
+  sandbox.window = sandbox;
+  sandbox.self = sandbox;
+  sandbox.ChickadeeUI = {
+    setStatus: (el, text, kind) => { sandbox.lastStatus = { text, kind }; },
+    escapeHtml: (s) => String(s == null ? '' : s),
+    escapeAttr: (s) => String(s == null ? '' : s),
+  };
+  sandbox.ChickadeeTestRenderers = renderers || {};
+  sandbox.ChickadeeLanguage = {
+    checkKindUnsupportedReason: language.checkKindUnsupportedReason || (() => null),
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  const api = sandbox.initTestEditorModal({ csrfToken: 't', getSectionID: () => '' });
+  return { api, els, sandbox, docHandlers, bodyHandlers, created };
+}
+
+/// A renderer that records every call the shell makes on it.
+function recordingRenderer(name, log) {
+  return {
+    mount: () => log.push(name + ':mount'),
+    reset: (kind) => log.push(name + ':reset:' + kind),
+    populate: (item) => log.push(name + ':populate:' + (item && item.id)),
+    readSpec: () => ({}),
+    persistAndSync: () => Promise.resolve(),
+    cleanup: () => log.push(name + ':cleanup'),
+    title: (editing) => (editing ? 'Edit ' + name : 'Add ' + name),
+  };
+}
+
+function renderers(log) {
+  return {
+    family: recordingRenderer('family', log),
+    check: recordingRenderer('check', log),
+    script: recordingRenderer('script', log),
+  };
+}
+
+// ── Editing must populate, not reset ────────────────────────────────────────
+
+test('editing a check populates it, whatever the hidden dropdown last showed', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+  h.els['test-editor-type'].value = 'boundary_equality';   // a FAMILY kind, stale
+
+  h.api.open({ editing: { mechanism: 'check', id: 'chk1', item: { id: 'chk1', kind: 'variable_exists' } } });
+
+  assert.ok(log.includes('check:populate:chk1'),
+    'the edit payload decides the renderer, not the leftover dropdown value');
+  assert.ok(!log.some((l) => l.endsWith(':reset:boundary_equality')),
+    'the modal must not open blank on an existing test');
+});
+
+test('editing a script populates the script renderer', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+  h.els['test-editor-type'].value = 'boundary_equality';
+
+  h.api.open({ editing: { mechanism: 'script', id: 's1', item: { id: 's1' } } });
+  assert.ok(log.includes('script:populate:s1'));
+});
+
+test('opening fresh resets to the chosen kind rather than populating', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+
+  h.api.open({ mechanism: 'family', kind: 'approximate_equality', presetType: true });
+  assert.ok(log.includes('family:reset:approximate_equality'));
+  assert.ok(!log.some((l) => l.includes(':populate:')));
+});
+
+test('the renderer mounts once, then is reused across opens', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+
+  h.api.open({ mechanism: 'family', kind: 'boundary_equality', presetType: true });
+  h.api.close();
+  h.api.open({ mechanism: 'family', kind: 'boundary_equality', presetType: true });
+
+  assert.equal(log.filter((l) => l === 'family:mount').length, 1);
+});
+
+// ── Teardown ────────────────────────────────────────────────────────────────
+
+test('closing tears the active renderer down', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+
+  h.api.open({ mechanism: 'script', kind: 'script', presetType: true });
+  log.length = 0;
+  h.api.close();
+
+  assert.deepEqual(log, ['script:cleanup'], 'a CodeMirror or kernel worker must not outlive the modal');
+  assert.equal(h.els['test-editor-body'] && true, true);
+});
+
+test('switching mechanism tears the previous renderer down first', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+
+  h.api.open({ mechanism: 'script', kind: 'script', presetType: true });
+  log.length = 0;
+  h.api.open({ mechanism: 'family', kind: 'boundary_equality', presetType: true });
+
+  assert.equal(log[0], 'script:cleanup', 'the old renderer is cleaned up before the new one runs');
+  assert.ok(log.includes('family:reset:boundary_equality'));
+});
+
+test('a renderer whose cleanup throws does not block the close', () => {
+  const log = [];
+  const rs = renderers(log);
+  rs.script.cleanup = () => { throw new Error('boom'); };
+  const h = load({ renderers: rs });
+
+  h.api.open({ mechanism: 'script', kind: 'script', presetType: true });
+  h.api.close();   // must not throw
+});
+
+// ── Degraded cases ──────────────────────────────────────────────────────────
+
+test('a missing renderer says so instead of showing a blank body', () => {
+  const log = [];
+  const rs = renderers(log);
+  delete rs.check;
+  const h = load({ renderers: rs });
+
+  h.api.open({ mechanism: 'check', kind: 'variable_exists', presetType: true });
+
+  assert.equal(h.sandbox.lastStatus.kind, 'error');
+  assert.match(h.sandbox.lastStatus.text, /unavailable/i);
+});
+
+// ── The type picker ─────────────────────────────────────────────────────────
+
+test('the type picker is hidden when editing and when the type was preset', () => {
+  const log = [];
+  const h = load({ renderers: renderers(log) });
+  const row = h.els['test-editor-type-row'];
+
+  h.api.open({ editing: { mechanism: 'check', id: 'c', item: { id: 'c', kind: 'variable_exists' } } });
+  assert.equal(row.style.display, 'none');
+
+  h.api.open({ mechanism: 'family', kind: 'boundary_equality', presetType: true });
+  assert.equal(row.style.display, 'none');
+
+  h.api.open({ mechanism: 'family', kind: 'boundary_equality' });
+  assert.equal(row.style.display, 'flex', 'without a preset the picker is the fallback');
+});
+
+// ── The catalog ─────────────────────────────────────────────────────────────
+
+test('every catalog entry names one of the three renderer mechanisms', () => {
+  const h = load({ renderers: renderers([]) });
+  const catalog = h.sandbox.ChickadeeTestEditorCatalog;
+  assert.ok(catalog.length > 0, 'an empty catalog would make every assertion here vacuous');
+
+  for (const group of catalog) {
+    assert.ok(group.group, 'each group is labelled for the instructor');
+    assert.ok(group.items.length > 0);
+    for (const item of group.items) {
+      assert.ok(['family', 'check', 'script'].includes(item.mechanism),
+        `${item.value} names an unknown mechanism ${item.mechanism}`);
+      assert.ok(item.label && item.value);
+    }
+  }
+});
+
+// A kind the assignment's language cannot save is DISABLED with its reason
+// rather than hidden (#1290) — hiding would leave the instructor wondering.
+// Only check kinds are ever filtered: all pattern kinds render in every
+// language.
+test('unsupported check kinds are asked about; family kinds never are', () => {
+  const asked = [];
+  const h = load({
+    renderers: renderers([]),
+    language: { checkKindUnsupportedReason: (v) => { asked.push(v); return v === 'figure_count' ? 'Lua has no plotting library' : null; } },
+  });
+
+  const catalog = h.sandbox.ChickadeeTestEditorCatalog;
+  const checkKinds = catalog.flatMap((g) => g.items).filter((i) => i.mechanism === 'check').map((i) => i.value);
+  const familyKinds = catalog.flatMap((g) => g.items).filter((i) => i.mechanism === 'family').map((i) => i.value);
+
+  assert.ok(checkKinds.length > 0 && familyKinds.length > 0);
+  checkKinds.forEach((k) => assert.ok(asked.includes(k), `check kind ${k} was never checked for support`));
+  familyKinds.forEach((k) => assert.ok(!asked.includes(k), `family kind ${k} must not be filtered`));
+});

--- a/changelog.d/widget-unit-tests-2.md
+++ b/changelog.d/widget-unit-tests-2.md
@@ -1,0 +1,25 @@
+### Added
+
+- **The four remaining untested authoring widgets have unit tests** — 43 tests
+  across `support-files.js`, `section-items-dnd.js`, `section-inputs-editor.js`
+  and `test-editor-modal.js`, which between them upload course data, order the
+  dashboard, save per-section inputs and author every test. None of it was
+  visible to an existing gate: the render tests never run page JS, and the
+  visual harness captures none of these surfaces.
+
+  What they pin is the part that fails silently rather than loudly:
+
+  - an upload posts `tier: "support", isTest: false` — get that wrong and the
+    file is stored as a **test** and starts being graded — and a batch that
+    fails partway must not report success;
+  - a drag that ends where it started posts **nothing**, a within-section
+    reorder posts the whole mixed tbody (assignments *and* content items, or
+    the omitted type's numbering comes out wrong), and the two types use
+    different move endpoints;
+  - the page-level flush covers **every** section-inputs form, since a missed
+    one is an author's edit dropped behind a successful-looking save, and a
+    rejected save must not tell the workbench pane its values are fresh;
+  - the test-editor shell populates from the edit payload rather than the
+    hidden dropdown's leftover value (the regression that made editing a check
+    or script open a blank form), and tears the previous renderer down — a
+    CodeMirror instance or kernel worker — on both close and mode switch.


### PR DESCRIPTION
Finishes item 6 of the component re-engineering list. `support-files.js`, `section-items-dnd.js`, `section-inputs-editor.js` and `test-editor-modal.js` between them upload course data, order the dashboard, save per-section inputs and author every test — and none had a unit test. None is visible to an existing gate either: the render tests never run page JS, and the visual harness captures none of these surfaces.

**43 tests**, aimed at what fails silently rather than loudly.

## What each pins

**`support-files.js` (11).** An upload posts `tier: "support", isTest: false` — get that wrong and the file is stored as a **test** and starts being graded. A batch that fails partway stops rather than reporting success; an unreadable file is reported, not swallowed; the picker is cleared so the same file can be re-picked. This flow existed as near-identical inline copies on the two authoring pages, the create page's being the stale fork of the pair; nothing was checking that the survivor stays right.

**`section-items-dnd.js` (9).** A drag that ends where it started posts **nothing** — picking a row up and putting it back is not a change. A within-section reorder posts the whole mixed tbody, assignments *and* content items together, or the omitted type's numbering comes out wrong. The two types have **different** move endpoints, so sending a content item to the assignment one would 404 and lose the move. Plus the ungrouped section's `""` id, the empty-section placeholder, and that row links get `draggable="false"` so native link drag can't hijack the row.

**`section-inputs-editor.js` (12).** The page-level flush covers **every** section form — a missed one is an author's edit dropped behind a successful-looking save. A rejected save must not tell the workbench pane its values are fresh (that would re-render a notebook against values the server refused), while an opaque redirect *is* success. Submitting the panel saves in place rather than navigating.

**`test-editor-modal.js` (11).** The shell populates from the edit payload rather than the hidden dropdown's leftover value — the regression that made editing a check or a script open a **blank form**. It tears the previous renderer down (a CodeMirror instance or a kernel worker) on both close and mode switch, survives a renderer whose `cleanup` throws, and says "unavailable" rather than showing an empty body when a renderer module failed to load. The catalog is asserted non-empty before anything is checked against it, and unsupported *check* kinds are asked about while *family* kinds never are (#1290's disable-with-reason rule).

## Two harness notes

Both first looked like code failures and weren't:

- The `FileReader` stub resolves on a **real** timer — its `setTimeout` binds lexically to the host's, not the sandbox's — so settling needs macrotasks, not just a microtask drain. Draining only microtasks made every upload test see zero fetches.
- The modal builds its chrome with `innerHTML` and then looks the parts up by id, which is what makes a canned-element stub sufficient for a 500-line module.

## Testing

Full `Tests/BrowserRunnerJSTests/*.mjs` sweep: 478 tests, 447 pass, 0 fail (31 pre-existing skips). `scripts/eslint.sh` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_