### PR TITLE
feat(ui): mark a per-student dataset from the Files panel

### DIFF
--- a/Public/assignment-edit-page.js
+++ b/Public/assignment-edit-page.js
@@ -161,6 +161,9 @@
         deleteURL: function (name) {
             return '/instructor/' + encodeURIComponent(assignmentID) + '/scripts/' + encodeURIComponent(name);
         },
+        datasetsURL: function () {
+            return '/instructor/' + encodeURIComponent(assignmentID) + '/datasets';
+        },
         onChange: function () { ChickadeeSurfaceSwap.refreshEditSurface(); }
     });
 

--- a/Public/assignment-new-page.js
+++ b/Public/assignment-new-page.js
@@ -117,6 +117,9 @@
                 return '/instructor/new/draft/scripts/' + encodeURIComponent(name)
                      + '?draftID=' + encodeURIComponent(draftID);
             },
+            datasetsURL: function () {
+                return '/instructor/new/draft/datasets?draftID=' + encodeURIComponent(draftID);
+            },
             onChange: function () { window.location.reload(); }
         });
     }

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2046,6 +2046,25 @@ code { font-family: var(--font-mono); font-size: .9em; }
 /* A function checkbox item in the generate-tests checklist (built in JS). */
 .fn-check-item { font-size: var(--text-sm); display: flex; align-items: center; gap: .3rem; cursor: pointer; }
 
+/* Per-student dataset control under a support-file name in the Files panel
+   (support-files.js, both authoring pages — hence the global sheet rather
+   than either page's block). The row-count field is shown only while the file
+   is marked, by the `hidden` attribute, so JS toggles an attribute rather
+   than writing display. */
+.dataset-control {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: .4rem;
+    margin-top: .25rem;
+    font-size: var(--text-sm);
+    color: var(--gray-600);
+}
+.dataset-toggle { display: flex; align-items: center; gap: .3rem; cursor: pointer; }
+.dataset-size-field { display: inline-flex; align-items: center; gap: .3rem; }
+.dataset-size-field[hidden] { display: none; }
+.dataset-size { width: 6rem; }
+
 /* Pattern-family editor body internals. */
 .label-note { color: var(--gray-600); font-weight: 400; }
 .subhead-label { font-size: var(--text-base); }

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -7,17 +7,25 @@
 // this config carries:
 //
 //   window.initSupportFiles({
-//     csrfToken:  value for the x-csrf-token request header
-//     uploadURL:  () => POST target for {filename, content, tier, isTest}
-//     deleteURL:  (name) => DELETE target for one stored support file
-//     onChange:   () => run after a successful upload batch or delete
-//                 (the edit surface re-renders in place; the create page
-//                 reloads its draft)
+//     csrfToken:   value for the x-csrf-token request header
+//     uploadURL:   () => POST target for {filename, content, tier, isTest}
+//     deleteURL:   (name) => DELETE target for one stored support file
+//     datasetsURL: () => GET/PUT target for {datasets: [DatasetSpec]}
+//     onChange:    () => run after a successful upload batch or delete
+//                  (the edit surface re-renders in place; the create page
+//                  reloads its draft)
 //   })
 //
 // Expects the shared markup ids: #add-support-file-btn,
 // #support-file-upload-input, #support-file-upload-status, and per-row
 // .js-support-file-delete-btn[data-filename] buttons.
+//
+// The per-row dataset control (docs/datasets.md Phase 1) lives here too: it is
+// the same markup on both pages, so it is the same implementation on both —
+// the endpoints are the only difference, and they are already what this config
+// carries.  It deliberately does NOT call onChange: a dataset mark changes no
+// row and no file, so re-rendering the surface (or reloading the draft) would
+// throw away the instructor's place on the page for nothing.
 (function () {
     'use strict';
 
@@ -27,6 +35,139 @@
             reader.onload = function () { resolve(reader.result); };
             reader.onerror = function () { reject(new Error('Could not read ' + file.name)); };
             reader.readAsText(file);
+        });
+    }
+
+    // Rows a newly-marked dataset starts at.  The field is editable
+    // immediately and the number is not magic — it only keeps the control from
+    // being marked-with-no-size, which is a spec the server accepts (it means
+    // "the whole file") but which reads as an unfinished edit.
+    var DEFAULT_SAMPLE_ROWS = 100;
+
+    // The dataset control listens on the document, so it is bound once per
+    // document rather than once per init — the same guard (and the same
+    // reason) as suite-table.js's dragover: a caller that re-inits after an
+    // in-place write would otherwise stack one more writer per save, and each
+    // of them PUTs.
+    var boundDatasetControls = false;
+
+    // ── Per-student dataset marks ───────────────────────────────────────────
+    //
+    // Each row's checkbox + row-count field describe one DatasetSpec.  The
+    // endpoint takes the whole array, so every edit reads the current specs,
+    // replaces the entry for this one file, and PUTs the result — which is
+    // also what preserves a spec for a file this page isn't showing (one an
+    // agent marked on a file that has since been renamed, say).
+    function initDatasetControls(config, csrfToken) {
+        if (typeof config.datasetsURL !== 'function') return;
+        if (boundDatasetControls) return;
+        boundDatasetControls = true;
+
+        // Writes are serialized. Each PUT carries the whole array, so two
+        // overlapping edits would both be built from the pre-edit state and
+        // the first one's change would vanish.
+        var queue = Promise.resolve();
+
+        function rows() {
+            return Array.prototype.slice.call(
+                document.querySelectorAll('tr[data-support-file]'));
+        }
+        function statusOf(row) { return row.querySelector('.js-dataset-status'); }
+
+        // Paints every row from the server's specs, so a row the edit didn't
+        // name still ends up showing what the manifest holds.
+        function render(specs) {
+            var byFile = {};
+            (specs || []).forEach(function (spec) { byFile[spec.file] = spec; });
+            rows().forEach(function (row) {
+                var toggle = row.querySelector('.js-dataset-toggle');
+                var field = row.querySelector('.js-dataset-size-field');
+                var size = row.querySelector('.js-dataset-size');
+                if (!toggle || !field || !size) return;
+                var spec = byFile[row.getAttribute('data-support-file')];
+                toggle.checked = !!spec;
+                field.hidden = !spec;
+                size.value = (spec && spec.sampleSize != null) ? String(spec.sampleSize) : '';
+            });
+        }
+
+        function fetchSpecs() {
+            return ChickadeeUI.fetchJSON(config.datasetsURL(), { csrfToken: csrfToken })
+                .then(function (body) { return (body && body.datasets) || []; });
+        }
+
+        // Restores the controls to what the server holds — used after a failed
+        // write so the page never shows a mark that was not saved.
+        function resync() {
+            return fetchSpecs().then(render).catch(function () { /* advisory */ });
+        }
+
+        // `spec` null clears the mark for `filename`.
+        function commit(filename, spec, row) {
+            queue = queue.then(function () {
+                ChickadeeUI.setStatus(statusOf(row), 'Saving…');
+                return fetchSpecs().then(function (current) {
+                    var next = current.filter(function (d) { return d.file !== filename; });
+                    if (spec) next.push(spec);
+                    return ChickadeeUI.fetchJSON(config.datasetsURL(), {
+                        method: 'PUT',
+                        csrfToken: csrfToken,
+                        body: { datasets: next }
+                    });
+                }).then(function (body) {
+                    render((body && body.datasets) || []);
+                    ChickadeeUI.setStatus(statusOf(row), spec ? 'Saved' : 'Cleared', 'ok');
+                }).catch(function (e) {
+                    ChickadeeUI.setStatus(statusOf(row), '');
+                    ChickadeeUI.showActionError(
+                        'Could not save the dataset setting for "' + filename + '" — ' + e.message, row);
+                    return resync();
+                });
+            });
+            return queue;
+        }
+
+        document.body.addEventListener('change', function (ev) {
+            var target = ev.target;
+            if (!target || !target.closest) return;
+            var row = target.closest('tr[data-support-file]');
+            if (!row) return;
+            var filename = row.getAttribute('data-support-file');
+            if (!filename) return;
+            var size = row.querySelector('.js-dataset-size');
+            var field = row.querySelector('.js-dataset-size-field');
+
+            if (target.classList.contains('js-dataset-toggle')) {
+                if (!target.checked) {
+                    if (field) field.hidden = true;
+                    commit(filename, null, row);
+                    return;
+                }
+                var sampleRows = parseInt(size && size.value, 10);
+                if (!(sampleRows > 0)) sampleRows = DEFAULT_SAMPLE_ROWS;
+                if (size) size.value = String(sampleRows);
+                if (field) {
+                    field.hidden = false;
+                    if (size && size.focus) { size.focus(); size.select(); }
+                }
+                commit(filename, { file: filename, kind: 'rowSample', sampleSize: sampleRows }, row);
+                return;
+            }
+
+            if (target.classList.contains('js-dataset-size')) {
+                var toggle = row.querySelector('.js-dataset-toggle');
+                if (toggle && !toggle.checked) return;
+                var entered = parseInt(target.value, 10);
+                if (!(entered > 0)) {
+                    // Refuse rather than send: the server would reject it too,
+                    // and an inline message beside the field is a better answer
+                    // than a banner. Resync puts the saved number back.
+                    ChickadeeUI.setStatus(statusOf(row), 'Enter 1 or more rows', 'error');
+                    resync();
+                    return;
+                }
+                commit(filename, { file: filename, kind: 'rowSample', sampleSize: entered }, row);
+            }
         });
     }
 
