### PR TITLE
feat(datasets): balance a per-student sample across a column

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2064,6 +2064,10 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .dataset-size-field { display: inline-flex; align-items: center; gap: .3rem; }
 .dataset-size-field[hidden] { display: none; }
 .dataset-size { width: 6rem; }
+/* The column a stratified sample balances across; empty means a plain sample,
+   so the field carries the kind rather than a second control asking the same
+   question in different words. */
+.dataset-stratum { width: 10rem; }
 
 /* Pattern-family editor body internals. */
 .label-note { color: var(--gray-600); font-weight: 400; }

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -11,6 +11,7 @@
 //     uploadURL:   () => POST target for {filename, content, tier, isTest}
 //     deleteURL:   (name) => DELETE target for one stored support file
 //     datasetsURL: () => GET/PUT target for {datasets: [DatasetSpec]}
+//                  (a spec is {file, kind, sampleSize, stratumColumn?})
 //     onChange:    () => run after a successful upload batch or delete
 //                  (the edit surface re-renders in place; the create page
 //                  reloads its draft)
@@ -83,12 +84,43 @@
                 var toggle = row.querySelector('.js-dataset-toggle');
                 var field = row.querySelector('.js-dataset-size-field');
                 var size = row.querySelector('.js-dataset-size');
+                var stratumField = row.querySelector('.js-dataset-stratum-field');
+                var stratum = row.querySelector('.js-dataset-stratum');
                 if (!toggle || !field || !size) return;
                 var spec = byFile[row.getAttribute('data-support-file')];
                 toggle.checked = !!spec;
                 field.hidden = !spec;
                 size.value = (spec && spec.sampleSize != null) ? String(spec.sampleSize) : '';
+                if (stratumField) stratumField.hidden = !spec;
+                if (stratum) stratum.value = (spec && spec.stratumColumn) || '';
             });
+        }
+
+        // The spec a row currently describes. The KIND is derived from whether
+        // a column is named, rather than being a separate control: a stratified
+        // sample is exactly "a sample, balanced across this column", and a
+        // second widget asking the same question in different words is how the
+        // two would come to disagree.
+        function specFor(row, filename, sampleSize) {
+            var stratum = row.querySelector('.js-dataset-stratum');
+            var column = stratum ? stratum.value.trim() : '';
+            if (!column) {
+                return { file: filename, kind: 'rowSample', sampleSize: sampleSize };
+            }
+            return {
+                file: filename,
+                kind: 'stratifiedSample',
+                sampleSize: sampleSize,
+                stratumColumn: column
+            };
+        }
+
+        // The row count a row is currently showing, or null when it is blank
+        // or not a positive integer.
+        function sampleSizeIn(row) {
+            var size = row.querySelector('.js-dataset-size');
+            var value = parseInt(size && size.value, 10);
+            return value > 0 ? value : null;
         }
 
         function fetchSpecs() {
@@ -136,29 +168,32 @@
             if (!filename) return;
             var size = row.querySelector('.js-dataset-size');
             var field = row.querySelector('.js-dataset-size-field');
+            var stratumField = row.querySelector('.js-dataset-stratum-field');
 
             if (target.classList.contains('js-dataset-toggle')) {
                 if (!target.checked) {
                     if (field) field.hidden = true;
+                    if (stratumField) stratumField.hidden = true;
                     commit(filename, null, row);
                     return;
                 }
-                var sampleRows = parseInt(size && size.value, 10);
-                if (!(sampleRows > 0)) sampleRows = DEFAULT_SAMPLE_ROWS;
+                var sampleRows = sampleSizeIn(row) || DEFAULT_SAMPLE_ROWS;
                 if (size) size.value = String(sampleRows);
                 if (field) {
                     field.hidden = false;
                     if (size && size.focus) { size.focus(); size.select(); }
                 }
-                commit(filename, { file: filename, kind: 'rowSample', sampleSize: sampleRows }, row);
+                if (stratumField) stratumField.hidden = false;
+                commit(filename, specFor(row, filename, sampleRows), row);
                 return;
             }
 
-            if (target.classList.contains('js-dataset-size')) {
+            if (target.classList.contains('js-dataset-size')
+                || target.classList.contains('js-dataset-stratum')) {
                 var toggle = row.querySelector('.js-dataset-toggle');
                 if (toggle && !toggle.checked) return;
-                var entered = parseInt(target.value, 10);
-                if (!(entered > 0)) {
+                var entered = sampleSizeIn(row);
+                if (entered === null) {
                     // Refuse rather than send: the server would reject it too,
                     // and an inline message beside the field is a better answer
                     // than a banner. Resync puts the saved number back.
@@ -166,7 +201,7 @@
                     resync();
                     return;
                 }
-                commit(filename, { file: filename, kind: 'rowSample', sampleSize: entered }, row);
+                commit(filename, specFor(row, filename, entered), row);
             }
         });
     }

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -181,6 +181,15 @@
                                        aria-label="Rows per student from #(supportFile.name)">
                                 rows per student
                             </span>
+                            <span class="dataset-size-field js-dataset-stratum-field"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                balanced across
+                                <input type="text"
+                                       class="form-input input-sm dataset-stratum js-dataset-stratum"
+                                       value="#(supportFile.datasetStratumColumnOrEmpty)"
+                                       placeholder="column (optional)"
+                                       aria-label="Column to balance the sample of #(supportFile.name) across">
+                            </span>
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
                         </div>
                     </td>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -181,6 +181,15 @@ Create Assignment
                                        aria-label="Rows per student from #(supportFile.name)">
                                 rows per student
                             </span>
+                            <span class="dataset-size-field js-dataset-stratum-field"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                balanced across
+                                <input type="text"
+                                       class="form-input input-sm dataset-stratum js-dataset-stratum"
+                                       value="#(supportFile.datasetStratumColumnOrEmpty)"
+                                       placeholder="column (optional)"
+                                       aria-label="Column to balance the sample of #(supportFile.name) across">
+                            </span>
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
                         </div>
                     </td>

