### PR TITLE
refactor(ui): move the workbench surface swappers out of chickadee-ui.js

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -325,184 +325,22 @@
 
     // ── Re-rendering the surface you are on ──────────────────────────────────
     //
-    // `location.reload()` is the obvious way to pick up a server-side change,
-    // and on the merged workbench (#1266) it is destructive: the edit form and
-    // a live Pyodide kernel share one document, so reloading to show a renamed
-    // suite section costs a 10-30s kernel boot and any unsaved cells. That is
-    // the exact failure the merge exists to prevent, so the refresh re-renders
-    // the *edit half only*, by fetching this same URL and swapping that half's
-    // subtree.
+    // The implementation moved to Public/surface-swap.js as
+    // `ChickadeeSurfaceSwap`. It is the largest of the concerns split out of
+    // this module and the one with the most rules of its own: a fetch, a parse,
+    // a node-identity discipline, and the only place in the frontend that
+    // deliberately turns markup into running code.
     //
-    // On the standalone `/edit` page there is no kernel and no `#wb-shell`, so
-    // it stays a plain reload — same behaviour as before.
-    //
-    // Scroll position is preserved across the swap, because every caller is
-    // re-rendering after a small edit — uploading one support file, renaming
-    // one section — and landing back at the top of a long assignment each time
-    // is its own kind of lost work.
-
-    var EDIT_HALF_SELECTOR = '.wb-pane-edit';
-
-    /// Re-execute the inline `<script>` blocks in a freshly swapped subtree.
-    ///
-    /// `innerHTML` never executes scripts, so without this the new markup is
-    /// inert — no suite table, no editors. Only inline blocks are re-run:
-    /// `src=` modules are already loaded and merely *define* the globals the
-    /// inline blocks call, so re-fetching them would re-run their IIFEs and
-    /// double-bind. The inline blocks bind nothing to `document`/`window`
-    /// themselves; the two module-level listeners that do (suite-table's
-    /// dragover and pageshow) carry their own once-per-document guards.
-    /// Re-execute the inline scripts in a freshly swapped pane.
-    ///
-    /// CONTRACT, which this function had never had written down. A `<script>`
-    /// inserted by parsing HTML does not run — that is a deliberate platform
-    /// rule — so a pane swap has to re-create the elements to get their page
-    /// wiring back. That makes this the one place in the frontend that turns
-    /// markup into running code on purpose, and the boundary is therefore:
-    ///
-    ///   * `root` must be a fragment the SERVER rendered for this same-origin
-    ///     page (what `swapHalf` fetched). Never call it on markup that came
-    ///     from a user, a message body, or any other document.
-    ///   * `[src]` scripts are excluded by the selector: a swap re-runs page
-    ///     wiring, it does not re-fetch modules.
-    ///   * a `type` other than `text/javascript` is DATA — the JSON seed
-    ///     islands the authoring pages carry — and is left untouched, both
-    ///     because re-running it is meaningless and because a re-created
-    ///     element must keep its type to still be findable.
-    ///
-    /// It is internal on purpose: `swapHalf` is the only caller and the only
-    /// context where the first rule can be guaranteed. Exporting it would make
-    /// that guarantee someone else's to keep.
-    function runInlineScripts(root) {
-        var scripts = root.querySelectorAll('script:not([src])');
-        Array.prototype.forEach.call(scripts, function (old) {
-            // JSON seed blocks are data, not code — re-running them is
-            // meaningless and `type` must be preserved for the ones that are.
-            if (old.type && old.type !== 'text/javascript') return;
-            var s = document.createElement('script');
-            s.textContent = old.textContent;
-            old.parentNode.replaceChild(s, old);
-        });
-    }
-
-    var NOTEBOOK_HALF_SELECTOR = '.wb-notebook-body';
-
-    /// Fetch `url` and swap one half's subtree from the response.
-    ///
-    /// Shared by both halves so the failure handling, the "am I even on the
-    /// merged workbench" test, and the inline-script re-execution cannot drift
-    /// between them.
-    ///
-    /// `opts.keepElement` names an element (by id) to carry across the swap
-    /// rather than let `innerHTML` destroy. The notebook half needs this for
-    /// `#jl-frame`: 34 closures in notebook.js capture that element, and a
-    /// fresh one would leave every one of them on a detached node. Moving it
-    /// does reload it — which a notebook switch wants, since the kernel belongs
-    /// to whichever notebook is open.
-    function swapHalf(selector, url, opts) {
-        opts = opts || {};
-        if (typeof document === 'undefined') return Promise.resolve(false);
-        var half = document.querySelector(selector);
-        // Not the merged workbench — the standalone editor. Reload as before.
-        if (!half || !document.getElementById('wb-shell')) {
-            window.location.reload();
-            return Promise.resolve(true);
-        }
-        var scrollTop = half.scrollTop;
-        var kept = opts.keepElement ? document.getElementById(opts.keepElement) : null;
-        return fetch(url, {
-            credentials: 'same-origin',
-            headers: { 'X-Requested-With': 'fetch' }
-        }).then(function (res) {
-            if (!res.ok) throw new Error('refresh failed: ' + res.status);
-            return res.text();
-        }).then(function (html) {
-            var doc = new DOMParser().parseFromString(html, 'text/html');
-            var fresh = doc.querySelector(selector);
-            if (!fresh) throw new Error('refresh failed: ' + selector + ' not in response');
-
-            // Build the replacement as real nodes, NOT via `innerHTML`.
-            //
-            // `half.innerHTML = fresh.innerHTML` serializes to markup and
-            // re-parses it, which silently defeats `keepElement`: the element
-            // we meant to carry across would be written out as text and a brand
-            // new one built from it, leaving every closure that captured the
-            // original pointing at a detached node. Importing nodes preserves
-            // object identity for the one element that needs it.
-            var frag = document.createDocumentFragment();
-            Array.prototype.slice.call(fresh.childNodes).forEach(function (n) {
-                frag.appendChild(document.importNode(n, true));
-            });
-
-            if (kept) {
-                var incoming = frag.querySelector('#' + opts.keepElement);
-                if (!incoming) throw new Error('refresh failed: ' + opts.keepElement + ' not in response');
-                // The incoming element's attributes are the whole point — they
-                // name which notebook to open. Copy them onto ours, then put
-                // ours where the new one would have gone.
-                Array.prototype.forEach.call(incoming.attributes, function (a) {
-                    if (a.name !== 'id') kept.setAttribute(a.name, a.value);
-                });
-                incoming.parentNode.replaceChild(kept, incoming);
-            }
-
-            half.textContent = '';
-            half.appendChild(frag);
-            runInlineScripts(half);
-            half.scrollTop = scrollTop;
-            return true;
-        }).catch(function () {
-            // A failed refresh must not leave a half-swapped page. Whatever
-            // prompted it already happened server-side, so a full reload is
-            // correct — it costs the kernel, but showing stale state is worse.
-            window.location.reload();
-            return false;
-        });
-    }
-
-    /// Re-render the edit half in place after a write.
-    ///
-    /// `window.location.href`, not a stored URL: the merged page's own URL
-    /// already names exactly what to re-render, including which notebook is
-    /// open, so there is no second URL to keep in sync (and no DOM-sourced
-    /// navigation target to validate).
+    // Both names stay here as the call surface so that no call site changes in
+    // the same commit as the move, and both resolve at CALL time so the two
+    // files' load order does not matter.
     function refreshEditSurface() {
-        return swapHalf(EDIT_HALF_SELECTOR, window.location.href);
+        return root.ChickadeeSurfaceSwap.refreshEditSurface();
     }
 