@@ -80,6 +221,8 @@
                 }
             });
         }
+
+        initDatasetControls(config, csrfToken);
 
         document.body.addEventListener('click', async function (ev) {
             var btn = ev.target.closest && ev.target.closest('.js-support-file-delete-btn');

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -159,12 +159,30 @@
                 </tr>
                 <!-- Support files: data fixtures (CSVs, JSON, etc.) bundled
                      with the assignment.  Anything in the zip that isn't a
-                     test script and isn't a notebook lands here.  v0.4.114+. -->
+                     test script and isn't a notebook lands here.  v0.4.114+.
+                     The per-student dataset control is the same markup on the
+                     create page, driven by the same Public/support-files.js. -->
                 #for(supportFile in supportFileRows):
                 <tr data-support-file="#(supportFile.name)">
                     <td><strong>Support file</strong></td>
                     <td>
                         <a href="#(supportFile.url)"><code>#(supportFile.name)</code></a>
+                        <div class="dataset-control">
+                            <label class="dataset-toggle">
+                                <input type="checkbox" class="js-dataset-toggle"
+                                       #if(supportFile.isDataset):checked#endif>
+                                Per-student sample
+                            </label>
+                            <span class="dataset-size-field js-dataset-size-field"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                <input type="number" min="1" step="1"
+                                       class="form-input input-sm dataset-size js-dataset-size"
+                                       value="#(supportFile.datasetSampleSizeText)"
+                                       aria-label="Rows per student from #(supportFile.name)">
+                                rows per student
+                            </span>
+                            <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
+                        </div>
                     </td>
                     <td class="time">
                         <button class="btn action-btn action-danger js-support-file-delete-btn" type="button"

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -159,12 +159,30 @@ Create Assignment
                 <!-- Support files: data fixtures (CSVs, JSON, etc.) bundled
                      with the assignment.  Anything in the draft zip that
                      isn't a test script and isn't a notebook lands here.
-                     v0.4.132 / parity PR 3 of #433. -->
+                     v0.4.132 / parity PR 3 of #433.  The per-student dataset
+                     control is the same markup as the edit page's, driven by
+                     the same Public/support-files.js. -->
                 #for(supportFile in supportFileRows):
                 <tr data-support-file="#(supportFile.name)">
                     <td><strong>Support file</strong></td>
                     <td>
                         <a href="#(supportFile.url)"><code>#(supportFile.name)</code></a>
+                        <div class="dataset-control">
+                            <label class="dataset-toggle">
+                                <input type="checkbox" class="js-dataset-toggle"
+                                       #if(supportFile.isDataset):checked#endif>
+                                Per-student sample
+                            </label>
+                            <span class="dataset-size-field js-dataset-size-field"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                <input type="number" min="1" step="1"
+                                       class="form-input input-sm dataset-size js-dataset-size"
+                                       value="#(supportFile.datasetSampleSizeText)"
+                                       aria-label="Rows per student from #(supportFile.name)">
+                                rows per student
+                            </span>
+                            <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
+                        </div>
                     </td>
                     <td class="time">
                         <button class="btn action-btn action-danger js-support-file-delete-btn" type="button"

--- a/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
@@ -123,9 +123,9 @@ struct GetSupportFilesTool: ContentTool {
         }
 
         guard let filename = input.filename else {
-            let datasetSpecs = Dictionary(
-                (setup.decodedManifest()?.datasets ?? []).map { ($0.file, $0) },
-                uniquingKeysWith: { first, _ in first })
+            // The same lookup the authoring pages' Files panel reads, so this
+            // listing and that control cannot disagree about a file's mark.
+            let datasetSpecs = setup.decodedManifest()?.datasetSpecsByFile ?? [:]
             let entries = supportNames.sorted().map { name in
                 FileEntry(
                     filename: name,

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -1,0 +1,111 @@
+// APIServer/Routes/Web/DatasetEditHelpers.swift
+//
+// Shared core for the datasets handlers — both the assignment-scoped pair
+// (`/instructor/:assignmentID/datasets`) and the draft-scoped pair the create
+// page uses (`/instructor/new/draft/datasets?draftID=<id>`).  Same split as
+// `SuiteEditHelpers.swift`: the handlers own auth + setup resolution, this file
+// owns validation and the manifest write, so the create page cannot drift into
+// accepting a spec the edit page rejects.
+//
+// See docs/datasets.md (Phase 1) for what a spec means at delivery time.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// The request body of either PUT.  The whole array is the payload: a write
+/// replaces the assignment's dataset specs, so a caller sends the complete
+/// desired state rather than a delta.
+struct DatasetsBody: Content {
+    var datasets: [DatasetSpec]
+}
+
+/// The response of either GET or PUT — the specs as the manifest now holds
+/// them, which is what the Files panel renders its controls from.
+struct DatasetsResponse: Content {
+    var datasets: [DatasetSpec]
+}
+
+/// Reads the dataset specs off a setup's manifest.  An undecodable manifest
+/// reports no datasets rather than failing the read: the panel then shows every
+/// support file as unmarked, which is what a manifest carrying no `datasets`
+/// key means anyway.
+func datasetSpecs(inManifest manifest: String) -> [DatasetSpec] {
+    guard let data = manifest.data(using: .utf8),
+        let props = try? ManifestCodec.decoder.decode(TestProperties.self, from: data)
+    else { return [] }
+    return props.datasets
+}
+
+/// Validates `datasets` against the setup's bundled files and writes the
+/// resulting array into the manifest, replacing whatever was there.
+///
+/// This is a whole-array replace, not a patch — callers send the complete
+/// desired state.
+///
+/// Rejects (`.badRequest`), in the order a caller is likely to hit them:
+///   - a `file` that is not a bare filename.  The value is joined onto
+///     directory paths at read time (`DatasetResolver`) and at delivery time on
+///     both the server and the worker, so a separator or traversal component
+///     would read outside the setup directory (#1104).
+///   - a `file` the setup zip does not bundle.  A dataset marks an existing
+///     support file as per-student; it never introduces one.
+///   - a non-positive `sampleSize`.
+///   - two specs for the same file, which is incoherent — the two would
+///     disagree about how many rows a student gets, and which one wins is a
+///     detail of whichever consumer happens to fold the array.
+func applyDatasetsEdit(
+    setup: APITestSetup, datasets: [DatasetSpec], on db: Database
+) async throws {
+    let zipEntries = Set(
+        listZipEntries(zipPath: setup.zipPath).map { entry in
+            entry.hasPrefix("./") ? String(entry.dropFirst(2)) : entry
+        })
+    var seenFiles: Set<String> = []
+    for spec in datasets {
+        guard FilenameSafety.bareFilename(spec.file) != nil else {
+            throw Abort(
+                .badRequest,
+                reason: "Dataset file '\(spec.file)' must be a bare filename with no path components.")
+        }
+        guard zipEntries.contains(spec.file) else {
+            throw Abort(
+                .badRequest,
+                reason: "Dataset file '\(spec.file)' is not among this assignment's bundled files.")
+        }
+        if let n = spec.sampleSize, n <= 0 {
+            throw Abort(.badRequest, reason: "sampleSize for '\(spec.file)' must be positive.")
+        }
+        guard seenFiles.insert(spec.file).inserted else {
+            throw Abort(.badRequest, reason: "Dataset file '\(spec.file)' is listed more than once.")
+        }
+    }
+
+    // Splice the updated array into the manifest JSON, preserving every other
+    // field.  Using JSONSerialization lets us avoid rebuilding the entire
+    // manifest from components (no risk of dropping unrecognised keys).
+    guard let manifestData = setup.manifest.data(using: .utf8),
+        var dict = try? JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
+    else {
+        throw Abort(.internalServerError, reason: "Could not decode assignment manifest.")
+    }
+
+    if datasets.isEmpty {
+        dict.removeValue(forKey: "datasets")
+    } else {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let encoded = try encoder.encode(datasets)
+        if let parsed = try? JSONSerialization.jsonObject(with: encoded) as? [Any] {
+            dict["datasets"] = parsed
+        }
+    }
+
+    let newData = try JSONSerialization.data(withJSONObject: dict)
+    guard let newManifest = String(data: newData, encoding: .utf8) else {
+        throw Abort(.internalServerError, reason: "Could not re-encode assignment manifest.")
+    }
+    setup.manifest = newManifest
+    try await setup.save(on: db)
+}

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewPage.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewPage.swift
@@ -88,7 +88,13 @@ extension DraftAssignmentRoutes {
                     order: row.order,
                     dependsOn: row.dependsOn,
                     points: row.points,
-                    displayName: row.displayName
+                    displayName: row.displayName,
+                    // Carried, not re-derived: this rebuild exists only to
+                    // rewrite `url` against the draft-scoped download endpoint,
+                    // and dropping the dataset pair here would blank every mark
+                    // on the create page while the edit page still showed it.
+                    isDataset: row.isDataset,
+                    datasetSampleSize: row.datasetSampleSize
                 )
             }
     }

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
@@ -21,6 +21,8 @@
 //   PUT    /instructor/new/draft/families?draftID=<id>
 //   POST   /instructor/new/draft/scripts?draftID=<id>
 //   DELETE /instructor/new/draft/scripts/:filename?draftID=<id>
+//   GET    /instructor/new/draft/datasets?draftID=<id>
+//   PUT    /instructor/new/draft/datasets?draftID=<id>
 
 import Core
 import Fluent
@@ -105,6 +107,29 @@ extension DraftAssignmentRoutes {
         let filename = try safeScriptFilename(from: req)
         try await deleteScriptFromSetup(setup: setup, filename: filename, on: req.db)
         return .noContent
+    }
+
+    // MARK: - GET /instructor/new/draft/datasets
+    //
+    // Draft-scoped sibling of `getDatasets` / `putDatasets`, so the create
+    // page's Files panel can mark a per-student dataset before publish rather
+    // than having to publish first and come back. Same shared core, so the two
+    // pages cannot accept different specs.
+
+    @Sendable
+    func getDraftDatasets(req: Request) async throws -> DatasetsResponse {
+        let setup = try await loadDraftSetupForRead(req)
+        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
+    }
+
+    // MARK: - PUT /instructor/new/draft/datasets
+
+    @Sendable
+    func putDraftDatasets(req: Request) async throws -> DatasetsResponse {
+        let setup = try await loadDraftSetupForWrite(req)
+        let body = try req.content.decode(DatasetsBody.self)
+        try await applyDatasetsEdit(setup: setup, datasets: body.datasets, on: req.db)
+        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
     }
 
     // MARK: - GET /instructor/new/draft/files/item?draftID=<id>&name=<filename>

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes.swift
@@ -38,6 +38,8 @@ struct DraftAssignmentRoutes: RouteCollection {
         r.post("new", "draft", "scripts", use: createDraftScript)
         r.delete("new", "draft", "scripts", ":filename", use: deleteDraftScript)
         r.get("new", "draft", "files", "item", use: downloadDraftSetupItem)
+        r.get("new", "draft", "datasets", use: getDraftDatasets)
+        r.put("new", "draft", "datasets", use: putDraftDatasets)
         // Draft-scoped suite-section CRUD (mirrors the published routes).
         r.post("new", "draft", "suite-sections", use: createDraftSuiteSection)
         r.post("new", "draft", "suite-sections", "reorder", use: reorderDraftSuiteSections)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
@@ -9,6 +9,9 @@
 // same filename — so the notebook's `pd.read_csv("…")` line is unchanged
 // but every student sees their own rows.
 //
+// Validation and the manifest write live in `DatasetEditHelpers.swift`, shared
+// with the draft-scoped pair the create page uses.
+//
 // See docs/datasets.md (Phase 1) for the full design.
 
 import Core
@@ -18,25 +21,12 @@ import Vapor
 
 extension PublishedAssignmentRoutes {
 
-    struct DatasetsBody: Content {
-        var datasets: [DatasetSpec]
-    }
-
-    struct DatasetsResponse: Content {
-        var datasets: [DatasetSpec]
-    }
-
     // MARK: - GET /instructor/:assignmentID/datasets
 
     @Sendable
     func getDatasets(req: Request) async throws -> DatasetsResponse {
         let (_, setup) = try await loadAssignmentAndSetupForStaffRead(req)
-        guard let manifestData = setup.manifest.data(using: .utf8),
-            let props = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData)
-        else {
-            return DatasetsResponse(datasets: [])
-        }
-        return DatasetsResponse(datasets: props.datasets)
+        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
     }
 
     // MARK: - PUT /instructor/:assignmentID/datasets
@@ -45,61 +35,10 @@ extension PublishedAssignmentRoutes {
     func putDatasets(req: Request) async throws -> DatasetsResponse {
         let (_, setup) = try await loadAssignmentAndSetupForWrite(req, atLeast: .ta)
         let body = try req.content.decode(DatasetsBody.self)
-
-        // Validate: each spec must name a bundled support file by bare
-        // filename — no separators or traversal components, because the value
-        // is joined onto directory paths at read time (`DatasetResolver`) and
-        // at delivery time on both the server and the worker (#1104). It must
-        // also actually exist in the setup zip: a dataset marks an existing
-        // support file as per-student, it never introduces a new file.
-        // sampleSize if present must be positive.
-        let zipEntries = Set(
-            listZipEntries(zipPath: setup.zipPath).map { entry in
-                entry.hasPrefix("./") ? String(entry.dropFirst(2)) : entry
-            })
-        for spec in body.datasets {
-            guard FilenameSafety.bareFilename(spec.file) != nil else {
-                throw Abort(
-                    .badRequest,
-                    reason: "Dataset file '\(spec.file)' must be a bare filename with no path components.")
-            }
-            guard zipEntries.contains(spec.file) else {
-                throw Abort(
-                    .badRequest,
-                    reason: "Dataset file '\(spec.file)' is not among this assignment's bundled files.")
-            }
-            if let n = spec.sampleSize, n <= 0 {
-                throw Abort(.badRequest, reason: "sampleSize for '\(spec.file)' must be positive.")
-            }
-        }
-
-        // Splice the updated datasets array into the manifest JSON, preserving
-        // every other field. Using JSONSerialization lets us avoid rebuilding the
-        // entire manifest from components (no risk of dropping unrecognised keys).
-        guard let manifestData = setup.manifest.data(using: .utf8),
-            var dict = try? JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
-        else {
-            throw Abort(.internalServerError, reason: "Could not decode assignment manifest.")
-        }
-
-        if body.datasets.isEmpty {
-            dict.removeValue(forKey: "datasets")
-        } else {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.sortedKeys]
-            let encoded = try encoder.encode(body.datasets)
-            if let parsed = try? JSONSerialization.jsonObject(with: encoded) as? [Any] {
-                dict["datasets"] = parsed
-            }
-        }
-
-        let newData = try JSONSerialization.data(withJSONObject: dict)
-        guard let newManifest = String(data: newData, encoding: .utf8) else {
-            throw Abort(.internalServerError, reason: "Could not re-encode assignment manifest.")
-        }
-        setup.manifest = newManifest
-        try await setup.save(on: req.db)
-
-        return DatasetsResponse(datasets: body.datasets)
+        try await applyDatasetsEdit(setup: setup, datasets: body.datasets, on: req.db)
+        // Read back rather than echoing the request: the response is what the
+        // Files panel renders its controls from, so it has to be the state the
+        // manifest now holds.
+        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
     }
 }

--- a/Sources/APIServer/Routes/Web/SuiteRowContexts.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowContexts.swift
@@ -44,9 +44,47 @@ struct EditableSuiteRow: Encodable {
     let dependsOn: [String]  // script names of prerequisites; empty == none
     let points: Int  // grade weight; 1 = default (unweighted)
     let displayName: String?  // optional human-readable name shown to students
+    /// True when this file is marked a per-student dataset (docs/datasets.md).
+    /// Only meaningful on a support row; a test script is never a dataset.
+    let isDataset: Bool
+    /// Rows each student receives for a dataset row; nil = whole file (and nil
+    /// on every non-dataset row).
+    let datasetSampleSize: Int?
 
     /// Empty string when displayName is nil — Leaf doesn't support `??` in templates.
     var displayNameOrEmpty: String { displayName ?? "" }
+
+    /// The sample size as an input-ready string — empty when there is none, so
+    /// the number field renders blank rather than "nil" (same reason
+    /// `displayNameOrEmpty` exists).
+    var datasetSampleSizeText: String { datasetSampleSize.map(String.init) ?? "" }
+
+    /// The dataset pair defaults to "not a dataset": every construction site
+    /// but the two support-file row builders is describing a test script, and
+    /// a script is never a per-student dataset.
+    init(
+        name: String,
+        url: String,
+        isTest: Bool,
+        tier: String,
+        order: Int,
+        dependsOn: [String],
+        points: Int,
+        displayName: String?,
+        isDataset: Bool = false,
+        datasetSampleSize: Int? = nil
+    ) {
+        self.name = name
+        self.url = url
+        self.isTest = isTest
+        self.tier = tier
+        self.order = order
+        self.dependsOn = dependsOn
+        self.points = points
+        self.displayName = displayName
+        self.isDataset = isDataset
+        self.datasetSampleSize = datasetSampleSize
+    }
 
     /// Display name if set, otherwise the filename stem (extension stripped).
     /// Used as the default value of the name input in the assignment editor.
@@ -71,8 +109,11 @@ struct EditableSuiteRow: Encodable {
         case dependsOn
         case points
         case displayName
+        case isDataset
+        case datasetSampleSize
         case displayNameOrEmpty
         case displayNameOrStem
+        case datasetSampleSizeText
         case dependsOnJSON
     }
 
@@ -86,8 +127,11 @@ struct EditableSuiteRow: Encodable {
         try container.encode(dependsOn, forKey: .dependsOn)
         try container.encode(points, forKey: .points)
         try container.encodeIfPresent(displayName, forKey: .displayName)
+        try container.encode(isDataset, forKey: .isDataset)
+        try container.encodeIfPresent(datasetSampleSize, forKey: .datasetSampleSize)
         try container.encode(displayNameOrEmpty, forKey: .displayNameOrEmpty)
         try container.encode(displayNameOrStem, forKey: .displayNameOrStem)
+        try container.encode(datasetSampleSizeText, forKey: .datasetSampleSizeText)
         try container.encode(dependsOnJSON, forKey: .dependsOnJSON)
     }
 }

--- a/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
@@ -142,6 +142,11 @@ func currentSetupFiles(
             return lhs < rhs
         }
 
+    // Per-student dataset marks, from the one lookup `get_support_files` reads
+    // (`TestProperties.datasetSpecsByFile`) so the Files panel and the MCP
+    // listing cannot report different states for the same file.
+    let datasetSpecs = setup.decodedManifest()?.datasetSpecsByFile ?? [:]
+
     // Generated entries (pattern-family or notebook-check output) are
     // represented by their generator's row in the suite table, so omit
     // them from the raw script list here.
@@ -156,7 +161,9 @@ func currentSetupFiles(
             order: entry?.order ?? (idx + 1),
             dependsOn: entry?.dependsOn ?? [],
             points: entry?.points ?? 1,
-            displayName: entry?.name
+            displayName: entry?.name,
+            isDataset: datasetSpecs[name] != nil,
+            datasetSampleSize: datasetSpecs[name]?.sampleSize
         )
     }
 
@@ -196,6 +203,10 @@ func editableSuiteRowsForSetup(_ setup: APITestSetup) -> [EditableSuiteRow] {
         return map
     }()
 
+    // Same one lookup as `currentSetupFiles` above, so the create page's Files
+    // panel reports what the edit page's does for the same manifest.
+    let datasetSpecs = setup.decodedManifest()?.datasetSpecsByFile ?? [:]
+
     // Generated entries (pattern-family or notebook-check output) are
     // represented collectively by their family's / check's row in the
     // suite table — hide them from the raw list so instructors don't see
@@ -211,7 +222,9 @@ func editableSuiteRowsForSetup(_ setup: APITestSetup) -> [EditableSuiteRow] {
             order: info?.order ?? (idx + 1),
             dependsOn: info?.dependsOn ?? [],
             points: info?.points ?? 1,
-            displayName: info?.name
+            displayName: info?.name,
+            isDataset: datasetSpecs[name] != nil,
+            datasetSampleSize: datasetSpecs[name]?.sampleSize
         )
     }
     .sorted { lhs, rhs in

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -299,6 +299,19 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// `patternFamilies` / `globalExpressions`).
     public let datasets: [DatasetSpec]
 
+    /// The dataset specs keyed by the support filename each one marks, for the
+    /// surfaces that ask "is *this* file a dataset, and at what sample size?"
+    /// — the MCP support-file listing and the authoring pages' Files panel.
+    /// Both read this rather than folding `datasets` themselves, so the agent
+    /// surface and the web UI cannot report different states for one file.
+    /// A duplicate `file` keeps the first spec — a tie-break for manifests that
+    /// arrived by some route other than an authoring door (bundle import, a
+    /// hand-edited zip), since the datasets PUTs reject a body naming one file
+    /// twice and `set_dataset` replaces a file's spec rather than appending.
+    public var datasetSpecsByFile: [String: DatasetSpec] {
+        Dictionary(datasets.map { ($0.file, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
     /// Filenames the instructor has designated as **grader-only** (option B —
     /// see docs/datasets.md): bundled in the test setup so the native worker's
     /// grading scripts can read them, but withheld from every student-facing

--- a/Tests/APITests/DatasetsRouteRoundTripTests.swift
+++ b/Tests/APITests/DatasetsRouteRoundTripTests.swift
@@ -1,0 +1,312 @@
+// Tests/APITests/DatasetsRouteRoundTripTests.swift
+//
+// The Files-panel dataset control reads and writes the datasets endpoints, so
+// what it needs proved is the round trip: GET the current specs, PUT the whole
+// desired array, and GET back exactly what was stored. Render tests prove the
+// templates resolve; they do not exercise page JS, so this covers the contract
+// the control depends on rather than the control itself.
+//
+// Covered on BOTH pairs — `/instructor/:assignmentID/datasets` (edit page) and
+// `/instructor/new/draft/datasets` (create page). The draft pair is new, and
+// its whole point is that the create page can mark a dataset before publish;
+// it shares the apply core (`DatasetEditHelpers.swift`) with the published
+// pair, and these tests are what hold the two to the same answers.
+//
+// Spec-level rejections (traversal, unbundled file) live in
+// DatasetsRouteValidationTests; what is asserted here is that the draft pair
+// enforces them too, and that neither pair accepts two specs for one file.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class DatasetsRouteRoundTripTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-datasets-rt")
+    }
+
+    private struct Fixture {
+        let assignmentID: String
+        let draftID: String
+        let cookie: String
+        let csrf: String
+    }
+
+    /// A course with one published assignment and one unpublished draft, both
+    /// bundling `cases.csv` + `notes.txt`, plus an instructor session.
+    private func fixture(_ tag: String) async throws -> Fixture {
+        let course = APICourse(code: "DSR\(tag)", name: "Datasets Round Trip", enrollmentMode: .auto)
+        try await course.save(on: app.db)
+        let courseID = try course.requireID()
+
+        let manifest = """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
+            """
+        let setupID = "dsr_\(UUID().uuidString.prefix(8))"
+        try await makeSetup(id: setupID, manifest: manifest, courseID: courseID)
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: "Datasets Lab",
+            dueAt: nil, isOpen: true, deadlineOverrideActive: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+
+        let draftID = "dsrdraft_\(UUID().uuidString.prefix(8))"
+        try await makeSetup(id: draftID, manifest: manifest, courseID: courseID)
+
+        let username = "dsr_inst_\(tag)"
+        let cookie = try await loginUser(username: username, password: "pw", role: "user", on: app)
+        try await promoteToInstructor(username, on: app)
+        let (csrf, sessionCookie) = try await csrfFields(
+            for: "/instructor/\(assignment.publicID)/edit", cookie: cookie, on: app)
+        return Fixture(
+            assignmentID: assignment.publicID, draftID: draftID,
+            cookie: sessionCookie, csrf: csrf)
+    }
+
+    private func makeSetup(id: String, manifest: String, courseID: UUID) async throws {
+        let zipPath = app.testSetupsDirectory + id + ".zip"
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dsr-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("id\n1\n2\n3\n".utf8).write(to: root.appendingPathComponent("cases.csv"))
+        try Data("notes".utf8).write(to: root.appendingPathComponent("notes.txt"))
+        try writeZipFixture(of: root, to: zipPath)
+        let setup = APITestSetup(id: id, manifest: manifest, zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+    }
+
+    /// GETs the datasets endpoint and returns the decoded specs.
+    private func get(_ path: String, _ fx: Fixture) async throws -> [DatasetSpec] {
+        var specs: [DatasetSpec] = []
+        try await app.asyncTest(
+            .GET, path,
+            beforeRequest: { req in req.headers.add(name: .cookie, value: fx.cookie) },
+            afterResponse: { res in
+                #expect(res.status == .ok, "GET \(path) — \(res.body.string)")
+                specs = try res.content.decode(DatasetsResponse.self).datasets
+            })
+        return specs
+    }
+
+    /// PUTs a raw JSON body and returns the response (status + body) for the
+    /// caller to assert on.
+    @discardableResult
+    private func put(
+        _ path: String, _ fx: Fixture, body: String, expect expected: HTTPStatus, _ note: Comment
+    ) async throws -> String {
+        var responseBody = ""
+        try await app.asyncTest(
+            .PUT, path,
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: fx.cookie)
+                req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                req.headers.contentType = .json
+                req.body = ByteBuffer(string: body)
+            },
+            afterResponse: { res in
+                #expect(res.status == expected, "\(note) — got \(res.status): \(res.body.string)")
+                responseBody = res.body.string
+            })
+        return responseBody
+    }
+
+    // MARK: - Published: GET → PUT → GET
+
+    @Test func publishedDatasetsRoundTrip() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("p")
+            let path = "/instructor/\(fx.assignmentID)/datasets"
+
+            #expect(try await get(path, fx).isEmpty, "an assignment starts with no datasets")
+
+            // Mark.
+            let marked = try await put(
+                path, fx, body: #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":25}]}"#,
+                expect: .ok, "marking a bundled file is accepted")
+            #expect(marked.contains("cases.csv"), "the PUT echoes the stored state back")
+
+            var stored = try await get(path, fx)
+            #expect(stored.count == 1)
+            #expect(stored.first?.file == "cases.csv")
+            #expect(stored.first?.sampleSize == 25)
+            #expect(stored.first?.kind == .rowSample)
+
+            // Change the sample size — the whole array is the payload.
+            try await put(
+                path, fx, body: #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":40}]}"#,
+                expect: .ok, "re-PUTting the same file changes its sample size")
+            stored = try await get(path, fx)
+            #expect(stored.count == 1, "a re-PUT replaces rather than appends")
+            #expect(stored.first?.sampleSize == 40)
+
+            // Clear.
+            try await put(path, fx, body: #"{"datasets":[]}"#, expect: .ok, "an empty array clears every mark")
+            #expect(try await get(path, fx).isEmpty)
+        }
+    }
+
+    @Test func publishedDatasetsPutPreservesTheRestOfTheManifest() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("m")
+            try await put(
+                "/instructor/\(fx.assignmentID)/datasets", fx,
+                body: #"{"datasets":[{"file":"cases.csv","sampleSize":3}]}"#,
+                expect: .ok, "marking a bundled file is accepted")
+
+            let assignment = try #require(
+                try await assignmentByPublicID(fx.assignmentID, on: app.db))
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let props = try #require(setup.decodedManifest())
+            #expect(props.datasets.first?.file == "cases.csv")
+            #expect(props.timeLimitSeconds == 10, "the write splices, it does not rebuild")
+            #expect(props.schemaVersion == 1)
+        }
+    }
+
+    // MARK: - Draft: the create page's pair
+
+    @Test func draftDatasetsRoundTrip() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("d")
+            let path = "/instructor/new/draft/datasets?draftID=\(fx.draftID)"
+
+            #expect(try await get(path, fx).isEmpty, "a draft starts with no datasets")
+
+            try await put(
+                path, fx, body: #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":12}]}"#,
+                expect: .ok, "a draft accepts a mark on a bundled file")
+
+            let stored = try await get(path, fx)
+            #expect(stored.count == 1)
+            #expect(stored.first?.file == "cases.csv")
+            #expect(stored.first?.sampleSize == 12)
+
+            try await put(path, fx, body: #"{"datasets":[]}"#, expect: .ok, "a draft mark can be cleared")
+            #expect(try await get(path, fx).isEmpty)
+        }
+    }
+
+    @Test func draftDatasetsEnforceTheSharedValidation() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("v")
+            let path = "/instructor/new/draft/datasets?draftID=\(fx.draftID)"
+
+            try await put(
+                path, fx, body: #"{"datasets":[{"file":"../../.worker-secret","sampleSize":2}]}"#,
+                expect: .badRequest, "the draft pair rejects a traversal path too")
+            try await put(
+                path, fx, body: #"{"datasets":[{"file":"absent.csv","sampleSize":2}]}"#,
+                expect: .badRequest, "the draft pair rejects a file the zip does not bundle")
+            try await put(
+                path, fx, body: #"{"datasets":[{"file":"cases.csv","sampleSize":0}]}"#,
+                expect: .badRequest, "the draft pair rejects a non-positive sample size")
+            #expect(try await get(path, fx).isEmpty, "a rejected write stores nothing")
+        }
+    }
+
+    @Test func draftDatasetsRequireADraftID() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("n")
+            try await put(
+                "/instructor/new/draft/datasets", fx,
+                body: #"{"datasets":[]}"#,
+                expect: .badRequest, "the draft pair is addressed by draftID")
+        }
+    }
+
+    // MARK: - The control the Files panel renders from those specs
+    //
+    // What the round trip cannot show is that the stored spec reaches the
+    // markup. These GET the two authoring pages and read the control back out
+    // of the HTML: a checked toggle and the saved row count on the marked file,
+    // an unchecked toggle and a hidden field on the plain one.
+
+    private func page(_ path: String, _ fx: Fixture) async throws -> String {
+        var html = ""
+        try await app.asyncTest(
+            .GET, path,
+            beforeRequest: { req in req.headers.add(name: .cookie, value: fx.cookie) },
+            afterResponse: { res in
+                #expect(res.status == .ok, "GET \(path) — \(res.status)")
+                html = res.body.string
+            })
+        return html
+    }
+
+    /// The support-file row's markup, from its `data-support-file` anchor to
+    /// the end of that table row.
+    private func rowMarkup(for filename: String, in html: String) throws -> String {
+        let anchor = "data-support-file=\"\(filename)\""
+        let start = try #require(html.range(of: anchor), "no row for \(filename)")
+        let rest = html[start.upperBound...]
+        let end = try #require(rest.range(of: "</tr>"), "row for \(filename) never closes")
+        return String(rest[..<end.lowerBound])
+    }
+
+    @Test func editPageRendersTheDatasetControlFromTheStoredSpec() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("e")
+            try await put(
+                "/instructor/\(fx.assignmentID)/datasets", fx,
+                body: #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":25}]}"#,
+                expect: .ok, "marking a bundled file is accepted")
+
+            let html = try await page("/instructor/\(fx.assignmentID)/edit", fx)
+            let marked = try rowMarkup(for: "cases.csv", in: html)
+            #expect(marked.contains("js-dataset-toggle"))
+            #expect(marked.contains("checked"), "a marked file renders a checked toggle")
+            #expect(marked.contains("value=\"25\""), "and its stored row count")
+            #expect(marked.contains("hidden") == false, "and shows the row-count field")
+
+            let plain = try rowMarkup(for: "notes.txt", in: html)
+            #expect(plain.contains("js-dataset-toggle"))
+            #expect(plain.contains("checked") == false, "an unmarked file renders an unchecked toggle")
+            #expect(plain.contains("hidden"), "and keeps its row-count field hidden")
+        }
+    }
+
+    @Test func createPageRendersTheDatasetControlFromTheStoredSpec() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("c")
+            try await put(
+                "/instructor/new/draft/datasets?draftID=\(fx.draftID)", fx,
+                body: #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":8}]}"#,
+                expect: .ok, "a draft accepts a mark on a bundled file")
+
+            let html = try await page("/instructor/new?draftID=\(fx.draftID)", fx)
+            let marked = try rowMarkup(for: "cases.csv", in: html)
+            #expect(marked.contains("js-dataset-toggle"))
+            #expect(marked.contains("checked"))
+            #expect(marked.contains("value=\"8\""))
+            #expect(marked.contains("hidden") == false)
+
+            let plain = try rowMarkup(for: "notes.txt", in: html)
+            #expect(plain.contains("checked") == false)
+            #expect(plain.contains("hidden"))
+        }
+    }
+
+    // MARK: - Two specs for one file are incoherent on either pair
+
+    @Test func duplicateSpecsForOneFileAreRejected() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("x")
+            let body = #"""
+                {"datasets":[{"file":"cases.csv","sampleSize":5},{"file":"cases.csv","sampleSize":9}]}
+                """#
+            try await put(
+                "/instructor/\(fx.assignmentID)/datasets", fx, body: body,
+                expect: .badRequest, "one file cannot carry two sample sizes")
+            try await put(
+                "/instructor/new/draft/datasets?draftID=\(fx.draftID)", fx, body: body,
+                expect: .badRequest, "the draft pair agrees")
+        }
+    }
+}

--- a/Tests/APITests/SupportFileDatasetRowTests.swift
+++ b/Tests/APITests/SupportFileDatasetRowTests.swift
@@ -1,0 +1,148 @@
+// Tests/APITests/SupportFileDatasetRowTests.swift
+//
+// The Files panel's per-student dataset control renders from the support-file
+// rows, so the dataset mark has to survive every step between the manifest and
+// the template: both row builders (edit page and create page), the create
+// page's URL rewrite, and `EditableSuiteRow`'s hand-written `encode(to:)` —
+// which is where a new field silently fails to reach Leaf, because a row that
+// encodes without it renders as an unmarked control rather than as an error.
+//
+// The marks themselves come from `TestProperties.datasetSpecsByFile`, the one
+// lookup `get_support_files` reads, so the UI and the MCP listing cannot report
+// different states for the same file (docs/datasets.md Phase 1).
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct SupportFileDatasetRowTests {
+
+    /// A setup bundling one marked dataset (`cases.csv`, 25 rows), one plain
+    /// support file, and one graded script.
+    private func makeSetup(in directory: URL) throws -> APITestSetup {
+        let zipPath = directory.appendingPathComponent("setup.zip").path
+        try ahMakeZip(
+            at: zipPath,
+            entries: [
+                ("assignment.ipynb", "{}"),
+                ("cases.csv", "id\n1\n2\n3\n"),
+                ("notes.txt", "notes"),
+                ("publictest_a.py", "print('ok')"),
+            ])
+        return APITestSetup(
+            id: "setup_ds",
+            manifest: """
+                {
+                  "schemaVersion": 1,
+                  "gradingMode": "worker",
+                  "requiredFiles": [],
+                  "testSuites": [{"tier":"public","script":"publictest_a.py"}],
+                  "datasets": [{"file":"cases.csv","kind":"rowSample","sampleSize":25}],
+                  "timeLimitSeconds": 10,
+                  "makefile": null
+                }
+                """,
+            zipPath: zipPath,
+            courseID: UUID())
+    }
+
+    private func withSetup(_ body: (APITestSetup) throws -> Void) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("support-file-dataset-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try body(try makeSetup(in: root))
+    }
+
+    // MARK: - The edit page's rows
+
+    @Test func currentSetupFilesMarksTheDatasetRowOnly() throws {
+        try withSetup { setup in
+            let rows = currentSetupFiles(
+                for: setup, assignmentID: "asg123", solutionFilename: nil
+            ).existingSuiteRows
+
+            let dataset = try #require(rows.first { $0.name == "cases.csv" })
+            #expect(dataset.isDataset)
+            #expect(dataset.datasetSampleSize == 25)
+            #expect(dataset.datasetSampleSizeText == "25")
+
+            let plain = try #require(rows.first { $0.name == "notes.txt" })
+            #expect(plain.isDataset == false)
+            #expect(plain.datasetSampleSize == nil)
+            #expect(plain.datasetSampleSizeText.isEmpty)
+
+            // A graded script is never a dataset, whatever the manifest says.
+            let script = try #require(rows.first { $0.name == "publictest_a.py" })
+            #expect(script.isDataset == false)
+        }
+    }
+
+    // MARK: - The create page's rows
+
+    @Test func draftRowsCarryTheMarkThroughTheURLRewrite() throws {
+        try withSetup { setup in
+            let base = editableSuiteRowsForSetup(setup)
+            let baseDataset = try #require(base.first { $0.name == "cases.csv" })
+            #expect(baseDataset.isDataset)
+            #expect(baseDataset.datasetSampleSize == 25)
+
+            // The create page rebuilds support rows purely to point `url` at
+            // the draft-scoped download; the mark must survive that copy.
+            let rewritten = DraftAssignmentRoutes().newAssignmentSupportFileRows(
+                setup: setup, suiteRows: base)
+            let row = try #require(rewritten.first { $0.name == "cases.csv" })
+            #expect(row.isDataset)
+            #expect(row.datasetSampleSize == 25)
+            #expect(row.url.contains("/instructor/new/draft/files/item"))
+            #expect(rewritten.first { $0.name == "notes.txt" }?.isDataset == false)
+        }
+    }
+
+    // MARK: - What Leaf actually receives
+
+    @Test func encodedRowExposesTheDatasetFieldsToLeaf() throws {
+        let row = EditableSuiteRow(
+            name: "cases.csv", url: "#", isTest: false, tier: "support", order: 1,
+            dependsOn: [], points: 1, displayName: nil,
+            isDataset: true, datasetSampleSize: 25)
+        let encoded = try JSONSerialization.jsonObject(with: try JSONEncoder().encode(row))
+        let dict = try #require(encoded as? [String: Any])
+
+        #expect(dict["isDataset"] as? Bool == true)
+        #expect(dict["datasetSampleSize"] as? Int == 25)
+        #expect(dict["datasetSampleSizeText"] as? String == "25")
+    }
+
+    @Test func unmarkedRowEncodesAnEmptySampleSizeText() throws {
+        let row = EditableSuiteRow(
+            name: "notes.txt", url: "#", isTest: false, tier: "support", order: 1,
+            dependsOn: [], points: 1, displayName: nil)
+        let encoded = try JSONSerialization.jsonObject(with: try JSONEncoder().encode(row))
+        let dict = try #require(encoded as? [String: Any])
+
+        #expect(dict["isDataset"] as? Bool == false)
+        #expect(dict["datasetSampleSize"] == nil)
+        #expect((dict["datasetSampleSizeText"] as? String)?.isEmpty == true)
+    }
+
+    // MARK: - One lookup behind both surfaces
+
+    @Test func datasetSpecsByFileKeysEverySpecItsFile() throws {
+        let props = try ManifestCodec.decoder.decode(
+            TestProperties.self,
+            from: Data(
+                """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,
+                 "makefile":null,
+                 "datasets":[{"file":"a.csv","kind":"rowSample","sampleSize":5},
+                             {"file":"b.csv","kind":"rowSample"}]}
+                """.utf8))
+
+        #expect(props.datasetSpecsByFile["a.csv"]?.sampleSize == 5)
+        #expect(props.datasetSpecsByFile["b.csv"]?.sampleSize == nil)
+        #expect(props.datasetSpecsByFile["absent.csv"] == nil)
+    }
+}

--- a/changelog.d/datasets-files-panel-control.md
+++ b/changelog.d/datasets-files-panel-control.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Per-student datasets are markable from the Files panel.** Each support-file
+  row on the assignment create and edit pages now carries a "Per-student sample"
+  toggle and a row count, saved in place with no page reload. Marking a dataset
+  had shipped as `PUT /instructor/:id/datasets` and the `set_dataset` MCP tool
+  only, so an instructor without an agent had no way to do it at all. The
+  create page gets the same control against a new draft-scoped
+  `GET`/`PUT /instructor/new/draft/datasets`, which shares the published pair's
+  validation, and both pages read their marks from the one lookup
+  `get_support_files` reports from — so the web UI and the agent surface cannot
+  disagree about a file. A `datasets` array naming the same file twice is now
+  rejected by either endpoint rather than leaving which spec wins to whichever
+  consumer folds the array.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -393,16 +393,20 @@ they explore in the editor is exactly what the worker grades.
 
 ### Instructor view
 
-In the **Files** panel (`Resources/Views/assignment-edit.leaf:119–130`) the
-support-file row gains one inline control, modeled on the existing **Global
-Inputs** name+value pattern (`:136–187`):
+In the **Files** panel of both authoring pages
+(`Resources/Views/_assignment-edit-body.leaf` and `assignment-new.leaf`, the
+`supportFileRows` loop) each support-file row carries one inline control. What
+shipped is flatter than the expanding "Personalize ▾" this note first sketched
+— the row count is the only setting, so there was nothing worth hiding behind
+a disclosure:
 
 ```
-Support file   assignment4_vitaldb_cases.csv  [download]   [ Personalize ▾ ] [Remove]
-   └─ expanded:   Sample [ 500 ] rows per student        ✓ saved
+Support file   assignment4_vitaldb_cases.csv                          [Remove]
+               [x] Per-student sample  [ 500 ] rows per student        Saved
 ```
 
-Persisted via a small `PUT /instructor/:id/datasets` endpoint mirroring
+Persisted via `PUT /instructor/:id/datasets` (published) or
+`PUT /instructor/new/draft/datasets?draftID=…` (create page), mirroring
 `PUT /global-variables`. The uploaded file becomes the server-side *source*;
 students receive only their sample.
 
@@ -495,18 +499,42 @@ pool. Secrecy becomes load-bearing only for Phase 2 mystery answers.
    beside `PersonalizationSubstitution.gradingInputs`, job-payload plumbing,
    the per-job file write, source-hiding from student-facing zips/symlinks.
 3. **Editor delivery** — per-student file write + symlink suppression.
-4. **UI** — the Files-panel inline control + `PUT /datasets` endpoint.
+4. **UI** — the Files-panel inline control + `PUT /datasets` endpoint (the
+   endpoint shipped with slice 2; the control, and the draft-scoped sibling
+   endpoint the create page needed, landed later — see "Authoring surfaces"
+   above).
 5. **Browser delivery** — only when a personalized dataset is used on a
    browser-graded assignment.
 6. **Phase 1.5** — stratified sampling + the arbitrary-Python `slice` escape
    hatch (reuses `PersonalizationEvaluator`'s file-writing subprocess), the
    bridge to Phase 2.
 
-**Authoring surfaces:** the `PUT /instructor/:id/datasets` endpoint shipped
-with the slices above, but the Files-panel inline control has not landed yet —
-the first shipping authoring surface is the **`set_dataset` MCP tool** (mark a
-bundled support file with a `sampleSize`, `remove:true` to clear;
-`get_support_files` reports `isDataset` / `datasetSampleSize`).
+**Authoring surfaces:** two, and they agree by construction.
+
+- The **Files-panel control** on both authoring pages: each support-file row
+  carries a "Per-student sample" toggle and a row count, saved in place with no
+  page reload. The create page writes through a draft-scoped
+  `GET`/`PUT /instructor/new/draft/datasets`, the edit page through the
+  published `GET`/`PUT /instructor/:id/datasets`; both pairs share one
+  validation + manifest-write core (`DatasetEditHelpers.swift`), so a spec one
+  page accepts is one the other accepts. The behaviour lives once, in
+  `Public/support-files.js`, which both pages already load — the two templates
+  carry the same markup and differ only in the endpoint their page file passes
+  in.
+- The **`set_dataset` MCP tool** (mark a bundled support file with a
+  `sampleSize`, `remove:true` to clear).
+
+Both report from the same lookup — `TestProperties.datasetSpecsByFile`, read by
+`get_support_files` for its `isDataset` / `datasetSampleSize` fields and by the
+two support-row builders for the panel's controls — so the agent surface and
+the web UI cannot describe one file differently.
+
+A PUT **replaces the whole array**; it is not a patch endpoint, so a caller
+sends the complete desired state. Either PUT rejects a body naming one file
+twice, and `set_dataset` drops any existing spec for the file before appending
+its own — two specs for one file would disagree about how many rows a student
+gets, and which one won would be a detail of whichever consumer folded the
+array.
 
 ## Train/test splits & grader-only files (option B)
 


### PR DESCRIPTION
Slice A of the datasets handoff — the Files-panel dataset control. Slice B
(stratified sampling) is deliberately not here: the handoff gates it on this
merging first.

## What was missing

`PUT /instructor/:id/datasets` and the `set_dataset` MCP tool both shipped, but
the inline control never landed, so an instructor without an agent had no way
to mark a per-student dataset at all.

## The control

Each support-file row on **both** authoring pages now carries a "Per-student
sample" toggle and a row count, saved in place with no page reload. Marking a
file prefills 100 rows (editable immediately) and PUTs; editing the count PUTs;
clearing the toggle PUTs an array without that file. A non-positive count is
refused beside the field rather than sent, and a failed write resyncs the
controls from the server so the page never shows a mark that was not saved.

The behaviour lives once, in `Public/support-files.js`, which both pages
already load. The two templates carry the same markup and differ only in the
endpoint their page file passes in — no fourth per-page JS fork. Its
document-level listener is bound once per document, the guard suite-table.js
documents for the same reason.

## The create page needed a target

`GET`/`PUT /instructor/new/draft/datasets`, the draft-scoped sibling, so a
dataset can be marked before publish rather than by publishing and coming back.
It shares one validation + manifest-write core with the published pair
(`DatasetEditHelpers.swift`), so a spec one page accepts is one the other
accepts; the draft tests assert the shared rejections fire there too. Both
pairs read the manifest back after the write instead of echoing the request,
because the response is what the control re-renders from.

## One lookup behind both surfaces

`isDataset` / `datasetSampleSize` reach the templates through
`TestProperties.datasetSpecsByFile` — the one lookup `get_support_files` now
reports from — so the web UI and the agent surface cannot describe the same
file differently. The create page's support-row rebuild (which exists only to
rewrite `url`) carries the pair rather than re-deriving it; dropping it there
would have blanked every mark on that page while the edit page still showed it.

## One behaviour change beyond the control

A `datasets` array naming the same file twice is now rejected by either PUT.
Two specs for one file disagree about how many rows a student gets, and which
one won was a detail of whichever consumer folded the array (`DatasetResolver`
takes the last, `get_support_files` took the first). `set_dataset` already
replaced rather than appended, so it could not produce one.

## Tests

- `DatasetsRouteRoundTripTests` — GET → PUT → GET on both pairs (mark, change
  the size, clear), the manifest splice preserving everything else, the shared
  rejections on the draft pair, duplicate specs refused by both, and **both
  pages rendering the control from a stored spec** (a checked toggle with its
  row count on the marked file; unchecked and hidden on the plain one).
- `SupportFileDatasetRowTests` — both row builders, the create page's URL
  rewrite, and `EditableSuiteRow`'s hand-written `encode(to:)`, which is where
  a new field silently fails to reach Leaf: a row that encodes without it
  renders as an unmarked control rather than as an error.

Render tests do not exercise page JS, so the control itself still wants a
manual pass in a browser: toggle on, change the count, clear, and confirm each
survives a reload.

## Checks

`scripts/format.sh`, `lint.sh`, `swiftlint.sh` (0 violations), `check-styles.sh`
(including class resolution, design tokens, the page-style ratchet),
`eslint.sh`, `no-new-xctest.sh`, `no-language-defaults.sh`,
`generate-js-constants.sh --check` and `check-runner-wasm-size.sh` all green.
One `changelog.d/` fragment; `VERSION`, `ChickadeeVersion.swift` and
`CHANGELOG.md` untouched. `docs/datasets.md` updated — its "Authoring surfaces"
note still said this control had not landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YH9Rf5v8eSHWtiryUMdfeK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH9Rf5v8eSHWtiryUMdfeK)_