--- a/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
@@ -40,6 +40,13 @@ struct GetSupportFilesTool: ContentTool {
         let datasetSampleSize: Int?
         /// True when the file is a per-student dataset (docs/datasets.md).
         let isDataset: Bool
+        /// "rowSample" or "stratifiedSample" for a dataset; nil otherwise.
+        let datasetKind: String?
+        /// The column a stratified dataset balances across; nil otherwise.
+        /// Reported for the same reason the sample size is: an agent that
+        /// cannot read a mark back cannot preserve it, and the Files panel
+        /// shows both.
+        let datasetStratumColumn: String?
     }
 
     struct Output: Encodable, Sendable {
@@ -64,7 +71,8 @@ struct GetSupportFilesTool: ContentTool {
         + "get_solution). Omit filename to list filenames and sizes; pass filename to read that file's "
         + "UTF-8 content, capped at maxBytes (default 65536) with truncated:true when the file is "
         + "larger — so a big dataset returns a useful head. Listed entries report per-student "
-        + "dataset marks (isDataset / datasetSampleSize — set them with set_dataset). Write "
+        + "dataset marks (isDataset / datasetSampleSize / datasetKind / datasetStratumColumn — set "
+        + "them with set_dataset). Write "
         + "support files with "
         + "author_script(tier:\"support\"). Read-only, instructor-authored content only; use it to "
         + "confirm a data file is actually bundled (and what its columns/rows look like) before "
@@ -131,7 +139,9 @@ struct GetSupportFilesTool: ContentTool {
                     filename: name,
                     sizeBytes: extractZipEntry(zipPath: setup.zipPath, entryName: name)?.count ?? 0,
                     datasetSampleSize: datasetSpecs[name]?.sampleSize,
-                    isDataset: datasetSpecs[name] != nil)
+                    isDataset: datasetSpecs[name] != nil,
+                    datasetKind: datasetSpecs[name]?.kind.rawValue,
+                    datasetStratumColumn: datasetSpecs[name]?.stratumColumn)
             }
             return Output(
                 assignmentPublicID: assignment.publicID,

--- a/Sources/APIServer/MCP/Tools/SetDatasetTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetDatasetTool.swift
@@ -25,6 +25,9 @@ struct SetDatasetTool: ContentTool {
         let filename: String
         /// Rows each student receives. Required unless `remove` is true.
         let sampleSize: Int?
+        /// A column name to balance the sample across; omitted for a plain
+        /// row sample.
+        let stratumColumn: String?
         /// True to clear the dataset mark (the file becomes an ordinary shared
         /// support file again).
         let remove: Bool?
@@ -33,6 +36,10 @@ struct SetDatasetTool: ContentTool {
     struct DatasetEntry: Encodable, Sendable {
         let file: String
         let sampleSize: Int?
+        /// "rowSample" or "stratifiedSample" — reported so an agent can read
+        /// back which kind of slice a file is marked for, not just that it is.
+        let kind: String
+        let stratumColumn: String?
     }
 
     struct Output: Encodable, Sendable {
@@ -51,7 +58,12 @@ struct SetDatasetTool: ContentTool {
         + "The full uploaded file becomes the server-side pool; students never see it. Structural "
         + "checks (columns, dtypes, figure counts) are unaffected; exact-value checks against the "
         + "shared file would break, so pair datasets with structural or per-student checks. Pick "
-        + "sampleSize large enough that every category a groupby exercise needs still appears. Like "
+        + "sampleSize large enough that every category a groupby exercise needs still appears — or "
+        + "pass stratumColumn to have the sample balanced across that column's distinct values, "
+        + "which guarantees every category survives into every student's copy (including a rare one "
+        + "a plain sample would usually drop). A stratum column must exist in the file's header and "
+        + "have no more distinct values than sampleSize; both are checked here, against the file. "
+        + "Like "
         + "the web editor's dataset control this does not close the assignment or re-run validation "
         + "(the suite is unchanged); existing submissions pick up their slice on the next regrade. "
         + "List support files with get_support_files (dataset marks are reported there); pass "
@@ -70,6 +82,14 @@ struct SetDatasetTool: ContentTool {
                 "description": .string(
                     "Data rows each student receives (>= 1; the header row is always kept). "
                         + "Required unless remove is true."),
+            ]),
+            "stratumColumn": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Optional. A column name from the file's header; the sample is then apportioned "
+                        + "across that column's distinct values so every category appears in every "
+                        + "student's slice. Must have no more distinct values than sampleSize. Omit "
+                        + "for a plain random row sample."),
             ]),
             "remove": .object([
                 "type": .string("boolean"),
@@ -134,15 +154,32 @@ struct SetDatasetTool: ContentTool {
                     detail: "\"\(cleaned)\" is not a support file — only support data files can "
                         + "be per-student datasets.")
             }
+            // The same check the web endpoints run, from the same place: a
+            // stratum column has to exist in this file and have no more
+            // categories than the sample has rows. The materializer degrades
+            // quietly on both at delivery time, so this is where an agent finds
+            // out — with the file's real column names in the message.
+            if let issue = DatasetSpecValidation.issue(
+                with: spec(from: input, filename: cleaned),
+                sourceCSV: extractZipEntry(zipPath: setup.zipPath, entryName: cleaned)
+                    .flatMap { String(data: $0, encoding: .utf8) })
+            {
+                throw MCPToolError.invalidArguments(tool: Self.name, detail: issue)
+            }
         }
 
+        let written = spec(from: input, filename: cleaned)
         try await mutateManifest(setup: setup, on: context.db) { dict in
             var specs = (dict["datasets"] as? [[String: Any]]) ?? []
+            // Replaced, never appended — two specs for one file would disagree
+            // about how many rows a student gets, and both PUT endpoints reject
+            // such a pair outright.
             specs.removeAll { ($0["file"] as? String) == cleaned }
             if !remove {
-                var spec: [String: Any] = ["file": cleaned, "kind": "rowSample"]
-                if let sampleSize = input.sampleSize { spec["sampleSize"] = sampleSize }
-                specs.append(spec)
+                var entry: [String: Any] = ["file": cleaned, "kind": written.kind.rawValue]
+                if let sampleSize = written.sampleSize { entry["sampleSize"] = sampleSize }
+                if let column = written.stratumColumn { entry["stratumColumn"] = column }
+                specs.append(entry)
             }
             if specs.isEmpty {
                 dict.removeValue(forKey: "datasets")
@@ -152,8 +189,27 @@ struct SetDatasetTool: ContentTool {
         }
 
         let datasets = (setup.decodedManifest()?.datasets ?? []).map {
-            DatasetEntry(file: $0.file, sampleSize: $0.sampleSize)
+            DatasetEntry(
+                file: $0.file, sampleSize: $0.sampleSize,
+                kind: $0.kind.rawValue, stratumColumn: $0.stratumColumn)
         }
         return Output(assignmentPublicID: assignment.publicID, datasets: datasets)
+    }
+
+    /// The spec this call would write, built once and used for both the
+    /// validation and the manifest entry — so the thing that is checked is the
+    /// thing that is stored.
+    ///
+    /// A blank `stratumColumn` reads as "no column": an agent clearing the
+    /// field means a plain row sample, not a stratified spec that fails
+    /// validation on the emptiness it just asked for.
+    private func spec(from input: Input, filename: String) -> DatasetSpec {
+        let column = input.stratumColumn?.trimmingCharacters(in: .whitespaces)
+        let stratum = (column?.isEmpty ?? true) ? nil : column
+        return DatasetSpec(
+            file: filename,
+            kind: stratum == nil ? .rowSample : .stratifiedSample,
+            sampleSize: input.sampleSize,
+            stratumColumn: stratum)
     }
 }

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -55,6 +55,11 @@ func datasetSpecs(inManifest manifest: String) -> [DatasetSpec] {
 ///   - two specs for the same file, which is incoherent — the two would
 ///     disagree about how many rows a student gets, and which one wins is a
 ///     detail of whichever consumer happens to fold the array.
+///   - a stratified spec that does not fit its file (`DatasetSpecValidation`):
+///     no column named, a column the file does not have, or a sample too small
+///     to hold one row of every category. The materializer degrades quietly on
+///     all three at delivery time, which is only safe because this refuses them
+///     while an instructor is still holding the form.
 func applyDatasetsEdit(
     setup: APITestSetup, datasets: [DatasetSpec], on db: Database
 ) async throws {
@@ -79,6 +84,16 @@ func applyDatasetsEdit(
         }
         guard seenFiles.insert(spec.file).inserted else {
             throw Abort(.badRequest, reason: "Dataset file '\(spec.file)' is listed more than once.")
+        }
+        // Reads the file only when a spec claims to stratify — an ordinary row
+        // sample needs nothing from the bytes, and these files are course
+        // datasets, not small.
+        if spec.kind == .stratifiedSample || spec.stratumColumn != nil {
+            let text = extractZipEntry(zipPath: setup.zipPath, entryName: spec.file)
+                .flatMap { String(data: $0, encoding: .utf8) }
+            if let issue = DatasetSpecValidation.issue(with: spec, sourceCSV: text) {
+                throw Abort(.badRequest, reason: issue)
+            }
         }
     }
 

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewPage.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewPage.swift
@@ -94,7 +94,8 @@ extension DraftAssignmentRoutes {
                     // and dropping the dataset pair here would blank every mark
                     // on the create page while the edit page still showed it.
                     isDataset: row.isDataset,
-                    datasetSampleSize: row.datasetSampleSize
+                    datasetSampleSize: row.datasetSampleSize,
+                    datasetStratumColumn: row.datasetStratumColumn
                 )
             }
     }