-    /// Open a different notebook (file and/or view) without leaving the page.
-    ///
-    /// The kernel restarts regardless — it is bound to the open notebook — so
-    /// what this buys is the *edit half*: it is not rebuilt, so its open
-    /// editors and any metadata typed but not yet saved survive, where a
-    /// navigation took them with it.
-    ///
-    /// **Known limitation: the edit half's scroll position is not preserved.**
-    /// Emptying the notebook half reflows the grid, and while it is empty the
-    /// edit half stops overflowing, which clamps its `scrollTop` to 0. Writing
-    /// the old value back — synchronously or on the next frame — does not
-    /// survive; something resets it again before the layout settles, and I did
-    /// not isolate what. Called out rather than papered over: an author who
-    /// switches notebooks lands back at the top of the edit half. Their *work*
-    /// is intact, which is the property that matters, and this is strictly
-    /// better than the navigation it replaces, which lost the work too.
     function refreshNotebookSurface(url) {
-        return swapHalf(NOTEBOOK_HALF_SELECTOR, url, { keepElement: 'jl-frame' })
-            .then(function (ok) {
-                if (!ok) return false;
-                // Re-read the new data-* attributes and re-mount. Absent on a
-                // page with no notebook half, which is not an error.
-                if (typeof window.chickadeeRemountNotebook === 'function') {
-                    window.chickadeeRemountNotebook();
-                }
-                return true;
-            });
+        return root.ChickadeeSurfaceSwap.refreshNotebookSurface(url);
     }
-
-    // The sessionStorage round-trip that used to restore scroll after the
-    // pane's `location.replace` is gone with the navigation itself: the swap
-    // never unloads the document, so `refreshEditSurface` just reads
-    // `half.scrollTop` before and writes it back after.
 
     // Warns when a chosen date falls within three days of a UWaterloo
     // important date.  Hoisted here from three inline copies that had already

