### PR TITLE
refactor(ui): move the inline accordion out of chickadee-ui.js

### DIFF
--- a/Public/accordion-row.js
+++ b/Public/accordion-row.js
@@ -1,0 +1,162 @@
+// Public/accordion-row.js
+//
+// The one inline detail-row accordion: an editor that expands in a `<tr>`
+// beneath the row being edited. Two editors use it — the suite table
+// (suite-table.js) and the achievements editor (achievements-editor.js) — and
+// it lives in one place so they animate and tear down identically.
+//
+// Split out of chickadee-ui.js, which had accumulated eighteen unrelated
+// functions behind one name. This one is a widget with its own DOM contract
+// and its own animation rules, not a shared utility in the sense that escaping
+// a string is, and it was loaded on every page for the two that call it.
+//
+//   ChickadeeAccordion.CARET_HTML
+//       the disclosure caret markup, so a row that opens an accordion draws
+//       the same caret as every other one.
+//
+//   build({colspan})  -> { tr, host, saveBtn, cancelBtn, status, anim, inner }
+//       the detail-row skeleton, NOT yet inserted. The caller inserts
+//       `parts.tr` wherever it belongs — the two editors have different
+//       placement rules — and mounts its editor into `parts.host`.
+//
+//   open(parts, parentRow) -> parts
+//       animates the inserted row open (0fr -> 1fr) and marks `parentRow`
+//       expanded; scrolls it into view. Pass parentRow = null when appending a
+//       brand-new row that has no parent yet.
+//
+//   close(tr, opts) -> finishNow()
+//       animates the row closed and removes it. The returned function
+//       completes the teardown synchronously, which is what lets a new editor
+//       open before the old one's animation has finished. `opts.immediate` (or
+//       the user's reduced-motion setting) tears down synchronously to begin
+//       with. `opts.onDone` runs once, just before removal, while the content
+//       is still mounted — for editor-specific cleanup such as rescuing a
+//       singleton editor body. `opts.parentRow` un-marks the parent row.
+//
+// The height animation is the single-row grid `grid-template-rows: 0fr -> 1fr`
+// technique (see styles.css): it animates the editor's intrinsic height with no
+// magic max-height, which matters because the family editor's height varies a
+// lot.
+//
+// Two rules here exist because of engine behaviour rather than design:
+//
+//   * the open is a DOUBLE requestAnimationFrame, so the 0fr starting state
+//     paints before the flip to 1fr. A single frame does not reliably start the
+//     transition across engines, and a transition that never starts is a row
+//     that never reveals its overflow.
+//   * every animated path carries a TIMEOUT fallback, because `transitionend`
+//     does not fire in a backgrounded tab or under a `display: none` ancestor.
+//     Without it, `close` would leave the detail row in the table forever.
+(function (global) {
+    'use strict';
+
+    var CARET_HTML = '<span class="accordion-caret" aria-hidden="true">'
+        + '<svg class="icon" aria-hidden="true"><use href="#i-chevron-right"/></svg></span>';
+
+    function prefersReducedMotion() {
+        return !!(global.matchMedia && global.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    }
+
+    function build(opts) {
+        opts = opts || {};
+        var tr = document.createElement('tr');
+        tr.className = 'suite-detail-row';
+        var td = document.createElement('td');
+        td.setAttribute('colspan', String(opts.colspan || 4));
+        var anim = document.createElement('div');
+        anim.className = 'suite-detail-anim';
+        var inner = document.createElement('div');
+        inner.className = 'suite-detail-inner';
+        var host = document.createElement('div');
+        host.className = 'suite-detail-host';
+        var actions = document.createElement('div');
+        actions.className = 'suite-detail-actions';
+        var saveBtn = document.createElement('button');
+        saveBtn.type = 'button';
+        saveBtn.className = 'btn btn-primary btn-compact';
+        saveBtn.textContent = 'Save';
+        var cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'btn btn-compact';
+        cancelBtn.textContent = 'Cancel';
+        var status = document.createElement('span');
+        status.className = 'suite-detail-status card-meta';
+        actions.appendChild(saveBtn);
+        actions.appendChild(cancelBtn);
+        actions.appendChild(status);
+        inner.appendChild(host);
+        inner.appendChild(actions);
+        anim.appendChild(inner);
+        td.appendChild(anim);
+        tr.appendChild(td);
+        return {
+            tr: tr, host: host, saveBtn: saveBtn,
+            cancelBtn: cancelBtn, status: status, anim: anim, inner: inner
+        };
+    }
+
+    function open(parts, parentRow) {
+        if (parentRow) parentRow.classList.add('suite-row-expanded');
+        var anim = parts.anim;
+        var inner = parts.inner;
+        // The inner clips while the row is partly open (the CSS default). Once
+        // fully open, reveal overflow so editor popovers/tooltips aren't clipped.
+        function reveal() { if (inner) inner.style.overflow = 'visible'; }
+        if (prefersReducedMotion() || !anim) {
+            if (anim) anim.classList.add('is-open');
+            reveal();
+        } else {
+            global.requestAnimationFrame(function () {
+                global.requestAnimationFrame(function () { anim.classList.add('is-open'); });
+            });
+            var revealed = false;
+            anim.addEventListener('transitionend', function (e) {
+                if (e.propertyName === 'grid-template-rows' && !revealed) { revealed = true; reveal(); }
+            });
+            setTimeout(function () { if (!revealed) { revealed = true; reveal(); } }, 280);
+        }
+        if (parts.tr && parts.tr.scrollIntoView) parts.tr.scrollIntoView({ block: 'nearest' });
+        return parts;
+    }
+
+    function close(tr, opts) {
+        opts = opts || {};
+        var parentRow = opts.parentRow || null;
+        var done = false;
+        function finish() {
+            if (done) return;
+            done = true;
+            if (opts.onDone) { try { opts.onDone(); } catch (e) { /* the row still goes away */ } }
+            if (tr && tr.parentNode) tr.parentNode.removeChild(tr);
+            if (parentRow) parentRow.classList.remove('suite-row-expanded');
+        }
+        var anim = tr ? tr.querySelector('.suite-detail-anim') : null;
+        if (opts.immediate || prefersReducedMotion() || !anim || !tr || !tr.parentNode) {
+            finish();
+            return finish;
+        }
+        // Re-clip before collapsing (open() set overflow:visible once expanded),
+        // so content is clipped as the row shrinks rather than spilling out.
+        var inner = tr.querySelector('.suite-detail-inner');
+        if (inner) inner.style.overflow = 'hidden';
+        anim.addEventListener('transitionend', function (e) {
+            if (e.propertyName === 'grid-template-rows') finish();
+        });
+        setTimeout(finish, 320);
+        anim.classList.remove('is-open');
+        return finish;
+    }
+
+    global.ChickadeeAccordion = {
+        CARET_HTML: CARET_HTML,
+        build: build,
+        open: open,
+        close: close
+    };
+
+    // Node export for the .mjs unit tests (Tests/BrowserRunnerJSTests);
+    // browsers take the global above.
+    if (typeof module === 'object' && module.exports) {
+        module.exports = global.ChickadeeAccordion;
+    }
+})(typeof self !== 'undefined' ? self : this);

--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -264,133 +264,25 @@
 
     // ── Shared accordion (inline detail-row editor) ──────────────────────────
     //
-    // Both the suite editor (suite-table.js) and the achievements editor
-    // (achievements-editor.js) expand an inline editor in a detail <tr> beneath
-    // the row being edited.  This is the one implementation of that pattern so
-    // the two editors animate and tear down identically.
+    // The implementation moved to Public/accordion-row.js as
+    // `ChickadeeAccordion`. It is a widget with its own DOM contract and its
+    // own animation rules, not a shared utility in the sense that escaping a
+    // string is, and it was living in the module base.leaf loads on every page
+    // for the sake of two authoring pages.
     //
-    //   build({colspan})  -> { tr, host, saveBtn, cancelBtn, status, anim }
-    //                        the detail-row skeleton, NOT yet inserted.  The
-    //                        caller inserts parts.tr wherever it belongs (the
-    //                        two editors have different placement rules) and
-    //                        mounts its editor into parts.host.
-    //   open(parts, row)  -> animates the inserted row open (0fr -> 1fr) and
-    //                        marks `row` (the parent) expanded; scrolls it into
-    //                        view.  Pass row=null when appending a brand-new row.
-    //   close(tr, opts)   -> animates the row closed and removes it; returns a
-    //                        finishNow() that completes it synchronously (used
-    //                        when a new editor must open before the old one's
-    //                        animation finishes).  opts.immediate (or the user's
-    //                        reduced-motion setting) tears down synchronously.
-    //                        opts.onDone runs once, just before removal, while
-    //                        content is still mounted — for editor-specific
-    //                        cleanup (e.g. rescuing a singleton editor body).
-    //
-    // The height animation is the single-row grid `grid-template-rows: 0fr->1fr`
-    // technique (see styles.css): it animates the editor's intrinsic height with
-    // no magic max-height, which matters because the family editor's height
-    // varies a lot.
-    var CARET_HTML = '<span class="accordion-caret" aria-hidden="true">'
-        + '<svg class="icon" aria-hidden="true"><use href="#i-chevron-right"/></svg></span>';
-
-    function prefersReducedMotion() {
-        return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
-    }
-
-    function buildAccordionRow(opts) {
-        opts = opts || {};
-        var tr = document.createElement('tr');
-        tr.className = 'suite-detail-row';
-        var td = document.createElement('td');
-        td.setAttribute('colspan', String(opts.colspan || 4));
-        var anim = document.createElement('div');
-        anim.className = 'suite-detail-anim';
-        var inner = document.createElement('div');
-        inner.className = 'suite-detail-inner';
-        var host = document.createElement('div');
-        host.className = 'suite-detail-host';
-        var actions = document.createElement('div');
-        actions.className = 'suite-detail-actions';
-        var saveBtn = document.createElement('button');
-        saveBtn.type = 'button';
-        saveBtn.className = 'btn btn-primary btn-compact';
-        saveBtn.textContent = 'Save';
-        var cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'btn btn-compact';
-        cancelBtn.textContent = 'Cancel';
-        var status = document.createElement('span');
-        status.className = 'suite-detail-status card-meta';
-        actions.appendChild(saveBtn);
-        actions.appendChild(cancelBtn);
-        actions.appendChild(status);
-        inner.appendChild(host);
-        inner.appendChild(actions);
-        anim.appendChild(inner);
-        td.appendChild(anim);
-        tr.appendChild(td);
-        return {
-            tr: tr, host: host, saveBtn: saveBtn,
-            cancelBtn: cancelBtn, status: status, anim: anim, inner: inner
-        };
-    }
-
-    function openAccordionRow(parts, parentRow) {
-        if (parentRow) parentRow.classList.add('suite-row-expanded');
-        var anim = parts.anim;
-        var inner = parts.inner;
-        // The inner clips while the row is partly open (the CSS default).  Once
-        // fully open, reveal overflow so editor popovers/tooltips aren't clipped.
-        function reveal() { if (inner) inner.style.overflow = 'visible'; }
-        if (prefersReducedMotion() || !anim) {
-            if (anim) anim.classList.add('is-open');
-            reveal();
-        } else {
-            // Double rAF: let the 0fr starting state paint before flipping to
-            // 1fr, so the grid-template-rows transition actually runs (a single
-            // frame is not reliable across engines).
-            requestAnimationFrame(function () {
-                requestAnimationFrame(function () { anim.classList.add('is-open'); });
-            });
-            var revealed = false;
-            anim.addEventListener('transitionend', function (e) {
-                if (e.propertyName === 'grid-template-rows' && !revealed) { revealed = true; reveal(); }
-            });
-            // Fallback if transitionend never fires (e.g. tab backgrounded).
-            setTimeout(function () { if (!revealed) { revealed = true; reveal(); } }, 280);
-        }
-        if (parts.tr && parts.tr.scrollIntoView) parts.tr.scrollIntoView({ block: 'nearest' });
-        return parts;
-    }
-
-    function closeAccordionRow(tr, opts) {
-        opts = opts || {};
-        var parentRow = opts.parentRow || null;
-        var done = false;
-        function finish() {
-            if (done) return;
-            done = true;
-            if (opts.onDone) { try { opts.onDone(); } catch (e) { /* ignore */ } }
-            if (tr && tr.parentNode) tr.parentNode.removeChild(tr);
-            if (parentRow) parentRow.classList.remove('suite-row-expanded');
-        }
-        var anim = tr ? tr.querySelector('.suite-detail-anim') : null;
-        if (opts.immediate || prefersReducedMotion() || !anim || !tr || !tr.parentNode) {
-            finish();
-            return finish;
-        }
-        // Re-clip before collapsing (open() set overflow:visible once expanded),
-        // so content is clipped as the row shrinks rather than spilling out.
-        var inner = tr.querySelector('.suite-detail-inner');
-        if (inner) inner.style.overflow = 'hidden';
-        anim.addEventListener('transitionend', function (e) {
-            if (e.propertyName === 'grid-template-rows') finish();
-        });
-        // Fallback if transitionend never fires (e.g. a display:none ancestor).
-        setTimeout(finish, 320);
-        anim.classList.remove('is-open');
-        return finish;
-    }
+    // `ChickadeeUI.accordion` stays as the call surface so that no call site
+    // changes in the same commit as the move; repointing the suite and
+    // achievements editors at `ChickadeeAccordion` and dropping this is a
+    // later, separate step. Each member is looked up at CALL time, so the two
+    // files' load order does not matter — including `CARET_HTML`, which is a
+    // getter for exactly that reason: reading it eagerly here would capture
+    // whatever the other file had defined at the moment this one ran.
+    var accordion = {
+        get CARET_HTML() { return root.ChickadeeAccordion.CARET_HTML; },
+        build: function (opts) { return root.ChickadeeAccordion.build(opts); },
+        open: function (parts, parentRow) { return root.ChickadeeAccordion.open(parts, parentRow); },
+        close: function (tr, opts) { return root.ChickadeeAccordion.close(tr, opts); }
+    };
 
     // Tell the assignment-workbench shell that something on this page changed
     // in a way the *other* pane cares about.
@@ -668,12 +560,7 @@
         refreshEditSurface: refreshEditSurface,
         refreshNotebookSurface: refreshNotebookSurface,
         renderSparkline: renderSparkline,
-        accordion: {
-            CARET_HTML: CARET_HTML,
-            build: buildAccordionRow,
-            open: openAccordionRow,
-            close: closeAccordionRow
-        }
+        accordion: accordion
     };
 
     // Node export for the .mjs unit tests (Tests/BrowserRunnerJSTests);

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1835,7 +1835,8 @@ code { font-family: var(--font-mono); font-size: .9em; }
 
 /* Inline editor (accordion) hosted in a detail row beneath a suite/achievement
    row.  Shared by the suite editor (suite-table.js) and the achievements editor
-   (achievements-editor.js) through ChickadeeUI.accordion. */
+   (achievements-editor.js) through ChickadeeUI.accordion, which delegates to
+   ChickadeeAccordion in Public/accordion-row.js. */
 .suite-row-expanded > td { background: var(--gray-100); }
 /* A continuous left accent bar ties the open editor to its row (mirrors the
    status colour-strips at .status-pass &c.). */

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -28,6 +28,7 @@
          complete by the time an inline page script runs.  Order between the two
          does not matter: the re-exports look the delegate up at call time. -->
     <script src="/sparkline.js?v=#appVersion()"></script>