--- a/Sources/APIServer/Routes/Web/SuiteRowContexts.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowContexts.swift
@@ -50,6 +50,11 @@ struct EditableSuiteRow: Encodable {
     /// Rows each student receives for a dataset row; nil = whole file (and nil
     /// on every non-dataset row).
     let datasetSampleSize: Int?
+    /// The column a stratified dataset balances across; nil for a plain row
+    /// sample. The control derives the spec's kind from this being set, so it
+    /// has to travel with the row or an edit would rewrite a stratified spec
+    /// into a plain one.
+    let datasetStratumColumn: String?
 
     /// Empty string when displayName is nil — Leaf doesn't support `??` in templates.
     var displayNameOrEmpty: String { displayName ?? "" }
@@ -58,6 +63,9 @@ struct EditableSuiteRow: Encodable {
     /// the number field renders blank rather than "nil" (same reason
     /// `displayNameOrEmpty` exists).
     var datasetSampleSizeText: String { datasetSampleSize.map(String.init) ?? "" }
+
+    /// The stratum column as an input-ready string — empty when there is none.
+    var datasetStratumColumnOrEmpty: String { datasetStratumColumn ?? "" }
 
     /// The dataset pair defaults to "not a dataset": every construction site
     /// but the two support-file row builders is describing a test script, and
@@ -72,7 +80,8 @@ struct EditableSuiteRow: Encodable {
         points: Int,
         displayName: String?,
         isDataset: Bool = false,
-        datasetSampleSize: Int? = nil
+        datasetSampleSize: Int? = nil,
+        datasetStratumColumn: String? = nil
     ) {
         self.name = name
         self.url = url
@@ -84,6 +93,7 @@ struct EditableSuiteRow: Encodable {
         self.displayName = displayName
         self.isDataset = isDataset
         self.datasetSampleSize = datasetSampleSize
+        self.datasetStratumColumn = datasetStratumColumn
     }
 
     /// Display name if set, otherwise the filename stem (extension stripped).
@@ -111,9 +121,11 @@ struct EditableSuiteRow: Encodable {
         case displayName
         case isDataset
         case datasetSampleSize
+        case datasetStratumColumn
         case displayNameOrEmpty
         case displayNameOrStem
         case datasetSampleSizeText
+        case datasetStratumColumnOrEmpty
         case dependsOnJSON
     }
 
@@ -129,9 +141,11 @@ struct EditableSuiteRow: Encodable {
         try container.encodeIfPresent(displayName, forKey: .displayName)
         try container.encode(isDataset, forKey: .isDataset)
         try container.encodeIfPresent(datasetSampleSize, forKey: .datasetSampleSize)
+        try container.encodeIfPresent(datasetStratumColumn, forKey: .datasetStratumColumn)
         try container.encode(displayNameOrEmpty, forKey: .displayNameOrEmpty)
         try container.encode(displayNameOrStem, forKey: .displayNameOrStem)
         try container.encode(datasetSampleSizeText, forKey: .datasetSampleSizeText)
+        try container.encode(datasetStratumColumnOrEmpty, forKey: .datasetStratumColumnOrEmpty)
         try container.encode(dependsOnJSON, forKey: .dependsOnJSON)
     }
 }

--- a/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
@@ -163,7 +163,8 @@ func currentSetupFiles(
             points: entry?.points ?? 1,
             displayName: entry?.name,
             isDataset: datasetSpecs[name] != nil,
-            datasetSampleSize: datasetSpecs[name]?.sampleSize
+            datasetSampleSize: datasetSpecs[name]?.sampleSize,
+            datasetStratumColumn: datasetSpecs[name]?.stratumColumn
         )
     }
 
@@ -224,7 +225,8 @@ func editableSuiteRowsForSetup(_ setup: APITestSetup) -> [EditableSuiteRow] {
             points: info?.points ?? 1,
             displayName: info?.name,
             isDataset: datasetSpecs[name] != nil,
-            datasetSampleSize: datasetSpecs[name]?.sampleSize
+            datasetSampleSize: datasetSpecs[name]?.sampleSize,
+            datasetStratumColumn: datasetSpecs[name]?.stratumColumn
         )
     }
     .sorted { lhs, rhs in

--- a/Sources/Core/DatasetMaterializer.swift
+++ b/Sources/Core/DatasetMaterializer.swift
@@ -29,6 +29,19 @@ public enum DatasetMaterializer {
         switch spec.kind {
         case .rowSample:
             return sampleRows(csv: source, sampleSize: spec.sampleSize ?? .max, seedHex: seedHex)
+        case .stratifiedSample:
+            // A stratified spec with no column, or one naming a column this
+            // file does not have, degrades to a plain row sample rather than
+            // failing. Authoring refuses both (see `DatasetSpec.stratumColumn`),
+            // so reaching here means the file changed under a saved spec — and
+            // the only reader left is a student being graded, who would rather
+            // have their N rows unstratified than the whole pool everyone else
+            // has. Loud at authoring, forgiving at delivery.
+            guard let column = spec.stratumColumn, !column.isEmpty else {
+                return sampleRows(csv: source, sampleSize: spec.sampleSize ?? .max, seedHex: seedHex)
+            }
+            return sampleStratifiedRows(
+                csv: source, sampleSize: spec.sampleSize ?? .max, column: column, seedHex: seedHex)
         }
     }
 
@@ -43,17 +56,7 @@ public enum DatasetMaterializer {
     /// it has no data rows, when `sampleSize` is non-positive, or when
     /// `sampleSize` is ≥ the number of data rows.
     static func sampleRows(csv: String, sampleSize: Int, seedHex: String) -> String {
-        // CR+LF is a single Swift `Character` (one extended grapheme cluster),
-        // so `split(separator: "\n")` would not see the LF inside a CRLF line
-        // ending and would return the whole file as one "line".  Normalize to
-        // LF via string replacement (which matches the CRLF grapheme) first.
-        let normalized = csv.replacingOccurrences(of: "\r\n", with: "\n")
-            .replacingOccurrences(of: "\r", with: "\n")
-        let hadTrailingNewline = normalized.hasSuffix("\n")
-        var lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
-        if hadTrailingNewline, lines.last?.isEmpty == true {
-            lines.removeLast()
-        }
+        let (lines, hadTrailingNewline) = normalizedLines(of: csv)
         guard lines.count > 1 else { return csv }  // header-only or empty
 
         let header = lines[0]
@@ -74,6 +77,206 @@ public enum DatasetMaterializer {
         out.append(contentsOf: chosen.map { lines[$0] })
         let result = out.joined(separator: "\n")
         return hadTrailingNewline ? result + "\n" : result
+    }
+
+    /// Deterministically sample `sampleSize` data rows apportioned across the
+    /// distinct values of `column`, so every category in the pool survives into
+    /// the student's slice.
+    ///
+    /// Same envelope as `sampleRows`: header preserved, chosen rows in original
+    /// order, LF output, trailing newline mirrored, and the whole file returned
+    /// unchanged when the sample would not be a reduction.  Falls back to a
+    /// plain row sample when `column` is not in the header — the delivery-time
+    /// half of the rule on `DatasetSpec.stratumColumn`.
+    ///
+    /// Apportionment is Hamilton's method with a floor of one row per stratum,
+    /// computed in integer arithmetic (no `Double`: the point of this file is
+    /// that the same inputs give the same bytes on every platform forever, and
+    /// a rounding difference would be an invisible way to lose that).  When the
+    /// budget cannot cover one row per stratum — the file grew categories after
+    /// the spec was saved — the first `sampleSize` strata in file order get one
+    /// row each.
+    static func sampleStratifiedRows(
+        csv: String, sampleSize: Int, column: String, seedHex: String
+    ) -> String {
+        let (lines, hadTrailingNewline) = normalizedLines(of: csv)
+        guard lines.count > 1 else { return csv }  // header-only or empty
+
+        let header = lines[0]
+        let rowCount = lines.count - 1
+        guard sampleSize > 0, sampleSize < rowCount else { return csv }  // keep everything
+
+        let headerFields = splitCSVLine(header)
+        guard let columnIndex = headerFields.firstIndex(of: column) else {
+            return sampleRows(csv: csv, sampleSize: sampleSize, seedHex: seedHex)
+        }
+
+        // Strata in order of first appearance — a stable order that needs no
+        // string comparison, so no question of collation ever arises.
+        var strataOrder: [String] = []
+        var rowsByStratum: [String: [Int]] = [:]
+        for index in 1..<lines.count {
+            let fields = splitCSVLine(lines[index])
+            // A short row has no value for this column; "" is a category like
+            // any other, and grouping it keeps every row eligible.
+            let value = columnIndex < fields.count ? fields[columnIndex] : ""
+            if rowsByStratum[value] == nil {
+                rowsByStratum[value] = []
+                strataOrder.append(value)
+            }
+            rowsByStratum[value]?.append(index)
+        }
+
+        let sizes = strataOrder.map { rowsByStratum[$0]?.count ?? 0 }
+        let allocation = apportion(sampleSize: sampleSize, sizes: sizes, total: rowCount)
+
+        // One PRNG stream walked in stratum order, so the whole slice is one
+        // deterministic sequence rather than N independent ones.
+        var rng = SplitMix64(seed: fnv1a64(seedHex))
+        var chosen: [Int] = []
+        for (position, stratum) in strataOrder.enumerated() {
+            guard var indices = rowsByStratum[stratum] else { continue }
+            let take = allocation[position]
+            if take <= 0 { continue }
+            if take >= indices.count {
+                chosen.append(contentsOf: indices)
+                continue
+            }
+            for i in 0..<take {
+                let j = i + Int(rng.next(upperBound: UInt64(indices.count - i)))
+                indices.swapAt(i, j)
+            }
+            chosen.append(contentsOf: indices.prefix(take))
+        }
+        chosen.sort()
+
+        var out: [Substring] = [header]
+        out.append(contentsOf: chosen.map { lines[$0] })
+        let result = out.joined(separator: "\n")
+        return hadTrailingNewline ? result + "\n" : result
+    }
+
+    /// Splits `sampleSize` across strata: one row each, then the remainder in
+    /// proportion to stratum size, leftovers to the largest fractional
+    /// remainders (ties to the earlier stratum).  Never allocates more rows
+    /// than a stratum holds.
+    ///
+    /// Returns counts parallel to `sizes`.  Internal rather than private so the
+    /// apportionment can be tested on its own — the row selection around it is
+    /// seeded, and a table of expected splits is far easier to read than a
+    /// slice of a CSV.
+    static func apportion(sampleSize: Int, sizes: [Int], total: Int) -> [Int] {
+        guard !sizes.isEmpty else { return [] }
+        // More strata than rows to give away: one row each to as many strata as
+        // the budget covers, in file order.
+        guard sampleSize > sizes.count else {
+            return sizes.indices.map { $0 < sampleSize ? 1 : 0 }
+        }
+
+        var allocation = sizes.map { min(1, $0) }
+        // Hamilton over the rows left after the floor, against each stratum's
+        // remaining capacity.
+        let spare = sizes.map { max(0, $0 - 1) }
+        let spareTotal = spare.reduce(0, +)
+        let remaining = sampleSize - allocation.reduce(0, +)
+        if remaining > 0, spareTotal > 0 {
+            var remainders: [(index: Int, remainder: Int)] = []
+            for i in sizes.indices {
+                let exact = spare[i] * remaining
+                allocation[i] += exact / spareTotal
+                remainders.append((i, exact % spareTotal))
+            }
+            var leftover = sampleSize - allocation.reduce(0, +)
+            // Largest remainder first; ties by position, so the split is a
+            // function of the inputs alone.
+            remainders.sort { $0.remainder == $1.remainder ? $0.index < $1.index : $0.remainder > $1.remainder }
+            var pass = 0
+            while leftover > 0, pass < remainders.count {
+                let i = remainders[pass].index
+                if allocation[i] < sizes[i] {
+                    allocation[i] += 1
+                    leftover -= 1
+                }
+                pass += 1
+            }
+            // A stratum can be capped out while another still has room (the
+            // proportional pass does not know about caps), so sweep in file
+            // order until the budget is spent or nothing can absorb it.
+            var progressed = true
+            while leftover > 0, progressed {
+                progressed = false
+                for i in sizes.indices where leftover > 0 && allocation[i] < sizes[i] {
+                    allocation[i] += 1
+                    leftover -= 1
+                    progressed = true
+                }
+            }
+        }
+        return allocation
+    }
+
+    /// Splits `csv` into lines with CR/CRLF normalized away, reporting whether
+    /// the input ended with a newline.  Shared by both sampling kinds so their
+    /// line handling cannot drift.
+    ///
+    /// CR+LF is a single Swift `Character` (one extended grapheme cluster), so
+    /// `split(separator: "\n")` would not see the LF inside a CRLF ending and
+    /// would return the whole file as one "line".
+    private static func normalizedLines(of csv: String) -> (lines: [Substring], trailingNewline: Bool) {
+        let normalized = csv.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let hadTrailingNewline = normalized.hasSuffix("\n")
+        var lines = normalized.split(separator: "\n", omittingEmptySubsequences: false)
+        if hadTrailingNewline, lines.last?.isEmpty == true {
+            lines.removeLast()
+        }
+        return (lines, hadTrailingNewline)
+    }
+
+    /// Splits one CSV record into fields, honouring double-quoted fields and
+    /// doubled quotes inside them.
+    ///
+    /// Quotes matter here even though the surrounding format assumes no
+    /// embedded newlines: a quoted comma ANYWHERE earlier in the row shifts
+    /// every later field by one, so a naive comma split would read a
+    /// neighbouring column's values as the strata and silently stratify by the
+    /// wrong thing. Embedded newlines remain out of scope — a record is a
+    /// physical line, as `sampleRows` has always assumed.
+    static func splitCSVLine(_ line: Substring) -> [String] {
+        var fields: [String] = []
+        var current = ""
+        var inQuotes = false
+        var iterator = line.makeIterator()
+        var pending: Character?
+        while let character = pending ?? iterator.next() {
+            pending = nil
+            if inQuotes {
+                if character == "\"" {
+                    if let next = iterator.next() {
+                        if next == "\"" {
+                            current.append("\"")  // an escaped quote
+                        } else {
+                            inQuotes = false
+                            pending = next
+                        }
+                    } else {
+                        inQuotes = false
+                    }
+                } else {
+                    current.append(character)
+                }
+                continue
+            }
+            switch character {
+            case "\"": inQuotes = true
+            case ",":
+                fields.append(current)
+                current = ""
+            default: current.append(character)
+            }
+        }
+        fields.append(current)
+        return fields
     }
 }
 

--- a/Sources/Core/DatasetSpecValidation.swift
+++ b/Sources/Core/DatasetSpecValidation.swift
@@ -1,0 +1,90 @@
+// Core/DatasetSpecValidation.swift
+//
+// The save-time half of the stratified-sampling contract (docs/datasets.md
+// Phase 1.5).
+//
+// `DatasetMaterializer` degrades quietly when a stratified spec does not fit
+// its file — an unknown column falls back to a plain row sample — because by
+// delivery time the only reader is a student being graded, and there is nothing
+// they could do about an error. That forgiveness is only safe if the mistake is
+// caught somewhere it CAN be fixed, which is here: every authoring door runs
+// this before writing a spec, so a typo'd column name is refused in the second
+// it is typed rather than silently unstratifying a whole class's data.
+//
+// It answers about the spec and the file's text alone — no zip, no database, no
+// Vapor — so the web endpoints and the MCP tool ask one question and get one
+// answer, and each wraps the result in its own error type.
+
+import Foundation
+
+/// Save-time checks a dataset spec must pass against the file it marks.
+public enum DatasetSpecValidation {
+
+    /// How many column names an error message lists before trailing off. A
+    /// clinical extract can have hundreds; a wall of them helps nobody.
+    static let maxListedColumns = 12
+
+    /// Returns why `spec` cannot be saved against `sourceCSV`, or nil when it
+    /// is fine.
+    ///
+    /// `sourceCSV` is the marked file's text, or nil when the file's bytes are
+    /// not UTF-8 — which is itself a rejection for a stratified spec, since the
+    /// column cannot be found in bytes that are not a text table.
+    ///
+    /// The message is user-facing: it names what is wrong, and where the answer
+    /// is knowable (the available columns, the number of categories) it says
+    /// that too, because the instructor cannot see the file from the form they
+    /// are typing into.
+    public static func issue(with spec: DatasetSpec, sourceCSV: String?) -> String? {
+        guard spec.kind == .stratifiedSample else {
+            // A column on a plain row sample would be stored and then ignored
+            // at delivery — the silent-mismatch shape this whole file exists to
+            // prevent — so it is refused rather than dropped.
+            if let column = spec.stratumColumn, !column.isEmpty {
+                return "'\(spec.file)': a stratum column only applies to a stratified sample."
+            }
+            return nil
+        }
+
+        guard let column = spec.stratumColumn?.trimmingCharacters(in: .whitespaces), !column.isEmpty else {
+            return "'\(spec.file)': a stratified sample needs the name of the column to balance across."
+        }
+        guard let sourceCSV else {
+            return "'\(spec.file)' is not UTF-8 text, so it has no columns to balance across."
+        }
+
+        let rows = sourceCSV.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: true)
+        guard let header = rows.first else {
+            return "'\(spec.file)' is empty, so it has no columns to balance across."
+        }
+
+        let columns = DatasetMaterializer.splitCSVLine(header)
+        guard let columnIndex = columns.firstIndex(of: column) else {
+            return "'\(spec.file)' has no column named '\(column)'. Its columns are: \(list(columns))."
+        }
+
+        // The instructor's real question is "will every category survive?", and
+        // it is answerable here and nowhere else: a sample smaller than the
+        // number of categories cannot include them all, whatever the
+        // apportionment does.
+        var categories: Set<String> = []
+        for row in rows.dropFirst() {
+            let fields = DatasetMaterializer.splitCSVLine(row)
+            categories.insert(columnIndex < fields.count ? fields[columnIndex] : "")
+        }
+        if let sampleSize = spec.sampleSize, sampleSize < categories.count {
+            return
+                "'\(spec.file)': column '\(column)' has \(categories.count) distinct values, so a sample "
+                + "of \(sampleSize) rows cannot include them all. Raise the sample size to at least "
+                + "\(categories.count), or balance across a column with fewer categories."
+        }
+        return nil
+    }
+
+    private static func list(_ columns: [String]) -> String {
+        let shown = columns.prefix(maxListedColumns).map { "'\($0)'" }.joined(separator: ", ")
+        return columns.count > maxListedColumns ? shown + ", …" : shown
+    }
+}

--- a/Sources/Core/Models/DatasetSpec.swift
+++ b/Sources/Core/Models/DatasetSpec.swift
@@ -18,8 +18,16 @@
 ///   tabular (CSV) source, keyed to the per-(student, assignment) seed.  The
 ///   header row is always preserved and the chosen rows keep their original
 ///   order.
+/// - `stratifiedSample`: the same, but the sample is apportioned across the
+///   distinct values of `stratumColumn` so every category present in the pool
+///   is still present in the student's slice.  A plain `rowSample` can drop a
+///   rare category entirely, which turns a `groupby` exercise into a different
+///   exercise for that student; this is the fix for that, and the reason the
+///   `set_dataset` advice "pick a sample size large enough that every category
+///   still appears" exists.
 public enum DatasetKind: String, Codable, Sendable, Equatable {
     case rowSample
+    case stratifiedSample
 }
 
 /// Marks one bundled support file as a per-student dataset.
@@ -29,14 +37,28 @@ public struct DatasetSpec: Codable, Equatable, Sendable {
     /// per-student slice is delivered under this same name.
     public let file: String
     public let kind: DatasetKind
-    /// Rows per student for `.rowSample`.  `nil` (or a value ≥ the row count)
-    /// means "the whole file" — every student gets the full source.
+    /// Rows per student.  `nil` (or a value ≥ the row count) means "the whole
+    /// file" — every student gets the full source.
     public let sampleSize: Int?
+    /// The header name of the column whose distinct values are the strata, for
+    /// `.stratifiedSample`.  Nil for `.rowSample`, which has no strata.
+    ///
+    /// Authoring surfaces refuse a `.stratifiedSample` spec without one, and
+    /// refuse a column the file's header does not carry — a stratum column is
+    /// only checkable against the file, and an instructor can fix a typo in
+    /// seconds where a student cannot fix anything.  `DatasetMaterializer`
+    /// still degrades rather than fails when it cannot find the column at
+    /// delivery time, because by then the only reader is a student's grade.
+    public let stratumColumn: String?
 
-    public init(file: String, kind: DatasetKind = .rowSample, sampleSize: Int? = nil) {
+    public init(
+        file: String, kind: DatasetKind = .rowSample, sampleSize: Int? = nil,
+        stratumColumn: String? = nil
+    ) {
         self.file = file
         self.kind = kind
         self.sampleSize = sampleSize
+        self.stratumColumn = stratumColumn
     }
 
     public init(from decoder: Decoder) throws {
@@ -44,5 +66,6 @@ public struct DatasetSpec: Codable, Equatable, Sendable {
         file = try c.decode(String.self, forKey: .file)
         kind = try c.decodeIfPresent(DatasetKind.self, forKey: .kind) ?? .rowSample
         sampleSize = try c.decodeIfPresent(Int.self, forKey: .sampleSize)
+        stratumColumn = try c.decodeIfPresent(String.self, forKey: .stratumColumn)
     }
 }

--- a/Tests/APITests/DatasetsRouteRoundTripTests.swift
+++ b/Tests/APITests/DatasetsRouteRoundTripTests.swift
@@ -75,7 +75,10 @@ import VaporTesting
             .appendingPathComponent("dsr-zip-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
-        try Data("id\n1\n2\n3\n".utf8).write(to: root.appendingPathComponent("cases.csv"))
+        // Two columns on purpose: `ward` has two categories (a stratified
+        // sample of 2 fits), `id` has three (so a sample of 2 cannot hold them
+        // all) — the two sides of the stratum rule, in one fixture.
+        try Data("id,ward\n1,3A\n2,3B\n3,3A\n".utf8).write(to: root.appendingPathComponent("cases.csv"))
         try Data("notes".utf8).write(to: root.appendingPathComponent("notes.txt"))
         try writeZipFixture(of: root, to: zipPath)
         let setup = APITestSetup(id: id, manifest: manifest, zipPath: zipPath, courseID: courseID)
@@ -290,6 +293,83 @@ import VaporTesting
             let plain = try rowMarkup(for: "notes.txt", in: html)
             #expect(plain.contains("checked") == false)
             #expect(plain.contains("hidden"))
+        }
+    }
+
+    // MARK: - Stratified specs are checked against the file, at both doors
+    //
+    // `DatasetMaterializer` degrades quietly when a stratified spec does not fit
+    // its file — that is deliberate, since at delivery time the only reader is a
+    // student being graded. It is only safe because the spec cannot be SAVED in
+    // that state, which is what these assert.
+
+    @Test func stratifiedSpecRoundTripsWithItsColumn() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("s")
+            let path = "/instructor/\(fx.assignmentID)/datasets"
+            try await put(
+                path, fx,
+                body:
+                    #"{"datasets":[{"file":"cases.csv","kind":"stratifiedSample","sampleSize":2,"stratumColumn":"ward"}]}"#,
+                expect: .ok, "a column the file has, with room for its categories")
+
+            let stored = try await get(path, fx)
+            #expect(stored.first?.kind == .stratifiedSample)
+            #expect(stored.first?.stratumColumn == "ward")
+            #expect(stored.first?.sampleSize == 2)
+        }
+    }
+
+    @Test func stratifiedSpecRejectionsFireOnBothPairs() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("t")
+            for (label, path) in [
+                ("published", "/instructor/\(fx.assignmentID)/datasets"),
+                ("draft", "/instructor/new/draft/datasets?draftID=\(fx.draftID)"),
+            ] {
+                try await put(
+                    path, fx,
+                    body: #"{"datasets":[{"file":"cases.csv","kind":"stratifiedSample","sampleSize":2}]}"#,
+                    expect: .badRequest, "\(label): a stratified spec needs a column")
+                try await put(
+                    path, fx,
+                    body:
+                        #"{"datasets":[{"file":"cases.csv","kind":"stratifiedSample","sampleSize":2,"stratumColumn":"unit"}]}"#,
+                    expect: .badRequest, "\(label): a column the file does not have")
+                try await put(
+                    path, fx,
+                    body:
+                        #"{"datasets":[{"file":"cases.csv","kind":"stratifiedSample","sampleSize":2,"stratumColumn":"id"}]}"#,
+                    expect: .badRequest, "\(label): a sample too small for every category")
+                try await put(
+                    path, fx,
+                    body:
+                        #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":2,"stratumColumn":"id"}]}"#,
+                    expect: .badRequest, "\(label): a column on a plain sample would be stored and ignored")
+                #expect(try await get(path, fx).isEmpty, "\(label): a rejected write stores nothing")
+            }
+        }
+    }
+
+    @Test func editPageRendersAStratifiedSpecsColumn() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("r")
+            try await put(
+                "/instructor/\(fx.assignmentID)/datasets", fx,
+                body:
+                    #"{"datasets":[{"file":"cases.csv","kind":"stratifiedSample","sampleSize":2,"stratumColumn":"ward"}]}"#,
+                expect: .ok, "a valid stratified spec")
+
+            let html = try await page("/instructor/\(fx.assignmentID)/edit", fx)
+            let marked = try rowMarkup(for: "cases.csv", in: html)
+            #expect(marked.contains("js-dataset-stratum"))
+            #expect(marked.contains("value=\"ward\""), "the saved column reaches the control")
+
+            // Without the column in the row, editing the sample size would
+            // rewrite the spec back to a plain sample — the silent downgrade
+            // this field exists to prevent.
+            let plain = try rowMarkup(for: "notes.txt", in: html)
+            #expect(plain.contains("value=\"\""), "an unmarked file renders an empty column field")
         }
     }
 