--- a/Public/surface-swap.js
+++ b/Public/surface-swap.js
@@ -1,0 +1,213 @@
+// Public/surface-swap.js
+//
+// Re-rendering half of the merged assignment workbench in place, without
+// navigating.
+//
+// Split out of chickadee-ui.js, which had accumulated eighteen unrelated
+// functions behind one name. This is the largest of those concerns and the one
+// with the most rules of its own: a fetch, a parse, a node-identity discipline,
+// and the only place in the frontend that deliberately turns markup into
+// running code.
+//
+//   ChickadeeSurfaceSwap.refreshEditSurface()
+//   ChickadeeSurfaceSwap.refreshNotebookSurface(url)
+//
+// `ChickadeeUI` re-exports both under their existing names, so no call site
+// changed when this moved. Unlike the other two splits, this one is reached
+// from a module base.leaf already loads on every page — inplace-forms.js calls
+// refreshEditSurface() after every successful in-place save — so it is loaded
+// there beside chickadee-ui.js rather than on the two workbench pages.
+//
+// `location.reload()` is the obvious way to pick up a server-side change,
+// and on the merged workbench (#1266) it is destructive: the edit form and
+// a live Pyodide kernel share one document, so reloading to show a renamed
+// suite section costs a 10-30s kernel boot and any unsaved cells. That is
+// the exact failure the merge exists to prevent, so the refresh re-renders
+// the *edit half only*, by fetching this same URL and swapping that half's
+// subtree.
+//
+// On the standalone `/edit` page there is no kernel and no `#wb-shell`, so
+// it stays a plain reload — same behaviour as before.
+//
+// Scroll position is preserved across the swap, because every caller is
+// re-rendering after a small edit — uploading one support file, renaming
+// one section — and landing back at the top of a long assignment each time
+// is its own kind of lost work.
+
+(function (global) {
+    'use strict';
+
+    var EDIT_HALF_SELECTOR = '.wb-pane-edit';
+
+    /// Re-execute the inline `<script>` blocks in a freshly swapped subtree.
+    ///
+    /// `innerHTML` never executes scripts, so without this the new markup is
+    /// inert — no suite table, no editors. Only inline blocks are re-run:
+    /// `src=` modules are already loaded and merely *define* the globals the
+    /// inline blocks call, so re-fetching them would re-run their IIFEs and
+    /// double-bind. The inline blocks bind nothing to `document`/`window`
+    /// themselves; the two module-level listeners that do (suite-table's
+    /// dragover and pageshow) carry their own once-per-document guards.
+    /// Re-execute the inline scripts in a freshly swapped pane.
+    ///
+    /// CONTRACT, which this function had never had written down. A `<script>`
+    /// inserted by parsing HTML does not run — that is a deliberate platform
+    /// rule — so a pane swap has to re-create the elements to get their page
+    /// wiring back. That makes this the one place in the frontend that turns
+    /// markup into running code on purpose, and the boundary is therefore:
+    ///
+    ///   * `root` must be a fragment the SERVER rendered for this same-origin
+    ///     page (what `swapHalf` fetched). Never call it on markup that came
+    ///     from a user, a message body, or any other document.
+    ///   * `[src]` scripts are excluded by the selector: a swap re-runs page
+    ///     wiring, it does not re-fetch modules.
+    ///   * a `type` other than `text/javascript` is DATA — the JSON seed
+    ///     islands the authoring pages carry — and is left untouched, both
+    ///     because re-running it is meaningless and because a re-created
+    ///     element must keep its type to still be findable.
+    ///
+    /// It is internal on purpose: `swapHalf` is the only caller and the only
+    /// context where the first rule can be guaranteed. Exporting it would make
+    /// that guarantee someone else's to keep.
+    function runInlineScripts(pane) {
+        var scripts = pane.querySelectorAll('script:not([src])');
+        Array.prototype.forEach.call(scripts, function (old) {
+            // JSON seed blocks are data, not code — re-running them is
+            // meaningless and `type` must be preserved for the ones that are.
+            if (old.type && old.type !== 'text/javascript') return;
+            var s = document.createElement('script');
+            s.textContent = old.textContent;
+            old.parentNode.replaceChild(s, old);
+        });
+    }
+
+    var NOTEBOOK_HALF_SELECTOR = '.wb-notebook-body';
+
+    /// Fetch `url` and swap one half's subtree from the response.
+    ///
+    /// Shared by both halves so the failure handling, the "am I even on the
+    /// merged workbench" test, and the inline-script re-execution cannot drift
+    /// between them.
+    ///
+    /// `opts.keepElement` names an element (by id) to carry across the swap
+    /// rather than let `innerHTML` destroy. The notebook half needs this for
+    /// `#jl-frame`: 34 closures in notebook.js capture that element, and a
+    /// fresh one would leave every one of them on a detached node. Moving it
+    /// does reload it — which a notebook switch wants, since the kernel belongs
+    /// to whichever notebook is open.
+    function swapHalf(selector, url, opts) {
+        opts = opts || {};
+        if (typeof document === 'undefined') return Promise.resolve(false);
+        var half = document.querySelector(selector);
+        // Not the merged workbench — the standalone editor. Reload as before.
+        if (!half || !document.getElementById('wb-shell')) {
+            global.location.reload();
+            return Promise.resolve(true);
+        }
+        var scrollTop = half.scrollTop;
+        var kept = opts.keepElement ? document.getElementById(opts.keepElement) : null;
+        return fetch(url, {
+            credentials: 'same-origin',
+            headers: { 'X-Requested-With': 'fetch' }
+        }).then(function (res) {
+            if (!res.ok) throw new Error('refresh failed: ' + res.status);
+            return res.text();
+        }).then(function (html) {
+            var doc = new DOMParser().parseFromString(html, 'text/html');
+            var fresh = doc.querySelector(selector);
+            if (!fresh) throw new Error('refresh failed: ' + selector + ' not in response');
+
+            // Build the replacement as real nodes, NOT via `innerHTML`.
+            //
+            // `half.innerHTML = fresh.innerHTML` serializes to markup and
+            // re-parses it, which silently defeats `keepElement`: the element
+            // we meant to carry across would be written out as text and a brand
+            // new one built from it, leaving every closure that captured the
+            // original pointing at a detached node. Importing nodes preserves
+            // object identity for the one element that needs it.
+            var frag = document.createDocumentFragment();
+            Array.prototype.slice.call(fresh.childNodes).forEach(function (n) {
+                frag.appendChild(document.importNode(n, true));
+            });
+
+            if (kept) {
+                var incoming = frag.querySelector('#' + opts.keepElement);
+                if (!incoming) throw new Error('refresh failed: ' + opts.keepElement + ' not in response');
+                // The incoming element's attributes are the whole point — they
+                // name which notebook to open. Copy them onto ours, then put
+                // ours where the new one would have gone.
+                Array.prototype.forEach.call(incoming.attributes, function (a) {
+                    if (a.name !== 'id') kept.setAttribute(a.name, a.value);
+                });
+                incoming.parentNode.replaceChild(kept, incoming);
+            }
+
+            half.textContent = '';
+            half.appendChild(frag);
+            runInlineScripts(half);
+            half.scrollTop = scrollTop;
+            return true;
+        }).catch(function () {
+            // A failed refresh must not leave a half-swapped page. Whatever
+            // prompted it already happened server-side, so a full reload is
+            // correct — it costs the kernel, but showing stale state is worse.
+            global.location.reload();
+            return false;
+        });
+    }
+
+    /// Re-render the edit half in place after a write.
+    ///
+    /// `window.location.href`, not a stored URL: the merged page's own URL
+    /// already names exactly what to re-render, including which notebook is
+    /// open, so there is no second URL to keep in sync (and no DOM-sourced
+    /// navigation target to validate).
+    function refreshEditSurface() {
+        return swapHalf(EDIT_HALF_SELECTOR, global.location.href);
+    }
+
+    /// Open a different notebook (file and/or view) without leaving the page.
+    ///
+    /// The kernel restarts regardless — it is bound to the open notebook — so
+    /// what this buys is the *edit half*: it is not rebuilt, so its open
+    /// editors and any metadata typed but not yet saved survive, where a
+    /// navigation took them with it.
+    ///
+    /// **Known limitation: the edit half's scroll position is not preserved.**
+    /// Emptying the notebook half reflows the grid, and while it is empty the
+    /// edit half stops overflowing, which clamps its `scrollTop` to 0. Writing
+    /// the old value back — synchronously or on the next frame — does not
+    /// survive; something resets it again before the layout settles, and I did
+    /// not isolate what. Called out rather than papered over: an author who
+    /// switches notebooks lands back at the top of the edit half. Their *work*
+    /// is intact, which is the property that matters, and this is strictly
+    /// better than the navigation it replaces, which lost the work too.
+    function refreshNotebookSurface(url) {
+        return swapHalf(NOTEBOOK_HALF_SELECTOR, url, { keepElement: 'jl-frame' })
+            .then(function (ok) {
+                if (!ok) return false;
+                // Re-read the new data-* attributes and re-mount. Absent on a
+                // page with no notebook half, which is not an error.
+                if (typeof global.chickadeeRemountNotebook === 'function') {
+                    global.chickadeeRemountNotebook();
+                }
+                return true;
+            });
+    }
+
+    // The sessionStorage round-trip that used to restore scroll after the
+    // pane's `location.replace` is gone with the navigation itself: the swap
+    // never unloads the document, so `refreshEditSurface` just reads
+    // `half.scrollTop` before and writes it back after.
+
+    global.ChickadeeSurfaceSwap = {
+        refreshEditSurface: refreshEditSurface,
+        refreshNotebookSurface: refreshNotebookSurface
+    };
+
+    // Node export for the .mjs unit tests (Tests/BrowserRunnerJSTests);
+    // browsers take the global above.
+    if (typeof module === 'object' && module.exports) {
+        module.exports = global.ChickadeeSurfaceSwap;
+    }
+})(typeof self !== 'undefined' ? self : this);

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -29,6 +29,7 @@
          does not matter: the re-exports look the delegate up at call time. -->
     <script src="/sparkline.js?v=#appVersion()"></script>
     <script src="/accordion-row.js?v=#appVersion()"></script>