+    <script src="/accordion-row.js?v=#appVersion()"></script>
     <!-- Same reason, same place: page inline scripts call
          ChickadeeRelativeTime.applyRelativeTimes() during parse, so it cannot
          wait for the end of <body>. -->

--- a/Tests/BrowserRunnerJSTests/accordion-row.test.mjs
+++ b/Tests/BrowserRunnerJSTests/accordion-row.test.mjs
@@ -1,0 +1,367 @@
+// Unit tests for Public/accordion-row.js — the inline detail-row editor the
+// suite table and the achievements table expand beneath a row.
+//
+// It had no tests while it lived inside chickadee-ui.js, and it is the kind of
+// code that fails invisibly: every one of its animation paths ends in a
+// teardown, and a teardown that does not run leaves a stranded detail row in
+// the table with an editor still mounted in it. Three of its rules are here
+// because of engine behaviour rather than design, and each is pinned below:
+//
+//   * the open is a DOUBLE requestAnimationFrame — one frame does not reliably
+//     start the transition, and a transition that never starts is a row that
+//     never reveals its overflow, which clips the editor's popovers;
+//   * every animated path carries a TIMEOUT fallback, because transitionend
+//     does not fire in a backgrounded tab or under a display:none ancestor;
+//   * the teardown runs exactly ONCE however it is reached — the caller's
+//     synchronous finishNow(), the transition, and the fallback timer all
+//     race, and running onDone twice would tear down an editor body that has
+//     already been rescued.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/accordion-row.js'), 'utf8');
+
+/// A DOM stub with just enough structure for the accordion: elements that
+/// remember their class list, style, children and listeners.
+function makeEl(tag) {
+  const el = {
+    tagName: String(tag).toUpperCase(),
+    className: '',
+    textContent: '',
+    type: '',
+    style: {},
+    attrs: {},
+    children: [],
+    parentNode: null,
+    handlers: {},
+    scrolledIntoView: null,
+    setAttribute(n, v) { this.attrs[n] = String(v); },
+    getAttribute(n) { return this.attrs[n] ?? null; },
+    appendChild(c) { c.parentNode = this; this.children.push(c); return c; },
+    removeChild(c) {
+      this.children = this.children.filter((x) => x !== c);
+      c.parentNode = null;
+      return c;
+    },
+    addEventListener(type, fn) { (this.handlers[type] ||= []).push(fn); },
+    fire(type, e) { (this.handlers[type] || []).slice().forEach((fn) => fn(e || {})); },
+    scrollIntoView(opts) { this.scrolledIntoView = opts; },
+    querySelector(sel) {
+      const want = sel.replace('.', '');
+      const walk = (node) => {
+        for (const c of node.children) {
+          if (String(c.className).split(/\s+/).includes(want)) return c;
+          const hit = walk(c);
+          if (hit) return hit;
+        }
+        return null;
+      };
+      return walk(this);
+    },
+  };
+  el.classes = new Set();
+  el.classList = {
+    add: (...c) => c.forEach((n) => el.classes.add(n)),
+    remove: (...c) => c.forEach((n) => el.classes.delete(n)),
+    contains: (n) => el.classes.has(n),
+  };
+  return el;
+}
+
+function load({ reducedMotion = false } = {}) {
+  const timers = [];
+  const rafs = [];
+  const sandbox = {
+    document: { createElement: makeEl },
+    String,
+    Array,
+    Object,
+    setTimeout: (fn, ms) => { timers.push({ fn, ms }); return timers.length; },
+    matchMedia: (q) => ({ matches: reducedMotion && q.includes('reduce') }),
+    requestAnimationFrame: (fn) => { rafs.push(fn); return rafs.length; },
+  };
+  sandbox.self = sandbox;
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  return {
+    A: sandbox.ChickadeeAccordion,
+    timers,
+    rafs,
+    /// Run every currently-queued animation frame callback, one frame's worth.
+    frame() { const due = rafs.splice(0, rafs.length); due.forEach((fn) => fn()); },
+    /// Fire the fallback timer(s) the browser would fire after the deadline.
+    fireTimers() { const due = timers.splice(0, timers.length); due.forEach((t) => t.fn()); },
+  };
+}
+
+/// A built detail row, inserted into a stub table body, with a parent row.
+function mounted(h, opts) {
+  const parts = h.A.build(opts);
+  const tbody = makeEl('tbody');
+  const parentRow = makeEl('tr');
+  tbody.appendChild(parentRow);
+  tbody.appendChild(parts.tr);
+  return { parts, tbody, parentRow };
+}
+
+// ── build ───────────────────────────────────────────────────────────────────
+
+test('build returns the skeleton unattached, for the caller to place', () => {
+  const h = load();
+  const parts = h.A.build({ colspan: 4 });
+
+  assert.equal(parts.tr.tagName, 'TR');
+  assert.equal(parts.tr.parentNode, null,
+    'the two editors place the row differently, so build must not insert it');
+  assert.equal(parts.tr.className, 'suite-detail-row');
+  assert.equal(parts.host.className, 'suite-detail-host');
+  assert.equal(parts.saveBtn.textContent, 'Save');
+  assert.equal(parts.cancelBtn.textContent, 'Cancel');
+});
+
+test('the buttons are type=button, so neither submits the page form', () => {
+  const h = load();
+  const parts = h.A.build({});
+  assert.equal(parts.saveBtn.type, 'button');
+  assert.equal(parts.cancelBtn.type, 'button');
+});
+
+test('colspan comes from the caller and defaults rather than rendering "undefined"', () => {
+  const h = load();
+  assert.equal(h.A.build({ colspan: 7 }).tr.children[0].getAttribute('colspan'), '7');
+  assert.equal(h.A.build().tr.children[0].getAttribute('colspan'), '4');
+});
+
+test('the caret markup is aria-hidden, since the row label carries the meaning', () => {
+  const h = load();
+  assert.match(h.A.CARET_HTML, /aria-hidden="true"/);
+  assert.match(h.A.CARET_HTML, /accordion-caret/);
+});
+
+// ── open ────────────────────────────────────────────────────────────────────
+
+test('the open flips to is-open only after a SECOND animation frame', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.open(m.parts, m.parentRow);
+  assert.equal(m.parts.anim.classList.contains('is-open'), false,
+    'flipping in the same frame as insertion skips the transition entirely');
+
+  h.frame();
+  assert.equal(m.parts.anim.classList.contains('is-open'), false, 'one frame is not enough');
+
+  h.frame();
+  assert.equal(m.parts.anim.classList.contains('is-open'), true);
+});
+
+test('the parent row is marked expanded, and the detail row is scrolled to', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.open(m.parts, m.parentRow);
+  assert.equal(m.parentRow.classList.contains('suite-row-expanded'), true);
+  assert.equal(m.parts.tr.scrolledIntoView.block, 'nearest');
+});
+
+test('opening with no parent row is fine — a brand-new row has none yet', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+  h.A.open(m.parts, null);   // must not throw
+  h.frame(); h.frame();
+  assert.equal(m.parts.anim.classList.contains('is-open'), true);
+});
+
+test('overflow is revealed only once the height transition ends', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.open(m.parts, m.parentRow);
+  assert.notEqual(m.parts.inner.style.overflow, 'visible',
+    'revealing early would let a partly-open row spill its editor over the table');
+
+  // Another property finishing is not the one we are waiting for.
+  m.parts.anim.fire('transitionend', { propertyName: 'opacity' });
+  assert.notEqual(m.parts.inner.style.overflow, 'visible');
+
+  m.parts.anim.fire('transitionend', { propertyName: 'grid-template-rows' });
+  assert.equal(m.parts.inner.style.overflow, 'visible',
+    'an editor popover must not be clipped by the row that hosts it');
+});
+
+test('the reveal still happens if transitionend never fires', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.open(m.parts, m.parentRow);
+  h.fireTimers();          // the backgrounded-tab case
+  assert.equal(m.parts.inner.style.overflow, 'visible');
+});
+
+test('under reduced motion the row opens immediately, with no frames at all', () => {
+  const h = load({ reducedMotion: true });
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.open(m.parts, m.parentRow);
+  assert.equal(m.parts.anim.classList.contains('is-open'), true);
+  assert.equal(m.parts.inner.style.overflow, 'visible');
+  assert.equal(h.rafs.length, 0);
+});
+
+// ── close ───────────────────────────────────────────────────────────────────
+
+test('the row is removed and the parent un-marked when the collapse ends', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+  m.parentRow.classList.add('suite-row-expanded');
+
+  h.A.close(m.parts.tr, { parentRow: m.parentRow });
+  assert.equal(m.parts.tr.parentNode, m.tbody, 'it stays mounted while it animates');
+  assert.equal(m.parts.anim.classList.contains('is-open'), false);
+
+  m.parts.anim.fire('transitionend', { propertyName: 'grid-template-rows' });
+  assert.equal(m.parts.tr.parentNode, null);
+  assert.equal(m.parentRow.classList.contains('suite-row-expanded'), false);
+});
+
+test('the row is re-clipped before collapsing, so content does not spill out', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+  m.parts.inner.style.overflow = 'visible';   // as open() left it
+
+  h.A.close(m.parts.tr, {});
+  assert.equal(m.parts.inner.style.overflow, 'hidden');
+});
+
+test('onDone runs while the content is still mounted, and exactly once', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+  const seen = [];
+
+  const finishNow = h.A.close(m.parts.tr, {
+    parentRow: m.parentRow,
+    onDone: () => seen.push(m.parts.tr.parentNode === m.tbody),
+  });
+
+  finishNow();
+  m.parts.anim.fire('transitionend', { propertyName: 'grid-template-rows' });
+  h.fireTimers();
+
+  assert.deepEqual(seen, [true],
+    'the editor body is rescued in onDone, so it must run once and before removal');
+});
+
+test('the returned finishNow tears down synchronously, for an immediate re-open', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  const finishNow = h.A.close(m.parts.tr, { parentRow: m.parentRow });
+  finishNow();
+
+  assert.equal(m.parts.tr.parentNode, null,
+    'a new editor opens before the old row finished animating; the old row must be gone');
+});
+
+test('the row is removed even if transitionend never fires', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.close(m.parts.tr, { parentRow: m.parentRow });
+  h.fireTimers();
+  assert.equal(m.parts.tr.parentNode, null, 'otherwise a stranded detail row survives forever');
+});
+
+test('immediate and reduced motion both remove the row with no animation', () => {
+  for (const [label, h, opts] of [
+    ['immediate', load(), { immediate: true }],
+    ['reduced motion', load({ reducedMotion: true }), {}],
+  ]) {
+    const m = mounted(h, { colspan: 4 });
+    h.A.close(m.parts.tr, { ...opts, parentRow: m.parentRow });
+    assert.equal(m.parts.tr.parentNode, null, label);
+    assert.equal(h.timers.length, 0, `${label}: no fallback timer is armed`);
+  }
+});
+
+test('an onDone that throws does not strand the row in the table', () => {
+  const h = load();
+  const m = mounted(h, { colspan: 4 });
+
+  h.A.close(m.parts.tr, {
+    immediate: true,
+    parentRow: m.parentRow,
+    onDone: () => { throw new Error('the editor rescue failed'); },
+  });
+
+  assert.equal(m.parts.tr.parentNode, null);
+  assert.equal(m.parentRow.classList.contains('suite-row-expanded'), false);
+});
+
+test('closing a row that was never inserted is a no-op, not a throw', () => {
+  const h = load();
+  const parts = h.A.build({ colspan: 4 });
+  h.A.close(parts.tr, {})();
+  h.A.close(null, {});
+});
+
+// ── The ChickadeeUI delegation ──────────────────────────────────────────────
+//
+// `ChickadeeUI.accordion` survives the move as the call surface, so the two
+// editors' call sites did not change in the commit that moved the code. What
+// that seam has to get right is TIMING: base.leaf loads the two files as
+// siblings, and if chickadee-ui.js read `ChickadeeAccordion` while defining its
+// own exports, it would capture whatever existed at that instant — undefined
+// when it happens to load first. Every member resolves at call time instead,
+// `CARET_HTML` included, which is why it is a getter rather than a value.
+
+test('ChickadeeUI.accordion delegates at call time, in either load order', async () => {
+  const uiSource = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+
+  for (const uiFirst of [true, false]) {
+    const sandbox = {
+      document: {
+        createElement: makeEl,
+        querySelector: () => null,
+        addEventListener() {},
+        body: { addEventListener() {} },
+      },
+      Promise, JSON, Object, Error, Array, String,
+      setTimeout: () => 1,
+      matchMedia: () => ({ matches: true }),   // reduced motion: no frames needed
+      requestAnimationFrame: () => 1,
+    };
+    sandbox.window = sandbox;
+    sandbox.self = sandbox;
+    vm.createContext(sandbox);
+
+    const order = uiFirst ? [uiSource, source] : [source, uiSource];
+    order.forEach((src) => vm.runInContext(src, sandbox));
+
+    const label = uiFirst ? 'chickadee-ui.js first' : 'accordion-row.js first';
+    const surface = sandbox.ChickadeeUI.accordion;
+
+    assert.equal(surface.CARET_HTML, sandbox.ChickadeeAccordion.CARET_HTML,
+      `${label}: reading the caret eagerly would capture undefined in one of these orders`);
+
+    const parts = surface.build({ colspan: 3 });
+    assert.equal(parts.tr.children[0].getAttribute('colspan'), '3', label);
+
+    const tbody = makeEl('tbody');
+    const parentRow = makeEl('tr');
+    tbody.appendChild(parentRow);
+    tbody.appendChild(parts.tr);
+
+    surface.open(parts, parentRow);
+    assert.equal(parentRow.classList.contains('suite-row-expanded'), true, label);
+
+    surface.close(parts.tr, { parentRow });
+    assert.equal(parts.tr.parentNode, null, label);
+    assert.equal(parentRow.classList.contains('suite-row-expanded'), false, label);
+  }
+});