--- a/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
+++ b/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
@@ -67,7 +67,11 @@ import Testing
                 SetDatasetTool.name, SetDatasetTool.outputSchema,
                 SetDatasetTool.Output(
                     assignmentPublicID: "abc123",
-                    datasets: [SetDatasetTool.DatasetEntry(file: "cases.csv", sampleSize: 100)])
+                    datasets: [
+                        SetDatasetTool.DatasetEntry(
+                            file: "cases.csv", sampleSize: 100,
+                            kind: "rowSample", stratumColumn: nil)
+                    ])
             ),
             (
                 SetMinimumRunnerVersionTool.name, SetMinimumRunnerVersionTool.outputSchema,

--- a/Tests/APITests/MCP/SetDatasetToolTests.swift
+++ b/Tests/APITests/MCP/SetDatasetToolTests.swift
@@ -62,12 +62,12 @@ import Vapor
 
     private func run(
         _ app: Application, publicID: String, filename: String,
-        sampleSize: Int? = nil, remove: Bool? = nil
+        sampleSize: Int? = nil, stratumColumn: String? = nil, remove: Bool? = nil
     ) async throws -> SetDatasetTool.Output {
         try await SetDatasetTool().execute(
             SetDatasetTool.Input(
                 assignmentPublicID: publicID, filename: filename,
-                sampleSize: sampleSize, remove: remove),
+                sampleSize: sampleSize, stratumColumn: stratumColumn, remove: remove),
             context(app))
     }
 
