### PR TITLE
Per-student datasets: close the expression loop, then derive values

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2068,6 +2068,10 @@ code { font-family: var(--font-mono); font-size: .9em; }
    so the field carries the kind rather than a second control asking the same
    question in different words. */
 .dataset-stratum { width: 10rem; }
+/* Shown instead of the derivation fields when a spec holds transforms the panel
+   cannot represent — it steps aside rather than rendering a partial view it
+   would then save over. */
+.dataset-note { font-style: italic; color: var(--gray-600); }
 
 /* Pattern-family editor body internals. */
 .label-note { color: var(--gray-600); font-weight: 400; }

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -135,12 +135,34 @@
         }
 
         // `spec` null clears the mark for `filename`.
+        // The spec to PUT for `filename`: what this control decided, laid over
+        // whatever the manifest already held for that file.
+        //
+        // The panel owns exactly three fields — kind, sampleSize and
+        // stratumColumn — and a spec can carry more (transforms, and whatever
+        // comes after them). Sending only the fields the panel knows about would
+        // drop the rest on an unrelated edit, which is how a stratified spec
+        // came within a release of being silently downgraded to a plain sample
+        // by someone adjusting a row count. So carry everything forward and
+        // overwrite only what was just set.
+        function merged(current, filename, spec) {
+            var prior = current.filter(function (d) { return d.file === filename; })[0] || {};
+            var out = {};
+            Object.keys(prior).forEach(function (k) { out[k] = prior[k]; });
+            Object.keys(spec).forEach(function (k) { out[k] = spec[k]; });
+            // A plain row sample has no stratum column, and a stale one left
+            // behind would be refused by the server as a spec that stores a
+            // setting its kind ignores.
+            if (out.kind === 'rowSample') delete out.stratumColumn;
+            return out;
+        }
+
         function commit(filename, spec, row) {
             queue = queue.then(function () {
                 ChickadeeUI.setStatus(statusOf(row), 'Saving…');
                 return fetchSpecs().then(function (current) {
                     var next = current.filter(function (d) { return d.file !== filename; });
-                    if (spec) next.push(spec);
+                    if (spec) next.push(merged(current, filename, spec));
                     return ChickadeeUI.fetchJSON(config.datasetsURL(), {
                         method: 'PUT',
                         csrfToken: csrfToken,

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -44,6 +44,9 @@
     // being marked-with-no-size, which is a spec the server accepts (it means
     // "the whole file") but which reads as an unfinished edit.
     var DEFAULT_SAMPLE_ROWS = 100;
+    // Percent of rows a newly-named blanking column starts at. Low enough that
+    // the data is still workable, high enough to be noticed on a small sample.
+    var DEFAULT_BLANK_PERCENT = 10;
 
     // The dataset control listens on the document, so it is bound once per
     // document rather than once per init — the same guard (and the same
@@ -93,7 +96,44 @@
                 size.value = (spec && spec.sampleSize != null) ? String(spec.sampleSize) : '';
                 if (stratumField) stratumField.hidden = !spec;
                 if (stratum) stratum.value = (spec && spec.stratumColumn) || '';
+
+                var blankField = row.querySelector('.js-dataset-blank-field');
+                if (blankField) blankField.hidden = !spec;
+                var step = editableStep(spec);
+                var columns = row.querySelector('.js-dataset-blank-columns');
+                var percent = row.querySelector('.js-dataset-blank-percent');
+                // A spec whose transforms this panel cannot represent leaves the
+                // fields alone AND disabled: painting a partial view of it is how
+                // the next edit would save over the part not shown.
+                var owned = ownsTransforms(spec);
+                if (columns) {
+                    columns.disabled = !owned;
+                    if (owned) columns.value = step ? (step.columns || []).join(', ') : '';
+                }
+                if (percent) {
+                    percent.disabled = !owned;
+                    if (owned) {
+                        percent.value = (step && step.rate != null)
+                            ? String(Math.round(step.rate * 100)) : '';
+                    }
+                }
             });
+        }
+
+        // The panel edits exactly one shape: no transforms, or a single
+        // missingValues step. The model is an ordered list with more kinds to
+        // come, so a spec authored through MCP can hold something with no fields
+        // here. Saying so explicitly is what lets the panel decline to touch it
+        // rather than quietly narrowing it on the next row-count edit.
+        function ownsTransforms(spec) {
+            var list = (spec && spec.transforms) || [];
+            return list.length === 0
+                || (list.length === 1 && list[0].kind === 'missingValues');
+        }
+
+        function editableStep(spec) {
+            if (!ownsTransforms(spec)) return null;
+            return ((spec && spec.transforms) || [])[0] || null;
         }
 
         // The spec a row currently describes. The KIND is derived from whether
@@ -104,15 +144,44 @@
         function specFor(row, filename, sampleSize) {
             var stratum = row.querySelector('.js-dataset-stratum');
             var column = stratum ? stratum.value.trim() : '';
-            if (!column) {
-                return { file: filename, kind: 'rowSample', sampleSize: sampleSize };
+            var spec = column
+                ? {
+                    file: filename,
+                    kind: 'stratifiedSample',
+                    sampleSize: sampleSize,
+                    stratumColumn: column
+                }
+                : { file: filename, kind: 'rowSample', sampleSize: sampleSize };
+
+            // Only claim `transforms` when the panel's fields are live. When
+            // they are disabled the key is omitted entirely, so the merge in
+            // `commit` carries the stored steps through untouched.
+            var columns = row.querySelector('.js-dataset-blank-columns');
+            if (columns && !columns.disabled) {
+                spec.transforms = blankStepIn(row);
             }
-            return {
-                file: filename,
-                kind: 'stratifiedSample',
-                sampleSize: sampleSize,
-                stratumColumn: column
-            };
+            return spec;
+        }
+
+        // The derivation steps a row describes: one missingValues step when
+        // columns are named, and none otherwise. As with the stratum column, the
+        // field carries whether the step EXISTS rather than a separate checkbox
+        // that could contradict it.
+        function blankStepIn(row) {
+            var columns = row.querySelector('.js-dataset-blank-columns');
+            var percent = row.querySelector('.js-dataset-blank-percent');
+            var named = (columns ? columns.value : '')
+                .split(',')
+                .map(function (name) { return name.trim(); })
+                .filter(function (name) { return name.length > 0; });
+            if (!named.length) return [];
+            var pct = parseInt(percent && percent.value, 10);
+            if (!(pct > 0)) pct = DEFAULT_BLANK_PERCENT;
+            if (percent) percent.value = String(pct);
+            // Authored as a percentage because that is how an instructor says
+            // it; stored as the 0 < rate <= 1 fraction the materializer folds to
+            // an integer count.
+            return [{ kind: 'missingValues', columns: named, rate: pct / 100 }];
         }
 
         // The row count a row is currently showing, or null when it is blank
@@ -191,11 +260,13 @@
             var size = row.querySelector('.js-dataset-size');
             var field = row.querySelector('.js-dataset-size-field');
             var stratumField = row.querySelector('.js-dataset-stratum-field');
+            var blankField = row.querySelector('.js-dataset-blank-field');
 
             if (target.classList.contains('js-dataset-toggle')) {
                 if (!target.checked) {
                     if (field) field.hidden = true;
                     if (stratumField) stratumField.hidden = true;
+                    if (blankField) blankField.hidden = true;
                     commit(filename, null, row);
                     return;
                 }
@@ -206,12 +277,15 @@
                     if (size && size.focus) { size.focus(); size.select(); }
                 }
                 if (stratumField) stratumField.hidden = false;
+                if (blankField) blankField.hidden = false;
                 commit(filename, specFor(row, filename, sampleRows), row);
                 return;
             }
 
             if (target.classList.contains('js-dataset-size')
-                || target.classList.contains('js-dataset-stratum')) {
+                || target.classList.contains('js-dataset-stratum')
+                || target.classList.contains('js-dataset-blank-columns')
+                || target.classList.contains('js-dataset-blank-percent')) {
                 var toggle = row.querySelector('.js-dataset-toggle');
                 if (toggle && !toggle.checked) return;
                 var entered = sampleSizeIn(row);

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -190,6 +190,26 @@
                                        placeholder="column (optional)"
                                        aria-label="Column to balance the sample of #(supportFile.name) across">
                             </span>
+                            <span class="dataset-size-field js-dataset-blank-field"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                blanking
+                                <input type="text"
+                                       class="form-input input-sm dataset-stratum js-dataset-blank-columns"
+                                       value="#(supportFile.datasetBlankColumnsOrEmpty)"
+                                       placeholder="columns (optional)"
+                                       #if(!supportFile.datasetTransformsEditable):disabled#endif
+                                       aria-label="Columns to blank values in for #(supportFile.name)">
+                                in
+                                <input type="number" min="1" max="100" step="1"
+                                       class="form-input input-sm dataset-size js-dataset-blank-percent"
+                                       value="#(supportFile.datasetBlankPercentText)"
+                                       #if(!supportFile.datasetTransformsEditable):disabled#endif
+                                       aria-label="Percent of rows to blank for #(supportFile.name)">
+                                % of rows
+                            </span>
+                            #if(!supportFile.datasetTransformsEditable):
+                            <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
+                            #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
                         </div>
                     </td>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -190,6 +190,26 @@ Create Assignment
                                        placeholder="column (optional)"
                                        aria-label="Column to balance the sample of #(supportFile.name) across">
                             </span>
+                            <span class="dataset-size-field js-dataset-blank-field"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                blanking
+                                <input type="text"
+                                       class="form-input input-sm dataset-stratum js-dataset-blank-columns"
+                                       value="#(supportFile.datasetBlankColumnsOrEmpty)"
+                                       placeholder="columns (optional)"
+                                       #if(!supportFile.datasetTransformsEditable):disabled#endif
+                                       aria-label="Columns to blank values in for #(supportFile.name)">
+                                in
+                                <input type="number" min="1" max="100" step="1"
+                                       class="form-input input-sm dataset-size js-dataset-blank-percent"
+                                       value="#(supportFile.datasetBlankPercentText)"
+                                       #if(!supportFile.datasetTransformsEditable):disabled#endif
+                                       aria-label="Percent of rows to blank for #(supportFile.name)">
+                                % of rows
+                            </span>
+                            #if(!supportFile.datasetTransformsEditable):
+                            <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
+                            #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
                         </div>
                     </td>

--- a/Sources/APIServer/MCP/Protocol/DatasetTransformProse.swift
+++ b/Sources/APIServer/MCP/Protocol/DatasetTransformProse.swift
@@ -1,0 +1,27 @@
+// APIServer/MCP/Protocol/DatasetTransformProse.swift
+//
+// How the dataset transform kinds are SPELLED in agent-facing copy, derived
+// from `DatasetTransform.Kind.allCases` in one place.
+//
+// Same reasoning as `MCPLanguageProse`, applied before the list can go stale
+// rather than after: a hand-typed kind list in a tool description is prose, and
+// prose is the surface no compiler and no `allCases` test reaches. The language
+// list had to be fixed twice — the second time because the first fix repaired
+// the string it was looking at instead of the class — so this one starts
+// derived while there is exactly one kind and nothing to get wrong yet.
+//
+// A second transform kind needs no edit to any tool description.
+
+import Core
+
+enum DatasetTransformProse {
+
+    /// The kinds as a wire-token list for a schema description:
+    /// `"missingValues"`, and with a second kind `"missingValues" or "x"`.
+    static var kinds: String {
+        let quoted = DatasetTransform.Kind.allCases.map { "\"\($0.rawValue)\"" }
+        guard let last = quoted.last else { return "" }
+        guard quoted.count > 1 else { return last }
+        return quoted.dropLast().joined(separator: ", ") + " or " + last
+    }
+}

--- a/Sources/APIServer/MCP/Tools/SetDatasetTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetDatasetTool.swift
@@ -31,6 +31,16 @@ struct SetDatasetTool: ContentTool {
         /// True to clear the dataset mark (the file becomes an ordinary shared
         /// support file again).
         let remove: Bool?
+        /// Derivation steps applied after sampling. Omitted means "leave whatever
+        /// is already there" — an agent adjusting sampleSize must not silently
+        /// drop the transforms it was not asked about. Send `[]` to clear them.
+        let transforms: [TransformInput]?
+    }
+
+    struct TransformInput: Decodable, Sendable {
+        let kind: String
+        let columns: [String]?
+        let rate: Double?
     }
 
     struct DatasetEntry: Encodable, Sendable {
@@ -40,6 +50,15 @@ struct SetDatasetTool: ContentTool {
         /// back which kind of slice a file is marked for, not just that it is.
         let kind: String
         let stratumColumn: String?
+        /// Reported for the same reason as `kind`: an agent that cannot read a
+        /// file's transforms back cannot tell whether its edit preserved them.
+        let transforms: [TransformEntry]
+    }
+
+    struct TransformEntry: Encodable, Sendable {
+        let kind: String
+        let columns: [String]
+        let rate: Double?
     }
 
     struct Output: Encodable, Sendable {
@@ -95,6 +114,21 @@ struct SetDatasetTool: ContentTool {
                 "type": .string("boolean"),
                 "description": .string("True to clear the dataset mark for this file."),
             ]),
+            "transforms": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Optional. Derivation steps applied to the student's rows AFTER sampling, in "
+                        + "order. Sampling decides which rows a student gets; a transform alters the "
+                        + "values in them, so the pool becomes a template each student varies on. "
+                        + "Kinds: " + DatasetTransformProse.kinds + ". Each step takes columns (an "
+                        + "explicit list of header names — there is no wildcard, so a column a "
+                        + "notebook check asserts on cannot be altered by accident) and rate (the "
+                        + "fraction of the student's rows affected, above 0 and at most 1). A "
+                        + "transform never adds, removes, renames or reorders a column. Note this "
+                        + "changes the values a student computes over, so pair it with per-student "
+                        + "expected values rather than a fixed one. OMIT this to leave existing "
+                        + "transforms untouched; send [] to clear them."),
+            ]),
         ]),
         "required": .array([.string("assignmentPublicID"), .string("filename")]),
         "additionalProperties": .bool(false),
@@ -123,6 +157,13 @@ struct SetDatasetTool: ContentTool {
                 tool: Self.name,
                 detail: "filename must be a bare filename with no path components.")
         }