+    <script src="/surface-swap.js?v=#appVersion()"></script>
     <!-- Same reason, same place: page inline scripts call
          ChickadeeRelativeTime.applyRelativeTimes() during parse, so it cannot
          wait for the end of <body>. -->

--- a/Tests/BrowserRunnerJSTests/refresh-edit-surface.test.mjs
+++ b/Tests/BrowserRunnerJSTests/refresh-edit-surface.test.mjs
@@ -28,7 +28,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import vm from 'node:vm';
 
-const source = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+const source = await fs.readFile(path.resolve('Public/surface-swap.js'), 'utf8');
 
 /// A minimal element stub: enough surface for the swap path to run.
 ///
@@ -116,15 +116,18 @@ function load(opts = {}) {
   };
   window.parent = window;
 
+  // `self`, because surface-swap.js resolves its global as
+  // `typeof self !== 'undefined' ? self : this`.
   const context = vm.createContext({
     window,
     document,
     globalThis: {},
+    self: window,
     fetch: window.fetch,
     DOMParser: window.DOMParser,
   });
   vm.runInContext(source, context);
-  return { ui: window.ChickadeeUI, calls, half, freshHalf };
+  return { ui: window.ChickadeeSurfaceSwap, calls, half, freshHalf };
 }
 
 test('refreshEditSurface: swaps the edit half in place, never navigating', async () => {

--- a/Tests/BrowserRunnerJSTests/swap-half.test.mjs
+++ b/Tests/BrowserRunnerJSTests/swap-half.test.mjs
@@ -1,0 +1,437 @@
+// Unit tests for the pane swap in Public/chickadee-ui.js — the mechanism that
+// re-renders half of the merged workbench without navigating.
+//
+// `refresh-edit-surface.test.mjs` covers the swap's OUTER decisions: swap vs.
+// reload, which URL, scroll restoration, and the reload fallback on failure.
+// Its DOM stub deliberately reports no scripts and no carried element, so two
+// of the swap's rules were never exercised by anything. Both are the kind that
+// fail silently:
+//
+//   * `runInlineScripts`, the one place in the frontend that turns markup into
+//     running code on purpose. A `<script>` inserted by parsing HTML does not
+//     run — a deliberate platform rule — so the swap re-creates the element to
+//     get the page's wiring back. Get its exclusions wrong and you either
+//     double-load a module or execute a JSON seed island.
+//   * `keepElement`, which carries `#jl-frame` across the swap by object
+//     identity. 34 closures in notebook.js captured that element; rebuilding it
+//     leaves every one of them on a detached node, and the page still LOOKS
+//     right — the notebook renders, and nothing it does afterwards works.
+//
+// So this file is a real-enough DOM: nodes with identity, a fragment that
+// actually moves its children, and a parser whose output is a tree rather than
+// a string. Identity is the whole subject, and a stub that returns fresh
+// objects would make every assertion here vacuous.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/surface-swap.js'), 'utf8');
+
+// ── A miniature DOM ─────────────────────────────────────────────────────────
+
+let nextNodeID = 1;
+
+function node(tagName, attrs = {}, children = []) {
+  const el = {
+    nodeID: nextNodeID++,
+    tagName: String(tagName).toUpperCase(),
+    attrs: { ...attrs },
+    children: [],
+    parentNode: null,
+    scrollTop: 0,
+    _text: '',
+
+    get attributes() {
+      return Object.keys(this.attrs).map((name) => ({ name, value: this.attrs[name] }));
+    },
+    get id() { return this.attrs.id ?? ''; },
+    get type() { return this.attrs.type ?? ''; },
+    set type(v) { this.attrs.type = v; },
+    get textContent() { return this._text; },
+    set textContent(v) {
+      // Assigning textContent empties the element, which is how the swap clears
+      // the half before appending the new subtree. An emptied element stops
+      // overflowing, so the browser clamps its scroll offset to 0 — modelled,
+      // because without it the scroll-restoration assertion below passes
+      // whether or not the restore exists.
+      this.children.forEach((c) => { c.parentNode = null; });
+      this.children = [];
+      this._text = String(v);
+      this.scrollTop = 0;
+    },
+
+    setAttribute(name, value) { this.attrs[name] = String(value); },
+    getAttribute(name) { return this.attrs[name] ?? null; },
+    hasAttribute(name) { return name in this.attrs; },
+
+    appendChild(child) {
+      // A DocumentFragment MOVES its children rather than being inserted
+      // itself. Modelled, because `runInlineScripts` runs against the half
+      // AFTER the append and would find nothing if the fragment stayed whole.
+      if (child.isFragment) {
+        child.children.slice().forEach((c) => this.appendChild(c));
+        child.children = [];
+        return child;
+      }
+      if (child.parentNode) child.parentNode.removeChild(child);
+      child.parentNode = this;
+      this.children.push(child);
+      this._text = '';
+      return child;
+    },
+    removeChild(child) {
+      this.children = this.children.filter((c) => c !== child);
+      child.parentNode = null;
+      return child;
+    },
+    replaceChild(fresh, old) {
+      const at = this.children.indexOf(old);
+      if (at < 0) throw new Error('replaceChild: node is not a child');
+      if (fresh.parentNode) fresh.parentNode.removeChild(fresh);
+      this.children[at] = fresh;
+      fresh.parentNode = this;
+      old.parentNode = null;
+      return old;
+    },
+
+    get childNodes() { return this.children.slice(); },
+
+    /// Depth-first search for `#id` and for the two script selectors the swap
+    /// uses. Deliberately narrow: an over-general matcher would let a wrong
+    /// selector in the source still pass here.
+    querySelector(sel) {
+      return descendants(this).find((n) => matches(n, sel)) ?? null;
+    },
+    querySelectorAll(sel) {
+      return descendants(this).filter((n) => matches(n, sel));
+    },
+  };
+  Object.entries(attrs).forEach(([k, v]) => { el.attrs[k] = String(v); });
+  children.forEach((c) => el.appendChild(c));
+  return el;
+}
+
+function descendants(root) {
+  const out = [];
+  const walk = (n) => n.children.forEach((c) => { out.push(c); walk(c); });
+  walk(root);
+  return out;
+}
+
+function matches(n, sel) {
+  if (sel === 'script:not([src])') return n.tagName === 'SCRIPT' && !n.hasAttribute('src');
+  if (sel.startsWith('#')) return n.attrs.id === sel.slice(1);
+  if (sel.startsWith('.')) return String(n.attrs.class || '').split(/\s+/).includes(sel.slice(1));
+  return n.tagName === sel.toUpperCase();
+}
+
+function fragment() {
+  const f = node('#fragment');
+  f.isFragment = true;
+  return f;
+}
+
+/// A deep copy with FRESH identity, which is what `importNode` is.
+function importNode(n) {
+  const copy = node(n.tagName, n.attrs, n.children.map(importNode));
+  copy._text = n._text;
+  return copy;
+}
+
+// ── The harness ─────────────────────────────────────────────────────────────
+
+/// Load chickadee-ui.js with `freshHalf` as the subtree the refresh fetches.
+///
+/// `keptID` seeds an element already in the live document, so the carried-over
+/// path has something with identity to carry.
+function load({ freshHalf, selector = '.wb-pane-edit', keptID = null, fetchFails = false } = {}) {
+  const calls = [];
+  const half = node('div', { class: selector.slice(1) }, [node('p', {}, [])]);
+  half.scrollTop = 420;
+  const kept = keptID ? node('iframe', { id: keptID, 'data-file': 'old.ipynb' }) : null;
+  const created = [];
+
+  const document = {
+    body: { getAttribute: () => null },
+    querySelector: (sel) => (matches(half, sel) ? half : null),
+    getElementById: (id) => {
+      if (id === 'wb-shell') return {};
+      if (kept && id === keptID) return kept;
+      return null;
+    },
+    createElement: (tag) => { const el = node(tag); created.push(el); return el; },
+    createDocumentFragment: fragment,
+    importNode: (n) => importNode(n),
+  };
+
+  const window = {
+    location: {
+      href: 'https://chickadee.example/instructor/DEJr2f/workbench',
+      reload: () => calls.push({ kind: 'reload' }),
+    },
+    document,
+    addEventListener: () => {},
+    fetch: (url, init) => {
+      calls.push({ kind: 'fetch', url, init });
+      if (fetchFails) return Promise.reject(new Error('network'));
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('<html/>') });
+    },
+    DOMParser: class {
+      parseFromString() {
+        return { querySelector: (sel) => (matches(freshHalf, sel) ? freshHalf : null) };
+      }
+    },
+  };
+  window.parent = window;
+
+  // `self`, because surface-swap.js resolves its global as
+  // `typeof self !== 'undefined' ? self : this` — the same shape every split-out
+  // module uses.
+  const context = vm.createContext({
+    window, document, globalThis: {}, self: window,
+    fetch: window.fetch, DOMParser: window.DOMParser,
+    Array, Object, String, Promise, Error, setTimeout,
+  });
+  vm.runInContext(source, context);
+  return { ui: window.ChickadeeSurfaceSwap, calls, half, kept, created, document, window };
+}
+
+/// The subtree the server sends back for the edit half.
+function freshEditHalf(children) {
+  return node('div', { class: 'wb-pane-edit' }, children);
+}
+
+function scriptNode(text, attrs = {}) {
+  const s = node('script', attrs);
+  s._text = text;
+  return s;
+}
+
+// ── runInlineScripts ────────────────────────────────────────────────────────
+
+test('an inline script is RE-CREATED, because a parsed one would never run', async () => {
+  const original = scriptNode('initSuiteTable();');
+  const { ui, half } = load({ freshHalf: freshEditHalf([original]) });
+
+  await ui.refreshEditSurface();
+
+  const live = half.querySelectorAll('script:not([src])');
+  assert.equal(live.length, 1);
+  assert.equal(live[0].textContent, 'initSuiteTable();');
+  assert.notEqual(live[0].nodeID, original.nodeID,
+    'a script element inserted by parsing HTML is inert; only a freshly created one executes');
+});
+
+test('a src= script is left alone, so a swap never re-runs a module', async () => {
+  const module = scriptNode('', { src: '/suite-table.js' });
+  const { ui, half } = load({ freshHalf: freshEditHalf([module]) });
+
+  await ui.refreshEditSurface();
+
+  const live = half.children.filter((n) => n.tagName === 'SCRIPT');
+  assert.equal(live.length, 1);
+  assert.equal(live[0].getAttribute('src'), '/suite-table.js');
+  // Re-created it would re-fetch and re-run the module's IIFE, double-binding
+  // every listener it installs.
+  assert.equal(live[0].children.length, 0);
+  assert.equal(live[0].textContent, '');
+});
+
+test('a JSON seed island is data: not re-run, and it keeps its type', async () => {
+  const seed = scriptNode('{"language":"r"}', { type: 'application/json', id: 'assignment-language-seed' });
+  const { ui, half } = load({ freshHalf: freshEditHalf([seed]) });
+
+  await ui.refreshEditSurface();
+
+  const live = half.querySelector('#assignment-language-seed');
+  assert.ok(live, 'the seed must stay findable — every authoring editor reads it by id');
+  assert.equal(live.getAttribute('type'), 'application/json',
+    'a re-created element without its type would be executed as script by the browser');
+  assert.equal(live.textContent, '{"language":"r"}');
+});
+
+test('scripts nested inside the swapped subtree are re-run too, not just top-level ones', async () => {
+  const inner = scriptNode('initSection();');
+  const { ui, half } = load({
+    freshHalf: freshEditHalf([node('section', { class: 'section-block' }, [inner])]),
+  });
+
+  await ui.refreshEditSurface();
+
+  const live = half.querySelectorAll('script:not([src])');
+  assert.equal(live.length, 1);
+  assert.notEqual(live[0].nodeID, inner.nodeID);
+  assert.equal(live[0].parentNode.tagName, 'SECTION', 'and it stays where the markup put it');
+});
+
+test('a swapped half with no scripts at all is fine', async () => {
+  const { ui, half } = load({ freshHalf: freshEditHalf([node('p')]) });
+  assert.equal(await ui.refreshEditSurface(), true);
+  assert.equal(half.children.length, 1);
+});
+
+// ── The swap itself ─────────────────────────────────────────────────────────
+
+test('the old content is replaced by the new, and scroll survives it', async () => {
+  const { ui, half } = load({ freshHalf: freshEditHalf([node('h2'), node('table')]) });
+
+  await ui.refreshEditSurface();
+
+  assert.deepEqual(half.children.map((n) => n.tagName), ['H2', 'TABLE']);
+  assert.equal(half.scrollTop, 420,
+    're-rendering after a one-line edit must not send the author back to the top');
+});
+
+test('the swapped nodes are copies, so the fetched document is not adopted', async () => {
+  const incoming = node('table', { id: 'suite' });
+  const fresh = freshEditHalf([incoming]);
+  const { ui, half } = load({ freshHalf: fresh });
+
+  await ui.refreshEditSurface();
+
+  assert.notEqual(half.children[0].nodeID, incoming.nodeID);
+  assert.equal(incoming.parentNode, fresh, 'the parsed document keeps its own tree');
+});
+
+// ── keepElement ─────────────────────────────────────────────────────────────
+
+test('the carried element keeps its IDENTITY across the swap', async () => {
+  const incomingFrame = node('iframe', { id: 'jl-frame', 'data-file': 'new.ipynb' });
+  const { ui, half, kept } = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [node('div', {}, [incomingFrame])]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+  });
+
+  await ui.refreshNotebookSurface('/instructor/DEJr2f/workbench?file=new.ipynb');
+
+  const live = half.querySelector('#jl-frame');
+  assert.equal(live, kept,
+    '34 closures captured this element; a rebuilt one leaves every one of them detached');
+  assert.notEqual(live.nodeID, incomingFrame.nodeID);
+});
+
+test('the carried element takes on the incoming attributes, but keeps its id', async () => {
+  const incomingFrame = node('iframe', { id: 'jl-frame', 'data-file': 'new.ipynb', 'data-view': 'notebook' });
+  const { ui, kept } = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [incomingFrame]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+  });
+
+  await ui.refreshNotebookSurface('/x');
+
+  assert.equal(kept.getAttribute('data-file'), 'new.ipynb',
+    'the incoming attributes name which notebook to open — they are the point of the swap');
+  assert.equal(kept.getAttribute('data-view'), 'notebook');
+  assert.equal(kept.getAttribute('id'), 'jl-frame');
+});
+
+test('the carried element lands where the incoming one would have gone', async () => {
+  const incomingFrame = node('iframe', { id: 'jl-frame' });
+  const wrapper = node('div', { class: 'jl-wrap' }, [incomingFrame]);
+  const { ui, half, kept } = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [node('header'), wrapper]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+  });
+
+  await ui.refreshNotebookSurface('/x');
+
+  assert.equal(kept.parentNode.getAttribute('class'), 'jl-wrap');
+  assert.equal(half.querySelectorAll('#jl-frame').length, 1, 'and there is exactly one of it');
+});
+
+// The failure is louder than a missing frame, on purpose: a swap that silently
+// dropped `#jl-frame` would leave the notebook half with no editor in it.
+test('a response missing the carried element falls back to a reload', async () => {
+  const { ui, calls } = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [node('p')]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+  });
+
+  assert.equal(await ui.refreshNotebookSurface('/x'), false);
+  assert.equal(calls.filter((c) => c.kind === 'reload').length, 1);
+});
+
+// ── refreshNotebookSurface ──────────────────────────────────────────────────
+
+test('a successful notebook swap re-mounts, so the moved frame opens the new file', async () => {
+  const incomingFrame = node('iframe', { id: 'jl-frame', 'data-file': 'new.ipynb' });
+  const h = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [incomingFrame]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+  });
+  let remounts = 0;
+  h.window.chickadeeRemountNotebook = () => { remounts += 1; };
+
+  assert.equal(await h.ui.refreshNotebookSurface('/x'), true);
+  assert.equal(remounts, 1,
+    'the frame was MOVED, not rebuilt, so nothing re-reads its new data-* without this');
+});
+
+test('a failed notebook swap does not re-mount a frame that never moved', async () => {
+  const h = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [node('p')]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+    fetchFails: true,
+  });
+  let remounts = 0;
+  h.window.chickadeeRemountNotebook = () => { remounts += 1; };
+
+  assert.equal(await h.ui.refreshNotebookSurface('/x'), false);
+  assert.equal(remounts, 0);
+  assert.equal(h.calls.filter((c) => c.kind === 'reload').length, 1);
+});
+
+test('a page with no remount hook swaps without complaint', async () => {
+  const h = load({
+    freshHalf: node('div', { class: 'wb-notebook-body' }, [node('iframe', { id: 'jl-frame' })]),
+    selector: '.wb-notebook-body',
+    keptID: 'jl-frame',
+  });
+  assert.equal(await h.ui.refreshNotebookSurface('/x'), true);
+});
+
+// ── The ChickadeeUI delegation ──────────────────────────────────────────────
+//
+// Both names survive the move on `ChickadeeUI`, so no call site changed in the
+// commit that moved the code — and one of those call sites is inplace-forms.js,
+// which base.leaf loads on EVERY page and which calls refreshEditSurface()
+// after every successful in-place save. That is why this module is loaded from
+// base.leaf beside chickadee-ui.js rather than on the two workbench pages, and
+// why the delegation has to resolve at call time in either load order.
+
+test('ChickadeeUI re-exports both refreshers, in either load order', async () => {
+  const uiSource = await fs.readFile(path.resolve('Public/chickadee-ui.js'), 'utf8');
+
+  for (const uiFirst of [true, false]) {
+    const label = uiFirst ? 'chickadee-ui.js first' : 'surface-swap.js first';
+    const h = load({ freshHalf: freshEditHalf([node('h2')]) });
+
+    // chickadee-ui.js needs a little more of a document than the swap does.
+    h.document.querySelectorAll = () => [];
+    h.document.addEventListener = () => {};
+    h.document.body.appendChild = () => {};
+    h.document.body.addEventListener = () => {};
+    h.window.JSON = JSON;
+
+    // The harness already ran surface-swap.js; running chickadee-ui.js after it
+    // covers one order, and re-running surface-swap.js afterwards covers the
+    // other (re-defining the global is exactly what a later load would do).
+    const context = h.window;
+    vm.runInContext(uiSource, vm.createContext(Object.assign(context, { self: context })));
+    if (!uiFirst) vm.runInContext(source, context);
+
+    assert.equal(typeof context.ChickadeeUI.refreshEditSurface, 'function', label);
+    assert.equal(await context.ChickadeeUI.refreshEditSurface(), true,
+      `${label}: the re-export must reach the real implementation, not a stale capture`);
+    assert.deepEqual(h.half.children.map((n) => n.tagName), ['H2'], label);
+  }
+});