@@ -195,6 +195,102 @@ import Vapor
                 _ = try await run(
                     app, publicID: assignment.publicID, filename: "../cases.csv", sampleSize: 2)
             }
+        }
+    }
+
+    // MARK: - Stratified sampling
+    //
+    // The fixture's `cases.csv` is `caseid,age` with three rows, so `age` is a
+    // three-category column — small enough that the sample-size rule bites at
+    // 2 and passes at 3.
+
+    @Test func marksAStratifiedDataset() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let out = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv",
+                sampleSize: 3, stratumColumn: "age")
+            #expect(out.datasets.first?.kind == "stratifiedSample")
+            #expect(out.datasets.first?.stratumColumn == "age")
+
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(
+                setup.decodedManifest()?.datasets == [
+                    DatasetSpec(
+                        file: "cases.csv", kind: .stratifiedSample, sampleSize: 3, stratumColumn: "age")
+                ])
+        }
+    }
+
+    @Test func supportFileListingReportsTheStratum() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv",
+                sampleSize: 3, stratumColumn: "age")
+
+            let listing = try await GetSupportFilesTool().execute(
+                GetSupportFilesTool.Input(
+                    assignmentPublicID: assignment.publicID, filename: nil, maxBytes: nil),
+                context(app))
+            let entry = try #require(listing.files?.first { $0.filename == "cases.csv" })
+            #expect(entry.datasetKind == "stratifiedSample")
+            #expect(entry.datasetStratumColumn == "age")
+        }
+    }
+
+    @Test func aPlainMarkReportsItsKindToo() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await run(app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2)
+
+            let listing = try await GetSupportFilesTool().execute(
+                GetSupportFilesTool.Input(
+                    assignmentPublicID: assignment.publicID, filename: nil, maxBytes: nil),
+                context(app))
+            let entry = try #require(listing.files?.first { $0.filename == "cases.csv" })
+            #expect(entry.datasetKind == "rowSample")
+            #expect(entry.datasetStratumColumn == nil)
+        }
+    }
+
+    @Test func rejectsAColumnTheFileDoesNotHave() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await run(
+                    app, publicID: assignment.publicID, filename: "cases.csv",
+                    sampleSize: 3, stratumColumn: "ward")
+            }
+        }
+    }
+
+    @Test func rejectsASampleTooSmallToHoldEveryCategory() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Three distinct ages, two rows to give out.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await run(
+                    app, publicID: assignment.publicID, filename: "cases.csv",
+                    sampleSize: 2, stratumColumn: "age")
+            }
+        }
+    }
+
+    @Test func aBlankColumnMeansAPlainRowSample() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let out = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv",
+                sampleSize: 2, stratumColumn: "   ")
+            #expect(out.datasets.first?.kind == "rowSample")
+            #expect(out.datasets.first?.stratumColumn == nil)
         }
     }
 }

--- a/Tests/CoreTests/DatasetMaterializerFixtureTests.swift
+++ b/Tests/CoreTests/DatasetMaterializerFixtureTests.swift
@@ -1,0 +1,107 @@
+// Tests/CoreTests/DatasetMaterializerFixtureTests.swift
+//
+// The byte-level pin on per-student dataset slicing.
+//
+// `DatasetMaterializerTests` asserts the PROPERTIES of a slice — deterministic
+// within a run, header kept, order preserved. Those all hold for a materializer
+// that quietly starts choosing different rows: two runs of the new code agree
+// with each other perfectly. This file is the other half, and the one that
+// matters when the materializer is edited: the exact bytes a known (source,
+// spec, seed) produced before the edit.
+//
+// Why it is load-bearing. A student's slice is resolved from their seed at
+// every delivery — the editor at notebook open, the worker at grade time, a
+// re-grade months later. Nothing is stored. So a change in row selection is not
+// a version bump, it is the student's data changing underneath them: the
+// `describe()` numbers in their notebook stop matching what the grader sees,
+// and a re-grade of an old submission scores against rows the student never
+// had. The output must stay identical FOREVER, not merely self-consistent.
+//
+// If an edit fails one of these, the edit is wrong — do not re-baseline the
+// literal. A genuinely new behaviour belongs behind a new `DatasetKind` case,
+// which is exactly how stratified sampling was added beside `rowSample`.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct DatasetMaterializerFixtureTests {
+
+    /// Two fixed 64-hex seeds, in the shape `PersonalizationSeed` produces.
+    private let seedA = String(repeating: "a1b2", count: 16)
+    private let seedB = String(repeating: "9f3c", count: 16)
+
+    /// A 20-row two-column CSV — small enough to pin whole, wide enough that a
+    /// row is identifiable in a failure diff.
+    private let source20 = """
+        id,ward
+        0,3A
+        1,3B
+        2,3A
+        3,4C
+        4,3B
+        5,3A
+        6,4C
+        7,3B
+        8,3A
+        9,4C
+        10,3B
+        11,3A
+        12,4C
+        13,3B
+        14,3A
+        15,4C
+        16,3B
+        17,3A
+        18,4C
+        19,3B
+
+        """
+
+    @Test func rowSampleFiveOfTwentySeedA() {
+        let out = DatasetMaterializer.materialize(
+            source: source20, spec: DatasetSpec(file: "cases.csv", sampleSize: 5), seedHex: seedA)
+        #expect(
+            out == """
+                id,ward
+                1,3B
+                4,3B
+                6,4C
+                16,3B
+                17,3A
+
+                """)
+    }
+
+    @Test func rowSampleFiveOfTwentySeedB() {
+        let out = DatasetMaterializer.materialize(
+            source: source20, spec: DatasetSpec(file: "cases.csv", sampleSize: 5), seedHex: seedB)
+        #expect(
+            out == """
+                id,ward
+                1,3B
+                3,4C
+                10,3B
+                11,3A
+                15,4C
+
+                """)
+    }
+
+    /// A sample big enough to walk the PRNG's rejection-sampling path many
+    /// times, pinned by the chosen indices rather than the whole document.
+    @Test func rowSampleThirtyOfTwoHundredSeedA() {
+        var source = "id\n"
+        source += (0..<200).map(String.init).joined(separator: "\n")
+        source += "\n"
+        let out = DatasetMaterializer.materialize(
+            source: source, spec: DatasetSpec(file: "cases.csv", sampleSize: 30), seedHex: seedA)
+        let rows = out.split(separator: "\n").dropFirst().compactMap { Int($0) }
+        #expect(
+            rows == [
+                2, 6, 15, 27, 34, 35, 46, 60, 62, 85, 90, 93, 94, 97, 100,
+                107, 113, 121, 122, 134, 143, 148, 149, 159, 165, 168, 175, 191, 193, 199,
+            ])
+    }
+}

