### PR TITLE
fix(core): stop zip subprocesses reading the global environ at spawn

### DIFF
--- a/Sources/Core/ZipArchiver.swift
+++ b/Sources/Core/ZipArchiver.swift
@@ -140,7 +140,7 @@ private func runZipProcess(
         // terminationHandler runs on Foundation's queue and resumes the
         // continuation independently.
         acquireZipProcessLock()
-        let proc = Process()
+        let proc = makeZipProcess()
         proc.executableURL = URL(fileURLWithPath: executablePath)
         proc.arguments = arguments
         if let dir = workingDirectory {

--- a/Sources/Core/ZipProcessSerialization.swift
+++ b/Sources/Core/ZipProcessSerialization.swift
@@ -71,6 +71,47 @@ public func acquireZipProcessLock() {
     zipProcessLock.lock()
 }
 
+/// The parent environment, read **once** for the lifetime of the process.
+///
+/// `Process.run()` with a nil `environment` does not inherit for free: it
+/// reads the global environ itself, at spawn time. That makes every zip spawn
+/// an unsynchronized *reader* of a structure `setenv`/`unsetenv` reallocates
+/// underneath it — and this codebase has writers, since several test suites
+/// mutate environment variables and Swift Testing runs them concurrently with
+/// everything else.
+///
+/// It is the same race the EFAULT retry above exists for, in the half that
+/// retry cannot reach. When the kernel notices the bad address, `run()` throws
+/// EFAULT and the retry absorbs it. When the read instead walks a reallocated
+/// environ in user space, the process takes a SIGSEGV and there is nothing to
+/// catch — observed on `api-tests` as `Bad pointer dereference at 0x210`, the
+/// crashing thread showing `_ProcessInfo.environment.getter` under
+/// `Process.run()`.
+///
+/// `withAsyncEnvLock` cannot help either, for a related reason: its contract
+/// asks every reader to take the lock, and a zip spawn is an **undeclared**
+/// reader — the read happens inside Foundation, not in any helper anyone
+/// thought to wrap.
+///
+/// A snapshot does not remove the read, it removes the *repetition*: one read
+/// per process instead of one per spawn. The contents are exactly what these
+/// spawns inherited before, so nothing about their behaviour changes — and
+/// nothing on this path consults the environment anyway, since the children
+/// are `zip` and `unzip`.
+private let zipProcessEnvironment: [String: String] = ProcessInfo.processInfo.environment
+
+/// A `Process` for a zip/unzip spawn, with its environment already set.
+///
+/// Always construct zip subprocesses through this rather than `Process()`.
+/// A bare one has a nil `environment` and so opts back into the implicit
+/// read above — silently, with every existing test still green, which is
+/// why `ZipProcessEnvironmentTests` fails on one.
+public func makeZipProcess() -> Process {
+    let process = Process()
+    process.environment = zipProcessEnvironment
+    return process
+}
+
 /// Pair with `acquireZipProcessLock()`.
 public func releaseZipProcessLock() {
     zipProcessLock.unlock()
@@ -114,7 +155,7 @@ public func runZipProcessCapturingStdout(
     workingDirectory: URL? = nil
 ) throws -> ZipProcessResult {
     let (process, stdoutPipe) = try withZipProcessLock { () throws -> (Process, Pipe) in
-        let process = Process()
+        let process = makeZipProcess()
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
         if let workingDirectory {

--- a/Tests/CoreTests/ZipProcessEnvironmentTests.swift
+++ b/Tests/CoreTests/ZipProcessEnvironmentTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import Core
+
+/// Guards the environment snapshot that keeps zip subprocesses from reading the
+/// global environ at spawn time.
+///
+/// The failure this prevents is not a test failure — it is a SIGSEGV. A
+/// `Process` with a nil `environment` reads the global environ itself when it
+/// spawns, racing `setenv`/`unsetenv` from the suites that mutate environment
+/// variables. When the kernel notices the bad address the EFAULT retry absorbs
+/// it; when the read walks a reallocated environ in user space, the process
+/// dies mid-run and there is nothing to catch.
+///
+/// That makes this exactly the kind of regression a normal test cannot see: a
+/// new bare `Process()` on the zip path would opt back into the crash with every
+/// other test still green, and the crash it opts into is rare and lands on
+/// whichever unrelated pull request happens to be running.
+@Suite("Zip process environment")
+struct ZipProcessEnvironmentTests {
+
+    /// The property the factory exists to supply, pinned as a property of
+    /// Foundation rather than assumed.
+    ///
+    /// Without this, every assertion below would still pass if Foundation
+    /// started defaulting `environment` to the parent's — and the factory would
+    /// be guarding something that no longer needed guarding, with no way to
+    /// tell.
+    @Test("a bare Process really does start with no environment")
+    func bareProcessHasNilEnvironment() {
+        #expect(Process().environment == nil)
+    }
+
+    @Test("the factory hands back a Process that will not read environ at spawn")
+    func factorySetsEnvironment() throws {
+        let env = try #require(makeZipProcess().environment)
+        #expect(!env.isEmpty, "an empty snapshot would change what the child inherits")
+    }
+
+    /// Snapshot, not re-read: the point is one read per process rather than one
+    /// per spawn, so two calls must hand back the same contents.
+    @Test("the snapshot is taken once, not per call")
+    func snapshotIsStable() throws {
+        let first = try #require(makeZipProcess().environment)
+        let second = try #require(makeZipProcess().environment)
+        #expect(first == second)
+    }
+
+    /// The contents are whatever these spawns inherited before, so nothing about
+    /// their behaviour changes — only the number of racy reads.
+    @Test("the snapshot is the parent environment, not a substitute for it")
+    func snapshotMatchesParent() throws {
+        let env = try #require(makeZipProcess().environment)
+        let parent = ProcessInfo.processInfo.environment
+        // PATH is the one every spawn here actually depends on.
+        #expect(env["PATH"] == parent["PATH"])
+    }
+
+    /// The drift guard.
+    ///
+    /// Two exemptions, both of which this guard needed in order to stop
+    /// matching itself:
+    ///
+    ///   * a match preceded by an identifier character is part of a longer name
+    ///     (`makeZipProcess`, `runZipProcess`), not a construction;
+    ///   * the factory's own BODY holds the one legitimate construction —
+    ///     exempting its signature line is not enough, since the construction is
+    ///     on the next one.
+    ///
+    /// Comment lines are skipped for the same reason: prose describing a
+    /// forbidden construction is not one, and a scanner that cannot tell the
+    /// difference is how #1266's Leaf finding went wrong.
+    @Test("no zip source constructs a Process directly")
+    func zipSourcesUseTheFactory() throws {
+        let sources = ["Sources/Core/ZipArchiver.swift", "Sources/Core/ZipProcessSerialization.swift"]
+        // The factory's own body holds the one legitimate construction, so it
+        // is exempt — but only its body. Matching the signature LINE is not
+        // enough: the construction is on the next one, which is how the first
+        // version of this guard failed, correctly, against itself.
+        let factorySignature = "public func makeZipProcess() -> Process {"
+        var insideFactory = false
+
+        for relative in sources {
+            let url = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // CoreTests
+                .deletingLastPathComponent()  // Tests
+                .deletingLastPathComponent()  // repo root
+                .appendingPathComponent(relative)
+            let text = try String(contentsOf: url, encoding: .utf8)
+
+            var offending: [Int] = []
+            for (index, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+                if line.contains(factorySignature) {
+                    insideFactory = true
+                } else if insideFactory && line == "}" {
+                    insideFactory = false
+                }
+                guard let range = line.range(of: "Process(") else { continue }
+                // Preceded by an identifier character → part of a longer name
+                // (makeZipProcess, runZipProcess…), not a construction.
+                if range.lowerBound > line.startIndex {
+                    let before = line[line.index(before: range.lowerBound)]
+                    if before.isLetter || before.isNumber || before == "_" { continue }
+                }
+                // Comments describe the rule; they do not break it. Naming the
+                // forbidden construction in prose is how a scanner that cannot
+                // tell markup from prose about markup gets it wrong (#1266).
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("//") || trimmed.hasPrefix("///") { continue }
+                if insideFactory { continue }
+                offending.append(index + 1)
+            }
+
+            #expect(
+                offending.isEmpty,
+                """
+                \(relative) constructs a Process directly at line(s) \(offending). \
+                Use makeZipProcess(): a bare Process has a nil environment, which \
+                makes the spawn read the global environ and race setenv.
+                """)
+        }
+    }
+}

--- a/changelog.d/zip-process-environ-race.md
+++ b/changelog.d/zip-process-environ-race.md
@@ -1,0 +1,36 @@
+### Fixed
+
+- **Zip subprocesses no longer read the global environ at spawn time**, closing
+  a race that killed CI runs with a SIGSEGV rather than a test failure.
+
+  `Process.run()` with a nil `environment` does not inherit for free: it reads
+  the global environ itself. Neither zip spawn set one, so both were
+  unsynchronized *readers* of a structure `setenv`/`unsetenv` reallocates —
+  and several test suites mutate environment variables while Swift Testing runs
+  everything else concurrently.
+
+  This is the race `ZipProcessSerialization.swift` already existed for, in the
+  half its retry cannot reach. When the kernel notices the bad address, `run()`
+  throws EFAULT and the retry absorbs it; when the read instead walks a
+  reallocated environ in user space, the process dies mid-run. `withAsyncEnvLock`
+  could not help either: its contract asks every reader to take the lock, and a
+  zip spawn is an **undeclared** reader — the read happens inside Foundation,
+  not in any helper anyone thought to wrap.
+
+  Both spawns now come from `makeZipProcess()`, which supplies an environment
+  snapshot taken once per process. The contents are exactly what these spawns
+  inherited before — the children are `zip` and `unzip`, which consult no
+  environment — so only the number of racy reads changes, from one per spawn to
+  one per process.
+
+  Scope is deliberately the zip paths. Three other Foundation `Process` sites
+  construct bare (`MimeTypeDetector`, `RunnerProfileDetector` ×2) and have the
+  same exposure in principle. Broadening looks free and is not: a snapshot taken
+  at process start does not reflect a later `setenv`, so any spawn whose child is
+  meant to observe a mutated variable would break silently. The zip children
+  consult none, which is what makes them safe to convert.
+
+  `ZipProcessEnvironmentTests` guards it, including a control that pins "a bare
+  `Process` really does start with a nil environment" — without which the guard
+  could be protecting a property Foundation had started supplying anyway, with
+  no way to tell.


### PR DESCRIPTION
Supersedes #1316, whose diagnosis this keeps and whose code no longer matches the tree. **The bug is still live on `main`.**

## The bug

`Process.run()` with a nil `environment` does not inherit for free — it reads the global environ *itself*, at spawn time. Neither zip spawn sets one, so both are unsynchronized **readers** of a structure `setenv`/`unsetenv` reallocates, racing the suites that mutate environment variables under Swift Testing's concurrency.

This is the race `ZipProcessSerialization.swift` was already written for, in the half its retry cannot reach:

- kernel notices the bad address → `run()` throws EFAULT → the retry absorbs it;
- the read walks a reallocated environ in user space → **SIGSEGV**, and there is nothing to catch.

`withAsyncEnvLock` cannot help either, for a related reason: its contract asks every reader to take the lock, and a zip spawn is an **undeclared** reader — the read happens inside Foundation, not in any helper anyone thought to wrap.

## The fix

Both spawns come from `makeZipProcess()`, which supplies a snapshot taken once per process. Contents are exactly what these spawns inherited before, so nothing about their behaviour changes; only the number of racy reads does — one per process instead of one per spawn.

## Scope, deliberately narrow

Three other bare `Process()` sites exist (`MimeTypeDetector`, `RunnerProfileDetector` ×2) with the same exposure in principle. Broadening looks free and is not: **a snapshot taken at process start does not reflect a later `setenv`**, so any spawn whose child is meant to observe a mutated variable would break silently. The zip children are `zip` and `unzip` and consult no environment, which is what makes them safe to convert.

## Why re-implemented rather than rebased

#1316 is 146 commits behind, and this shallow clone has no common ancestor with it. More to the point, it patches **seven** call sites across `ZipArchiver`, `TestSetupZipHelpers` and `NotebookContentHelpers` — the latter two no longer spawn anything, having consolidated into these two. Most of that diff would conflict against code that has since been restructured. ~15 lines of source against a 16-file resolution.

## The guard, and how it failed first

`ZipProcessEnvironmentTests` fails on a new bare construction, which would otherwise opt back into the crash with every other test still green.

**Its first version failed against itself** — the exemption matched the factory's *signature* line, but the construction is on the next one, so it flagged `makeZipProcess` for doing exactly what it exists to do. That is the same class of mistake as the #1266 Leaf finding cited three lines above it: a scanner that cannot tell a construction from a description of one. It now tracks the factory's body, and skips comment lines for the same reason.

Verified to bite in both directions, and re-verified after `swift-format` reflowed it:

```
✔ a bare Process really does start with no environment      ← the control
✔ the factory hands back a Process that will not read environ at spawn
✔ the snapshot is taken once, not per call
✔ the snapshot is the parent environment, not a substitute for it
✔ no zip source constructs a Process directly               ← fails on a revert,
                                                              naming ZipArchiver.swift:143
```

The control matters more than it looks: without it the suite would keep passing if Foundation ever started defaulting `environment` to the parent's, and the factory would be guarding a property nobody needed, with no way to notice.

## What this does NOT prove

A green run does not show the crash is fixed. It was observed once, and a race not firing is indistinguishable from a race removed. The argument is **structural** — the implicit per-spawn read is gone from both paths — not statistical.

## Verification

`swift test --filter ZipProcess`, `scripts/lint.sh`, `scripts/swiftlint.sh` (0 violations, 1021 files).

---
_Generated by [Claude Code](https://claude.ai/code/session_013sPtFJsfPyAeY6iMJMzVoB)_