--- a/changelog.d/accordion-extraction.md
+++ b/changelog.d/accordion-extraction.md
@@ -1,0 +1,27 @@
+### Changed
+
+- **The inline detail-row accordion moved out of `chickadee-ui.js` into
+  `Public/accordion-row.js`** as `ChickadeeAccordion`. It is the widget the
+  suite table and the achievements table expand beneath a row — a thing with its
+  own DOM contract and its own animation rules, not a shared utility in the
+  sense that escaping a string is — and it was living in the module `base.leaf`
+  loads on every page for the sake of two authoring pages.
+
+  No call site changes: `ChickadeeUI.accordion` remains the call surface. Every
+  member resolves at call time, `CARET_HTML` included, which is why it is a
+  getter rather than a value — the two files load as siblings, and reading the
+  caret eagerly would capture `undefined` in whichever order put this one first.
+
+  It also picks up its first nineteen tests. What they pin is the part that
+  fails silently rather than loudly, because every one of its animation paths
+  ends in a teardown and a teardown that does not run leaves a stranded detail
+  row with an editor still mounted in it:
+
+  - the open flips to `is-open` only on the SECOND animation frame — one frame
+    does not reliably start the transition, and a transition that never starts
+    is a row that never reveals its overflow, which clips the editor's popovers;
+  - every animated path carries a timeout fallback, because `transitionend`
+    does not fire in a backgrounded tab or under a `display: none` ancestor;
+  - the teardown runs exactly once however it is reached: the caller's
+    synchronous `finishNow()`, the transition and the fallback timer all race,
+    and running `onDone` twice would tear down an editor body already rescued.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,8 +15,8 @@ import js from '@eslint/js';
 // short — but "short" no longer means "hang everything off ChickadeeUI",
 // which is how that module reached eighteen unrelated functions behind one
 // name.  A genuinely separate concern gets its own file and its own name
