### PR TITLE
fix(ci): unbreak the ZAP baseline scan, and derive its compose fixture

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Check runner wasm size budget
         run: scripts/check-runner-wasm-size.sh
 
+      - name: Check the CI compose fixture covers every required variable
+        run: scripts/ci-compose-env.sh --check
+
   # Single shared compile of the whole package + all test targets.  The
   # resulting `.build/` tree is cached and reused by every test job below
   # via `swift test --skip-build`, replacing five from-scratch compiles

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -18,15 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # RUNNER_SHARED_SECRET is a required compose variable (#1273 unmounted the
-      # data volume from the runner, making the environment its only channel to
-      # the secret), so compose refuses to interpolate without it and the scan
-      # never starts. Server and runner only need to agree, so an ephemeral
-      # value generated per run is sufficient.
+      # Derived from docker-compose.yml rather than written inline here: compose
+      # refuses to start when a ${VAR:?} it requires is unset, and this workflow
+      # runs weekly, so an inline fixture goes stale silently for as long as it
+      # takes someone to open a schedule-only run. The same script is run with
+      # --check by the format-lint job, which is what turns that into a PR-time
+      # failure. See its header.
       - name: Write CI .env
-        run: |
-          printf 'AUTH_MODE=local\nENABLE_NON_SSO_AUTH_MODES=true\nRUNNER_SHARED_SECRET=%s\n' \
-            "$(openssl rand -base64 32)" > .env
+        run: scripts/ci-compose-env.sh
 
       - name: Start application
         run: docker compose up -d --build

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -18,8 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # RUNNER_SHARED_SECRET is a required compose variable (#1273 unmounted the
+      # data volume from the runner, making the environment its only channel to
+      # the secret), so compose refuses to interpolate without it and the scan
+      # never starts. Server and runner only need to agree, so an ephemeral
+      # value generated per run is sufficient.
       - name: Write CI .env
-        run: printf 'AUTH_MODE=local\nENABLE_NON_SSO_AUTH_MODES=true\n' > .env
+        run: |
+          printf 'AUTH_MODE=local\nENABLE_NON_SSO_AUTH_MODES=true\nRUNNER_SHARED_SECRET=%s\n' \
+            "$(openssl rand -base64 32)" > .env
 
       - name: Start application
         run: docker compose up -d --build

--- a/changelog.d/zap-baseline-runner-secret.md
+++ b/changelog.d/zap-baseline-runner-secret.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The weekly ZAP baseline scan runs again.** Making `RUNNER_SHARED_SECRET` a
+  required Compose variable (so the runner container, which no longer mounts the
+  data volume, could still learn it) left the ZAP workflow's CI `.env` short one
+  value, and `docker compose up` refused to interpolate. The scan had not
+  started since the change; the workflow now generates an ephemeral secret.

--- a/changelog.d/zap-baseline-runner-secret.md
+++ b/changelog.d/zap-baseline-runner-secret.md
@@ -4,4 +4,11 @@
   required Compose variable (so the runner container, which no longer mounts the
   data volume, could still learn it) left the ZAP workflow's CI `.env` short one
   value, and `docker compose up` refused to interpolate. The scan had not
-  started since the change; the workflow now generates an ephemeral secret.
+  started since the change.
+- **The CI Compose fixture is derived from `docker-compose.yml`, not hand-kept.**
+  `scripts/ci-compose-env.sh` writes the scan's `.env` from the required
+  `${VAR:?}` interpolations it finds, and the `format-lint` job runs it with
+  `--check` so a newly required variable fails on the PR that introduces it.
+  Previously the only signal was the weekly scan going red, which is how this
+  one stayed broken for two weeks. An unrecognised requirement is a loud failure
+  rather than an auto-generated value, so nothing silently boots misconfigured.

