### PR TITLE
test(ui): cover chickadee-ui's core, and write down what runInlineScripts may do

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -477,6 +477,27 @@
     /// double-bind. The inline blocks bind nothing to `document`/`window`
     /// themselves; the two module-level listeners that do (suite-table's
     /// dragover and pageshow) carry their own once-per-document guards.
+    /// Re-execute the inline scripts in a freshly swapped pane.
+    ///
+    /// CONTRACT, which this function had never had written down. A `<script>`
+    /// inserted by parsing HTML does not run — that is a deliberate platform
+    /// rule — so a pane swap has to re-create the elements to get their page
+    /// wiring back. That makes this the one place in the frontend that turns
+    /// markup into running code on purpose, and the boundary is therefore:
+    ///
+    ///   * `root` must be a fragment the SERVER rendered for this same-origin
+    ///     page (what `swapHalf` fetched). Never call it on markup that came
+    ///     from a user, a message body, or any other document.
+    ///   * `[src]` scripts are excluded by the selector: a swap re-runs page
+    ///     wiring, it does not re-fetch modules.
+    ///   * a `type` other than `text/javascript` is DATA — the JSON seed
+    ///     islands the authoring pages carry — and is left untouched, both
+    ///     because re-running it is meaningless and because a re-created
+    ///     element must keep its type to still be findable.
+    ///
+    /// It is internal on purpose: `swapHalf` is the only caller and the only
+    /// context where the first rule can be guaranteed. Exporting it would make
+    /// that guarantee someone else's to keep.
     function runInlineScripts(root) {
         var scripts = root.querySelectorAll('script:not([src])');
         Array.prototype.forEach.call(scripts, function (old) {

--- a/Tests/BrowserRunnerJSTests/chickadee-ui-core.test.mjs
+++ b/Tests/BrowserRunnerJSTests/chickadee-ui-core.test.mjs
@@ -1,0 +1,240 @@
+// Unit tests for the core of Public/chickadee-ui.js — the module loaded from
+// base.leaf on EVERY page, and the one with the fewest tests relative to its
+// reach.
+//
+// This covers the utilities the rest of the frontend is built on: escaping,
+// the CSRF token, the shared fetch-error extractor, and the JSON fetch
+// wrapper.
+//
+// NOT covered here: `runInlineScripts`, which re-executes script elements from
+// swapped HTML. It is internal to `swapHalf` and unexported, so reaching it
+// would mean widening the public API to suit a test. Its CONTRACT is now
+// written down in the source; covering its behaviour needs a `swapHalf`
+// harness (DOMParser, importNode, the keepElement identity rule), which is its
+// own slice.
+//
+// Each of these exists because it replaced drifted copies — escapeHtml
+// replaced per-file variants that disagreed on which characters they escaped,
+// extractErrorMessage replaced two copies flowing through the same slot (one
+// parsing JSON, the other scraping the Leaf error page). A shared
+// implementation only helps while it stays correct, and nothing was checking.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+
+function load({ meta = null, csrfField = null, fetchImpl } = {}) {
+  const created = [];
+  const doc = {
+    readyState: 'complete',
+    querySelector: (sel) => {
+      if (sel === 'meta[name="csrf-token"]') return meta === null ? null : { content: meta };
+      if (sel === 'input[name="_csrf"]') return csrfField === null ? null : { value: csrfField };
+      return null;
+    },
+    querySelectorAll: () => [],
+    createElement: (tag) => {
+      const el = { tagName: tag.toUpperCase(), textContent: '', type: '', attrs: {},
+        setAttribute(n, v) { this.attrs[n] = v; }, appendChild() {}, addEventListener() {} };
+      created.push(el);
+      return el;
+    },
+    addEventListener() {},
+    body: { appendChild() {}, addEventListener() {} },
+  };
+
+  const sandbox = { document: doc, Promise, JSON, Object, Error, Array, String, setTimeout, console: { error() {} } };
+  if (fetchImpl) sandbox.fetch = fetchImpl;
+  sandbox.window = sandbox;
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+  return { UI: sandbox.ChickadeeUI, created, doc };
+}
+
+const UI = load().UI;
+
+// ── Escaping ────────────────────────────────────────────────────────────────
+
+test('escapeHtml covers all five characters, and escapeAttr is the same function', () => {
+  assert.equal(UI.escapeHtml('<a href="x">O\'Brien & co</a>'),
+    '&lt;a href=&quot;x&quot;&gt;O&#39;Brien &amp; co&lt;/a&gt;');
+  // The per-file copies this replaced disagreed on " and ': both are escaped.
+  assert.equal(UI.escapeAttr('"\''), '&quot;&#39;');
+});
+
+test('escaping is ampersand-first, so an escape is never double-escaped wrong', () => {
+  assert.equal(UI.escapeHtml('&lt;'), '&amp;lt;');
+});
+
+test('null and undefined escape to the empty string rather than "null"', () => {
+  assert.equal(UI.escapeHtml(null), '');
+  assert.equal(UI.escapeHtml(undefined), '');
+  assert.equal(UI.escapeHtml(0), '0');
+});
+
+// ── CSRF token ──────────────────────────────────────────────────────────────
+
+test('the CSRF token comes from the meta tag, falling back to the hidden field', () => {
+  assert.equal(load({ meta: 'from-meta', csrfField: 'from-field' }).UI.getCsrfToken(), 'from-meta');
+  assert.equal(load({ meta: null, csrfField: 'from-field' }).UI.getCsrfToken(), 'from-field');
+  assert.equal(load({}).UI.getCsrfToken(), '', 'a page with neither yields "" rather than undefined');
+});
+
+// ── Error extraction ────────────────────────────────────────────────────────
+
+test('a JSON error body is read by reason, then error, then message', () => {
+  assert.equal(UI.extractErrorMessage('{"reason":"Name is required"}'), 'Name is required');
+  assert.equal(UI.extractErrorMessage('{"error":"nope"}'), 'nope');
+  assert.equal(UI.extractErrorMessage('{"message":"also nope"}'), 'also nope');
+  assert.equal(UI.extractErrorMessage('{"reason":"first","error":"second"}'), 'first');
+});
+
+test('the Leaf error page is scraped for its message', () => {
+  const page = '<html><body><p class="error-message">Assignment not found</p></body></html>';
+  assert.equal(UI.extractErrorMessage(page), 'Assignment not found');
+});
+
+// The scrape strips tags to a FIXPOINT, so a nested fragment cannot survive
+// one pass and reassemble into markup at the sink.
+test('tag stripping is run to a fixpoint', () => {
+  const page = '<p class="error-message">a<scr<script>ipt>b</p>';
+  const out = UI.extractErrorMessage(page);
+  assert.ok(!out.includes('<'), `nothing tag-like survives: ${out}`);
+});
+
+// Entities decode with &amp; LAST, so "&amp;lt;" becomes "&lt;" — one level —
+// and never "<". Decoding &amp; first would re-create markup from text that
+// was already safely escaped.
+test('entity decoding is one level, ampersand last', () => {
+  assert.equal(UI.extractErrorMessage('<p class="error-message">&amp;lt;script&amp;gt;</p>'), '&lt;script&gt;');
+  assert.equal(UI.extractErrorMessage('<p class="error-message">a &amp; b</p>'), 'a & b');
+});
+
+test('an unrecognized body is returned, truncated past 200 characters', () => {
+  assert.equal(UI.extractErrorMessage('plain text'), 'plain text');
+  const long = 'x'.repeat(500);
+  const out = UI.extractErrorMessage(long);
+  assert.equal(out.length, 201);
+  assert.ok(out.endsWith('…'));
+});
+
+test('an empty body extracts to the empty string', () => {
+  assert.equal(UI.extractErrorMessage(''), '');
+  assert.equal(UI.extractErrorMessage(null), '');
+});
+
+// ── fetchJSON ───────────────────────────────────────────────────────────────
+
+function fetchHarness(response) {
+  const calls = [];
+  const impl = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(response);
+  };
+  return { calls, impl };
+}
+
+test('a body is JSON-encoded and declared, and the CSRF token rides the header', async () => {
+  const h = fetchHarness({ ok: true, status: 200, json: () => Promise.resolve({ ok: 1 }) });
+  const { UI: ui } = load({ meta: 'tok', fetchImpl: h.impl });
+
+  const result = await ui.fetchJSON('/x', { method: 'PUT', body: { a: 1 } });
+  assert.deepEqual(result, { ok: 1 });
+  assert.equal(h.calls[0].opts.method, 'PUT');
+  assert.equal(h.calls[0].opts.headers['Content-Type'], 'application/json');
+  assert.equal(h.calls[0].opts.headers['x-csrf-token'], 'tok');
+  assert.equal(h.calls[0].opts.body, '{"a":1}');
+});
+
+test('a GET sends no body and no Content-Type', async () => {
+  const h = fetchHarness({ ok: true, status: 200, json: () => Promise.resolve(null) });
+  const { UI: ui } = load({ meta: 'tok', fetchImpl: h.impl });
+
+  await ui.fetchJSON('/x');
+  assert.equal(h.calls[0].opts.method, 'GET');
+  assert.equal(h.calls[0].opts.body, undefined);
+  assert.equal(h.calls[0].opts.headers['Content-Type'], undefined);
+});
+
+test('an explicit csrfToken wins over the page token', async () => {
+  const h = fetchHarness({ ok: true, status: 204 });
+  const { UI: ui } = load({ meta: 'page-token', fetchImpl: h.impl });
+
+  await ui.fetchJSON('/x', { method: 'DELETE', csrfToken: 'explicit' });
+  assert.equal(h.calls[0].opts.headers['x-csrf-token'], 'explicit');
+});
+
+test('204 resolves to null rather than failing to parse an empty body', async () => {
+  const h = fetchHarness({ ok: true, status: 204 });
+  const { UI: ui } = load({ fetchImpl: h.impl });
+  assert.equal(await ui.fetchJSON('/x', { method: 'DELETE' }), null);
+});
+
+test('a non-JSON success body resolves to null rather than throwing', async () => {
+  const h = fetchHarness({ ok: true, status: 200, json: () => Promise.reject(new Error('not json')) });
+  const { UI: ui } = load({ fetchImpl: h.impl });
+  assert.equal(await ui.fetchJSON('/x'), null);
+});
+
+test('a failure rejects with the SERVER message, not a bare status', async () => {
+  const h = fetchHarness({ ok: false, status: 422, text: () => Promise.resolve('{"reason":"Name is required"}') });
+  const { UI: ui } = load({ fetchImpl: h.impl });
+
+  await assert.rejects(() => ui.fetchJSON('/x', { method: 'POST', body: {} }),
+    /Name is required/);
+});
+
+test('a failure with an unreadable body still rejects with the status', async () => {
+  const h = fetchHarness({ ok: false, status: 500, text: () => Promise.resolve('') });
+  const { UI: ui } = load({ fetchImpl: h.impl });
+  await assert.rejects(() => ui.fetchJSON('/x'), /HTTP 500/);
+});
+
+// ── setStatus ───────────────────────────────────────────────────────────────
+//
+// The one status-line setter, which replaced six drifted copies. Its whole job
+// is that the three state classes are mutually exclusive: leaving a stale one
+// behind is how a status line reads green while saying something failed.
+
+function statusEl() {
+  const el = { textContent: 'stale', classes: new Set(['text-error']) };
+  el.classList = {
+    add: (...c) => c.forEach((n) => el.classes.add(n)),
+    remove: (...c) => c.forEach((n) => el.classes.delete(n)),
+  };
+  return el;
+}
+
+test('a status kind replaces the previous one rather than stacking', () => {
+  const el = statusEl();
+  UI.setStatus(el, 'Saved.', 'ok');
+  assert.equal(el.textContent, 'Saved.');
+  assert.deepEqual([...el.classes], ['text-ok'], 'the stale error class must not survive');
+});
+
+test('error, ok/success and everything else map to the three classes', () => {
+  const cases = [['error', 'text-error'], ['ok', 'text-ok'], ['success', 'text-ok'],
+    ['info', 'text-quiet'], [undefined, 'text-quiet']];
+  for (const [kind, expected] of cases) {
+    const el = statusEl();
+    UI.setStatus(el, 'x', kind);
+    assert.deepEqual([...el.classes], [expected], String(kind));
+  }
+});
+
+test('an empty message clears the text rather than printing "undefined"', () => {
+  const el = statusEl();
+  UI.setStatus(el, '', 'info');
+  assert.equal(el.textContent, '');
+  UI.setStatus(el, undefined, 'info');
+  assert.equal(el.textContent, '');
+});
+
+test('a missing element is a no-op, not a throw', () => {
+  UI.setStatus(null, 'x', 'ok');
+});

--- a/changelog.d/chickadee-ui-core-tests.md
+++ b/changelog.d/chickadee-ui-core-tests.md
@@ -1,0 +1,32 @@
+### Added
+
+- **The frontend's core utilities have unit tests.** `chickadee-ui.js` loads on
+  every page and had the least coverage relative to its reach. 21 tests now pin
+  the pieces the rest of the frontend is built on: `escapeHtml`/`escapeAttr`
+  (all five characters, ampersand-first, null → `""` rather than `"null"`), the
+  CSRF token's meta-then-hidden-field fallback, `extractErrorMessage` (JSON
+  `reason`/`error`/`message` order, the Leaf error-page scrape, and its two
+  safety rules — tags stripped to a **fixpoint** so a nested fragment cannot
+  survive one pass, and entities decoded with `&amp;` **last** so `&amp;lt;`
+  becomes `&lt;` and never `<`), and `fetchJSON` (header and body encoding, an
+  explicit token overriding the page's, 204 → null, a non-JSON success → null,
+  and a failure rejecting with the *server's* message rather than a bare
+  status), and `setStatus`, whose whole job is that its three state classes are
+  mutually exclusive — a stale one left behind is how a status line reads green
+  while saying something failed.
+
+### Changed
+
+- **`runInlineScripts` has the written contract it never had.** It is the one
+  place in the frontend that deliberately turns markup back into running code,
+  so the boundary is now stated in the source: `root` must be a fragment the
+  server rendered for this same-origin page, `[src]` scripts are excluded
+  because a swap re-runs page wiring rather than re-fetching modules, and a
+  non-`text/javascript` type is data (the JSON seed islands) and is left
+  untouched. It stays internal on purpose — `swapHalf` is the only caller and
+  the only context where the first rule can be guaranteed, and exporting it
+  would make that guarantee someone else's to keep.
+
+  Its *behaviour* is still uncovered: reaching it needs a `swapHalf` harness
+  (DOMParser, `importNode`, the keepElement identity rule), which is a slice of
+  its own rather than something to fake by widening the API for a test.


### PR DESCRIPTION
Slice (a) of the last item on the component re-engineering list. `chickadee-ui.js` loads on every page from `base.leaf` and had the least coverage relative to its reach.

**21 tests** on the utilities the rest of the frontend is built on. Each of them exists because it replaced drifted copies — which is exactly why leaving them unchecked was a poor trade:

| | replaced |
|---|---|
| `escapeHtml` / `escapeAttr` | per-file variants that disagreed on which characters they escaped |
| `extractErrorMessage` | two copies flowing through the same slot — one parsing JSON, one scraping the Leaf error page |
| `setStatus` | six copies |

## Two safety properties, not conveniences

The error-page scrape has two rules that are easy to "simplify" into a hole, so both are pinned:

- **Tags are stripped to a fixpoint**, so a nested fragment (`<scr<script>ipt>`) cannot survive one pass and reassemble at the sink.
- **Entities decode with `&amp;` last**, so `&amp;lt;` becomes `&lt;` — one level — and never `<`. Decoding `&amp;` first would re-create markup out of text that was already safely escaped.

`setStatus`'s whole job is likewise that its three state classes are mutually exclusive: a stale one left behind is how a status line reads green while saying something failed.

## `runInlineScripts`: contract written, behaviour deliberately not faked

It's the one place in the frontend that turns markup back into running code on purpose, and it had neither a test nor a written contract. The contract now lives in the source: `root` must be a fragment the **server** rendered for this same-origin page, `[src]` scripts are excluded (a swap re-runs page wiring, it doesn't re-fetch modules), and a non-`text/javascript` type is data — the JSON seed islands — and is left untouched.

Its **behaviour is still uncovered**, and I'd rather say so than pretend. It is unexported and internal to `swapHalf`, so reaching it from a test would mean widening the public API to suit the test — and the guarantee the contract rests on is one only `swapHalf` can make. Covering it properly needs a `swapHalf` harness (DOMParser, `importNode`, the keepElement identity rule that a previous bug turned on), which is a slice of its own.

## What this does not do

This is the tests-first half. The actual decomposition — splitting the accordion, sparkline and surface-swapper concerns out of the 18-function module into named files — is deliberately *not* in here: it's a no-behaviour-change refactor that's much safer to do once the seams underneath it are pinned, and it wants its own reviewable PR per concern.

## Testing

`node --test chickadee-ui-core.test.mjs` 21/21; full sweep 495 tests / 0 fail; `scripts/eslint.sh` and `scripts/check-styles.sh` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_