+
+        // Built once, from the stored spec plus this call's changes, and used
+        // for both the validation and the manifest entry — so the thing that is
+        // checked is the thing that is stored.
+        let written = spec(
+            from: input, filename: cleaned,
+            existing: setup.decodedManifest()?.datasetSpecsByFile[cleaned])
 
         if !remove {
             guard let sampleSize = input.sampleSize, sampleSize >= 1 else {
@@ -160,7 +201,7 @@ struct SetDatasetTool: ContentTool {
             // quietly on both at delivery time, so this is where an agent finds
             // out — with the file's real column names in the message.
             if let issue = DatasetSpecValidation.issue(
-                with: spec(from: input, filename: cleaned),
+                with: written,
                 sourceCSV: extractZipEntry(zipPath: setup.zipPath, entryName: cleaned)
                     .flatMap { String(data: $0, encoding: .utf8) })
             {
@@ -168,7 +209,6 @@ struct SetDatasetTool: ContentTool {
             }
         }
 
-        let written = spec(from: input, filename: cleaned)
         try await mutateManifest(setup: setup, on: context.db) { dict in
             var specs = (dict["datasets"] as? [[String: Any]]) ?? []
             // Replaced, never appended — two specs for one file would disagree
@@ -179,6 +219,15 @@ struct SetDatasetTool: ContentTool {
                 var entry: [String: Any] = ["file": cleaned, "kind": written.kind.rawValue]
                 if let sampleSize = written.sampleSize { entry["sampleSize"] = sampleSize }
                 if let column = written.stratumColumn { entry["stratumColumn"] = column }
+                if !written.transforms.isEmpty {
+                    entry["transforms"] = written.transforms.map { transform -> [String: Any] in
+                        var step: [String: Any] = [
+                            "kind": transform.kind.rawValue, "columns": transform.columns,
+                        ]
+                        if let rate = transform.rate { step["rate"] = rate }
+                        return step
+                    }
+                }
                 specs.append(entry)
             }
             if specs.isEmpty {
@@ -191,7 +240,10 @@ struct SetDatasetTool: ContentTool {
         let datasets = (setup.decodedManifest()?.datasets ?? []).map {
             DatasetEntry(
                 file: $0.file, sampleSize: $0.sampleSize,
-                kind: $0.kind.rawValue, stratumColumn: $0.stratumColumn)
+                kind: $0.kind.rawValue, stratumColumn: $0.stratumColumn,
+                transforms: $0.transforms.map {
+                    TransformEntry(kind: $0.kind.rawValue, columns: $0.columns, rate: $0.rate)
+                })
         }
         return Output(assignmentPublicID: assignment.publicID, datasets: datasets)
     }
@@ -203,13 +255,28 @@ struct SetDatasetTool: ContentTool {
     /// A blank `stratumColumn` reads as "no column": an agent clearing the
     /// field means a plain row sample, not a stratified spec that fails
     /// validation on the emptiness it just asked for.
-    private func spec(from input: Input, filename: String) -> DatasetSpec {
+    private func spec(from input: Input, filename: String, existing: DatasetSpec?) -> DatasetSpec {
         let column = input.stratumColumn?.trimmingCharacters(in: .whitespaces)
         let stratum = (column?.isEmpty ?? true) ? nil : column
         return DatasetSpec(
             file: filename,
             kind: stratum == nil ? .rowSample : .stratifiedSample,
             sampleSize: input.sampleSize,
-            stratumColumn: stratum)
+            stratumColumn: stratum,
+            // Omitted means "leave them alone". Rebuilding a spec from only the
+            // fields a caller mentioned is how this surface twice came within a
+            // release of downgrading data it did not understand; a field is
+            // dropped here only when the caller says so, by sending [].
+            transforms: input.transforms.map(Self.transforms(from:)) ?? existing?.transforms ?? [])
+    }
+
+    /// Maps the wire shape to the model. An unrecognised kind is dropped rather
+    /// than guessed at — validation then refuses the spec, naming what is
+    /// supported, instead of silently storing a step that would never run.
+    private static func transforms(from inputs: [TransformInput]) -> [DatasetTransform] {
+        inputs.compactMap { input in
+            guard let kind = DatasetTransform.Kind(rawValue: input.kind) else { return nil }
+            return DatasetTransform(kind: kind, columns: input.columns ?? [], rate: input.rate)
+        }
     }
 }

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -85,10 +85,13 @@ func applyDatasetsEdit(
         guard seenFiles.insert(spec.file).inserted else {
             throw Abort(.badRequest, reason: "Dataset file '\(spec.file)' is listed more than once.")
         }
-        // Reads the file only when a spec claims to stratify — an ordinary row
-        // sample needs nothing from the bytes, and these files are course
-        // datasets, not small.
-        if spec.kind == .stratifiedSample || spec.stratumColumn != nil {
+        // Reads the file only when a spec claims something CHECKABLE against it
+        // — a stratum column or a transform's columns. An ordinary row sample
+        // needs nothing from the bytes, and these files are course datasets, not
+        // small. The transform arm matters as much as the stratum one: a
+        // transform naming a column the file does not have is absorbed silently
+        // at delivery, so this is the only place it can be reported.
+        if spec.kind == .stratifiedSample || spec.stratumColumn != nil || !spec.transforms.isEmpty {
             let text = extractZipEntry(zipPath: setup.zipPath, entryName: spec.file)
                 .flatMap { String(data: $0, encoding: .utf8) }
             if let issue = DatasetSpecValidation.issue(with: spec, sourceCSV: text) {

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewPage.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewPage.swift
@@ -95,7 +95,8 @@ extension DraftAssignmentRoutes {
                     // on the create page while the edit page still showed it.
                     isDataset: row.isDataset,
                     datasetSampleSize: row.datasetSampleSize,
-                    datasetStratumColumn: row.datasetStratumColumn
+                    datasetStratumColumn: row.datasetStratumColumn,
+                    datasetTransforms: row.datasetTransforms
                 )
             }
     }

--- a/Sources/APIServer/Routes/Web/SuiteRowContexts.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowContexts.swift
@@ -4,6 +4,7 @@
 // edit-assignment pages.  Split from the original
 // `AssignmentContextTypes.swift`.
 
+import Core
 import Foundation
 
 /// One section block's server-rendered shell in the suite editor.  Named
@@ -55,6 +56,11 @@ struct EditableSuiteRow: Encodable {
     /// has to travel with the row or an edit would rewrite a stratified spec
     /// into a plain one.
     let datasetStratumColumn: String?
+    /// The spec's derivation steps (docs/datasets.md). Carried so the panel can
+    /// render the one shape it edits — and, more importantly, so it can tell
+    /// when a spec holds a shape it CANNOT edit and step aside rather than
+    /// overwrite it.
+    let datasetTransforms: [DatasetTransform]
 
     /// Empty string when displayName is nil — Leaf doesn't support `??` in templates.
     var displayNameOrEmpty: String { displayName ?? "" }
@@ -66,6 +72,36 @@ struct EditableSuiteRow: Encodable {
 
     /// The stratum column as an input-ready string — empty when there is none.
     var datasetStratumColumnOrEmpty: String { datasetStratumColumn ?? "" }
+
+    /// Whether the Files panel can represent this spec's transforms.
+    ///
+    /// The panel edits exactly one shape: no transforms, or a single
+    /// `missingValues` step. The model is richer than that — an ordered list,
+    /// and more kinds to come — so a spec authored through MCP can hold
+    /// something the panel has no fields for. Rendering such a spec into the
+    /// fields it does have would silently discard the rest on the next edit,
+    /// which is the same silent-downgrade shape the stratum column exists to
+    /// avoid. So the panel asks first, and shows a disabled control saying the
+    /// steps are agent-authored rather than pretending to own them.
+    var datasetTransformsEditable: Bool {
+        datasetTransforms.isEmpty
+            || (datasetTransforms.count == 1 && datasetTransforms[0].kind == .missingValues)
+    }
+
+    /// The blanked columns as a comma-separated string — empty when no
+    /// `missingValues` step is present.
+    var datasetBlankColumnsOrEmpty: String {
+        guard datasetTransformsEditable else { return "" }
+        return datasetTransforms.first?.columns.joined(separator: ", ") ?? ""
+    }
+
+    /// The blank rate as a whole-number percentage for the form, or empty.
+    /// Authored as a percentage because that is how an instructor says it; the
+    /// stored value is the `0 < rate <= 1` fraction the materializer folds.
+    var datasetBlankPercentText: String {
+        guard datasetTransformsEditable, let rate = datasetTransforms.first?.rate else { return "" }
+        return String(Int((rate * 100).rounded()))
+    }
 
     /// The dataset pair defaults to "not a dataset": every construction site
     /// but the two support-file row builders is describing a test script, and
@@ -81,7 +117,8 @@ struct EditableSuiteRow: Encodable {
         displayName: String?,
         isDataset: Bool = false,
         datasetSampleSize: Int? = nil,
-        datasetStratumColumn: String? = nil
+        datasetStratumColumn: String? = nil,
+        datasetTransforms: [DatasetTransform] = []
     ) {
         self.name = name
         self.url = url
@@ -94,6 +131,7 @@ struct EditableSuiteRow: Encodable {
         self.isDataset = isDataset
         self.datasetSampleSize = datasetSampleSize
         self.datasetStratumColumn = datasetStratumColumn
+        self.datasetTransforms = datasetTransforms
     }
 
     /// Display name if set, otherwise the filename stem (extension stripped).
@@ -126,6 +164,12 @@ struct EditableSuiteRow: Encodable {
         case displayNameOrStem
         case datasetSampleSizeText
         case datasetStratumColumnOrEmpty
+        // The derivation fields the panel renders. `datasetTransforms` itself is
+        // deliberately NOT encoded — Leaf has no use for the array, and the
+        // three derived strings are exactly what the control's inputs need.
+        case datasetTransformsEditable
+        case datasetBlankColumnsOrEmpty
+        case datasetBlankPercentText
         case dependsOnJSON
     }
 
@@ -146,6 +190,9 @@ struct EditableSuiteRow: Encodable {
         try container.encode(displayNameOrStem, forKey: .displayNameOrStem)
         try container.encode(datasetSampleSizeText, forKey: .datasetSampleSizeText)
         try container.encode(datasetStratumColumnOrEmpty, forKey: .datasetStratumColumnOrEmpty)
+        try container.encode(datasetTransformsEditable, forKey: .datasetTransformsEditable)
+        try container.encode(datasetBlankColumnsOrEmpty, forKey: .datasetBlankColumnsOrEmpty)
+        try container.encode(datasetBlankPercentText, forKey: .datasetBlankPercentText)
         try container.encode(dependsOnJSON, forKey: .dependsOnJSON)
     }
 }

--- a/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
@@ -164,7 +164,8 @@ func currentSetupFiles(
             displayName: entry?.name,
             isDataset: datasetSpecs[name] != nil,
             datasetSampleSize: datasetSpecs[name]?.sampleSize,
-            datasetStratumColumn: datasetSpecs[name]?.stratumColumn
+            datasetStratumColumn: datasetSpecs[name]?.stratumColumn,
+            datasetTransforms: datasetSpecs[name]?.transforms ?? []
         )
     }
 
@@ -226,7 +227,8 @@ func editableSuiteRowsForSetup(_ setup: APITestSetup) -> [EditableSuiteRow] {
             displayName: info?.name,
             isDataset: datasetSpecs[name] != nil,
             datasetSampleSize: datasetSpecs[name]?.sampleSize,
-            datasetStratumColumn: datasetSpecs[name]?.stratumColumn
+            datasetStratumColumn: datasetSpecs[name]?.stratumColumn,
+            datasetTransforms: datasetSpecs[name]?.transforms ?? []
         )
     }
     .sorted { lhs, rhs in

--- a/Sources/APIServer/Services/DatasetOverlayDirectory.swift
+++ b/Sources/APIServer/Services/DatasetOverlayDirectory.swift
@@ -1,0 +1,68 @@
+// APIServer/Services/DatasetOverlayDirectory.swift
+//
+// A private view of an assignment's support files in which every per-student
+// dataset carries THIS student's slice.
+//
+// `PersonalizationEvaluator` spawns its interpreter with the cwd set to the
+// support-files directory so an expression can `open("cases.csv")`.  That
+// directory is shared by every student and holds the instructor's full pool, so
+// evaluating there answered a per-student question with the pool's data — see
+// docs/datasets.md, "Expressions read the student's slice, not the pool".
+//
+// Kept out of the evaluator because it is a different job (staging a directory,
+// not running an interpreter) and because the evaluator is already at its type
+// body limit.
+
+import Core
+import Foundation
+
+enum DatasetOverlayDirectory {
+
+    /// The directory an evaluation should run in: `supportFilesDirectory` itself
+    /// when nothing is personalized, otherwise a private overlay of it in which
+    /// every file in `datasetFiles` carries the student's slice.
+    ///
+    /// Returning the shared directory for the empty case is what keeps every
+    /// non-dataset assignment byte-for-byte unchanged, and it lives here rather
+    /// than at the call site so there is one answer to "where does this run".
+    ///
+    /// Everything the student does not personalize is a symlink to the shared
+    /// copy — cheap next to the subprocess this is setting up, and it keeps the
+    /// pool a single stored copy rather than one per evaluation.
+    ///
+    /// A dataset file whose slice cannot be written is left ABSENT rather than
+    /// symlinked to the pool: the expression then fails loudly ("no such file")
+    /// instead of quietly computing the instructor's answer and shipping it to
+    /// the student as their own, which is the defect this overlay exists to fix.
+    static func root(
+        over supportFilesDirectory: String,
+        datasetFiles: [String: String],
+        in tempDir: URL,
+        fm: FileManager = .default
+    ) -> URL {
+        let shared = URL(fileURLWithPath: supportFilesDirectory, isDirectory: true)
+        guard !datasetFiles.isEmpty else { return shared }
+        let overlay = tempDir.appendingPathComponent("support", isDirectory: true)
+        do {
+            try fm.createDirectory(at: overlay, withIntermediateDirectories: true)
+        } catch {
+            return shared
+        }
+
+        for entry in (try? fm.contentsOfDirectory(atPath: supportFilesDirectory)) ?? [] {
+            guard datasetFiles[entry] == nil else { continue }
+            try? fm.createSymbolicLink(
+                at: overlay.appendingPathComponent(entry),
+                withDestinationURL: shared.appendingPathComponent(entry))
+        }
+        for (name, contents) in datasetFiles {
+            // A dataset name is a bare filename by construction (`putDatasets`
+            // and `DatasetResolver` both refuse path components), but this joins
+            // onto a directory, so re-check rather than inherit the guarantee.
+            guard FilenameSafety.bareFilename(name) != nil else { continue }
+            try? contents.write(
+                to: overlay.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        return overlay
+    }
+}

--- a/Sources/APIServer/Services/PersonalizationEvaluator.swift
+++ b/Sources/APIServer/Services/PersonalizationEvaluator.swift
@@ -111,11 +111,22 @@ enum PersonalizationEvaluator {
         }
     }
 
+    /// Evaluates `expressions` with `seed` bound to the per-student seed.
+    ///
+    /// `datasetFiles` maps a support filename to the bytes THIS student
+    /// receives (`DatasetResolver.resolve`).  When it is non-empty the
+    /// subprocess runs against an overlay of the support directory in which
+    /// those files carry the student's slice, so an expression that reads a
+    /// per-student dataset computes that student's answer rather than the
+    /// instructor's pool.  Empty (the default) spawns directly in the support
+    /// directory exactly as before, so every non-dataset assignment is
+    /// byte-for-byte unchanged.
     static func evaluate(
         seedHex: String,
         staticVariables: [FamilyVariable],
         expressions: [PersonalizationExpression],
         supportFilesDirectory: String? = nil,
+        datasetFiles: [String: String] = [:],
         language: AssignmentLanguage,
         timeoutSeconds: Int = defaultTimeoutSeconds
     ) async throws -> [String: String] {
@@ -159,9 +170,17 @@ enum PersonalizationEvaluator {
         var env: [String: String] = ["CHICKADEE_ASSIGNMENT_SEED": seedHex]
         let spawnCwd: URL
         if let supportFilesDirectory, fm.fileExists(atPath: supportFilesDirectory) {
-            spawnCwd = URL(fileURLWithPath: supportFilesDirectory, isDirectory: true)
+            // A per-student dataset makes the shared support directory the WRONG
+            // thing to read: it holds the instructor's full pool, while the
+            // student holds a slice of it.  Evaluating there computed the pool's
+            // answer and delivered it as the student's expected value, so an
+            // `expectedVarRef` over a sampled dataset was wrong for the whole
+            // class.  Overlay the student's bytes instead — and never write them
+            // into the shared directory, which every student's evaluation reads.
+            spawnCwd = DatasetOverlayDirectory.root(
+                over: supportFilesDirectory, datasetFiles: datasetFiles, in: tempDir, fm: fm)
             if let pathVariable = language.supportFilesPathEnvironmentVariable {
-                env[pathVariable] = supportFilesDirectory
+                env[pathVariable] = spawnCwd.path
             }
         } else {
             spawnCwd = tempDir

--- a/Sources/APIServer/Services/PersonalizationSubstitution.swift
+++ b/Sources/APIServer/Services/PersonalizationSubstitution.swift
@@ -77,12 +77,25 @@ enum PersonalizationSubstitution {
                 evaluationError: nil)
         }
 
+        // The student's dataset slices, so an expression reading a per-student
+        // dataset sees what that student holds.  Resolved from the same source
+        // directory and seed the delivered file comes from, so the expression
+        // and the student's copy are the same bytes by construction rather than
+        // by two call sites agreeing.  Nil for every assignment declaring no
+        // datasets, which leaves the evaluation exactly as it was.
+        let datasetFiles =
+            supportFilesDirectory.flatMap {
+                DatasetResolver.resolve(
+                    manifest: manifest, seedHex: seedHex, sourceDirectory: $0)
+            } ?? [:]
+
         do {
             let evaluated = try await PersonalizationEvaluator.evaluate(
                 seedHex: seedHex,
                 staticVariables: staticVars,
                 expressions: allExpressions,
                 supportFilesDirectory: supportFilesDirectory,
+                datasetFiles: datasetFiles,
                 language: language)
             // Per-student values override literals on name collision (the
             // validator forbids cross-kind clashes at save time anyway).

--- a/Sources/Core/DatasetMaterializer.swift
+++ b/Sources/Core/DatasetMaterializer.swift
@@ -25,7 +25,19 @@ public enum DatasetMaterializer {
     /// Materialize `source` for the given spec and per-student seed.
     /// Returns the source unchanged for any kind/size that implies "the whole
     /// file" so callers can deliver the result unconditionally.
+    ///
+    /// Selection first, then each transform in array order — so a transform's
+    /// rate applies to the rows the student actually receives rather than to the
+    /// pool, and appending a step never re-decides an earlier one.
     public static func materialize(source: String, spec: DatasetSpec, seedHex: String) -> String {
+        let selected = select(source: source, spec: spec, seedHex: seedHex)
+        guard !spec.transforms.isEmpty else { return selected }
+        return spec.transforms.enumerated().reduce(selected) { csv, step in
+            apply(step.element, at: step.offset, to: csv, seedHex: seedHex)
+        }
+    }
+
+    private static func select(source: String, spec: DatasetSpec, seedHex: String) -> String {
         switch spec.kind {
         case .rowSample:
             return sampleRows(csv: source, sampleSize: spec.sampleSize ?? .max, seedHex: seedHex)
@@ -222,7 +234,7 @@ public enum DatasetMaterializer {
     /// CR+LF is a single Swift `Character` (one extended grapheme cluster), so
     /// `split(separator: "\n")` would not see the LF inside a CRLF ending and
     /// would return the whole file as one "line".
-    private static func normalizedLines(of csv: String) -> (lines: [Substring], trailingNewline: Bool) {
+    static func normalizedLines(of csv: String) -> (lines: [Substring], trailingNewline: Bool) {
         let normalized = csv.replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
         let hadTrailingNewline = normalized.hasSuffix("\n")
@@ -285,7 +297,7 @@ public enum DatasetMaterializer {
 /// standard library's `RandomNumberGenerator` helpers, whose bit-consumption
 /// is not a stable contract.  Intentionally not conforming to
 /// `RandomNumberGenerator` to keep callers off `random(in:using:)`.
-private struct SplitMix64 {
+struct SplitMix64 {
     private var state: UInt64
 
     init(seed: UInt64) { state = seed }
@@ -310,7 +322,7 @@ private struct SplitMix64 {
 
 /// FNV-1a 64-bit hash over a string's UTF-8 bytes.  Deterministic and
 /// dependency-free — used only to fold a 64-hex seed into a PRNG seed.
-private func fnv1a64(_ string: String) -> UInt64 {
+func fnv1a64(_ string: String) -> UInt64 {
     var hash: UInt64 = 0xcbf2_9ce4_8422_2325
     for byte in string.utf8 {
         hash ^= UInt64(byte)

--- a/Sources/Core/DatasetSpecValidation.swift
+++ b/Sources/Core/DatasetSpecValidation.swift
@@ -36,6 +36,76 @@ public enum DatasetSpecValidation {
     /// that too, because the instructor cannot see the file from the form they
     /// are typing into.
     public static func issue(with spec: DatasetSpec, sourceCSV: String?) -> String? {
+        if let issue = transformIssue(with: spec, sourceCSV: sourceCSV) { return issue }
+        return selectionIssue(with: spec, sourceCSV: sourceCSV)
+    }
+
+    /// Why `spec`'s transform list cannot be saved, or nil.
+    ///
+    /// Every check here pairs with something `DatasetMaterializer` absorbs
+    /// silently at delivery: a step with no columns, an unknown column, a
+    /// missing or out-of-range rate, and a rate too small to reach one row of
+    /// the student's sample all leave the data untouched. Untouched data is the
+    /// right answer for a student being graded and the wrong answer for an
+    /// instructor who thinks they asked for something.
+    static func transformIssue(with spec: DatasetSpec, sourceCSV: String?) -> String? {
+        guard !spec.transforms.isEmpty else { return nil }
+        let columns = sourceCSV.flatMap { csv -> [String]? in
+            let rows = csv.replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+                .split(separator: "\n", omittingEmptySubsequences: true)
+            return rows.first.map { DatasetMaterializer.splitCSVLine($0) }
+        }
+
+        var seen: Set<String> = []
+        for transform in spec.transforms {
+            let label = "'\(spec.file)': \(transform.kind.rawValue)"
+            guard !transform.columns.isEmpty else {
+                return "\(label) names no column, so it would change nothing."
+            }
+            for column in transform.columns {
+                guard let columns else {
+                    return "'\(spec.file)' is not UTF-8 text, so it has no columns to transform."
+                }
+                guard columns.contains(column) else {
+                    return "\(label): '\(spec.file)' has no column named '\(column)'. "
+                        + "Its columns are: \(list(columns))."
+                }
+                // Two steps of one kind on one column would each blank a
+                // different subset and the result would depend on their order
+                // in a way nobody authored.
+                guard seen.insert("\(transform.kind.rawValue)|\(column)").inserted else {
+                    return "\(label) is applied to '\(column)' more than once."
+                }
+            }
+            if let issue = rateIssue(transform, spec: spec, label: label) { return issue }
+        }
+        return nil
+    }
+
+    /// A rate must be present, within `0 < rate <= 1`, and large enough to reach
+    /// at least one row of the sample the student actually receives — the
+    /// integer fold `(rows * permille) / 1000` is what delivery uses, so a rate
+    /// below one row's worth silently does nothing.
+    private static func rateIssue(
+        _ transform: DatasetTransform, spec: DatasetSpec, label: String
+    ) -> String? {
+        guard let rate = transform.rate else {
+            return "\(label) needs a rate — the fraction of rows to affect, above 0 and at most 1."
+        }
+        guard rate > 0, rate <= 1 else {
+            return "\(label): a rate of \(rate) is outside the allowed range (above 0, at most 1)."
+        }
+        guard let sampleSize = spec.sampleSize else { return nil }
+        let permille = Int((rate * 1000).rounded())
+        guard (sampleSize * permille) / 1000 > 0 else {
+            return "\(label): a rate of \(rate) over a \(sampleSize)-row sample affects no rows. "
+                + "Raise the rate, or the sample size."
+        }
+        return nil
+    }
+
+    private static func selectionIssue(with spec: DatasetSpec, sourceCSV: String?) -> String? {
         guard spec.kind == .stratifiedSample else {
             // A column on a plain row sample would be stored and then ignored
             // at delivery — the silent-mismatch shape this whole file exists to

--- a/Sources/Core/DatasetTransformApplication.swift
+++ b/Sources/Core/DatasetTransformApplication.swift
@@ -1,0 +1,141 @@
+// Core/DatasetTransformApplication.swift
+//
+// The delivery half of derivation (see docs/datasets.md).  `DatasetMaterializer`
+// selects the student's rows; this applies the spec's transforms to them.
+//
+// Determinism is harder here than for selection, because selection only ever
+// COPIES bytes while a transform decides new ones.  Three rules keep it:
+//
+//   1. No `Double` reaches a delivered byte.  `rate` is an authored number, so
+//      it is folded to an integer per-mille ONCE, up front; every per-cell
+//      decision after that is integer math.
+//   2. Each transform draws from its own stream, sub-seeded on the student's
+//      seed plus the step's index, kind and column.  A shared stream would mean
+//      appending a second transform re-rolls the first, silently changing data
+//      already delivered to every student in the class.
+//   3. Nothing iterates a `Dictionary` or `Set`.  Columns are visited in the
+//      order the instructor listed them, rows in file order.
+//
+// A transform that cannot apply leaves the data alone — an unknown column is
+// skipped, not guessed at.  `DatasetSpecValidation` refuses at save time
+// everything this absorbs at delivery, which is the only reason absorbing it is
+// safe: loud while an instructor can fix it, forgiving once the reader is a
+// student being graded.
+
+import Foundation
+
+extension DatasetMaterializer {
+
+    /// Applies one transform to an already-selected slice.  `index` is the
+    /// step's position in `DatasetSpec.transforms`, and is part of its sub-seed.
+    static func apply(
+        _ transform: DatasetTransform, at index: Int, to csv: String, seedHex: String
+    ) -> String {
+        switch transform.kind {
+        case .missingValues:
+            return blankCells(transform, at: index, in: csv, seedHex: seedHex)
+        }
+    }
+
+    /// Blanks `rate` of the rows in each named column.
+    ///
+    /// Returns `csv` untouched when the step cannot apply — no rate, a
+    /// non-positive rate, no data rows, or a column the file does not have.
+    static func blankCells(
+        _ transform: DatasetTransform, at index: Int, in csv: String, seedHex: String
+    ) -> String {
+        guard let permille = permille(of: transform.rate), permille > 0 else { return csv }
+        let (lines, hadTrailingNewline) = normalizedLines(of: csv)
+        guard lines.count > 1 else { return csv }
+
+        let headerFields = splitCSVLine(lines[0])
+        let rowCount = lines.count - 1
+        // The count is fixed before any per-cell work, so no float ever decides
+        // which cell is blanked — only how many are.
+        let affected = (rowCount * permille) / 1000
+        guard affected > 0 else { return csv }
+
+        var rows = lines.map(String.init)
+        for column in transform.columns {
+            guard let columnIndex = headerFields.firstIndex(of: column) else { continue }
+            // Sub-seeded per column as well as per step: adding a column to the
+            // list must not move which rows an existing column blanks.
+            var rng = SplitMix64(
+                seed: fnv1a64(
+                    "\(seedHex)|\(index)|\(transform.kind.rawValue)|\(column)"))
+            for row in chooseRows(count: affected, of: rowCount, using: &rng) {
+                rows[row] = blanking(field: columnIndex, in: rows[row])
+            }
+        }
+
+        let result = rows.joined(separator: "\n")
+        return hadTrailingNewline ? result + "\n" : result
+    }
+
+    /// `rate` as thousandths, or nil when it is absent or outside `0 < r <= 1`.
+    /// This is the one place the authored `Double` is read; everything
+    /// downstream is integer.
+    private static func permille(of rate: Double?) -> Int? {
+        guard let rate, rate > 0, rate <= 1 else { return nil }
+        return Int((rate * 1000).rounded())
+    }
+
+    /// `count` distinct row numbers in `1...rowCount`, in ascending order.
+    /// Partial Fisher-Yates over the row indices, matching how `sampleRows`
+    /// chooses rows so the two read the same way.
+    private static func chooseRows(
+        count: Int, of rowCount: Int, using rng: inout SplitMix64
+    ) -> [Int] {
+        var indices = Array(1...rowCount)
+        let take = min(count, rowCount)
+        for i in 0..<take {
+            let j = i + Int(rng.next(upperBound: UInt64(rowCount - i)))
+            indices.swapAt(i, j)
+        }
+        return indices.prefix(take).sorted()
+    }
+
+    /// `line` with field `index` replaced by an empty value.
+    ///
+    /// Edits the raw text in place rather than splitting and re-joining: a
+    /// rebuild would re-quote every OTHER field by this file's rules rather than
+    /// the source's, changing bytes in cells the transform was never asked to
+    /// touch.  A short row (fewer fields than the header) is returned unchanged.
+    private static func blanking(field index: Int, in line: String) -> String {
+        let ranges = fieldRanges(of: Substring(line))
+        guard index < ranges.count else { return line }
+        return line.replacingCharacters(in: ranges[index], with: "")
+    }
+
+    /// The raw span of each comma-separated field in `line`, using the same
+    /// quoting rules as `splitCSVLine` — a comma inside quotes is data, and a
+    /// doubled quote is an escaped one — so the two always agree on how many
+    /// fields a line has.
+    static func fieldRanges(of line: Substring) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var fieldStart = line.startIndex
+        var inQuotes = false
+        var i = line.startIndex
+        while i < line.endIndex {
+            let character = line[i]
+            if inQuotes {
+                if character == "\"" {
+                    let next = line.index(after: i)
+                    if next < line.endIndex, line[next] == "\"" {
+                        i = line.index(after: next)  // an escaped quote
+                        continue
+                    }
+                    inQuotes = false
+                }
+            } else if character == "\"" {
+                inQuotes = true
+            } else if character == "," {
+                ranges.append(fieldStart..<i)
+                fieldStart = line.index(after: i)
+            }
+            i = line.index(after: i)
+        }
+        ranges.append(fieldStart..<line.endIndex)
+        return ranges
+    }
+}

--- a/Sources/Core/Models/DatasetSpec.swift
+++ b/Sources/Core/Models/DatasetSpec.swift
@@ -50,15 +50,21 @@ public struct DatasetSpec: Codable, Equatable, Sendable {
     /// still degrades rather than fails when it cannot find the column at
     /// delivery time, because by then the only reader is a student's grade.
     public let stratumColumn: String?
+    /// Derivation steps applied to the student's rows after selection, in array
+    /// order (see `DatasetTransform`).  Empty — the decoded default — means the
+    /// student's slice carries the pool's values verbatim, which is every
+    /// dataset authored before derivation existed.
+    public let transforms: [DatasetTransform]
 
     public init(
         file: String, kind: DatasetKind = .rowSample, sampleSize: Int? = nil,
-        stratumColumn: String? = nil
+        stratumColumn: String? = nil, transforms: [DatasetTransform] = []
     ) {
         self.file = file
         self.kind = kind
         self.sampleSize = sampleSize
         self.stratumColumn = stratumColumn
+        self.transforms = transforms
     }
 
     public init(from decoder: Decoder) throws {
@@ -67,5 +73,6 @@ public struct DatasetSpec: Codable, Equatable, Sendable {
         kind = try c.decodeIfPresent(DatasetKind.self, forKey: .kind) ?? .rowSample
         sampleSize = try c.decodeIfPresent(Int.self, forKey: .sampleSize)
         stratumColumn = try c.decodeIfPresent(String.self, forKey: .stratumColumn)
+        transforms = try c.decodeIfPresent([DatasetTransform].self, forKey: .transforms) ?? []
     }
 }

--- a/Sources/Core/Models/DatasetTransform.swift
+++ b/Sources/Core/Models/DatasetTransform.swift
@@ -1,0 +1,63 @@
+// Core/Models/DatasetTransform.swift
+//
+// Derivation, as distinct from selection (see docs/datasets.md).
+//
+// `DatasetKind` answers "which rows does this student get".  A transform
+// answers "and what has been done to the values in them" — the step that turns
+// the instructor's pool from a table into a template.  They are separate axes
+// on purpose: "500 rows balanced by ward, then 2% of bp_systolic blanked" is
+// two independent decisions, and a `DatasetKind` case per combination is how
+// that enum reaches thirty cases.
+//
+// Selection runs first, then transforms in array order.  Both halves matter:
+// transforming after selection means a rate applies to what the student
+// actually receives rather than to the pool, and the order is load-bearing
+// because blanking then jittering is not jittering then blanking.
+//
+// Two rules keep a transform from breaking the assignment it personalizes:
+//
+//   - It never touches the schema.  No column is added, removed, renamed or
+//     reordered; rows and within-column values only.  The assignment ships
+//     code written against column NAMES, and a student whose `df["systolic"]`
+//     raises KeyError cannot fix that.
+//   - Columns are named explicitly; there is no "all columns" wildcard.  An
+//     instructor who blanks the column a notebook check asserts on has broken
+//     their own assignment, and making them name it is what lets the save-time
+//     check tell them so.
+
+/// One derivation step applied to a student's slice after selection.
+public struct DatasetTransform: Codable, Sendable, Equatable {
+
+    /// What the step does to the cells it touches.
+    ///
+    /// - `missingValues`: blanks a deterministic subset of cells in the named
+    ///   columns, so the student's data has holes to notice and handle.  Pure
+    ///   string replacement — no type inference and no formatting decisions,
+    ///   which is why it is the first derivation to ship.
+    public enum Kind: String, Codable, Sendable, Equatable, CaseIterable {
+        case missingValues
+    }
+
+    public let kind: Kind
+    /// The columns this step may alter, by header name.  Never empty in a
+    /// saved spec — a transform naming no column would silently do nothing.
+    public let columns: [String]
+    /// Fraction of the student's rows affected, in `0 < rate <= 1`.  Authored
+    /// as a `Double` because it is an authored number, but it never reaches a
+    /// delivered byte as one: the materializer folds it to an integer count
+    /// before any per-cell decision (see `DatasetMaterializer`).
+    public let rate: Double?
+
+    public init(kind: Kind, columns: [String], rate: Double? = nil) {
+        self.kind = kind
+        self.columns = columns
+        self.rate = rate
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try c.decode(Kind.self, forKey: .kind)
+        columns = try c.decodeIfPresent([String].self, forKey: .columns) ?? []
+        rate = try c.decodeIfPresent(Double.self, forKey: .rate)
+    }
+}

--- a/Tests/APITests/DatasetsRouteRoundTripTests.swift
+++ b/Tests/APITests/DatasetsRouteRoundTripTests.swift
@@ -373,6 +373,75 @@ import VaporTesting
         }
     }
 
+    // MARK: - Transforms survive the round trip on both pairs
+
+    @Test func transformsRoundTripThroughBothPairs() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("t")
+            let body = #"""
+                {"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":5,
+                "transforms":[{"kind":"missingValues","columns":["ward"],"rate":0.5}]}]}
+                """#
+            for path in [
+                "/instructor/\(fx.assignmentID)/datasets",
+                "/instructor/new/draft/datasets?draftID=\(fx.draftID)",
+            ] {
+                try await put(path, fx, body: body, expect: .ok, "a transform is storable")
+                let specs = try await get(path, fx)
+                #expect(specs.first?.transforms.count == 1, "\(path) reports it back")
+                #expect(specs.first?.transforms.first?.columns == ["ward"])
+                #expect(specs.first?.transforms.first?.rate == 0.5)
+            }
+        }
+    }
+
+    /// The Files panel owns kind, sampleSize and stratumColumn and nothing else,
+    /// so a payload shaped like the one it sends must not be able to clear a
+    /// transform it never knew about. The panel merges rather than rebuilds
+    /// (`Public/support-files.js`); this pins the server half — a PUT carrying
+    /// the transforms round-trips them rather than normalizing them away.
+    @Test func aControlShapedPayloadCarryingTransformsKeepsThem() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("m")
+            let path = "/instructor/\(fx.assignmentID)/datasets"
+            try await put(
+                path, fx,
+                body: #"""
+                    {"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":5,
+                    "transforms":[{"kind":"missingValues","columns":["ward"],"rate":0.5}]}]}
+                    """#, expect: .ok, "stored with a transform")
+
+            // What the panel PUTs after the merge: its three fields, plus the
+            // transform block carried forward untouched.
+            try await put(
+                path, fx,
+                body: #"""
+                    {"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":9,
+                    "transforms":[{"kind":"missingValues","columns":["ward"],"rate":0.5}]}]}
+                    """#, expect: .ok, "a row-count edit")
+
+            let specs = try await get(path, fx)
+            #expect(specs.first?.sampleSize == 9)
+            #expect(specs.first?.transforms.first?.columns == ["ward"])
+        }
+    }
+
+    @Test func aTransformNamingAnUnknownColumnIsRejectedOnBothPairs() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("u")
+            let body = #"""
+                {"datasets":[{"file":"cases.csv","sampleSize":5,
+                "transforms":[{"kind":"missingValues","columns":["nope"],"rate":0.5}]}]}
+                """#
+            try await put(
+                "/instructor/\(fx.assignmentID)/datasets", fx, body: body,
+                expect: .badRequest, "the column must exist in the file")
+            try await put(
+                "/instructor/new/draft/datasets?draftID=\(fx.draftID)", fx, body: body,
+                expect: .badRequest, "the draft pair agrees")
+        }
+    }
+
     // MARK: - Two specs for one file are incoherent on either pair
 
     @Test func duplicateSpecsForOneFileAreRejected() async throws {

--- a/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
+++ b/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
@@ -70,7 +70,7 @@ import Testing
                     datasets: [
                         SetDatasetTool.DatasetEntry(
                             file: "cases.csv", sampleSize: 100,
-                            kind: "rowSample", stratumColumn: nil)
+                            kind: "rowSample", stratumColumn: nil, transforms: [])
                     ])
             ),
             (

--- a/Tests/APITests/MCP/SetDatasetToolTests.swift
+++ b/Tests/APITests/MCP/SetDatasetToolTests.swift
@@ -62,12 +62,14 @@ import Vapor
 
     private func run(
         _ app: Application, publicID: String, filename: String,
-        sampleSize: Int? = nil, stratumColumn: String? = nil, remove: Bool? = nil
+        sampleSize: Int? = nil, stratumColumn: String? = nil, remove: Bool? = nil,
+        transforms: [SetDatasetTool.TransformInput]? = nil
     ) async throws -> SetDatasetTool.Output {
         try await SetDatasetTool().execute(
             SetDatasetTool.Input(
                 assignmentPublicID: publicID, filename: filename,
-                sampleSize: sampleSize, stratumColumn: stratumColumn, remove: remove),
+                sampleSize: sampleSize, stratumColumn: stratumColumn, remove: remove,
+                transforms: transforms),
             context(app))
     }
 
@@ -291,6 +293,96 @@ import Vapor
                 sampleSize: 2, stratumColumn: "   ")
             #expect(out.datasets.first?.kind == "rowSample")
             #expect(out.datasets.first?.stratumColumn == nil)
+        }
+    }
+
+    // MARK: - Transforms
+
+    private func blanking(_ columns: [String], rate: Double?) -> SetDatasetTool.TransformInput {
+        SetDatasetTool.TransformInput(kind: "missingValues", columns: columns, rate: rate)
+    }
+
+    @Test func storesAndReportsATransform() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let out = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2,
+                transforms: [blanking(["age"], rate: 0.5)])
+
+            #expect(out.datasets.first?.transforms.map(\.kind) == ["missingValues"])
+            #expect(out.datasets.first?.transforms.first?.columns == ["age"])
+            #expect(out.datasets.first?.transforms.first?.rate == 0.5)
+
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let specs = try #require(setup.decodedManifest()?.datasets)
+            #expect(
+                specs.first?.transforms == [
+                    DatasetTransform(kind: .missingValues, columns: ["age"], rate: 0.5)
+                ])
+        }
+    }
+
+    /// The shape that has twice come within a release of shipping: a surface
+    /// rebuilding a spec from only the fields it knows about, so an edit to one
+    /// setting drops another. Changing the sample size must not clear the
+    /// transforms the caller did not mention.
+    @Test func anUnrelatedEditPreservesTransforms() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2,
+                transforms: [blanking(["age"], rate: 0.5)])
+
+            // A second call that says nothing about transforms.
+            let out = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 3)
+
+            #expect(out.datasets.first?.sampleSize == 3)
+            #expect(
+                out.datasets.first?.transforms.first?.columns == ["age"],
+                "an edit to sampleSize must not drop the transform")
+        }
+    }
+
+    @Test func anEmptyTransformListClearsThem() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2,
+                transforms: [blanking(["age"], rate: 0.5)])
+
+            // Explicitly [] is the caller saying so, unlike omitting the field.
+            let out = try await run(
+                app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2,
+                transforms: [])
+            #expect(out.datasets.first?.transforms.isEmpty == true)
+        }
+    }
+
+    @Test func refusesATransformNamingAColumnTheFileDoesNotHave() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                try await run(
+                    app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2,
+                    transforms: [blanking(["nope"], rate: 0.5)])
+            }
+        }
+    }
+
+    @Test func refusesATransformWithNoRate() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                try await run(
+                    app, publicID: assignment.publicID, filename: "cases.csv", sampleSize: 2,
+                    transforms: [blanking(["age"], rate: nil)])
+            }
         }
     }
 }

--- a/Tests/APITests/PersonalizationDatasetSliceTests.swift
+++ b/Tests/APITests/PersonalizationDatasetSliceTests.swift
@@ -1,0 +1,187 @@
+// Tests/APITests/PersonalizationDatasetSliceTests.swift
+//
+// Pins the seam between the two per-student systems: an expression that reads a
+// per-student dataset must see THE STUDENT'S SLICE, not the instructor's pool.
+//
+// Before this, `PersonalizationEvaluator` spawned with its cwd set to the shared
+// support directory — which holds the full pool — so an `expectedVarRef`
+// expression over a sampled dataset resolved the pool's answer and delivered it
+// to every student as their own expected value.  Structural notebook checks did
+// not notice; any value-based check was wrong for the entire class, silently.
+//
+// Runs a real `python3` subprocess, like the other evaluator suites.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite(.timeLimit(.minutes(2))) struct PersonalizationDatasetSliceTests {
+
+    private let seed = String(repeating: "a1b2", count: 16)
+
+    /// A pool of `n` data rows under one `id` column.
+    private func indexedCSV(_ n: Int) -> String {
+        "id\n" + (0..<n).map(String.init).joined(separator: "\n") + "\n"
+    }
+
+    private func withSupportDir(_ body: (String) async throws -> Void) async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ds-slice-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await body(dir.path)
+    }
+
+    /// Counts the data rows the expression actually saw.
+    private let countRows = PersonalizationExpression(
+        name: "rows", expression: "sum(1 for line in open('cases.csv') if line.strip()) - 1")
+
+    // MARK: - The defect this closes
+
+    @Test func expressionSeesTheStudentsSliceRatherThanThePool() async throws {
+        try await withSupportDir { dir in
+            try indexedCSV(100).write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(
+                globalExpressions: [countRows],
+                datasets: [DatasetSpec(file: "cases.csv", sampleSize: 10)])
+
+            let resolution = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: seed, supportFilesDirectory: dir, language: .python)
+
+            #expect(resolution.evaluationError == nil)
+            // 10, not 100: the pool has 100 rows and would be the old answer.
+            #expect(resolution.substitutions["rows"] == "10")
+        }
+    }
+
+    @Test func expressionAgreesWithTheBytesTheStudentIsDelivered() async throws {
+        try await withSupportDir { dir in
+            let pool = indexedCSV(60)
+            try pool.write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let spec = DatasetSpec(file: "cases.csv", sampleSize: 7)
+            let manifest = TestProperties(
+                globalExpressions: [
+                    PersonalizationExpression(
+                        name: "first",
+                        expression: "int(open('cases.csv').read().splitlines()[1])")
+                ],
+                datasets: [spec])
+
+            let resolution = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: seed, supportFilesDirectory: dir, language: .python)
+
+            // The delivered slice is what DatasetResolver hands the worker and
+            // the editor; the expression must agree with it, not merely differ
+            // from the pool.
+            let delivered = DatasetMaterializer.materialize(
+                source: pool, spec: spec, seedHex: seed)
+            let firstDataRow = try #require(delivered.split(separator: "\n").dropFirst().first)
+            #expect(resolution.substitutions["first"] == String(firstDataRow))
+        }
+    }
+
+    @Test func sharedPoolIsNeverRewrittenForOneStudent() async throws {
+        try await withSupportDir { dir in
+            let pool = indexedCSV(40)
+            try pool.write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(
+                globalExpressions: [countRows],
+                datasets: [DatasetSpec(file: "cases.csv", sampleSize: 5)])
+
+            _ = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: seed, supportFilesDirectory: dir, language: .python)
+
+            // Every student's evaluation reads this directory. Materializing
+            // into it would hand the next student the previous one's slice.
+            let onDisk = try String(contentsOfFile: dir + "/cases.csv", encoding: .utf8)
+            #expect(onDisk == pool)
+        }
+    }
+
+    @Test func differentStudentsGetDifferentAnswers() async throws {
+        try await withSupportDir { dir in
+            try indexedCSV(200).write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(
+                globalExpressions: [
+                    PersonalizationExpression(
+                        name: "total",
+                        expression:
+                            "sum(int(x) for x in open('cases.csv').read().split()[1:])")
+                ],
+                datasets: [DatasetSpec(file: "cases.csv", sampleSize: 20)])
+
+            let a = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: String(repeating: "1234", count: 16),
+                supportFilesDirectory: dir, language: .python)
+            let b = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: String(repeating: "cdef", count: 16),
+                supportFilesDirectory: dir, language: .python)
+
+            #expect(a.substitutions["total"] != nil)
+            #expect(a.substitutions["total"] != b.substitutions["total"])
+        }
+    }
+
+    // MARK: - Everything that is not a dataset is untouched
+
+    @Test func nonDatasetAssignmentStillReadsSupportFilesDirectly() async throws {
+        try await withSupportDir { dir in
+            try "hello".write(toFile: dir + "/quotes.txt", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(
+                globalExpressions: [
+                    PersonalizationExpression(
+                        name: "text", expression: "open('quotes.txt').read()")
+                ])
+
+            let resolution = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: seed, supportFilesDirectory: dir, language: .python)
+
+            #expect(resolution.substitutions["text"] == "'hello'")
+        }
+    }
+
+    @Test func supportFilesBesideADatasetStillResolve() async throws {
+        try await withSupportDir { dir in
+            try indexedCSV(30).write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            try "ward-3B".write(toFile: dir + "/notes.txt", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(
+                globalExpressions: [
+                    PersonalizationExpression(
+                        name: "note", expression: "open('notes.txt').read()"),
+                    countRows,
+                ],
+                datasets: [DatasetSpec(file: "cases.csv", sampleSize: 4)])
+
+            let resolution = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: seed, supportFilesDirectory: dir, language: .python)
+
+            // The overlay replaces the dataset and symlinks the rest, so a
+            // helper beside it must still be readable.
+            #expect(resolution.substitutions["note"] == "'ward-3B'")
+            #expect(resolution.substitutions["rows"] == "4")
+        }
+    }
+
+    @Test func pythonHelperModulesStillImportThroughTheOverlay() async throws {
+        try await withSupportDir { dir in
+            try indexedCSV(30).write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            try "def bump(n):\n    return n + 1\n"
+                .write(toFile: dir + "/helpers.py", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(
+                globalExpressions: [
+                    PersonalizationExpression(name: "bumped", expression: "helpers.bump(41)")
+                ],
+                datasets: [DatasetSpec(file: "cases.csv", sampleSize: 4)])
+
+            let resolution = await PersonalizationSubstitution.resolve(
+                manifest: manifest, seedHex: seed, supportFilesDirectory: dir, language: .python)
+
+            // The auto-loaded helper resolves via the language's path variable,
+            // which must follow the overlay rather than stay on the pool.
+            #expect(resolution.evaluationError == nil)
+            #expect(resolution.substitutions["bumped"] == "42")
+        }
+    }
+}

--- a/Tests/APITests/SupportFileDatasetRowTests.swift
+++ b/Tests/APITests/SupportFileDatasetRowTests.swift
@@ -128,6 +128,56 @@ import Testing
         #expect((dict["datasetSampleSizeText"] as? String)?.isEmpty == true)
     }
 
+    // MARK: - Derivation fields the panel renders from
+
+    private func row(_ transforms: [DatasetTransform]) -> EditableSuiteRow {
+        EditableSuiteRow(
+            name: "cases.csv", url: "#", isTest: false, tier: "support", order: 1,
+            dependsOn: [], points: 1, displayName: nil,
+            isDataset: true, datasetSampleSize: 25, datasetTransforms: transforms)
+    }
+
+    @Test func aSingleMissingValuesStepIsEditableAndRendersItsFields() throws {
+        let row = row([
+            DatasetTransform(kind: .missingValues, columns: ["systolic", "ward"], rate: 0.25)
+        ])
+        #expect(row.datasetTransformsEditable)
+        // Comma-separated, because that is how the field takes them back.
+        #expect(row.datasetBlankColumnsOrEmpty == "systolic, ward")
+        // Stored as a fraction, shown as the percentage an instructor says.
+        #expect(row.datasetBlankPercentText == "25")
+    }
+
+    @Test func aSpecWithNoTransformsIsEditableAndRendersEmptyFields() throws {
+        #expect(row([]).datasetTransformsEditable)
+        #expect(row([]).datasetBlankColumnsOrEmpty.isEmpty)
+        #expect(row([]).datasetBlankPercentText.isEmpty)
+    }
+
+    /// The panel has fields for one step of one kind. Anything else must render
+    /// as not-editable with EMPTY fields — showing half of a two-step spec is
+    /// how the next unrelated edit would save over the half not shown.
+    @Test func aSpecThePanelCannotRepresentIsNotEditableAndShowsNothing() throws {
+        let twoSteps = row([
+            DatasetTransform(kind: .missingValues, columns: ["systolic"], rate: 0.25),
+            DatasetTransform(kind: .missingValues, columns: ["ward"], rate: 0.5),
+        ])
+        #expect(!twoSteps.datasetTransformsEditable)
+        #expect(twoSteps.datasetBlankColumnsOrEmpty.isEmpty)
+        #expect(twoSteps.datasetBlankPercentText.isEmpty)
+    }
+
+    @Test func theDerivationFieldsReachLeaf() throws {
+        let encoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(
+                row([DatasetTransform(kind: .missingValues, columns: ["systolic"], rate: 0.1)])))
+        let dict = try #require(encoded as? [String: Any])
+
+        #expect(dict["datasetTransformsEditable"] as? Bool == true)
+        #expect(dict["datasetBlankColumnsOrEmpty"] as? String == "systolic")
+        #expect(dict["datasetBlankPercentText"] as? String == "10")
+    }
+
     // MARK: - One lookup behind both surfaces
 
     @Test func datasetSpecsByFileKeysEverySpecItsFile() throws {

--- a/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
+++ b/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
@@ -1,0 +1,304 @@
+// Unit tests for the per-row dataset control in Public/support-files.js.
+//
+// The existing support-files tests cover upload and delete; they pass no
+// `datasetsURL`, so the dataset control returns early and is never exercised.
+// This harness supplies one, plus the row markup the control reads.
+//
+// What is worth pinning here is the PUT BODY, because every defect this control
+// has had is a defect in what it sends rather than in what it shows:
+//
+//   * the panel once wrote `kind: "rowSample"` unconditionally, which would have
+//     downgraded every stratified spec on the next row-count edit,
+//   * and it built each spec from a fixed field list, so any setting it had not
+//     been taught about was dropped by an unrelated edit.
+//
+// The transform fields make that second shape live again — the model is an
+// ordered list of steps and the panel has fields for exactly one — so the rules
+// asserted below are: the panel sends what it owns, and leaves alone what it
+// does not.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = await fs.readFile(path.resolve('Public/support-files.js'), 'utf8');
+
+// ── Minimal row markup ──────────────────────────────────────────────────────
+
+function makeInput(value = '', disabled = false) {
+  return {
+    value,
+    disabled,
+    checked: false,
+    hidden: false,
+    classes: [],
+    classList: { contains(name) { return this.owner.classes.indexOf(name) >= 0; } },
+    focus() {}, select() {},
+  };
+}
+
+/// One `tr[data-support-file]` carrying the control's six elements.
+function makeRow(filename) {
+  const parts = {
+    '.js-dataset-toggle': makeInput(),
+    '.js-dataset-size-field': makeInput(),
+    '.js-dataset-size': makeInput(),
+    '.js-dataset-stratum-field': makeInput(),
+    '.js-dataset-stratum': makeInput(),
+    '.js-dataset-blank-field': makeInput(),
+    '.js-dataset-blank-columns': makeInput(),
+    '.js-dataset-blank-percent': makeInput(),
+    '.js-dataset-status': makeInput(),
+  };
+  const row = {
+    filename,
+    parts,
+    getAttribute: (name) => (name === 'data-support-file' ? filename : null),
+    querySelector: (sel) => parts[sel] || null,
+  };
+  Object.keys(parts).forEach((sel) => {
+    const el = parts[sel];
+    el.owner = el;
+    el.classes = [sel.replace('.', '')];
+    el.classList.owner = el;
+    el.closest = (want) => (want === 'tr[data-support-file]' ? row : null);
+  });
+  return row;
+}
+
+function load({ specs = [] } = {}) {
+  const puts = [];
+  const bodyHandlers = {};
+  let stored = specs.slice();
+
+  const rows = [makeRow('cases.csv')];
+  const doc = {
+    readyState: 'complete',
+    getElementById: () => null,
+    body: { addEventListener(type, fn) { (bodyHandlers[type] ||= []).push(fn); } },
+    addEventListener() {},
+    querySelector: () => null,
+    querySelectorAll: (sel) => (sel === 'tr[data-support-file]' ? rows : []),
+  };
+
+  const sandbox = { document: doc, Promise, JSON, Error, Object, Array, Math, parseInt, setTimeout };
+  sandbox.ChickadeeUI = {
+    setStatus: () => {},
+    showActionError: () => {},
+    confirmAction: () => Promise.resolve(true),
+    // GET returns what the server holds; PUT records the body and becomes the
+    // new stored state, so a second edit is built from the first one's result.
+    fetchJSON: (url, opts) => {
+      if (opts && opts.method === 'PUT') {
+        // Round-tripped through JSON so the recorded body is a host-realm
+        // value: objects built inside the vm context carry that context's
+        // prototypes, and deepStrictEqual compares those too.
+        const body = JSON.parse(JSON.stringify(opts.body));
+        puts.push(body);
+        stored = body.datasets.slice();
+      }
+      return Promise.resolve({ datasets: stored });
+    },
+  };
+  sandbox.window = { ChickadeeUI: sandbox.ChickadeeUI };
+  sandbox.self = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox);
+
+  sandbox.window.initSupportFiles({
+    csrfToken: 'csrf',
+    uploadURL: () => '/u',
+    deleteURL: () => '/d',
+    datasetsURL: () => '/instructor/abc/datasets',
+    onChange: () => {},
+  });
+
+  return { puts, rows, bodyHandlers, stored: () => stored };
+}
+
+function change(h, row, selector) {
+  const target = row.querySelector(selector);
+  return Promise.all((h.bodyHandlers.change || []).map((fn) => fn({ target })));
+}
+
+async function settle() {
+  for (let i = 0; i < 6; i += 1) await new Promise((r) => setTimeout(r, 0));
+}
+
+const lastSpec = (h) => h.puts[h.puts.length - 1].datasets[0];
+
+// ── Authoring a step ────────────────────────────────────────────────────────
+
+test('naming columns sends one missingValues step at the shown percent', async () => {
+  const h = load({ specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 50 }] });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '50';
+  row.querySelector('.js-dataset-blank-columns').value = 'systolic, ward';
+  row.querySelector('.js-dataset-blank-percent').value = '25';
+
+  await change(h, row, '.js-dataset-blank-columns');
+  await settle();
+
+  const spec = lastSpec(h);
+  assert.equal(spec.transforms.length, 1);
+  assert.equal(spec.transforms[0].kind, 'missingValues');
+  // Comma-separated, trimmed — an instructor types them as prose.
+  assert.deepEqual(spec.transforms[0].columns, ['systolic', 'ward']);
+  // Authored as a percentage, stored as the 0 < rate <= 1 fraction.
+  assert.equal(spec.transforms[0].rate, 0.25);
+});
+
+test('a blank percent field falls back to the default rather than sending none', async () => {
+  const h = load({ specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 50 }] });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '50';
+  row.querySelector('.js-dataset-blank-columns').value = 'systolic';
+
+  await change(h, row, '.js-dataset-blank-columns');
+  await settle();
+
+  // A rate is required at save, so sending none would be rejected by the
+  // server for a spec the instructor plainly meant.
+  assert.equal(lastSpec(h).transforms[0].rate, 0.1);
+  assert.equal(row.querySelector('.js-dataset-blank-percent').value, '10');
+});
+
+test('clearing the columns field clears the step', async () => {
+  const h = load({
+    specs: [{
+      file: 'cases.csv', kind: 'rowSample', sampleSize: 50,
+      transforms: [{ kind: 'missingValues', columns: ['systolic'], rate: 0.25 }],
+    }],
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '50';
+  row.querySelector('.js-dataset-blank-columns').value = '   ';
+
+  await change(h, row, '.js-dataset-blank-columns');
+  await settle();
+
+  // Empty means "no step", the same way an empty stratum box means "no
+  // stratification" — the field carries whether the thing exists.
+  assert.deepEqual(lastSpec(h).transforms, []);
+});
+
+// ── Not clobbering what the panel does not own ──────────────────────────────
+
+test('a row-count edit preserves the step it was not asked about', async () => {
+  const h = load({
+    specs: [{
+      file: 'cases.csv', kind: 'rowSample', sampleSize: 50,
+      transforms: [{ kind: 'missingValues', columns: ['systolic'], rate: 0.25 }],
+    }],
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '90';
+  row.querySelector('.js-dataset-blank-columns').value = 'systolic';
+  row.querySelector('.js-dataset-blank-percent').value = '25';
+
+  await change(h, row, '.js-dataset-size');
+  await settle();
+
+  const spec = lastSpec(h);
+  assert.equal(spec.sampleSize, 90);
+  assert.deepEqual(spec.transforms[0].columns, ['systolic']);
+  assert.equal(spec.transforms[0].rate, 0.25);
+});
+
+test('a spec the panel cannot represent is left intact by an unrelated edit', async () => {
+  // Two steps: more than this control has fields for. Rendering it into the one
+  // pair of fields and saving would silently drop the second.
+  const authored = [
+    { kind: 'missingValues', columns: ['systolic'], rate: 0.25 },
+    { kind: 'missingValues', columns: ['ward'], rate: 0.5 },
+  ];
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 50, transforms: authored }],
+  });
+  const row = h.rows[0];
+  // First paint is server-side: the row arrives with the fields already
+  // disabled, because `SupportFileRow.datasetTransformsEditable` said the panel
+  // cannot represent this spec. (That half is pinned in Swift; what matters
+  // here is that the JS honours it.)
+  row.querySelector('.js-dataset-blank-columns').disabled = true;
+  row.querySelector('.js-dataset-blank-percent').disabled = true;
+
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '90';
+  await change(h, row, '.js-dataset-size');
+  await settle();
+
+  const spec = lastSpec(h);
+  assert.equal(spec.sampleSize, 90, 'the edit still lands');
+  assert.deepEqual(spec.transforms, authored, 'both steps survive it');
+});
+
+test('an unknown transform kind is preserved, not narrowed away', async () => {
+  // The kind a future release adds, seen by a panel that predates it.
+  const authored = [{ kind: 'formatNoise', columns: ['admitted'], rate: 0.3 }];
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 50, transforms: authored }],
+  });
+  const row = h.rows[0];
+  // Again server-rendered: an unrecognised kind is not representable either.
+  row.querySelector('.js-dataset-blank-columns').disabled = true;
+  row.querySelector('.js-dataset-blank-percent').disabled = true;
+
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '90';
+  await change(h, row, '.js-dataset-size');
+  await settle();
+
+  assert.deepEqual(lastSpec(h).transforms, authored);
+});
+
+test('a re-render disables the fields for a spec the panel cannot represent', async () => {
+  // The paint that follows a successful write, which is the one place the JS
+  // (rather than Leaf) decides the disabled state.
+  const authored = [
+    { kind: 'missingValues', columns: ['systolic'], rate: 0.25 },
+    { kind: 'missingValues', columns: ['ward'], rate: 0.5 },
+  ];
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 50, transforms: authored }],
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-blank-columns').disabled = true;
+  row.querySelector('.js-dataset-blank-percent').disabled = true;
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '90';
+
+  await change(h, row, '.js-dataset-size');
+  await settle();
+
+  // Still disabled, and still not showing half of a two-step spec.
+  assert.equal(row.querySelector('.js-dataset-blank-columns').disabled, true);
+  assert.equal(row.querySelector('.js-dataset-blank-columns').value, '');
+});
+
+test('a stratified spec keeps its kind when only the blanking changes', async () => {
+  const h = load({
+    specs: [{
+      file: 'cases.csv', kind: 'stratifiedSample', sampleSize: 50, stratumColumn: 'ward',
+    }],
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '50';
+  row.querySelector('.js-dataset-stratum').value = 'ward';
+  row.querySelector('.js-dataset-blank-columns').value = 'systolic';
+
+  await change(h, row, '.js-dataset-blank-columns');
+  await settle();
+
+  const spec = lastSpec(h);
+  assert.equal(spec.kind, 'stratifiedSample');
+  assert.equal(spec.stratumColumn, 'ward');
+  assert.equal(spec.transforms.length, 1);
+});

--- a/Tests/CoreTests/DatasetSpecValidationTests.swift
+++ b/Tests/CoreTests/DatasetSpecValidationTests.swift
@@ -108,6 +108,108 @@ import Testing
         #expect(issue?.contains("'c0'") == true)
     }
 
+    // MARK: - Transforms
+
+    private func withTransforms(
+        _ transforms: [DatasetTransform], sampleSize: Int? = nil
+    )
+        -> DatasetSpec
+    {
+        DatasetSpec(file: "cases.csv", sampleSize: sampleSize, transforms: transforms)
+    }
+
+    private func blank(_ columns: [String], rate: Double?) -> DatasetTransform {
+        DatasetTransform(kind: .missingValues, columns: columns, rate: rate)
+    }
+
+    @Test func aWellFormedTransformPasses() {
+        #expect(
+            DatasetSpecValidation.issue(
+                with: withTransforms([blank(["score"], rate: 0.5)]), sourceCSV: pool) == nil)
+    }
+
+    @Test func aTransformNamingAnUnknownColumnIsRefusedWithTheRealColumns() {
+        let issue = DatasetSpecValidation.issue(
+            with: withTransforms([blank(["scoer"], rate: 0.5)]), sourceCSV: pool)
+        #expect(issue?.contains("'scoer'") == true)
+        // The instructor cannot see the file from the form they are typing into.
+        #expect(issue?.contains("'score'") == true)
+        #expect(issue?.contains("'ward'") == true)
+    }
+
+    @Test func aTransformNamingNoColumnIsRefused() {
+        #expect(
+            DatasetSpecValidation.issue(with: withTransforms([blank([], rate: 0.5)]), sourceCSV: pool)
+                != nil)
+    }
+
+    @Test func aRateOutsideTheAllowedRangeIsRefused() {
+        for rate in [nil, 0, -0.5, 1.5] as [Double?] {
+            #expect(
+                DatasetSpecValidation.issue(
+                    with: withTransforms([blank(["score"], rate: rate)]), sourceCSV: pool) != nil,
+                "rate \(String(describing: rate)) should be refused")
+        }
+        #expect(
+            DatasetSpecValidation.issue(
+                with: withTransforms([blank(["score"], rate: 1)]), sourceCSV: pool) == nil,
+            "a rate of exactly 1 means every row, which is allowed")
+    }
+
+    /// The integer fold `(rows * permille) / 1000` is what delivery uses, so a
+    /// rate below one row's worth of the student's sample does nothing at all.
+    /// The instructor is the only person who can fix that.
+    @Test func aRateTooSmallForTheSampleIsRefused() {
+        let issue = DatasetSpecValidation.issue(
+            with: withTransforms([blank(["score"], rate: 0.01)], sampleSize: 10), sourceCSV: pool)
+        #expect(issue?.contains("affects no rows") == true)
+        // The same rate over a big enough sample is fine.
+        #expect(
+            DatasetSpecValidation.issue(
+                with: withTransforms([blank(["score"], rate: 0.01)], sampleSize: 100),
+                sourceCSV: pool) == nil)
+    }
+
+    @Test func oneKindTwiceOnOneColumnIsRefused() {
+        let issue = DatasetSpecValidation.issue(
+            with: withTransforms([blank(["score"], rate: 0.2), blank(["score"], rate: 0.3)]),
+            sourceCSV: pool)
+        #expect(issue?.contains("more than once") == true)
+    }
+
+    @Test func theSameKindOnDifferentColumnsIsFine() {
+        #expect(
+            DatasetSpecValidation.issue(
+                with: withTransforms([blank(["score"], rate: 0.2), blank(["ward"], rate: 0.3)]),
+                sourceCSV: pool) == nil)
+    }
+
+    @Test func everySilentTransformDegradationHasALoudRefusal() {
+        // Each of these leaves the data untouched at delivery — and each is
+        // refused at save. Untouched data is the right answer for a student
+        // being graded and the wrong answer for an instructor who thinks they
+        // asked for something.
+        let degrading: [DatasetSpec] = [
+            withTransforms([blank(["nope"], rate: 0.5)]),
+            withTransforms([blank([], rate: 0.5)]),
+            withTransforms([blank(["score"], rate: nil)]),
+            withTransforms([blank(["score"], rate: 0)]),
+            withTransforms([blank(["score"], rate: 0.01)], sampleSize: 10),
+        ]
+        for spec in degrading {
+            let delivered = DatasetMaterializer.materialize(
+                source: pool, spec: spec, seedHex: String(repeating: "a1b2", count: 16))
+            let inert = DatasetMaterializer.materialize(
+                source: pool,
+                spec: DatasetSpec(file: spec.file, sampleSize: spec.sampleSize),
+                seedHex: String(repeating: "a1b2", count: 16))
+            #expect(delivered == inert, "delivery absorbs: \(spec)")
+            #expect(
+                DatasetSpecValidation.issue(with: spec, sourceCSV: pool) != nil,
+                "save refuses: \(spec)")
+        }
+    }
+
     // MARK: - The pairing with the materializer
 
     @Test func everySilentDegradationHasALoudRefusal() {

--- a/Tests/CoreTests/DatasetTransformTests.swift
+++ b/Tests/CoreTests/DatasetTransformTests.swift
@@ -1,0 +1,239 @@
+// Tests/CoreTests/DatasetTransformTests.swift
+//
+// Pins derivation (docs/datasets.md): selection decides which rows a student
+// gets, a transform decides what has been done to the values in them.
+//
+// The byte pins here matter more than usual. Nothing about a student's slice is
+// stored — it is re-derived at every delivery, including a re-grade months later
+// — so a change in these bytes is not a version bump. It is the student's data
+// changing underneath them, and a re-grade scoring against rows they never had.
+// Never re-baseline a failing pin to make an edit pass: a genuinely new
+// behaviour is a new transform, not a changed one.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct DatasetTransformTests {
+
+    private let seed = String(repeating: "a1b2", count: 16)
+
+    /// Ten rows, three columns, values that make a blanked cell obvious.
+    private let pool = """
+        id,ward,systolic
+        1,3A,120
+        2,3B,131
+        3,3A,118
+        4,3C,142
+        5,3B,127
+        6,3A,135
+        7,3C,111
+        8,3B,150
+        9,3A,124
+        10,3C,139
+
+        """
+
+    private func blank(_ columns: [String], rate: Double) -> DatasetTransform {
+        DatasetTransform(kind: .missingValues, columns: columns, rate: rate)
+    }
+
+    private func spec(_ transforms: [DatasetTransform], sampleSize: Int? = nil) -> DatasetSpec {
+        DatasetSpec(file: "cases.csv", sampleSize: sampleSize, transforms: transforms)
+    }
+
+    private func materialize(_ spec: DatasetSpec, seedHex: String? = nil) -> String {
+        DatasetMaterializer.materialize(source: pool, spec: spec, seedHex: seedHex ?? seed)
+    }
+
+    // MARK: - Byte pins
+
+    @Test func missingValuesPinnedBytes() {
+        // 30% of 10 rows = 3 cells blanked in `systolic`, rows in file order,
+        // header and every other column untouched.
+        #expect(
+            materialize(spec([blank(["systolic"], rate: 0.3)]))
+                == """
+                id,ward,systolic
+                1,3A,120
+                2,3B,
+                3,3A,
+                4,3C,142
+                5,3B,127
+                6,3A,135
+                7,3C,111
+                8,3B,
+                9,3A,124
+                10,3C,139
+
+                """)
+    }
+
+    @Test func twoColumnsPinnedBytes() {
+        // 2 cells per column, each column drawing from its own sub-seeded
+        // stream — `systolic`'s rows here are the first two of the three it
+        // blanks at rate 0.3 above, which is the partial Fisher-Yates being
+        // consistent rather than a coincidence.
+        #expect(
+            materialize(spec([blank(["ward", "systolic"], rate: 0.2)]))
+                == """
+                id,ward,systolic
+                1,3A,120
+                2,3B,
+                3,3A,
+                4,3C,142
+                5,,127
+                6,3A,135
+                7,3C,111
+                8,,150
+                9,3A,124
+                10,3C,139
+
+                """)
+    }
+
+    // MARK: - Determinism
+
+    @Test func sameInputsGiveSameBytes() {
+        let s = spec([blank(["systolic"], rate: 0.4)])
+        #expect(materialize(s) == materialize(s))
+    }
+
+    @Test func differentSeedsBlankDifferentRows() {
+        let s = spec([blank(["systolic"], rate: 0.3)])
+        #expect(
+            materialize(s, seedHex: String(repeating: "1234", count: 16))
+                != materialize(s, seedHex: String(repeating: "cdef", count: 16)))
+    }
+
+    /// The rule that keeps already-delivered data from moving: a transform's
+    /// stream is sub-seeded on its own index, so appending a second step must
+    /// not re-roll the first.
+    @Test func appendingATransformLeavesTheFirstUntouched() {
+        let first = blank(["systolic"], rate: 0.3)
+        let alone = materialize(spec([first]))
+        let withSecond = materialize(spec([first, blank(["ward"], rate: 0.2)]))
+
+        // `systolic` must be blanked in exactly the same rows in both.
+        #expect(systolicColumn(of: alone) == systolicColumn(of: withSecond))
+        #expect(alone != withSecond, "the second transform must still have done something")
+    }
+
+    /// The same rule one level down: adding a column to a step must not move
+    /// which rows an existing column blanks.
+    @Test func addingAColumnLeavesTheOtherColumnUntouched() {
+        let alone = materialize(spec([blank(["systolic"], rate: 0.3)]))
+        let both = materialize(spec([blank(["systolic", "ward"], rate: 0.3)]))
+        #expect(systolicColumn(of: alone) == systolicColumn(of: both))
+    }
+
+    @Test func orderIsLoadBearing() {
+        // Two steps on one column in the other order are a different result, so
+        // the array order has to be stored rather than normalized away.
+        let a = materialize(spec([blank(["ward"], rate: 0.2), blank(["systolic"], rate: 0.5)]))
+        let b = materialize(spec([blank(["systolic"], rate: 0.5), blank(["ward"], rate: 0.2)]))
+        #expect(a != b)
+    }
+
+    // MARK: - The envelope selection already keeps
+
+    @Test func headerAndRowOrderAndRowCountAreUnchanged() {
+        let out = materialize(spec([blank(["systolic"], rate: 0.5)]))
+        let lines = out.split(separator: "\n", omittingEmptySubsequences: false)
+        let poolLines = pool.split(separator: "\n", omittingEmptySubsequences: false)
+        #expect(lines.count == poolLines.count)
+        #expect(lines.first == poolLines.first, "the header is never touched")
+        // Row identity is preserved — only the named column's cells change.
+        #expect(
+            lines.dropFirst().map { $0.split(separator: ",").first }
+                == poolLines.dropFirst().map { $0.split(separator: ",").first })
+    }
+
+    @Test func trailingNewlineMirrorsTheInput() {
+        let noTrailing = String(pool.dropLast())
+        let out = DatasetMaterializer.materialize(
+            source: noTrailing, spec: spec([blank(["systolic"], rate: 0.3)]), seedHex: seed)
+        #expect(!out.hasSuffix("\n"))
+        #expect(materialize(spec([blank(["systolic"], rate: 0.3)])).hasSuffix("\n"))
+    }
+
+    @Test func compositionWithSelectionAppliesToTheStudentsRows() {
+        let out = materialize(spec([blank(["systolic"], rate: 0.5)], sampleSize: 4))
+        let rows = out.split(separator: "\n").dropFirst()
+        #expect(rows.count == 4, "selection runs first")
+        // 50% of the 4 rows the student received, not of the 10-row pool.
+        #expect(rows.filter { $0.hasSuffix(",") }.count == 2)
+    }
+
+    @Test func quotedFieldsAroundABlankedCellKeepTheirBytes() {
+        let quoted = """
+            id,note,systolic
+            1,"Smith, J",120
+            2,"Doe, A",131
+
+            """
+        let out = DatasetMaterializer.materialize(
+            source: quoted,
+            spec: DatasetSpec(file: "c.csv", transforms: [blank(["systolic"], rate: 1)]),
+            seedHex: seed)
+        // A rebuild would re-quote by this file's rules rather than the
+        // source's; an in-place edit leaves every other cell byte-identical.
+        #expect(
+            out == """
+                id,note,systolic
+                1,"Smith, J",
+                2,"Doe, A",
+
+                """)
+    }
+
+    // MARK: - Degradation (each paired with a refusal in DatasetSpecValidationTests)
+
+    @Test func unappliableTransformsLeaveTheDataAlone() {
+        let unappliable: [DatasetTransform] = [
+            blank(["nope"], rate: 0.5),  // no such column
+            blank([], rate: 0.5),  // no columns named
+            DatasetTransform(kind: .missingValues, columns: ["systolic"], rate: nil),  // no rate
+            blank(["systolic"], rate: 0),  // a rate that affects nothing
+            blank(["systolic"], rate: 0.01),  // too small to reach one row of ten
+        ]
+        for transform in unappliable {
+            #expect(materialize(spec([transform])) == pool, "should be inert: \(transform)")
+        }
+    }
+
+    // MARK: - Back-compat
+
+    @Test func specWithoutTransformsKeyDecodesEmpty() throws {
+        let json = #"{"file":"cases.csv","kind":"rowSample","sampleSize":10}"#
+        let decoded = try JSONDecoder().decode(
+            DatasetSpec.self, from: Data(json.utf8))
+        #expect(decoded.transforms.isEmpty)
+    }
+
+    @Test func transformsRoundTrip() throws {
+        let original = spec([blank(["systolic"], rate: 0.25)], sampleSize: 5)
+        let decoded = try JSONDecoder().decode(
+            DatasetSpec.self, from: JSONEncoder().encode(original))
+        #expect(decoded == original)
+    }
+
+    /// A pre-derivation manifest must materialize to exactly what it did before
+    /// derivation existed — the property that makes this change safe to ship to
+    /// an assignment already in front of students.
+    @Test func aSpecWithNoTransformsIsUnchangedBySelectionAlone() {
+        let before = DatasetMaterializer.sampleRows(csv: pool, sampleSize: 4, seedHex: seed)
+        let after = DatasetMaterializer.materialize(
+            source: pool, spec: DatasetSpec(file: "cases.csv", sampleSize: 4), seedHex: seed)
+        #expect(before == after)
+    }
+
+    /// The `systolic` column's cells, as delivered.
+    private func systolicColumn(of csv: String) -> [String] {
+        csv.split(separator: "\n").dropFirst().map { line in
+            let fields = DatasetMaterializer.splitCSVLine(line)
+            return fields.count > 2 ? fields[2] : ""
+        }
+    }
+}

--- a/changelog.d/dataset-expression-slice.md
+++ b/changelog.d/dataset-expression-slice.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **A personalization expression now reads the student's dataset slice, not the
+  instructor's pool.** `PersonalizationEvaluator` spawned in the shared support
+  directory, which holds the full source pool, so an `=` expression over a
+  per-student dataset — the mechanism an `expectedVarRef` answer key uses —
+  computed the pool's answer and delivered it to every student as their own
+  expected value. Structural notebook checks did not notice; any value-based
+  check was wrong for the whole class, and identical for all of them. The
+  evaluation now runs against a private overlay in which each declared dataset
+  carries that student's bytes, resolved from the same source and seed the
+  delivered file comes from. Assignments declaring no datasets are unaffected.

--- a/changelog.d/dataset-transforms-missing-values.md
+++ b/changelog.d/dataset-transforms-missing-values.md
@@ -1,0 +1,26 @@
+### Added
+
+- **Per-student datasets can now derive values, not just select rows.** A
+  `DatasetSpec` carries an ordered `transforms` list alongside its selection
+  `kind`, so the instructor's pool becomes a template each student varies on.
+  The first transform is `missingValues`, which blanks a deterministic subset of
+  cells in explicitly named columns — teaching the handling of absent data,
+  which real health datasets arrive with. Selection runs first and transforms in
+  order, each drawing from its own sub-seeded stream so appending a step never
+  re-rolls an earlier one, and no `Double` reaches a delivered byte. A transform
+  never adds, removes, renames or reorders a column. Authored through
+  `set_dataset` and the two datasets endpoints; the Files panel does not offer
+  it yet, and deliberately will not until validation covers more than the
+  instructor's own variant.
+
+### Fixed
+
+- **The Files panel and `set_dataset` no longer rebuild a dataset spec from only
+  the fields they know about.** Both constructed a fresh spec on every edit, so
+  a setting one of them had not been taught about would be dropped by an
+  unrelated change — the shape that came within a release of silently
+  downgrading every stratified spec to a plain sample. Both now carry forward
+  what they were not asked to change. The datasets endpoints also read the
+  source file when a spec carries transforms, not only when it stratifies, so a
+  transform naming a column the file lacks is refused at save rather than
+  ignored at delivery.

--- a/changelog.d/dataset-transforms-ui.md
+++ b/changelog.d/dataset-transforms-ui.md
@@ -1,0 +1,16 @@
+### Added
+
+- **The Files panel can now author a `missingValues` step.** A dataset row grows
+  a "blanking … in … % of rows" control beside its sample size and stratum
+  column. As with the stratum column, the field carries whether the step exists
+  — naming columns creates it, clearing them removes it — so there is no mode
+  picker whose state could contradict the fields. Rates are authored as a
+  percentage and stored as the fraction the materializer folds to an integer
+  count.
+
+  The panel edits exactly one shape: no transforms, or a single `missingValues`
+  step. A spec holding anything richer — two steps, or a kind a later release
+  adds — renders with the fields **disabled** and a note that the steps are
+  agent-authored, and an unrelated edit to that row carries them through
+  untouched. Showing half of a two-step spec is how the next row-count edit
+  would save over the half not shown.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -616,20 +616,57 @@ what delivery computes, so 1% of a 10-row sample is genuinely zero cells. The
 check knows the sample size and can say so, which is the same move
 `stratifiedSample` makes when a sample is smaller than the category count.
 
+### The Files-panel control
+
+A dataset row carries the derivation step beside its sample size and stratum
+column:
+
+```
+[x] Per-student sample  [ 500 ] rows per student  balanced across [ ward ]
+    blanking [ bp_systolic ] in [ 10 ] % of rows                    Saved
+```
+
+Two design rules carried over from the stratum column:
+
+- **The field carries whether the step exists.** Naming columns creates the
+  step; clearing them removes it. There is no separate checkbox or mode picker,
+  because a second control asking the same question in different words is how
+  the two come to disagree.
+- **Percentages in, fractions stored.** An instructor says "10% of rows"; the
+  spec holds `rate: 0.1`, which delivery folds to an integer count.
+
+**The panel edits one shape, and knows it.** It has fields for no transforms or
+a single `missingValues` step. The model is an ordered list with more kinds to
+come, so a spec authored through MCP can hold something the panel cannot draw —
+two steps, or a future kind. Rendering that into the one pair of fields would
+show half the truth and then save over the other half on the next row-count
+edit, which is the silent-downgrade shape this feature has now produced twice.
+So `EditableSuiteRow.datasetTransformsEditable` asks first, and a spec the panel
+cannot represent renders **disabled**, with a note that the steps are
+agent-authored, and survives unrelated edits intact.
+
+That answer lives in two places on purpose and they are tested separately: Swift
+decides it for the server-rendered first paint, and `Public/support-files.js`
+honours it for every repaint after a save — omitting the `transforms` key
+entirely when its fields are disabled, so the merge carries the stored steps
+through.
+
 ### What is NOT built yet
 
-`missingValues` is agent-authored only — `set_dataset` and the two PUT endpoints
-accept it; the Files panel does not offer it. The panel does now **preserve**
-transforms it does not understand rather than dropping them on an unrelated
-edit, which is the property that made shipping the schema before the UI safe.
+`formatNoise` — inconsistent representations of the same value (stray
+whitespace, letter case, `2024-01-02` vs `02/01/2024`) — is the natural next
+transform, and the most pedagogically honest of the set: real health data
+arrives like this, and it is **answer-preserving**, so correct parsing yields
+the same result the pool would. It is also the only transform safe to author
+before multi-variant validation exists, for that reason.
 
-Two follow-ons are deliberately not here. **Multi-variant validation** (below)
-must land before any transform reaches the UI. And `numericJitter` is not
-implemented: `rowSample` already delivers anti-copying, so jitter buys little
-pedagogy while carrying the highest determinism cost and a provenance problem —
-a jittered VitalDB extract is no longer VitalDB, and a student reporting "the
-mean systolic in this cohort is 128" reports a number existing nowhere outside
-their own file.
+`numericJitter` is **not** implemented, and the recommendation is against it.
+`rowSample` already delivers anti-copying, so jitter buys little pedagogy while
+carrying the highest determinism cost and a provenance problem — a jittered
+VitalDB extract is no longer VitalDB, and a student reporting "the mean systolic
+in this cohort is 128" reports a number existing nowhere outside their own file.
+Whether an assignment's prose must disclose that its data is derived is a policy
+call for the maintainer, not a decision this design should make quietly.
 
 ### The gap this leaves: validation still exercises one variant
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -531,6 +531,120 @@ This is what makes a *value-based* check authorable on a dataset assignment at
 all, and it is the prerequisite for any transform that changes values rather
 than selecting rows.
 
+## Derivation — selection says which rows, a transform says what was done to them
+
+Phase 1 and 1.5 are both **selection**: `rowSample` and `stratifiedSample` decide
+which of the instructor's rows a student receives, and only ever copy bytes.
+**Derivation** alters the values themselves, so the pool becomes a *template*
+and each student gets a variation improvised on it.
+
+The two are separate axes on `DatasetSpec`, deliberately:
+
+```swift
+public let kind: DatasetKind               // SELECTION — unchanged meaning
+public let transforms: [DatasetTransform]  // DERIVATION — decodeIfPresent ?? []
+```
+
+"500 rows balanced by ward, then 2% of `bp_systolic` blanked" is two independent
+decisions. A `DatasetKind` case per combination is how that enum reaches thirty
+cases, so combinations are expressed as a list rather than enumerated. Every
+manifest written before derivation existed decodes to `transforms: []` and
+materializes to exactly the bytes it did before.
+
+**Selection runs first, then transforms in array order.** Both halves are
+load-bearing: transforming after selection means a rate applies to what the
+student actually receives rather than to the pool, and the order is stored
+because blanking then jittering is not jittering then blanking.
+
+### The rules that keep a transform from breaking its own assignment
+
+- **Never touch the schema.** No column added, removed, renamed or reordered.
+  The assignment ships code written against column *names*, and a student whose
+  `df["systolic"]` raises `KeyError` cannot fix that. Rows and within-column
+  values only.
+- **Columns are named explicitly** — there is no wildcard. An instructor who
+  blanks the column a notebook check asserts on has broken their own assignment;
+  making them name it is what lets the save-time check tell them so.
+- **A transform that cannot apply leaves the data alone**, and is refused at
+  save. Same pairing as the stratum column: forgiving at delivery, loud while an
+  instructor can still fix it.
+
+### Determinism, which is harder here than for selection
+
+Selection was platform-independent almost for free because it only copies bytes.
+Generating values is where that stops being free, so three rules are enforced by
+`DatasetTransformApplication.swift`:
+
+1. **No `Double` reaches a delivered byte.** `rate` is an authored number, so it
+   is folded to an integer per-mille once, up front — `(rows * permille) / 1000`
+   — and every per-cell decision after that is integer math.
+2. **Each step draws from its own sub-seeded stream**, keyed on the student's
+   seed plus the step's index, kind *and* column. A shared stream would mean
+   appending a second transform re-rolls the first, silently changing data
+   already delivered to a whole class. Two tests pin this: appending a step
+   leaves the first step's column byte-identical, and adding a column to a step
+   leaves the other column's rows unmoved.
+3. **Nothing iterates a `Dictionary` or `Set`.** Columns are visited in the
+   order the instructor listed them, rows in file order.
+
+A fourth rule is about *how* a cell is blanked: the raw line is edited in place
+rather than split and re-joined. A rebuild would re-quote every other field by
+this codebase's rules rather than the source's, changing bytes in cells the
+transform was never asked to touch.
+
+### `missingValues`
+
+The first derivation, and deliberately the simplest: it blanks a deterministic
+subset of cells in the named columns. Pure string replacement — no type
+inference and no formatting decisions — which is why it goes first. It teaches
+the handling of absent data, which is a real skill in health datasets rather
+than a synthetic difficulty.
+
+Save-time refusals (`DatasetSpecValidation.transformIssue`), each paired with
+something delivery absorbs silently:
+
+| Refused at save | Absorbed at delivery |
+|---|---|
+| a step naming no columns | leaves the data alone |
+| a column the file's header does not carry | that column is skipped |
+| a missing rate, or one outside `0 < rate <= 1` | the step does nothing |
+| a rate too small to reach one row of the sample | integer fold yields 0 cells |
+| the same kind twice on one column | order-dependent in a way nobody authored |
+
+That last row deserves its own note: `(sampleSize * permille) / 1000` is exactly
+what delivery computes, so 1% of a 10-row sample is genuinely zero cells. The
+check knows the sample size and can say so, which is the same move
+`stratifiedSample` makes when a sample is smaller than the category count.
+
+### What is NOT built yet
+
+`missingValues` is agent-authored only — `set_dataset` and the two PUT endpoints
+accept it; the Files panel does not offer it. The panel does now **preserve**
+transforms it does not understand rather than dropping them on an unrelated
+edit, which is the property that made shipping the schema before the UI safe.
+
+Two follow-ons are deliberately not here. **Multi-variant validation** (below)
+must land before any transform reaches the UI. And `numericJitter` is not
+implemented: `rowSample` already delivers anti-copying, so jitter buys little
+pedagogy while carrying the highest determinism cost and a provenance problem —
+a jittered VitalDB extract is no longer VitalDB, and a student reporting "the
+mean systolic in this cohort is 128" reports a number existing nowhere outside
+their own file.
+
+### The gap this leaves: validation still exercises one variant
+
+`hasPersonalization` counts expressions and variables, not `datasets`, so
+`materializeValidationGrading` returns early for a dataset-only assignment and
+validation grades against the **instructor's own** seed. For selection that is
+tolerable — the solution sees real rows, just fewer. For derivation it is not: a
+solution that assumes a column is never empty validates green and then fails for
+the students whose seed blanked it.
+
+This is why `missingValues` has no UI yet. Multi-variant validation — running the
+reference solution against N seeds and reporting per-variant results — is the
+gate that has to come before an instructor can reach for a transform from the
+Files panel.
+
 ### Build slices
 
 1. **Core** — `DatasetSpec`, `TestProperties.datasets` + `runnerSanitized`

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -491,6 +491,46 @@ For A4 this is **variety, not secrecy** — the sample is meant to be seen, so
 delivering it to the editor/browser is fine. The only thing hidden is the full
 pool. Secrecy becomes load-bearing only for Phase 2 mystery answers.
 
+### Expressions read the student's slice, not the pool
+
+The two per-student systems — `=` expressions and datasets — were built
+independently and, for one release, disagreed. `PersonalizationEvaluator` spawns
+its subprocess with the cwd set to the shared support directory so an expression
+can `open("cases.csv")`. That directory holds the instructor's **pool**, and is
+the same directory `DatasetResolver` reads as its *source*. In
+`WorkerJobRoutes.buildJobPayload` the two sat thirteen lines apart and neither
+knew about the other.
+
+The consequence was not a crash but a silent wrong answer. An expression
+computing `df["systolic"].mean()` returned the **pool's** mean, which then
+travelled the `expectedVarRef` path into `_ck_inputs.*` as that student's
+expected value — while the student held a slice with a different mean. Every
+student got the same expected value, and every student's own data disagreed with
+it. Only *structural* checks survived, which is why A4's five checks being
+structural read as a coincidence rather than as the ceiling it was.
+
+`PersonalizationSubstitution.resolve` now resolves the student's slices and hands
+them to the evaluator, which spawns against a private overlay: symlinks to every
+support file, with each declared dataset replaced by that student's bytes. Three
+properties are load-bearing:
+
+- **The shared directory is never written to.** Materializing a student's slice
+  there would hand the next student the previous one's data. The overlay is
+  per-evaluation and lives under the evaluator's existing temp directory.
+- **Same source, same seed, same bytes.** The overlay resolves through
+  `DatasetResolver` — the call the worker and editor already use — so the
+  expression and the student's delivered file agree by construction, not because
+  two call sites were kept in step.
+- **A slice that cannot be written is left absent, not symlinked to the pool.**
+  The expression then fails loudly with "no such file" rather than quietly
+  computing the instructor's answer and shipping it as the student's. This is the
+  one place the usual "forgiving at delivery" rule inverts: forgiveness here
+  means being confidently wrong about a grade.
+
+This is what makes a *value-based* check authorable on a dataset assignment at
+all, and it is the prerequisite for any transform that changes values rather
+than selecting rows.
+
 ### Build slices
 
 1. **Core** — `DatasetSpec`, `TestProperties.datasets` + `runnerSanitized`


### PR DESCRIPTION
Three slices toward meaningful per-student data, in the order where a mistake stays cheap. They're on one branch because the session is pinned to a single designated branch — **each is an independent, reviewable commit**.

Follows the derived-datasets handoff, with one reordering explained below.

---

## Commit 1 — `fix(datasets)`: expressions read the student's slice, not the pool

**This is a live silent-wrong-answer bug, not a new feature.**

`PersonalizationEvaluator` spawns its interpreter with the cwd set to the shared support-files directory so an expression can `open("cases.csv")`. That directory holds the instructor's **pool**, and is the same directory `DatasetResolver` reads as its *source*. In `WorkerJobRoutes.buildJobPayload` the two sat thirteen lines apart and neither knew the other existed.

The consequence was not a crash. An expression computing a statistic over a per-student dataset returned the **pool's** value, which then travelled the `expectedVarRef` path into `_ck_inputs.*` as that student's expected value — while the student held a slice with a different one. Every student got the same expected value and every student's own data disagreed with it. Only *structural* checks survived, which is why A4's five checks being structural reads as a ceiling rather than a coincidence.

`PersonalizationSubstitution.resolve` now resolves the student's slices through `DatasetResolver` — the same call the worker and editor already use, so the expression and the delivered file agree by construction rather than by two call sites being kept in step — and hands them to the evaluator, which runs against a private overlay: symlinks to every support file, each declared dataset replaced by that student's bytes.

Three properties are load-bearing:

- **The shared directory is never written to.** Materializing there would hand the next student the previous one's data.
- **A slice that cannot be written is left absent, not symlinked to the pool.** The expression then fails loudly with "no such file" rather than quietly computing the instructor's answer and shipping it as the student's. This is the one place the usual "forgiving at delivery" rule inverts — forgiveness here means being confidently wrong about a grade.
- **No datasets means no change.** The overlay returns the shared directory, so those evaluations are byte-for-byte as before.

One change to `resolve` covers all four delivery paths (worker, browser, validation, MCP preview).

**Baseline-verified.** With the wiring temporarily reverted, 4 of the 7 new tests fail with exactly the defect described — `rows` reads `100` (the pool) instead of `10`, and two different seeds both produce `19900`.

## Commit 2 — `feat(datasets)`: derivation via an ordered transform list

`DatasetSpec` gains `transforms: [DatasetTransform]` beside its selection `kind`, rather than `DatasetKind` cases per combination — "500 rows balanced by ward, then 2% of `bp_systolic` blanked" is two independent decisions, and enumerating their product is how that enum reaches thirty cases. Pre-derivation manifests decode to `[]` and materialize to the bytes they did before (pinned).

Selection runs first, then transforms in array order — so a rate applies to the rows the student actually receives, and the order is stored because blanking then jittering is not jittering then blanking.

**`missingValues`** is the first transform and deliberately the simplest: pure string replacement, no type inference, no formatting decisions.

### Determinism

Selection was platform-independent almost for free because it only copies bytes; generating values is where that stops. Four rules:

1. **No `Double` reaches a delivered byte** — `rate` folds to an integer per-mille once, up front.
2. **Each step draws from its own sub-seeded stream** (seed + index + kind + column), so appending a step never re-rolls an earlier one and adding a column never moves an existing column's rows. Both pinned.
3. **Nothing iterates a `Dictionary` or `Set`.**
4. **Cells are blanked by editing the raw line in place** — a split-and-rejoin would re-quote every *other* field by this codebase's rules rather than the source's.

### Safety rules

Transforms never add, remove, rename or reorder a column, and name columns explicitly with no wildcard: the assignment ships code written against column names, and a student whose `df["systolic"]` raises `KeyError` cannot fix that.

Every input the materializer absorbs quietly is refused at save. The rate check computes the same integer fold delivery does, so it can tell an instructor that 1% of a 10-row sample is genuinely zero cells.

### Two defects found while wiring the doors

- **Both authoring doors rebuilt a spec from only the fields they knew about.** That shape came within a release of downgrading every stratified spec to a plain sample. Both now carry forward what they weren't asked to change.
- **The datasets endpoints only read the source file when a spec stratified**, so a transform naming a column the file lacks was accepted at save and ignored at delivery.

## Commit 3 — `feat(ui)`: author a `missingValues` step from the Files panel

```
[x] Per-student sample  [ 500 ] rows per student  balanced across [ ward ]
    blanking [ bp_systolic ] in [ 10 ] % of rows                    Saved
```

Two rules carried over from the stratum column: **the field carries whether the step exists** (naming columns creates it, clearing them removes it — no mode picker whose state could contradict the fields), and **percentages in, fractions stored**.

**The panel edits one shape, and knows it.** It has fields for no transforms or a single `missingValues` step; the model is an ordered list with more kinds to come. A spec it cannot represent — two steps, or a future kind — renders with the fields **disabled** plus a note that the steps are agent-authored, and survives unrelated edits intact. Showing half of a two-step spec is how the next row-count edit would save over the half not shown.

That judgement lives in two places on purpose and is tested separately: Swift for the server-rendered first paint (`datasetTransformsEditable`), JS for every repaint after a save (omitting the `transforms` key when its fields are disabled, so the merge carries stored steps through).

The dataset control had **no JS coverage at all** — the existing harness passes no `datasetsURL`, so `initDatasetControls` returned early and nothing in it was ever exercised.

---

## Why this order, rather than the handoff's

The handoff opens with the schema and puts multi-variant validation second. I moved the expression-loop fix ahead of both: without it, no authoring construct can compute what any student's answer *should* be, so more transforms would just produce ungradeable variety on top of a silently wrong answer key. Its Slice A scaffolding (a pure `DatasetSpecValidation`, the byte-pin fixture, `everySilentDegradationHasALoudRefusal`) already arrived with #1436.

## Known gap, accepted deliberately

**Validation still exercises one variant.** `hasPersonalization` excludes `datasets`, so a dataset-only assignment skips `materializeValidationGrading` and validates on the instructor's seed. An instructor can now author blanking from the UI and get a green check that proves nothing about the students whose seed blanked a column their solution assumes is populated.

I'd originally gated the UI behind fixing this. It ships ahead of that gate **on purpose**, so the design can be handled and judged before more is built on it — but **multi-variant validation should land before this is used with a real class.** Recorded in `docs/datasets.md` rather than left implicit.

## Also not here

`numericJitter` is **not** implemented, and the docs recommend against it: `rowSample` already delivers anti-copying, so jitter buys little pedagogy while carrying the highest determinism cost and a provenance problem — a jittered VitalDB extract is no longer VitalDB. `formatNoise` is recorded as the natural next transform, and is **answer-preserving**, which makes it the only one safe to author before multi-variant validation exists.

## Testing

New: `PersonalizationDatasetSliceTests` (7), `DatasetTransformTests` (15), `support-files-datasets.test.mjs` (8), plus transform cases in `DatasetSpecValidationTests`, `SetDatasetToolTests`, `DatasetsRouteRoundTripTests` and `SupportFileDatasetRowTests`.

- 896 tests / 153 suites incl. render tests exercising both templates: green
- Full `CoreTests` (397 / 44): green
- `format.sh`, `lint.sh`, `swiftlint.sh --strict`, `check-styles.sh`, `eslint.sh`: green
- One `changelog.d/` fragment per commit; `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` untouched

**Not covered:** no manual browser pass. Render tests prove the templates resolve and the JS tests drive a stubbed DOM, but neither opens the page — the percentage-to-fraction round trip and the disabled-state rendering are the two things worth clicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3UhGV6jMYEdnji4aNGTxt