### PR TITLE
refactor(ui): move the sparkline renderer out of chickadee-ui.js

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -248,35 +248,18 @@
         });
     }
 
-    // Renders a sparkline (one bar per series entry) into `container`.
-    // `series` is an array of numbers / nulls (null = "no data", drawn as an
-    // empty slot). `labels` supplies the per-bar tooltip prefix and
-    // `formatPoint(value)` formats the value in the tooltip. Shared by the
-    // admin and instructor dashboard diagnostic cards, and (via `opts`) the
-    // admin Active Users card, which used to carry its own fork of this
-    // markup:
-    //   opts.floorPct    – floor the bar height of any populated (> 0) bucket
-    //                      so a lone entry shows a visible bar, not a 2px
-    //                      sliver indistinguishable from an empty one
-    //   opts.zeroIsEmpty – draw a zero-valued bucket with the empty-slot
-    //                      styling, not just a null one
+    // The sparkline renderer moved to Public/sparkline.js: rendering a chart is
+    // not a shared utility in the same sense as escaping a string, and this
+    // module — loaded from base.leaf on every page — had accumulated eighteen
+    // unrelated functions behind one name.
+    //
+    // `ChickadeeUI.renderSparkline` stays as the call surface so that no call
+    // site changes in the same commit as the move; repointing them at
+    // `ChickadeeSparkline.render` and dropping this is a later, separate step.
+    // The lookup happens at CALL time, so the two files' load order does not
+    // matter and this file gains no dependency on the other having run.
     function renderSparkline(container, series, labels, formatPoint, opts) {
-        if (!container) return;
-        series = Array.isArray(series) ? series : [];
-        labels = Array.isArray(labels) ? labels : [];
-        opts = opts || {};
-        var format = typeof formatPoint === 'function' ? formatPoint : function (v) { return String(v); };
-        var max = series.reduce(function (m, v) { return v == null ? m : Math.max(m, v); }, 0);
-        container.innerHTML = series.map(function (value, i) {
-            var pct = (value != null && max > 0) ? (value / max) * 100 : 0;
-            if (opts.floorPct > 0 && value > 0 && pct > 0) pct = Math.max(pct, opts.floorPct);
-            var empty = value == null || (opts.zeroIsEmpty && !value);
-            var title = (labels[i] || '') + ': ' + (value == null ? 'no data' : format(value));
-            return '<div class="spark-slot" title="' + escapeHtml(title) + '">'
-                + '<span class="spark-fill' + (empty ? ' spark-fill-empty' : '')
-                + '" style="--bar-h:' + pct.toFixed(1) + '%"></span>'
-                + '</div>';
-        }).join('');
+        return root.ChickadeeSparkline.render(container, series, labels, formatPoint, opts);
     }
 
     // ── Shared accordion (inline detail-row editor) ──────────────────────────