--- a/changelog.d/surface-swap-extraction.md
+++ b/changelog.d/surface-swap-extraction.md
@@ -1,0 +1,38 @@
+### Changed
+
+- **The workbench surface swappers moved out of `chickadee-ui.js` into
+  `Public/surface-swap.js`** as `ChickadeeSurfaceSwap`, completing the
+  decomposition of a module that had grown to eighteen unrelated functions
+  behind one name. This is the largest of the three concerns and the one with
+  the most rules of its own: a fetch, a parse, a node-identity discipline, and
+  the only place in the frontend that deliberately turns markup into running
+  code.
+
+  No call site changes: `ChickadeeUI.refreshEditSurface` and
+  `.refreshNotebookSurface` remain the call surface and resolve at call time.
+  One of those callers is `inplace-forms.js`, which `base.leaf` loads on every
+  page and which refreshes after every successful in-place save — so unlike the
+  other two splits this one could never have been page-scoped, and it is loaded
+  from `base.leaf` beside `chickadee-ui.js`.
+
+### Added
+
+- **The pane swap has a real-enough DOM harness** — 15 tests covering two rules
+  nothing was exercising. The existing suite covers the swap's outer decisions
+  (swap vs. reload, which URL, the reload fallback); its stub reports no scripts
+  and no carried element, so both of these failed silently:
+
+  - `runInlineScripts` re-creates inline `<script>` elements, because one
+    inserted by parsing HTML does not run — a deliberate platform rule. Its
+    exclusions are now pinned: a `src=` script is left alone (re-creating it
+    would re-run the module's IIFE and double-bind every listener it installs),
+    and a JSON seed island is data, left untouched and still findable by id with
+    its type intact.
+  - `keepElement` carries the notebook frame across the swap by object identity.
+    34 closures captured that element; rebuilding it leaves every one of them on
+    a detached node while the page still looks right.
+
+  Each assertion was checked against a deliberately broken source: dropping the
+  type guard, widening the selector to include `src=`, skipping the carried-over
+  replace, dropping the scroll restore, and turning any of the three call-time
+  re-exports into an eager capture each turn exactly the expected tests red.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,8 +15,9 @@ import js from '@eslint/js';
 // short — but "short" no longer means "hang everything off ChickadeeUI",
 // which is how that module reached eighteen unrelated functions behind one
 // name.  A genuinely separate concern gets its own file and its own name
-// (ChickadeeSparkline, ChickadeeAccordion); only things that really are shared
-// low-level utilities — escaping, CSRF, fetch — belong on ChickadeeUI.
+// (ChickadeeSparkline, ChickadeeAccordion, ChickadeeSurfaceSwap); only things
+// that really are shared low-level utilities — escaping, CSRF, fetch — belong
+// on ChickadeeUI.
 const chickadeeGlobals = {
   ChickadeeUI: 'readonly',
   ChickadeeInputsCore: 'readonly',
@@ -28,6 +29,10 @@ const chickadeeGlobals = {
   // achievements tables expand, split out of chickadee-ui.js: a widget with its
   // own DOM contract is not the same kind of thing as escaping a string.
   ChickadeeAccordion: 'readonly',
+  // Public/surface-swap.js — re-renders half of the merged workbench in place.
+  // Reached through ChickadeeUI's re-exports, so it is declared here for the
+  // one file that names it.
+  ChickadeeSurfaceSwap: 'readonly',
   // Public/authoring-language.js — the assignment's language facts, read by
   // every authoring editor.
   ChickadeeLanguage: 'readonly',


### PR DESCRIPTION
Last of three slices decomposing `Public/chickadee-ui.js` (after #1428 and #1429).

## What moves

`swapHalf`, `refreshEditSurface`, `refreshNotebookSurface` and the internal `runInlineScripts` → `Public/surface-swap.js` as `ChickadeeSurfaceSwap`. It is the largest of the three concerns and the one with the most rules of its own: a fetch, a parse, a node-identity discipline, and the only place in the frontend that deliberately turns markup into running code.

**No call site changes.** `ChickadeeUI.refreshEditSurface` and `.refreshNotebookSurface` remain the call surface, resolved at call time.

This is the one slice that could never have been scoped to the pages that use it: `inplace-forms.js` calls `refreshEditSurface()` after every successful in-place save, and `base.leaf` loads *it* on every page. So the new file loads from `base.leaf` beside `chickadee-ui.js`.

## The harness this finally allows

The existing suite covers the swap's outer decisions — swap vs. reload, which URL, scroll, the reload fallback. Its DOM stub reports no scripts and no carried element, so two rules had no coverage at all, and both fail silently:

- **`runInlineScripts`** re-creates inline `<script>` elements, because one inserted by parsing HTML does not run — a deliberate platform rule. Its exclusions are now pinned: a `src=` script is left alone (re-creating it would re-run the module's IIFE and double-bind every listener it installs), and a JSON seed island is *data* — left untouched and still findable by id with its `type` intact.
- **`keepElement`** carries `#jl-frame` across the swap by object identity. 34 closures in `notebook.js` captured that element; rebuilding it leaves every one of them on a detached node while the page still *looks* right — the notebook renders, and nothing it does afterwards works.

The tests use nodes with real identity and a fragment that actually moves its children, since identity is the subject and a stub returning fresh objects would make the file vacuous.

## Every assertion was checked against a broken source

Dropping the `type` guard, widening the selector to include `src=`, skipping the carried-element `replaceChild`, dropping the scroll restore, and turning a call-time re-export into an eager capture each turn **exactly** the expected tests red. The scroll assertion was vacuous on the first pass — the stub didn't model an emptied element's clamp to zero — so the stub was fixed, not the assertion.

## Where the module ends up

```
chickadee-ui.js   701 → 409     escaping, CSRF, status line, confirm dialog,
                                error extraction, fetchJSON, notifyWorkbench,
                                checkUWDates — plus three delegating re-exports
sparkline.js           83
accordion-row.js      162
surface-swap.js       213
```

## Verification

`node --test Tests/BrowserRunnerJSTests/*.mjs` (543 tests, 0 fail), `scripts/eslint.sh`, `scripts/check-styles.sh`, and the render suite (243 tests / 45 suites) since `base.leaf` changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_