--- a/scripts/ci-compose-env.sh
+++ b/scripts/ci-compose-env.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Writes the CI .env that `docker compose up` needs, and — with --check —
+# asserts this script still knows about every variable compose requires.
+#
+# The gap this closes, which shipped. docker-compose.yml marks a variable as
+# mandatory by interpolating it as ${NAME:?message}; compose then refuses to
+# start at all if it is unset. #1273 made RUNNER_SHARED_SECRET one of those
+# (the runner container stopped mounting the data volume, so the environment
+# became its only channel to the HMAC secret). The ZAP baseline workflow wrote
+# its own two-line .env inline, was never updated to match, and every scheduled
+# run since died at `docker compose up` before a single container started:
+#
+#     error while interpolating services.server.environment.RUNNER_SHARED_SECRET:
+#     required variable RUNNER_SHARED_SECRET is missing a value
+#
+# Nothing caught it for two weeks, because zap-baseline.yml runs weekly on a
+# schedule and has no PR-time signal at all. The compose change was green on its
+# own PR and stayed green on every PR after it; the only evidence was a red
+# square on a workflow nobody had reason to open.
+#
+# So the fixture is derived here instead of hand-maintained there, and the
+# derivation is checked on every PR by the format-lint job — which is the half
+# that matters. A weekly workflow cannot be trusted to report its own drift.
+#
+# Deliberately an assertion, not a generator. It would be easy to auto-generate
+# a value for anything compose demands and always start successfully, but that
+# invents semantics for a variable this script knows nothing about: a future
+# required DATABASE_HOST would get a random string, the server would boot
+# misconfigured, and the scan would fail later and far less legibly than compose
+# refusing up front. An unrecognised requirement is therefore a loud failure
+# telling a human to decide what the value should be.
+#
+# Deliberately awk and shell, with no python3. CI runs two similar images and
+# they are easy to confuse: the test jobs use chickadee/swift-ci:6.3-noble,
+# which .github/docker/ci-image/Dockerfile builds with python3 and friends,
+# while format-lint / build / browser-runner-tests run the plain mirror
+# chickadee/swift:6.3-noble, which has no python3 — noble does not bundle it.
+# The first cut of this guard used python3 and exited 127 in format-lint. A
+# guard should depend on nothing its job might not have.
+#
+# Usage:
+#   scripts/ci-compose-env.sh [path]   write the CI .env (default: ./.env)
+#   scripts/ci-compose-env.sh --check  verify the table below covers compose
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="${ROOT_DIR}/docker-compose.yml"
+
+MODE="write"
+OUT_PATH="${ROOT_DIR}/.env"
+if [ "${1:-}" = "--check" ]; then
+  MODE="check"
+elif [ -n "${1:-}" ]; then
+  OUT_PATH="$1"
+fi
+
+# Settings the scan itself needs. These are not compose-required; they select
+# the auth mode a scanner can actually log in under.
+BASE='AUTH_MODE=local
+ENABLE_NON_SSO_AUTH_MODES=true'
+
+# How each compose-REQUIRED variable is satisfied in CI. "random" mints a fresh
+# value per run; anything else is used as a literal. Add an entry here when
+# compose gains a required variable — and think about which of the two it wants.
+#
+# Server and runner only need to agree with each other, and nothing in CI
+# persists between runs, so a per-run secret is sufficient.
+SATISFIERS='RUNNER_SHARED_SECRET=random'
+
+if [ ! -f "$COMPOSE" ]; then
+  echo "ci-compose-env: ${COMPOSE} is missing" >&2
+  exit 1
+fi
+
+# ${NAME:?msg} and ${NAME?msg} are both compose's "required" forms. Lines that
+# are wholly a comment are skipped, so the commented-out db / nginx service
+# templates cannot contribute a requirement compose will never enforce; a `#`
+# mid-line is left alone, since it may sit inside a value or a default message.
+# A $${NAME:?} is compose's escape for a literal, not an interpolation.
+required="$(
+  awk '
+    {
+      line = $0
+      trimmed = line
+      sub(/^[ \t]+/, "", trimmed)
+      if (substr(trimmed, 1, 1) == "#") next
+      while (match(line, /[$][{][A-Za-z_][A-Za-z0-9_]*:?[?]/)) {
+        escaped = (RSTART > 1 && substr(line, RSTART - 1, 1) == "$")
+        name = substr(line, RSTART, RLENGTH)
+        line = substr(line, RSTART + RLENGTH)
+        if (escaped) continue
+        sub(/^[$][{]/, "", name)
+        sub(/:?[?]$/, "", name)
+        print name
+      }
+    }
+  ' "$COMPOSE" | awk '!seen[$0]++'
+)"
+
+# Completeness: a parser that silently matches nothing is indistinguishable from
+# a compose file with no requirements, and would sail through every check.
+if [ -z "$required" ]; then
+  echo "ci-compose-env: no required \${VAR:?...} interpolations found in" \
+    "docker-compose.yml — this guard is not reading the file" >&2
+  exit 1
+fi
+
+names_of() { printf '%s\n' "$1" | cut -d= -f1; }
+value_of() { printf '%s\n' "$1" | grep "^$2=" | cut -d= -f2-; }
+listed() { printf '%s\n' "$2" | grep -qxF "$1"; }
+
+known="$(printf '%s\n%s\n' "$(names_of "$BASE")" "$(names_of "$SATISFIERS")")"
+
+missing=""
+for name in $required; do
+  listed "$name" "$known" || missing="${missing}${missing:+, }${name}"
+done
+
+stale=""
+for name in $(names_of "$SATISFIERS"); do
+  listed "$name" "$required" || stale="${stale}${stale:+, }${name}"
+done
+
+status=0
+if [ -n "$missing" ]; then
+  echo "ci-compose-env: docker-compose.yml now requires ${missing}, which this" \
+    "script does not supply, so \`docker compose up\` will refuse to start in" \
+    "CI. Add an entry to SATISFIERS in scripts/ci-compose-env.sh — 'random'" \
+    "for a secret, or a literal for anything whose value carries meaning." >&2
+  status=1
+fi
+if [ -n "$stale" ]; then
+  echo "ci-compose-env: SATISFIERS lists ${stale}, which docker-compose.yml no" \
+    "longer requires. Drop the entry (or move it to BASE if CI still wants" \
+    "the value)." >&2
+  status=1
+fi
+[ "$status" -eq 0 ] || exit "$status"
+
+if [ "$MODE" = "check" ]; then
+  count="$(printf '%s\n' "$required" | wc -l | tr -d ' ')"
+  echo "ci-compose-env: OK (all ${count} compose-required variable(s) supplied:" \
+    "$(printf '%s\n' "$required" | sort | tr '\n' ' ' | sed 's/ $//'))."
+  exit 0
+fi
+
+# 32 bytes of urandom as hex: no shell metacharacters, so the value needs no
+# quoting and cannot be misread by compose's .env parser. `head` leads the
+# pipeline, so nothing downstream takes a SIGPIPE under `set -o pipefail`.
+random_value() { head -c 32 /dev/urandom | od -An -v -tx1 | tr -d ' \n'; }
+
+{
+  printf '%s\n' "$BASE"
+  for name in $(names_of "$SATISFIERS"); do
+    strategy="$(value_of "$SATISFIERS" "$name")"
+    if [ "$strategy" = "random" ]; then
+      printf '%s=%s\n' "$name" "$(random_value)"
+    else
+      printf '%s=%s\n' "$name" "$strategy"
+    fi
+  done
+} | sort > "$OUT_PATH"
+
+echo "ci-compose-env: wrote ${OUT_PATH} ($(wc -l < "$OUT_PATH" | tr -d ' ') variable(s))."


### PR DESCRIPTION
The weekly ZAP baseline scan has not actually scanned anything since Aug 3. It dies at `docker compose up`, before any container starts.

## What was happening

[Run 18](https://github.com/JimWallace/Chickadee/actions/runs/32007293948) (and run 17 before it) fails 19 seconds in:

```
error while interpolating services.server.environment.RUNNER_SHARED_SECRET:
required variable RUNNER_SHARED_SECRET is missing a value: set RUNNER_SHARED_SECRET in .env - see .env.example
```

#1273 unmounted the data volume from the Compose runner, so the environment became the only channel by which the runner learns the HMAC secret. Both services consequently interpolate `${RUNNER_SHARED_SECRET:?...}` (`docker-compose.yml` lines 87 and 115). The ZAP workflow's CI `.env` step still wrote only `AUTH_MODE` and `ENABLE_NON_SSO_AUTH_MODES`, so compose refuses to interpolate and the job exits 1.

Timeline lines up exactly: runs 1–16 green through Aug 3, #1273 lands Aug 5, runs 17 (Aug 10) and 18 (Aug 17) both fail identically. Nothing about the application or the scanner is broken — the CI fixture drifted from the compose contract.

Two secondary symptoms, both explained by the same cause: the `Tear down` step (`docker compose down -v`) fails identically, producing a second red ✗ that is not a second problem; and the uploaded `server-logs` artifact is an empty 260-byte file, because no container ever ran to log anything.

## The change

**Commit 1** supplies the missing value. **Commit 2** is the one worth reviewing.

The deeper problem is not the missing value, it is the missing signal. `zap-baseline.yml` runs weekly on a schedule and has no PR-time presence at all, so the compose change that broke it was green on its own PR and on every PR since. Fixing the `.env` by hand leaves that trap armed for the next required variable.

`scripts/ci-compose-env.sh` now owns the fixture. It reads the required `${VAR:?}` / `${VAR?}` interpolations out of `docker-compose.yml`, writes the `.env` the scan needs, and with `--check` asserts its table still covers them. The `format-lint` job runs the `--check`, so a newly required variable fails on the PR that introduces it.

Three design points:

**It asserts rather than generates.** Auto-generating a value for anything compose demands would always start successfully, but invents semantics for a variable the script knows nothing about — a future required `DATABASE_HOST` would get a random string, the server would boot misconfigured, and the scan would fail later and far less legibly than compose refusing up front. An unrecognised requirement is a loud failure naming the file and the fix.

**`format-lint` is the right home specifically because `swift-tests.yml` has no `paths:` filter**, so the guard cannot report green by being skipped. Putting it in `docker-build.yml`, which *is* path-filtered, would have rebuilt the #1330 failure this is modelled on. (`editor-smoke.yml` already solves the same problem the same way — trigger on every PR, filter inside a `changes` job, gate always reports.)

**It is awk and shell, depending on nothing.** The first cut used python3 and exited 127 in `format-lint`. CI runs two similar images that are easy to confuse: the test jobs use `chickadee/swift-ci:6.3-noble`, which `.github/docker/ci-image/Dockerfile` builds with python3 installed, while `format-lint` / `build` / `browser-runner-tests` run the plain mirror `chickadee/swift:6.3-noble`, which has none — noble does not bundle it. I read the ci-image Dockerfile and took it as proof of availability for a job that does not use that image. A guard should depend on nothing its own job might lack.

## Verification

The ZAP workflow only runs on `schedule` / `workflow_dispatch`, so CI on this PR exercises the guard but not the scan. Verified locally against the real compose file instead, with a failing `python3` shadowed onto `PATH` to prove the dependency is gone.

The fix:

- Old two-line `.env` → `docker compose config` reproduces the CI error verbatim.
- New derived `.env` → `docker compose config -q` exits 0, with a fresh 64-hex-character secret reaching both `server` and `runner`.

The guard, against a temporarily mutated copy of the real compose file:

| Scenario | Result |
|---|---|
| compose gains a new required var (the #1273 case, replayed) | fails, naming the var and the fix |
| requirement removed, table entry left behind | fails as stale |
| no-colon `${VAR?msg}` form | recognised as required |
| commented-out `db` / `nginx` service templates | contribute no phantom requirement |
| escaped `$${VAR:?}` | not mistaken for a requirement |
| parser matches nothing at all | fails its own completeness check rather than passing vacuously |

## Scope notes

`zap-baseline.yml` is the only workflow that writes a CI `.env` for compose. `docker-build.yml` names `docker-compose.yml` as a path trigger but never invokes compose.

One pre-existing warning is left alone: `HOSTNAME` is unset for compose (it is a bash shell variable, not exported), so the runner's `--worker-id` defaults to `runner-`. Cosmetic, predates this breakage, and did not stop runs 1–16 from passing.