--- a/Public/sparkline.js
+++ b/Public/sparkline.js
@@ -1,0 +1,83 @@
+// Public/sparkline.js
+//
+// The one sparkline renderer: a row of bars, one per series entry, for the
+// dashboard diagnostic cards.
+//
+// Split out of chickadee-ui.js, which had accumulated eighteen unrelated
+// functions behind one name — escaping, CSRF, fetch, a status line, a modal, a
+// chart renderer, an accordion, two surface swappers. Rendering a chart is not
+// a "shared utility" in the same sense as escaping a string, and keeping it in
+// there meant the module every page loads carried markup-building code most
+// pages never call.
+//
+//   ChickadeeSparkline.render(container, series, labels, formatPoint, opts)
+//
+// `series` is numbers and nulls, where null means "no data" and draws as an
+// empty slot; `labels[i]` prefixes bar i's tooltip and `formatPoint(value)`
+// formats the value in it. Two options exist because the admin Active Users
+// card used to carry its own fork of this markup rather than these flags:
+//
+//   opts.floorPct     floor the height of any populated (> 0) bucket, so a
+//                     lone entry shows a visible bar rather than a sliver
+//                     indistinguishable from an empty slot
+//   opts.zeroIsEmpty  draw a zero-valued bucket with the empty-slot styling,
+//                     not only a null one
+//
+// The bar height rides the `--bar-h` custom property. That is the one inline
+// custom property a template or a renderer may set (scripts/check-styles.sh
+// 4c): it varies per DATUM — it comes from the row being drawn — rather than
+// being a per-page dial for a design decision.
+(function (global) {
+    'use strict';
+
+    // The escape lives HERE rather than being borrowed from ChickadeeUI, for
+    // two reasons that turned out to be the same reason.
+    //
+    // This file builds a markup string and assigns it to `innerHTML`, so it is
+    // an HTML sink and it must own its own sanitizer: reaching for the escape
+    // through a global makes the safety of this file depend on another file
+    // having loaded, and the first draft of this extraction proved the point by
+    // falling back to a NON-escaping `String(...)` when that global was absent.
+    // CodeQL caught exactly that, and it was right — a scanner cannot follow a
+    // sanitizer through a global property either, so the barrier has to be in
+    // the file with the sink for a reader and a scanner alike to see it.
+    //
+    // The cost is a second copy of a function the June 2026 audit deduplicated,
+    // and the drift that copy invites is what `sparkline.test.mjs` pins: it
+    // asserts this agrees with `ChickadeeUI.escapeHtml` character for character.
+    function escape(text) {
+        return String(text == null ? '' : text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function render(container, series, labels, formatPoint, opts) {
+        if (!container) return;
+        series = Array.isArray(series) ? series : [];
+        labels = Array.isArray(labels) ? labels : [];
+        opts = opts || {};
+        var format = typeof formatPoint === 'function' ? formatPoint : function (v) { return String(v); };
+        var max = series.reduce(function (m, v) { return v == null ? m : Math.max(m, v); }, 0);
+        container.innerHTML = series.map(function (value, i) {
+            var pct = (value != null && max > 0) ? (value / max) * 100 : 0;
+            if (opts.floorPct > 0 && value > 0 && pct > 0) pct = Math.max(pct, opts.floorPct);
+            var empty = value == null || (opts.zeroIsEmpty && !value);
+            var title = (labels[i] || '') + ': ' + (value == null ? 'no data' : format(value));
+            return '<div class="spark-slot" title="' + escape(title) + '">'
+                + '<span class="spark-fill' + (empty ? ' spark-fill-empty' : '')
+                + '" style="--bar-h:' + pct.toFixed(1) + '%"></span>'
+                + '</div>';
+        }).join('');
+    }
+
+    global.ChickadeeSparkline = { render: render };
+
+    // Node export for the .mjs unit tests (Tests/BrowserRunnerJSTests);
+    // browsers take the global above.
+    if (typeof module === 'object' && module.exports) {
+        module.exports = global.ChickadeeSparkline;
+    }
+})(typeof self !== 'undefined' ? self : this);

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -22,6 +22,12 @@
          script tags, and they reference ChickadeeUI at parse time
          (e.g. csrf-token captures). -->
     <script src="/chickadee-ui.js?v=#appVersion()"></script>
+    <!-- Concerns split out of chickadee-ui.js, which had grown to eighteen
+         unrelated functions behind one name.  Loaded here beside it because
+         ChickadeeUI still re-exports them as its call surface, and it must be
+         complete by the time an inline page script runs.  Order between the two
+         does not matter: the re-exports look the delegate up at call time. -->
+    <script src="/sparkline.js?v=#appVersion()"></script>
     <!-- Same reason, same place: page inline scripts call
          ChickadeeRelativeTime.applyRelativeTimes() during parse, so it cannot
          wait for the end of <body>. -->

--- a/Tests/BrowserRunnerJSTests/sparkline.test.mjs
+++ b/Tests/BrowserRunnerJSTests/sparkline.test.mjs
@@ -1,0 +1,150 @@
+// Unit tests for Public/sparkline.js — the dashboard sparkline renderer,
+// split out of chickadee-ui.js.
+//
+// It had no tests inside the junk drawer either. What it gets wrong quietly is
+// the difference between "no data" and "zero": both draw a short bar, and if
+// the empty-slot styling stops being applied, an admin reads a dashboard where
+// a runner that reported zero jobs looks the same as one that reported nothing
+// at all.
+//
+// The last test here is the one that exists for a structural reason rather than
+// a behavioural one. This file assigns to `innerHTML`, so it owns its own
+// escape rather than borrowing ChickadeeUI's through a global — a sink whose
+// sanitizer lives in another file is one whose safety depends on load order,
+// and the first draft of this extraction proved it by degrading to a
+// non-escaping fallback when that global was absent. Owning the escape means a
+// second copy of a function the June 2026 audit deduplicated, so the copy is
+// pinned against the original character for character.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/sparkline.js'), 'utf8');
+
+function load() {
+  const sandbox = { Array, Math, String, module: { exports: {} } };
+  sandbox.ChickadeeUI = {
+    escapeHtml: (s) => String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;'),
+  };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+  return sandbox.module.exports;
+}
+
+const Spark = load();
+
+function draw(series, labels, format, opts) {
+  const container = { innerHTML: '' };
+  Spark.render(container, series, labels, format, opts);
+  return container.innerHTML;
+}
+
+function heights(html) {
+  return [...html.matchAll(/--bar-h:([\d.]+)%/g)].map((m) => Number(m[1]));
+}
+
+test('bars are scaled against the series maximum', () => {
+  const html = draw([5, 10, 0], ['a', 'b', 'c'], String);
+  assert.deepEqual(heights(html), [50, 100, 0]);
+});
+
+test('an all-zero series draws flat rather than dividing by zero', () => {
+  assert.deepEqual(heights(draw([0, 0], ['a', 'b'], String)), [0, 0]);
+});
+
+// "no data" and "zero" must not look alike on a dashboard.
+test('a null value is an empty slot; a zero is a real bar unless asked otherwise', () => {
+  const withNull = draw([null, 4], ['a', 'b'], String);
+  assert.equal((withNull.match(/spark-fill-empty/g) || []).length, 1);
+
+  const withZero = draw([0, 4], ['a', 'b'], String);
+  assert.equal(withZero.includes('spark-fill-empty'), false);
+
+  const zeroIsEmpty = draw([0, 4], ['a', 'b'], String, { zeroIsEmpty: true });
+  assert.equal((zeroIsEmpty.match(/spark-fill-empty/g) || []).length, 1);
+});
+
+test('floorPct lifts a populated bucket above the sliver threshold', () => {
+  // 1 against a max of 1000 is 0.1% — visually indistinguishable from empty.
+  assert.deepEqual(heights(draw([1, 1000], ['a', 'b'], String, { floorPct: 8 })), [8, 100]);
+  // It must not promote a genuinely empty bucket.
+  assert.deepEqual(heights(draw([0, 1000], ['a', 'b'], String, { floorPct: 8 })), [0, 100]);
+});
+
+test('the tooltip is label + formatted value, and says "no data" for a null', () => {
+  const html = draw([12, null], ['09:00', '10:00'], (v) => v + ' ms');
+  assert.ok(html.includes('title="09:00: 12 ms"'));
+  assert.ok(html.includes('title="10:00: no data"'));
+});
+
+// Labels come from a server payload; they reach an attribute, so they are
+// escaped rather than concatenated raw.
+test('a label with markup in it is escaped into the title attribute', () => {
+  const html = draw([1], ['" onmouseover="x()'], String);
+  assert.ok(!html.includes('onmouseover="x()'), `unescaped label: ${html}`);
+  assert.ok(html.includes('&quot;'));
+});
+
+test('missing labels and a missing formatter degrade rather than throw', () => {
+  const html = draw([1, 2], [], undefined);
+  assert.ok(html.includes('title=": 1"'));
+  assert.equal(heights(html).length, 2);
+});
+
+test('a non-array series renders nothing, and a missing container is a no-op', () => {
+  assert.equal(draw(null, [], String), '');
+  Spark.render(null, [1], [], String);   // must not throw
+});
+
+// The bar height is a per-datum value — it comes from the row being drawn —
+// which is why it is allowed to be an inline custom property at all
+// (check-styles.sh 4c). If this ever became a class or a fixed style, the
+// guard's rationale would need revisiting.
+test('the height rides the --bar-h custom property', () => {
+  const html = draw([3, 6], ['a', 'b'], String);
+  assert.ok(html.includes('style="--bar-h:50.0%"'));
+  assert.ok(html.includes('style="--bar-h:100.0%"'));
+});
+
+// ── The escape copy ─────────────────────────────────────────────────────────
+
+test('the local escape agrees with ChickadeeUI.escapeHtml, character for character', async () => {
+  const uiSource = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+  const uiSandbox = {
+    document: { querySelector: () => null, addEventListener() {}, body: { addEventListener() {} } },
+    Promise, JSON, Object, Error, Array, String, setTimeout,
+  };
+  uiSandbox.window = uiSandbox;
+  uiSandbox.self = uiSandbox;
+  vm.createContext(uiSandbox);
+  vm.runInContext(uiSource, uiSandbox);
+  const canonical = uiSandbox.ChickadeeUI.escapeHtml;
+
+  const Spark = load();
+  // Every character the two could disagree on, plus the null-ish inputs and an
+  // already-escaped entity (which must double-escape, not pass through).
+  //
+  // Non-empty strings only: a falsy label is replaced with '' by the renderer
+  // before the escape ever sees it, so including one would compare the
+  // renderer's own defaulting rather than the escaping. Which CHARACTERS get
+  // escaped is the thing that can drift, and every one of them is here.
+  const corpus = ['&', '<', '>', '"', "'", '&amp;', '&lt;script&gt;', '<img src=x onerror=1>',
+    "O'Brien & <b>co</b>", ' ', 'plain', '0', 'ünïcode', '&&<<>>""\'\''];
+
+  for (const input of corpus) {
+    // The renderer escapes into the title attribute, which is where the copy is
+    // actually used — so compare through the real sink rather than reaching for
+    // a private function.
+    const box = { innerHTML: '' };
+    Spark.render(box, [1], [input], (v) => String(v));
+    const rendered = /title="([^]*?)"><span/.exec(box.innerHTML)[1];
+    assert.equal(rendered, canonical(input) + ': ' + canonical('1'),
+      `escaping drifted for ${JSON.stringify(input)}`);
+  }
+});

--- a/changelog.d/sparkline-extraction.md
+++ b/changelog.d/sparkline-extraction.md
@@ -1,0 +1,24 @@
+### Changed
+
+- **The sparkline renderer moved out of `chickadee-ui.js` into
+  `Public/sparkline.js`.** That module is loaded from `base.leaf` on every page
+  and had accumulated eighteen unrelated functions behind one name — escaping,
+  CSRF, a fetch wrapper, a status line, a modal, a chart renderer, an accordion,
+  two surface swappers. Drawing a chart is not a shared utility in the sense
+  that escaping a string is.
+
+  No call site changes: `ChickadeeUI.renderSparkline` remains the call surface
+  and delegates to `ChickadeeSparkline.render`, looked up at call time so the
+  two files' load order does not matter. Repointing callers is a later, separate
+  step, kept out of the move so a move cannot hide a behaviour change.
+
+  The renderer picks up its first ten tests. Nine cover behaviour — the one
+  worth reading is that "no data" and "zero" must not draw alike. The tenth
+  exists for a structural reason: this file assigns to `innerHTML`, so it now
+  owns its escape rather than borrowing ChickadeeUI's through a global. The
+  first draft of the extraction borrowed it and silently degraded to a
+  **non-escaping** fallback when that global was absent, which CodeQL caught —
+  correctly, since a scanner cannot follow a sanitizer through a global property
+  any more than a reader can. Owning it costs a second copy of a function the
+  June 2026 audit deduplicated, so the test pins the copy against the original
+  character for character.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,11 +12,18 @@ import js from '@eslint/js';
 
 // Globals the classic scripts share by assignment onto window (defined in
 // chickadee-ui.js / grading-shared.js, consumed everywhere).  Keep this list
-// short — new cross-file API should hang off ChickadeeUI rather than adding
-// names.
+// short — but "short" no longer means "hang everything off ChickadeeUI",
+// which is how that module reached eighteen unrelated functions behind one
+// name.  A genuinely separate concern gets its own file and its own name
+// (ChickadeeSparkline); only things that really are shared low-level
+// utilities — escaping, CSRF, fetch — belong on ChickadeeUI.
 const chickadeeGlobals = {
   ChickadeeUI: 'readonly',
   ChickadeeInputsCore: 'readonly',
+  // Public/sparkline.js — the dashboard bar renderer, split out of
+  // chickadee-ui.js: drawing a chart is not the same kind of thing as
+  // escaping a string.
+  ChickadeeSparkline: 'readonly',
   // Public/authoring-language.js — the assignment's language facts, read by
   // every authoring editor.
   ChickadeeLanguage: 'readonly',


### PR DESCRIPTION
First of three slices decomposing `Public/chickadee-ui.js`, the module `base.leaf` loads on **every** page. It had accumulated eighteen unrelated functions behind one name — escaping, CSRF, a fetch wrapper, a status line, a modal, a chart renderer, an accordion, two surface swappers.

## What moves

`renderSparkline` → `Public/sparkline.js` as `ChickadeeSparkline.render`. Drawing a chart is not a shared utility in the sense that escaping a string is.

**No call site changes.** `ChickadeeUI.renderSparkline` stays as the call surface and delegates, looking the delegate up at *call* time so the two files' load order does not matter. Repointing callers is a later, separate step — kept out of the move so a move cannot hide a behaviour change. `base.leaf` loads the new file beside `chickadee-ui.js`, since `ChickadeeUI` must be complete before an inline page script runs.

## The escape

The new file owns its own escape rather than borrowing `ChickadeeUI`'s through a global.

The first draft of this PR did borrow it, with a fallback that **did not escape** when that global was absent — so label text would reach `innerHTML` raw. CodeQL flagged exactly that line, and it was right: a scanner cannot follow a sanitizer through a global property any more than a reader can, and a sink whose sanitizer lives in another file has its safety depend on load order.

The cost is a second copy of a function the June 2026 audit deduplicated, so a test pins the copy against the original **character for character**, compared through the real sink rather than a private function. Unescaping the apostrophe turns it red.

## Tests

Ten, its first. The behavioural one worth reading is that **"no data" and "zero" must not draw alike**: a null bucket and a zero bucket take the same empty styling only when the caller asks for it (`opts.zeroIsEmpty`), and a lone populated bucket is floored (`opts.floorPct`) so it shows a visible bar rather than a sliver indistinguishable from an empty slot. Both options exist because the admin Active Users card used to carry its own fork of this markup.

## Notes

- `--bar-h` stays the one inline custom property a renderer may set (`scripts/check-styles.sh` 4c): it varies per **datum**, rather than being a per-page dial for a design decision.
- `eslint.config.mjs`'s comment is corrected: "hang new API off ChickadeeUI" is the rule that produced the eighteen-function module.
- Render suite run locally as well, since templates changed: 243 tests / 45 suites pass.