-// (ChickadeeSparkline); only things that really are shared low-level
-// utilities — escaping, CSRF, fetch — belong on ChickadeeUI.
+// (ChickadeeSparkline, ChickadeeAccordion); only things that really are shared
+// low-level utilities — escaping, CSRF, fetch — belong on ChickadeeUI.
 const chickadeeGlobals = {
   ChickadeeUI: 'readonly',
   ChickadeeInputsCore: 'readonly',
@@ -24,6 +24,10 @@ const chickadeeGlobals = {
   // chickadee-ui.js: drawing a chart is not the same kind of thing as
   // escaping a string.
   ChickadeeSparkline: 'readonly',
+  // Public/accordion-row.js — the inline detail-row editor the suite and
+  // achievements tables expand, split out of chickadee-ui.js: a widget with its
+  // own DOM contract is not the same kind of thing as escaping a string.
+  ChickadeeAccordion: 'readonly',
   // Public/authoring-language.js — the assignment's language facts, read by
   // every authoring editor.
   ChickadeeLanguage: 'readonly',


### PR DESCRIPTION
Second of three slices decomposing `Public/chickadee-ui.js` (after #1428).

## What moves

The inline detail-row editor the suite table and the achievements table expand beneath a row → `Public/accordion-row.js` as `ChickadeeAccordion`. It is a widget with its own DOM contract and its own animation rules, not a shared utility in the sense that escaping a string is, and it was living in the module `base.leaf` loads on every page for the sake of two authoring pages.

**No call site changes.** `ChickadeeUI.accordion` stays as the call surface; neither `suite-table.js` nor `achievements-editor.js` is touched.

## `CARET_HTML` is a getter, and that is the point

`base.leaf` loads the two files as **siblings**, so it fixes no order between them. Reading `ChickadeeAccordion.CARET_HTML` while building `ChickadeeUI`'s exports would capture whatever existed at that instant — `undefined` in whichever order put `chickadee-ui.js` first. Every member resolves at call time instead, and the caret needs a getter to do so.

A test drives the whole surface in **both** load orders. Reverting the getter to a value turns it red.

## Tests

Nineteen, its first. What they pin is the part that fails silently, because every animation path ends in a teardown and a teardown that does not run leaves a stranded detail row with an editor still mounted in it:

- the open flips to `is-open` only on the **second** animation frame — one frame does not reliably start the transition, and a transition that never starts is a row that never reveals its overflow, which clips the editor's popovers;
- every animated path carries a timeout fallback, because `transitionend` does not fire in a backgrounded tab or under a `display: none` ancestor;
- the teardown runs **exactly once** however it is reached: the caller's synchronous `finishNow()`, the transition and the fallback timer all race, and running `onDone` twice would tear down an editor body already rescued.

The harness uses nodes with real identity and a `querySelector` narrow enough that a wrong selector in the source cannot still pass.

## Verification

`node --test Tests/BrowserRunnerJSTests/*.mjs` (528 tests, 0 fail), `scripts/eslint.sh`, `scripts/check-styles.sh`. `styles.css`'s comment about who reaches the accordion is updated to name the new module.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_