--- a/Tests/CoreTests/DatasetSpecValidationTests.swift
+++ b/Tests/CoreTests/DatasetSpecValidationTests.swift
@@ -1,0 +1,131 @@
+// Tests/CoreTests/DatasetSpecValidationTests.swift
+//
+// The save-time check every authoring door runs before storing a dataset spec
+// (docs/datasets.md Phase 1.5).
+//
+// It exists because `DatasetMaterializer` deliberately does NOT fail on a
+// stratified spec that does not fit its file — an unknown column degrades to a
+// plain row sample, because at delivery time the only reader is a student being
+// graded and an error helps them not at all. That forgiveness is only safe if
+// the mistake is refused where it can still be fixed, so what these assert is
+// the pairing: every case the materializer silently absorbs is a case this
+// refuses.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct DatasetSpecValidationTests {
+
+    private let pool = """
+        id,ward,score
+        1,3A,7
+        2,3B,4
+        3,3A,9
+
+        """
+
+    private func stratified(size: Int?, column: String?) -> DatasetSpec {
+        DatasetSpec(file: "cases.csv", kind: .stratifiedSample, sampleSize: size, stratumColumn: column)
+    }
+
+    @Test func aWellFormedStratifiedSpecPasses() {
+        #expect(DatasetSpecValidation.issue(with: stratified(size: 2, column: "ward"), sourceCSV: pool) == nil)
+    }
+
+    @Test func aPlainRowSampleNeedsNoFileAtAll() {
+        let spec = DatasetSpec(file: "cases.csv", sampleSize: 2)
+        #expect(DatasetSpecValidation.issue(with: spec, sourceCSV: nil) == nil)
+        #expect(DatasetSpecValidation.issue(with: spec, sourceCSV: pool) == nil)
+    }
+
+    @Test func aColumnOnAPlainRowSampleIsRefused() {
+        // Stored, then ignored at delivery — the silent-mismatch shape the
+        // whole check exists to prevent.
+        let spec = DatasetSpec(file: "cases.csv", kind: .rowSample, sampleSize: 2, stratumColumn: "ward")
+        let issue = DatasetSpecValidation.issue(with: spec, sourceCSV: pool)
+        #expect(issue?.contains("only applies to a stratified sample") == true)
+    }
+
+    @Test func aStratifiedSpecWithoutAColumnIsRefused() {
+        for column in [nil, "", "   "] {
+            let issue = DatasetSpecValidation.issue(with: stratified(size: 2, column: column), sourceCSV: pool)
+            #expect(issue != nil, "column \(String(describing: column))")
+        }
+    }
+
+    @Test func anUnknownColumnIsRefusedAndTheRealOnesAreNamed() {
+        let issue = DatasetSpecValidation.issue(with: stratified(size: 2, column: "unit"), sourceCSV: pool)
+        // The instructor cannot see the file from the form they are typing in,
+        // so the message has to carry what is actually there.
+        #expect(issue?.contains("'unit'") == true)
+        #expect(issue?.contains("'id'") == true)
+        #expect(issue?.contains("'ward'") == true)
+        #expect(issue?.contains("'score'") == true)
+    }
+
+    @Test func aSampleTooSmallForEveryCategoryIsRefused() {
+        // `id` has three distinct values; two rows cannot hold them all, and
+        // the apportionment would have to drop one.
+        let issue = DatasetSpecValidation.issue(with: stratified(size: 2, column: "id"), sourceCSV: pool)
+        #expect(issue?.contains("3 distinct values") == true)
+        #expect(issue?.contains("at least 3") == true)
+
+        #expect(
+            DatasetSpecValidation.issue(with: stratified(size: 3, column: "id"), sourceCSV: pool) == nil,
+            "a sample with room for every category passes")
+    }
+
+    @Test func aWholeFileSpecHasNoSizeToCheck() {
+        // nil means "the whole file", which trivially contains every category.
+        #expect(DatasetSpecValidation.issue(with: stratified(size: nil, column: "id"), sourceCSV: pool) == nil)
+    }
+
+    @Test func binaryOrEmptyFilesAreRefusedForStratification() {
+        let binary = DatasetSpecValidation.issue(with: stratified(size: 2, column: "ward"), sourceCSV: nil)
+        #expect(binary?.contains("not UTF-8 text") == true)
+        let empty = DatasetSpecValidation.issue(with: stratified(size: 2, column: "ward"), sourceCSV: "")
+        #expect(empty?.contains("empty") == true)
+    }
+
+    @Test func quotedHeadersResolveByTheirUnquotedName() {
+        let quoted = """
+            "id","ward, full name",score
+            1,3A,7
+            2,3B,4
+
+            """
+        #expect(
+            DatasetSpecValidation.issue(
+                with: stratified(size: 2, column: "ward, full name"), sourceCSV: quoted) == nil)
+    }
+
+    @Test func aLongHeaderIsTruncatedInTheMessage() {
+        let wide = (0..<40).map { "c\($0)" }.joined(separator: ",") + "\n1\n"
+        let issue = DatasetSpecValidation.issue(with: stratified(size: 2, column: "nope"), sourceCSV: wide)
+        #expect(issue?.contains("…") == true, "a 40-column extract does not dump 40 names")
+        #expect(issue?.contains("'c0'") == true)
+    }
+
+    // MARK: - The pairing with the materializer
+
+    @Test func everySilentDegradationHasALoudRefusal() {
+        // Each of these produces a plain row sample instead of a stratified one
+        // at delivery — and each is refused at save.
+        let degrading: [DatasetSpec] = [
+            stratified(size: 2, column: nil),
+            stratified(size: 2, column: ""),
+            stratified(size: 2, column: "unit"),
+        ]
+        let plain = DatasetMaterializer.materialize(
+            source: pool, spec: DatasetSpec(file: "cases.csv", sampleSize: 2),
+            seedHex: String(repeating: "a1b2", count: 16))
+        for spec in degrading {
+            let delivered = DatasetMaterializer.materialize(
+                source: pool, spec: spec, seedHex: String(repeating: "a1b2", count: 16))
+            #expect(delivered == plain, "delivery degrades: \(spec)")
+            #expect(DatasetSpecValidation.issue(with: spec, sourceCSV: pool) != nil, "save refuses: \(spec)")
+        }
+    }
+}

