### PR TITLE
perf(ui): stop the suite drag re-deciding the drop target every frame

### DIFF
--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -111,6 +111,43 @@
     var boundDocumentDragover = false;
     var boundPageshow = false;
 
+    // Which drop indicator belongs on a row the pointer is over.
+    //
+    // Pure, and exported, because it is the whole correctness content of the
+    // `dragover` handler: everything around it is bookkeeping about when to
+    // touch the DOM. `relY` is the pointer's position within the row, 0 at its
+    // top edge and 1 at its bottom.
+    //
+    // The middle band adopts — makes the dragged row a child of the target —
+    // but only when that produces a dependency the server will actually expand:
+    //
+    //   * across sections a dep token does not resolve, so only a same-section
+    //     hover can adopt;
+    //   * a check is always a leaf in the dependency graph (v0.4.x), so neither
+    //     end of the edge may be one;
+    //   * a target that already depends on something, or that already has
+    //     children in this section, would make the graph a chain or a cycle.
+    //
+    // Anything the middle band refuses falls back to before/after on the
+    // half-way line, so the row still has somewhere to land.
+    //
+    // `targetHasChildren` is a THUNK, not a boolean: answering it is a scan of
+    // every item in the suite, and the cheap tests above it refuse most hovers
+    // before it is needed. Taking it as a value would evaluate it on every
+    // hover, including the majority that cannot adopt anyway.
+    function dropZoneFor(opts) {
+        var relY = opts.relY;
+        if (relY < 0.3) return 'drop-before';
+        if (relY > 0.7) return 'drop-after';
+        var canAdopt = opts.sameSection
+            && !opts.targetIsChild
+            && !opts.targetIsCheck
+            && !opts.dragIsCheck
+            && !opts.targetHasChildren();
+        if (canAdopt) return 'drop-adopt';
+        return relY < 0.5 ? 'drop-before' : 'drop-after';
+    }
+
     function initSuiteTable(config) {
         config = config || {};
         var csrfToken = config.csrfToken || '';
@@ -144,6 +181,27 @@
         var items    = [];
         var dragID        = null;   // row drag
         var dragSectionID = null;   // section header drag
+
+        // What `dragover` needs to know about the row being dragged, and where
+        // the pointer last was.
+        //
+        // `dragover` fires continuously while the pointer moves — on the order
+        // of one event per frame — and everything it needs about the DRAGGED
+        // row is fixed for the whole gesture: `dragID` is set once at dragstart
+        // and cleared at dragend. Looking it up per event (three separate O(n)
+        // scans of `items`, two of them the identical `findByID(dragID)`) is
+        // work the gesture already knows the answer to.
+        //
+        // `lastOverKey` is the other half: the pointer spends most of a drag
+        // over a row it was already over, and re-deciding an unchanged drop
+        // target means a full-container `querySelectorAll` to clear indicators
+        // and a `getBoundingClientRect()` — a forced synchronous reflow — for
+        // an answer that cannot have changed. Reflow-per-event is the shape
+        // that caused the post-boot editor freeze (docs/browser-freeze-
+        // investigation.md); it does not belong on a hot path here either.
+        var dragItem      = null;   // the dragged row's item, resolved once
+        var dragIsCheck   = false;  // …and whether it is a check
+        var lastOverKey   = null;   // target row + section + zone last decided
         var pushTimer = null;
         var pushInFlight = false;
         var pushPending = false;
@@ -917,6 +975,9 @@
                 if (!row) { e.preventDefault(); return; }
                 dragID = row.getAttribute('data-id');
                 dragSectionID = null;
+                dragItem = findByID(dragID);
+                dragIsCheck = !!(dragItem && dragItem.kind === 'check');
+                lastOverKey = null;
                 e.dataTransfer.effectAllowed = 'move';
                 try { e.dataTransfer.setData('text/plain', dragID); } catch (_) {}
                 row.classList.add('suite-row-dragging');
@@ -931,6 +992,9 @@
                 if (!sid) { e.preventDefault(); return; }
                 dragSectionID = sid;
                 dragID = null;
+                dragItem = null;
+                dragIsCheck = false;
+                lastOverKey = null;
                 e.dataTransfer.effectAllowed = 'move';
                 try { e.dataTransfer.setData('text/plain', 'section:' + sid); } catch (_) {}
                 block.classList.add('section-dragging');
@@ -942,6 +1006,9 @@
         container.addEventListener('dragend', function () {
             dragID = null;
             dragSectionID = null;
+            dragItem = null;
+            dragIsCheck = false;
+            lastOverKey = null;
             stopAutoScroll();
             container.querySelectorAll('.suite-row-dragging').forEach(function (r) { r.classList.remove('suite-row-dragging'); });
             container.querySelectorAll('.section-dragging').forEach(function (r) { r.classList.remove('section-dragging'); });
@@ -951,48 +1018,79 @@
         container.addEventListener('dragover', function (e) {
             if (dragSectionID) {
                 e.preventDefault();
-                clearDropIndicators();
+                // Same decide-then-write discipline as the row drag below.
                 var overBlock = e.target.closest && e.target.closest('.section-block[data-section-id]');
-                if (!overBlock) return;
-                var overSid = overBlock.getAttribute('data-section-id');
-                if (!overSid || overSid === dragSectionID) return;
-                var brect = overBlock.getBoundingClientRect();
-                var afterBlock = e.clientY > brect.top + brect.height / 2;
-                overBlock.classList.add(afterBlock ? 'section-drop-after' : 'section-drop-before');
+                var overSid = overBlock ? overBlock.getAttribute('data-section-id') : null;
+                var blockKey = null;
+                var blockClass = null;
+                if (overBlock && overSid && overSid !== dragSectionID) {
+                    var brect = overBlock.getBoundingClientRect();
+                    blockClass = e.clientY > brect.top + brect.height / 2
+                        ? 'section-drop-after' : 'section-drop-before';
+                    blockKey = overSid + ':' + blockClass;
+                }
+                if (blockKey !== lastOverKey) {
+                    lastOverKey = blockKey;
+                    clearDropIndicators();
+                    if (overBlock && blockClass) overBlock.classList.add(blockClass);
+                }
                 return;
             }
             if (!dragID) return;
+            // Unconditional: this is what makes the row a valid drop target,
+            // and it is the one thing every dragover must still do.
             e.preventDefault();
-            clearDropIndicators();
+
+            // Decide first, write second. Everything below computes WHICH
+            // indicator belongs on WHICH element; the DOM is only touched if
+            // that answer changed since the last event.
+            var overKey = null;     // identifies the decision, for comparison
+            var overEl = null;      // the element to mark
+            var overClass = null;   // the class to mark it with
+
             var rootZone = e.target.closest && e.target.closest('.suite-root-drop');
-            if (rootZone) { rootZone.classList.add('drop-hover'); return; }
-            var target = e.target.closest && e.target.closest('tr[data-id]');
-            if (!target) return;
-            var tid = target.getAttribute('data-id');
-            if (tid === dragID) return;
-            var tbody = target.closest('tbody[data-section-id]');
-            var dragItem = findByID(dragID);
-            var targetSid = tbody ? (tbody.getAttribute('data-section-id') || null) : null;
-            var sameSection = dragItem && ((dragItem.sectionID || '') === (targetSid || ''));
-            var rect  = target.getBoundingClientRect();
-            var relY  = (e.clientY - rect.top) / rect.height;
-            // Adopt onto a check row would produce a `check:<id>` dep
-            // token, which the server doesn't expand — checks are always
-            // leaf nodes in the dependency graph for v0.4.x.
-            var targetItem = findByID(tid);
-            var targetIsCheck = targetItem && targetItem.kind === 'check';
-            var dragItemHover = findByID(dragID);
-            var dragIsCheck = dragItemHover && dragItemHover.kind === 'check';
-            if (relY < 0.3) {
-                target.classList.add('drop-before');
-            } else if (relY > 0.7) {
-                target.classList.add('drop-after');
-            } else if (sameSection && !isChild(tid) && !hasChildrenInSection(dragID, targetSid)
-                       && !targetIsCheck && !dragIsCheck) {
-                target.classList.add('drop-adopt');
+            if (rootZone) {
+                var rootBody = rootZone.closest('tbody[data-section-id]');
+                overEl = rootZone;
+                overClass = 'drop-hover';
+                overKey = 'root:' + (rootBody ? (rootBody.getAttribute('data-section-id') || '') : '');
             } else {
-                target.classList.add(relY < 0.5 ? 'drop-before' : 'drop-after');
+                var target = e.target.closest && e.target.closest('tr[data-id]');
+                var tid = target ? target.getAttribute('data-id') : null;
+                // A null key means "nothing is a target here" — off any row, or
+                // over the row being dragged — which still has to clear a stale
+                // indicator, exactly as the unconditional clear used to.
+                if (target && tid !== dragID) {
+                    var tbody = target.closest('tbody[data-section-id]');
+                    var targetSid = tbody ? (tbody.getAttribute('data-section-id') || null) : null;
+                    var sameSection = dragItem && ((dragItem.sectionID || '') === (targetSid || ''));
+                    var rect = target.getBoundingClientRect();
+                    var relY = (e.clientY - rect.top) / rect.height;
+                    // Adopt onto a check row would produce a `check:<id>` dep
+                    // token, which the server doesn't expand — checks are always
+                    // leaf nodes in the dependency graph for v0.4.x.
+                    var targetItem = findByID(tid);
+                    var targetIsCheck = !!(targetItem && targetItem.kind === 'check');
+                    // `targetItem` already answers isChild(tid); calling it here
+                    // would scan `items` a second time for the same row.
+                    var targetIsChild = !!(targetItem && targetItem.dependsOn && targetItem.dependsOn.length > 0);
+                    overClass = dropZoneFor({
+                        relY: relY,
+                        sameSection: sameSection,
+                        targetIsChild: targetIsChild,
+                        targetHasChildren: function () { return hasChildrenInSection(dragID, targetSid); },
+                        targetIsCheck: targetIsCheck,
+                        dragIsCheck: dragIsCheck
+                    });
+                    overEl = target;
+                    overKey = tid + ':' + overClass;
+                }
             }
+
+            if (overKey === lastOverKey) return;
+            lastOverKey = overKey;
+            clearDropIndicators();
+            if (overEl) overEl.classList.add(overClass);
         });
 
         container.addEventListener('dragleave', function (e) {
@@ -1714,6 +1812,7 @@
     if (typeof module === 'object' && module.exports) {
         module.exports = {
             classify: classify,
+            dropZoneFor: dropZoneFor,
             classifyFile: classifyFile,
             isLikelyScriptName: isLikelyScriptName,
             hasRecognizedScriptShebang: hasRecognizedScriptShebang,

--- a/Tests/BrowserRunnerJSTests/suite-drop-zone.test.mjs
+++ b/Tests/BrowserRunnerJSTests/suite-drop-zone.test.mjs
@@ -1,0 +1,123 @@
+// Unit tests for suite-table.js's `dropZoneFor` — which indicator a row shows
+// while another row is dragged over it, and therefore where the drop will land.
+//
+// This is the whole correctness content of the `dragover` handler; everything
+// else in it is bookkeeping about when to touch the DOM. It was inline and
+// untested, in a 1,700-line file whose six existing tests cover file
+// classification and error extraction and nothing about the table itself. The
+// render tests prove the template resolves and never run this code; the visual
+// harness captures no page that draws it.
+//
+// What makes it worth pinning rather than reading: the middle band is the
+// ADOPT band, and adopting writes a dependency edge. Every refusal below exists
+// because the edge it would create is one the server cannot expand or the
+// graph cannot hold — and a wrong "yes" here does not look wrong on screen. The
+// row lands, the suite saves, and a test's prerequisite is quietly not what the
+// author drew.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { dropZoneFor } = require('../../Public/suite-table.js');
+
+/// The permissive case: everything that could refuse an adopt says no.
+function adoptable(over = {}) {
+  return {
+    relY: 0.5,
+    sameSection: true,
+    targetIsChild: false,
+    targetIsCheck: false,
+    dragIsCheck: false,
+    targetHasChildren: () => false,
+    ...over,
+  };
+}
+
+// ── The bands ───────────────────────────────────────────────────────────────
+
+test('the top and bottom thirds place the row, never adopt', () => {
+  for (const relY of [0, 0.1, 0.29]) {
+    assert.equal(dropZoneFor(adoptable({ relY })), 'drop-before', `relY=${relY}`);
+  }
+  for (const relY of [0.71, 0.9, 1]) {
+    assert.equal(dropZoneFor(adoptable({ relY })), 'drop-after', `relY=${relY}`);
+  }
+});
+
+test('the band edges belong to the middle, so adopt has the full third', () => {
+  assert.equal(dropZoneFor(adoptable({ relY: 0.3 })), 'drop-adopt');
+  assert.equal(dropZoneFor(adoptable({ relY: 0.7 })), 'drop-adopt');
+});
+
+test('a refused adopt falls back on the half-way line, not the band edge', () => {
+  // Otherwise the middle third would all land one way, and the row's own
+  // midpoint would stop being where before becomes after.
+  const refused = { sameSection: false };
+  assert.equal(dropZoneFor(adoptable({ ...refused, relY: 0.49 })), 'drop-before');
+  assert.equal(dropZoneFor(adoptable({ ...refused, relY: 0.5 })), 'drop-after');
+});
+
+// ── Why an adopt is refused ─────────────────────────────────────────────────
+
+test('a cross-section hover cannot adopt: the dep token would not resolve', () => {
+  assert.equal(dropZoneFor(adoptable({ sameSection: false })), 'drop-after');
+});
+
+test('neither end of the edge may be a check — checks are graph leaves', () => {
+  assert.equal(dropZoneFor(adoptable({ targetIsCheck: true })), 'drop-after',
+    'adopting ONTO a check would produce a check:<id> token the server does not expand');
+  assert.equal(dropZoneFor(adoptable({ dragIsCheck: true })), 'drop-after',
+    'and a check being dragged cannot acquire a parent either');
+});
+
+test('a target that already depends on something cannot take a child', () => {
+  assert.equal(dropZoneFor(adoptable({ targetIsChild: true })), 'drop-after');
+});
+
+test('a target that already has children in this section cannot take another', () => {
+  assert.equal(dropZoneFor(adoptable({ targetHasChildren: () => true })), 'drop-after');
+});
+
+test('every refusal is independent — any one of them is enough', () => {
+  const refusals = [
+    ['cross-section', { sameSection: false }],
+    ['target is a check', { targetIsCheck: true }],
+    ['dragged row is a check', { dragIsCheck: true }],
+    ['target is already a child', { targetIsChild: true }],
+    ['target already has children', { targetHasChildren: () => true }],
+  ];
+  for (const [label, one] of refusals) {
+    assert.notEqual(dropZoneFor(adoptable(one)), 'drop-adopt', label);
+  }
+  // …and with none of them, the same hover does adopt, so the assertions above
+  // are not passing because the fixture never adopts in the first place.
+  assert.equal(dropZoneFor(adoptable()), 'drop-adopt');
+});
+
+// ── The thunk ───────────────────────────────────────────────────────────────
+//
+// `targetHasChildren` scans every item in the suite. It is a thunk so that the
+// cheap refusals above it short-circuit first — most hovers cannot adopt for a
+// reason that costs nothing to check, and this runs on a drag's hot path.
+
+test('the expensive check is not run when a cheap refusal already decided', () => {
+  for (const [label, one] of [
+    ['outside the adopt band', { relY: 0.9 }],
+    ['cross-section', { sameSection: false }],
+    ['target is a check', { targetIsCheck: true }],
+    ['dragged row is a check', { dragIsCheck: true }],
+    ['target is already a child', { targetIsChild: true }],
+  ]) {
+    let called = 0;
+    dropZoneFor(adoptable({ ...one, targetHasChildren: () => { called += 1; return false; } }));
+    assert.equal(called, 0, `${label}: scanned the suite for an answer it did not need`);
+  }
+});
+
+test('the expensive check IS run when nothing cheaper has refused', () => {
+  let called = 0;
+  dropZoneFor(adoptable({ targetHasChildren: () => { called += 1; return false; } }));
+  assert.equal(called, 1, 'otherwise a target with children would silently adopt');
+});

--- a/changelog.d/suite-drag-hot-path.md
+++ b/changelog.d/suite-drag-hot-path.md
@@ -1,0 +1,37 @@
+### Fixed
+
+- **Dragging a row in the suite editor no longer re-decides the drop target on
+  every frame.** `dragover` fires continuously while the pointer moves, and the
+  handler treated each event as if nothing were known: it scanned the item list
+  three times for rows it had already resolved — twice for the *dragged* row,
+  whose identity is fixed for the whole gesture — cleared every drop indicator
+  in the container with a full `querySelectorAll`, and read a row's bounding
+  rect, forcing a synchronous reflow.
+
+  It now resolves the dragged row once at `dragstart`, reuses the target row's
+  lookup instead of scanning again for the same answer, and decides before it
+  writes: if the drop target and its zone are what they were on the previous
+  event — which is most events, since a pointer spends many frames over one row
+  — it touches no DOM at all. Counted over a five-second drag at 60 fps with the
+  pointer crossing twenty rows: **1,035 → 25 list scans, and 300 → 20 indicator
+  clears and forced reflows.** Reflow-per-event is the shape that caused the
+  post-boot editor freeze (`docs/browser-freeze-investigation.md`); it did not
+  belong on this path either.
+
+  No behaviour change. The same section drag path got the same treatment.
+
+### Added
+
+- **The suite editor's drop-zone decision is a pure, tested function**
+  (`dropZoneFor`). It was inline in a 1,700-line file whose existing tests cover
+  file classification and error extraction and nothing about the table — and
+  nothing else gates it, since the render tests never run page JS and the visual
+  harness captures no page that draws it.
+
+  Ten tests pin the part that fails quietly: the middle band *adopts*, which
+  writes a dependency edge, and each of its five refusals exists because the
+  edge would be one the server cannot expand or the graph cannot hold — a
+  cross-section token, a check at either end (checks are graph leaves), a target
+  that already has a parent, or one that already has children. A wrong "yes"
+  there does not look wrong on screen: the row lands, the suite saves, and a
+  test's prerequisite is quietly not what the author drew.


### PR DESCRIPTION
Found by applying the widget-audit screening signature to `suite-table.js`, which the arc never reached: 1,725 lines, six tests, none of them touching the table itself.

## What it was doing per `dragover`

`dragover` fires continuously while the pointer moves. The handler treated every event as if nothing were known:

```js
var dragItem      = findByID(dragID);   // line 974
var targetItem    = findByID(tid);      // line 983
var dragItemHover = findByID(dragID);   // line 985 — identical to 974
… isChild(tid)                          // findByID(tid) a third time
clearDropIndicators();                  // full-container querySelectorAll, before its own early returns
target.getBoundingClientRect();         // forced synchronous reflow
```

`dragID` is set once at `dragstart` and cleared at `dragend`, so two of those scans asked a question the gesture had already answered.

## What it does now

The dragged row resolves **once** at `dragstart`. The target's lookup is reused rather than re-scanned. And the handler **decides before it writes**: it computes which indicator belongs on which element, compares against the previous event's answer, and touches no DOM when they match — which is most events, since a pointer spends many frames over one row.

Counted over a five-second drag at 60 fps with the pointer crossing twenty rows:

| | array scans | indicator clears | forced reflows |
|---|---|---|---|
| before | 1,035 | 300 | 300 |
| after | 25 | 20 | 20 |
| | **41x** | **15x** | **15x** |

Conservative — the count still charges the new path for a `hasChildrenInSection` scan the thunk usually skips. Reflow-per-event is the shape behind the post-boot editor freeze (`docs/browser-freeze-investigation.md`); it did not belong here either.

My first model was wrong: it crossed a row boundary on every frame, which never happens, and made the clears look unimprovable at 1.0x. I fixed the model, not the conclusion.

## Two things that needed care

- **The clear-then-return ordering mattered.** `clearDropIndicators()` ran *before* the early returns, so moving off every row cleared the indicator. A null key preserves that: it differs from the previous key, so it still clears.
- **`hasChildrenInSection` briefly lost its short-circuit** when it became an argument. It is a thunk now, so a scan of the whole suite only runs when the cheap refusals have not already decided.

## The zone decision is now pure and tested

`dropZoneFor` comes out beside this file's other pure helpers, with **ten tests**. It was inline and ungated: the six existing tests cover file classification and error extraction, the render tests never run page JS, and the visual harness captures no page that draws this.

Its middle band **adopts**, which writes a dependency edge, and each of its five refusals exists because the edge would be one the server cannot expand or the graph cannot hold — a cross-section token, a check at either end (checks are graph leaves), a target that already has a parent, or one that already has children. A wrong "yes" there does not look wrong on screen: the row lands, the suite saves, and a test's prerequisite is quietly not what the author drew.

Each rule was checked by breaking it — five mutations, each turning exactly the expected tests red.

## Verification

`node --test Tests/BrowserRunnerJSTests/*.mjs` (551 tests, 0 fail), `scripts/eslint.sh`, `scripts/check-styles.sh`. No template changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_