--- a/Tests/CoreTests/DatasetStratifiedSamplingTests.swift
+++ b/Tests/CoreTests/DatasetStratifiedSamplingTests.swift
@@ -1,0 +1,310 @@
+// Tests/CoreTests/DatasetStratifiedSamplingTests.swift
+//
+// `DatasetKind.stratifiedSample` (Phase 1.5 of docs/datasets.md): the same
+// per-student slice as `rowSample`, apportioned across the distinct values of
+// one column so every category in the pool survives into every student's copy.
+//
+// What is worth asserting here is what a plain row sample cannot promise —
+// every category present, sizes roughly proportional, the budget spent exactly
+// — plus the two properties the whole feature rests on: the output is a pure
+// function of (source, spec, seed), and the envelope (header, row order, line
+// endings) is identical to `rowSample`'s, since both kinds are delivered to the
+// same `pd.read_csv` line.
+//
+// Apportionment is tested directly rather than inferred from a slice: the
+// selection around it is seeded, so a table of expected splits is both easier
+// to read and stricter than counting rows in a CSV.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct DatasetStratifiedSamplingTests {
+
+    private let seedA = String(repeating: "a1b2", count: 16)
+    private let seedB = String(repeating: "9f3c", count: 16)
+
+    /// A pool whose `ward` column is deliberately lopsided: 60 rows in `3A`,
+    /// 30 in `3B`, 9 in `4C` and a single `ICU` row — the rare category a plain
+    /// row sample drops most of the time.
+    private func lopsidedPool() -> String {
+        var rows: [String] = ["id,ward,score"]
+        var id = 0
+        func add(_ ward: String, _ count: Int) {
+            for _ in 0..<count {
+                rows.append("\(id),\(ward),\(id % 7)")
+                id += 1
+            }
+        }
+        add("3A", 60)
+        add("3B", 30)
+        add("4C", 9)
+        add("ICU", 1)
+        return rows.joined(separator: "\n") + "\n"
+    }
+
+    private func wards(_ csv: String) -> [String] {
+        csv.split(separator: "\n").dropFirst().map { line in
+            String(DatasetMaterializer.splitCSVLine(line)[1])
+        }
+    }
+
+    private func spec(size: Int?, column: String? = "ward") -> DatasetSpec {
+        DatasetSpec(file: "cases.csv", kind: .stratifiedSample, sampleSize: size, stratumColumn: column)
+    }
+
+    // MARK: - The promise the kind exists to make
+
+    @Test func everyCategorySurvivesEvenTheSingletonOne() {
+        let pool = lopsidedPool()
+        // Ten different students, because the claim is about every slice, not
+        // about a lucky one.
+        for student in 0..<10 {
+            let seed = String(repeating: String(format: "%04x", student * 997 + 13), count: 16)
+            let out = DatasetMaterializer.materialize(source: pool, spec: spec(size: 20), seedHex: seed)
+            let present = Set(wards(out))
+            #expect(
+                present == ["3A", "3B", "4C", "ICU"],
+                "student \(student) lost a category: \(present.sorted())")
+        }
+    }
+
+    @Test func sampleSizeIsSpentExactly() {
+        let pool = lopsidedPool()
+        for size in [5, 20, 33, 99] {
+            let out = DatasetMaterializer.materialize(source: pool, spec: spec(size: size), seedHex: seedA)
+            #expect(wards(out).count == size, "size \(size)")
+        }
+    }
+
+    @Test func largerStrataGetMoreRows() {
+        let out = DatasetMaterializer.materialize(
+            source: lopsidedPool(), spec: spec(size: 40), seedHex: seedA)
+        var counts: [String: Int] = [:]
+        for ward in wards(out) { counts[ward, default: 0] += 1 }
+        // 60 / 30 / 9 / 1 of 100 rows, sampled 40 with a floor of one each.
+        #expect(counts["3A", default: 0] > counts["3B", default: 0])
+        #expect(counts["3B", default: 0] > counts["4C", default: 0])
+        #expect(counts["ICU"] == 1, "a stratum never yields more rows than it holds")
+    }
+
+    // MARK: - Determinism, the non-negotiable
+
+    @Test func sameSeedSameBytes() {
+        let pool = lopsidedPool()
+        let first = DatasetMaterializer.materialize(source: pool, spec: spec(size: 25), seedHex: seedA)
+        let second = DatasetMaterializer.materialize(source: pool, spec: spec(size: 25), seedHex: seedA)
+        #expect(first == second)
+    }
+
+    @Test func differentSeedsGenerallyDiffer() {
+        let pool = lopsidedPool()
+        let a = DatasetMaterializer.materialize(source: pool, spec: spec(size: 25), seedHex: seedA)
+        let b = DatasetMaterializer.materialize(source: pool, spec: spec(size: 25), seedHex: seedB)
+        #expect(a != b)
+    }
+
+    /// The byte-level pin, in the same spirit as `DatasetMaterializerFixtureTests`
+    /// — a student's stratified slice must not move either.
+    @Test func stratifiedOutputIsPinned() {
+        let source = """
+            id,ward
+            0,3A
+            1,3A
+            2,3A
+            3,3A
+            4,3B
+            5,3B
+            6,3B
+            7,4C
+            8,4C
+            9,ICU
+
+            """
+        let out = DatasetMaterializer.materialize(source: source, spec: spec(size: 6), seedHex: seedA)
+        #expect(
+            out == """
+                id,ward
+                1,3A
+                2,3A
+                4,3B
+                6,3B
+                7,4C
+                9,ICU
+
+                """)
+    }
+
+    // MARK: - The envelope matches rowSample's
+
+    @Test func headerAndRowOrderPreserved() {
+        let out = DatasetMaterializer.materialize(
+            source: lopsidedPool(), spec: spec(size: 30), seedHex: seedA)
+        #expect(out.hasPrefix("id,ward,score\n"))
+        let ids = out.split(separator: "\n").dropFirst().compactMap { Int(DatasetMaterializer.splitCSVLine($0)[0]) }
+        #expect(ids == ids.sorted(), "chosen rows keep their original order")
+        #expect(Set(ids).count == ids.count, "no duplicate rows")
+    }
+
+    @Test func wholeFileWhenTheSampleIsNotAReduction() {
+        let pool = lopsidedPool()
+        for size in [100, 101, nil] {
+            #expect(
+                DatasetMaterializer.materialize(source: pool, spec: spec(size: size), seedHex: seedA) == pool,
+                "size \(String(describing: size))")
+        }
+    }
+
+    @Test func crlfAndTrailingNewlineHandledAsInRowSample() {
+        let lf = "id,ward\n" + (0..<20).map { "\($0),\($0 % 3)" }.joined(separator: "\n")
+        let crlf = lf.replacingOccurrences(of: "\n", with: "\r\n")
+        let fromLF = DatasetMaterializer.materialize(source: lf, spec: spec(size: 6), seedHex: seedA)
+        let fromCRLF = DatasetMaterializer.materialize(source: crlf, spec: spec(size: 6), seedHex: seedA)
+        #expect(!fromCRLF.contains("\r"))
+        #expect(fromLF == fromCRLF, "line endings must not perturb selection")
+        #expect(!fromLF.hasSuffix("\n"), "a source without a trailing newline yields one without")
+    }
+
+    // MARK: - Degrading rather than failing at delivery
+
+    @Test func unknownColumnFallsBackToAPlainRowSample() {
+        let pool = lopsidedPool()
+        let missing = DatasetMaterializer.materialize(
+            source: pool, spec: spec(size: 12, column: "unit"), seedHex: seedA)
+        let plain = DatasetMaterializer.materialize(
+            source: pool, spec: DatasetSpec(file: "cases.csv", sampleSize: 12), seedHex: seedA)
+        #expect(missing == plain, "a column the file lost degrades to rowSample, not to the whole pool")
+        #expect(missing != pool)
+    }
+
+    @Test func absentColumnNameFallsBackToAPlainRowSample() {
+        let pool = lopsidedPool()
+        for column in [nil, ""] {
+            let out = DatasetMaterializer.materialize(
+                source: pool, spec: spec(size: 12, column: column), seedHex: seedA)
+            let plain = DatasetMaterializer.materialize(
+                source: pool, spec: DatasetSpec(file: "cases.csv", sampleSize: 12), seedHex: seedA)
+            #expect(out == plain, "column \(String(describing: column))")
+        }
+    }
+
+    @Test func rowsMissingTheColumnGroupTogetherRatherThanDropping() {
+        // A short row has no value for `ward`; it must still be eligible, or
+        // some students would silently receive fewer rows than they asked for.
+        let source = """
+            id,ward
+            0,3A
+            1
+            2,3A
+            3
+            4,3B
+            5,3B
+
+            """
+        let out = DatasetMaterializer.materialize(source: source, spec: spec(size: 4), seedHex: seedA)
+        #expect(out.split(separator: "\n").dropFirst().count == 4)
+    }
+
+    // MARK: - Apportionment on its own
+
+    @Test func apportionGivesEveryStratumAtLeastOne() {
+        let allocation = DatasetMaterializer.apportion(sampleSize: 20, sizes: [60, 30, 9, 1], total: 100)
+        #expect(allocation.allSatisfy { $0 >= 1 })
+        #expect(allocation.reduce(0, +) == 20)
+        #expect(allocation[3] == 1, "a one-row stratum can only ever give one row")
+    }
+
+    @Test func apportionIsProportionalOnTheRemainder() {
+        // 30 rows of 100, one floor row each, 26 shared out in proportion to
+        // the 96 rows that remain after the floor.
+        let allocation = DatasetMaterializer.apportion(sampleSize: 30, sizes: [60, 30, 9, 1], total: 100)
+        #expect(allocation.reduce(0, +) == 30)
+        #expect(allocation[0] > allocation[1])
+        #expect(allocation[1] > allocation[2])
+        #expect(allocation[3] == 1)
+    }
+
+    @Test func apportionNeverExceedsAStratumsRows() {
+        let sizes = [2, 2, 96]
+        let allocation = DatasetMaterializer.apportion(sampleSize: 50, sizes: sizes, total: 100)
+        #expect(allocation.reduce(0, +) == 50)
+        for (index, count) in allocation.enumerated() {
+            #expect(count <= sizes[index], "stratum \(index) over-allocated")
+        }
+    }
+
+    @Test func apportionSpendsTheBudgetWhenSmallStrataCapOut() {
+        // Every stratum but the last is a singleton, so the leftovers all have
+        // to land on the one that can absorb them.
+        let sizes = [1, 1, 1, 50]
+        let allocation = DatasetMaterializer.apportion(sampleSize: 20, sizes: sizes, total: 53)
+        #expect(allocation == [1, 1, 1, 17])
+    }
+
+    @Test func apportionWithMoreStrataThanBudgetTakesOneEachInFileOrder() {
+        let allocation = DatasetMaterializer.apportion(sampleSize: 2, sizes: [5, 5, 5, 5], total: 20)
+        #expect(allocation == [1, 1, 0, 0])
+    }
+
+    @Test func apportionIsAFunctionOfItsInputsAlone() {
+        let sizes = [17, 4, 39, 1, 8]
+        let first = DatasetMaterializer.apportion(sampleSize: 22, sizes: sizes, total: 69)
+        let second = DatasetMaterializer.apportion(sampleSize: 22, sizes: sizes, total: 69)
+        #expect(first == second)
+    }
+
+    // MARK: - CSV field splitting
+
+    @Test func quotedFieldsDoNotShiftLaterColumns() {
+        let fields = DatasetMaterializer.splitCSVLine(#"1,"Smith, John",3A,"say ""hi""",7"#)
+        #expect(fields == ["1", "Smith, John", "3A", #"say "hi""#, "7"])
+    }
+
+    @Test func plainAndEmptyFieldsSplitAsExpected() {
+        #expect(DatasetMaterializer.splitCSVLine("a,b,c") == ["a", "b", "c"])
+        #expect(DatasetMaterializer.splitCSVLine("a,,c") == ["a", "", "c"])
+        #expect(DatasetMaterializer.splitCSVLine("") == [""])
+        #expect(DatasetMaterializer.splitCSVLine("a,") == ["a", ""])
+    }
+
+    @Test func aQuotedCommaBeforeTheStratumColumnDoesNotMisgroup() {
+        // The defect a naive comma split would cause: `ward` read as a slice of
+        // the name, so the strata become one-per-row and every "category"
+        // survives trivially while the sample is meaningless.
+        let source = """
+            id,name,ward
+            0,"Smith, John",3A
+            1,"Doe, Jane",3B
+            2,"Roe, Rick",3A
+            3,"Poe, Edgar",3B
+
+            """
+        let out = DatasetMaterializer.materialize(
+            source: source,
+            spec: DatasetSpec(
+                file: "cases.csv", kind: .stratifiedSample, sampleSize: 2, stratumColumn: "ward"),
+            seedHex: seedA)
+        let picked = out.split(separator: "\n").dropFirst().map {
+            DatasetMaterializer.splitCSVLine($0)[2]
+        }
+        #expect(Set(picked) == ["3A", "3B"], "one row from each real ward")
+    }
+
+    // MARK: - Codable
+
+    @Test func stratifiedSpecRoundTrips() throws {
+        let spec = DatasetSpec(
+            file: "cases.csv", kind: .stratifiedSample, sampleSize: 500, stratumColumn: "ward")
+        let decoded = try JSONDecoder().decode(DatasetSpec.self, from: try JSONEncoder().encode(spec))
+        #expect(decoded == spec)
+    }
+
+    @Test func aSpecPredatingStratificationStillDecodes() throws {
+        let decoded = try JSONDecoder().decode(
+            DatasetSpec.self, from: Data(#"{"file":"cases.csv","kind":"rowSample","sampleSize":25}"#.utf8))
+        #expect(decoded.kind == .rowSample)
+        #expect(decoded.stratumColumn == nil)
+        #expect(decoded.sampleSize == 25)
+    }
+}

--- a/changelog.d/datasets-stratified-sampling.md
+++ b/changelog.d/datasets-stratified-sampling.md
@@ -1,0 +1,26 @@
+### Added
+
+- **Per-student datasets can be balanced across a column.** A dataset spec now
+  takes a `stratumColumn`, and `DatasetKind` a `stratifiedSample` case: the
+  sample is apportioned across that column's distinct values so every category
+  in the pool appears in every student's slice. A plain row sample can drop a
+  rare category outright, which quietly turns a `groupby` exercise into a
+  different exercise for the student who lost it. Set it from the Files panel
+  (an empty column box means a plain sample, so there is no separate kind to
+  keep in step) or with `set_dataset`; `get_support_files` reports both.
+  Apportionment is Hamilton's method with one row per category guaranteed,
+  in integer arithmetic — the materializer's contract is byte-identical output
+  for the same seed forever, and floating-point rounding would be an invisible
+  way to lose it. `rowSample`'s existing output is unchanged, pinned by a
+  fixture test committed before the change.
+
+### Changed
+
+- **A dataset spec that does not fit its file is now refused at save time.**
+  Both datasets endpoints and `set_dataset` check a stratified spec against the
+  file it marks: the column must exist in the header, and the sample must have
+  room for every category. The messages name the file's actual columns and its
+  category count. Delivery still degrades rather than failing — an unknown
+  column falls back to a plain row sample — because by then the only reader is
+  a student being graded, and that forgiveness is only safe if the mistake is
+  caught where an instructor can still fix it.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -505,9 +505,48 @@ pool. Secrecy becomes load-bearing only for Phase 2 mystery answers.
    above).
 5. **Browser delivery** — only when a personalized dataset is used on a
    browser-graded assignment.
-6. **Phase 1.5** — stratified sampling + the arbitrary-Python `slice` escape
-   hatch (reuses `PersonalizationEvaluator`'s file-writing subprocess), the
-   bridge to Phase 2.
+6. **Phase 1.5** — stratified sampling (shipped; see below). The
+   arbitrary-Python `slice` escape hatch that used to sit in this slice is
+   **not** planned: it was framed here as the bridge to Phase 2, and Phase 2 is
+   declined (#1434), so the escape hatch has nothing to bridge to. Stratified
+   sampling is the ceiling of the current design, not a step past it.
+
+### Stratified sampling (`DatasetKind.stratifiedSample`)
+
+A plain `rowSample` can drop a rare category outright — which quietly turns a
+`groupby` exercise into a different exercise for the student who lost it. A
+stratified spec names a `stratumColumn` and apportions the sample across that
+column's distinct values, so every category in the pool is in every student's
+slice.
+
+The apportionment is Hamilton's method with a floor of one row per stratum,
+in **integer arithmetic** — the point of `DatasetMaterializer` is that the same
+(source, spec, seed) yields the same bytes on every platform forever, and a
+floating-point rounding difference would be an invisible way to lose that.
+A stratum never yields more rows than it holds; leftovers sweep in file order
+to whichever strata still have room.
+
+Two halves of one rule, worth keeping together:
+
+- **Delivery degrades.** A stratified spec whose column the file no longer has
+  falls back to a plain row sample rather than failing — the student gets their
+  N rows unstratified instead of the whole pool everyone else has. By then the
+  only reader is a student being graded, and an error helps them not at all.
+- **Authoring refuses.** `DatasetSpecValidation` runs at every door (both PUTs
+  and `set_dataset`): a stratified spec needs a column, the column must be in
+  the file's header, and `sampleSize` must be at least the number of distinct
+  values — a smaller sample cannot hold every category whatever the
+  apportionment does. The messages name the file's real columns and its category
+  count, because the instructor cannot see the file from the form they are
+  typing into. A `stratumColumn` on a plain `rowSample` is refused too, rather
+  than stored and ignored.
+
+`DatasetSpecValidationTests.everySilentDegradationHasALoudRefusal` pins the
+pairing: every case delivery absorbs quietly is a case saving rejects.
+
+In the Files panel the column is the control — an empty box means a plain
+sample, a column name means a stratified one — so there is no separate kind
+picker for the two to disagree about.
 
 **Authoring surfaces:** two, and they agree by construction.
 


### PR DESCRIPTION
Slice B of the datasets handoff, now that Slice A (#1435) has merged. Stratified
sampling, built as the ceiling of the current design rather than a step toward
the declined query shim (#1434) — the invariant holds, `materialize` is still
`String` in, `String` out with no language anywhere near it.

## Why

A plain `rowSample` can drop a rare category outright, which quietly turns a
`groupby` exercise into a different exercise for the student who lost it. That
hazard is why `set_dataset`'s advice has always been "pick a sample size large
enough that every category still appears" — advice the instructor had no way to
act on except by guessing high. `DatasetKind.stratifiedSample` + a
`stratumColumn` on the spec apportion the sample across that column's distinct
values instead, so every category in the pool is in every student's slice.

## Determinism, which is the whole job of this file

**The `rowSample` pin was committed first, against untouched code** (`f2f46d6`),
so it is a real baseline rather than a description of the new behaviour. It
still passes: this change adds a kind beside `rowSample` and does not move a
single existing byte.

Apportionment is Hamilton's method with a floor of one row per stratum, in
**integer arithmetic**. Doubles would have been the obvious way to compute a
proportional share, and a rounding difference across platforms is an invisible
way to lose the property the file exists for. A stratum never yields more rows
than it holds; leftovers sweep in file order to whichever strata still have
room. The stratified output is pinned byte-for-byte too.

Field splitting honours quotes, because a quoted comma anywhere earlier in a row
shifts every later field — a naive split would stratify by a neighbouring column
and look like it worked.

## The two halves of one rule

- **Delivery degrades.** A stratified spec whose column the file no longer has
  falls back to a plain row sample rather than failing. By then the only reader
  is a student being graded, who would rather have their N rows unstratified
  than the whole pool everyone else has.
- **Authoring refuses.** `DatasetSpecValidation` runs at every door — both PUTs
  and `set_dataset` — rejecting a missing column, a column the file lacks, a
  sample smaller than the category count, and a `stratumColumn` on a plain
  `rowSample` (which would otherwise be stored and then ignored). The messages
  carry the file's real column names and its category count, because the
  instructor cannot see the file from the form they are typing into.

`DatasetSpecValidationTests.everySilentDegradationHasALoudRefusal` pins the
pairing directly: every case delivery absorbs quietly is a case saving rejects.

## The UI, and the silent downgrade it would otherwise have caused

Slice A's control wrote `kind: 'rowSample'` unconditionally. Left alone, editing
the sample size of a stratified dataset would have rewritten it to a plain one —
exactly the "an authoring surface silently ignores the new kind" failure the
handoff warns about, and now my own control's problem. So the control carries
the column, and **the column is the kind**: an empty box means a plain sample, a
column name means a stratified one. No separate picker for the two to disagree
about. `get_support_files` reports `datasetKind` / `datasetStratumColumn` for the
same reason — a mark an agent cannot read back is a mark it cannot preserve.

## Tests

- `DatasetStratifiedSamplingTests` — every category surviving across ten
  different students' seeds (including a one-row category), the budget spent
  exactly, larger strata getting more rows, a byte-level pin, the envelope
  matching `rowSample`'s, both fallback paths, apportionment as a table, and the
  quoted-comma case that would otherwise stratify by the wrong column.
- `DatasetSpecValidationTests` — each refusal, the messages naming real columns,
  and the degradation/refusal pairing.
- `SetDatasetToolTests` + `DatasetsRouteRoundTripTests` — the same rejections
  through both authoring surfaces, a stratified spec round-tripping, and the
  edit page rendering its column back into the control.

## Checks

`format.sh`, `lint.sh`, `swiftlint.sh` (0 violations), `check-styles.sh`,
`eslint.sh`, `no-new-xctest.sh`, `no-language-defaults.sh` green; CoreTests
(374) and the MCP suites (312) pass locally. One `changelog.d/` fragment;
`VERSION` / `ChickadeeVersion.swift` / `CHANGELOG.md` untouched.
`docs/datasets.md` updated — Phase 1.5 is now shipped, and its other half (the
arbitrary-Python `slice` escape hatch) is recorded as **not** planned, since it
was framed as the bridge to a Phase 2 that has been declined.

As with Slice A, no automated test exercises page JS: the column field wants a
manual pass in a browser (type a column, change the size, clear the column,
reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YH9Rf5v8eSHWtiryUMdfeK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YH9Rf5v8eSHWtiryUMdfeK)_