### PR TITLE
feat(datasets): dataset diagnostics, and validation across per-student variants

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2072,6 +2072,15 @@ code { font-family: var(--font-mono); font-size: .9em; }
    cannot represent — it steps aside rather than rendering a partial view it
    would then save over. */
 .dataset-note { font-style: italic; color: var(--gray-600); }
+/* Per-row estimates disclosure: how many rows two students share and how far
+   a slice drifts from the pool (docs/datasets.md).  A band with two bad ends
+   rather than a threshold, so the text is informational and never styled as
+   a warning.  Takes the full row width so it wraps under the inline
+   controls; the `hidden` attribute hides it (no display override here). */
+.dataset-diagnostics { flex-basis: 100%; font-size: var(--text-sm); color: var(--gray-600); }
+.dataset-diagnostics > summary { cursor: pointer; color: var(--gray-500); }
+.dataset-diagnostics-body { display: flex; flex-direction: column; gap: .15rem; margin-top: .25rem; }
+.dataset-diagnostics-line { display: block; }
 
 /* Pattern-family editor body internals. */
 .label-note { color: var(--gray-600); font-weight: 400; }

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -11,7 +11,9 @@
 //     uploadURL:   () => POST target for {filename, content, tier, isTest}
 //     deleteURL:   (name) => DELETE target for one stored support file
 //     datasetsURL: () => GET/PUT target for {datasets: [DatasetSpec]}
-//                  (a spec is {file, kind, sampleSize, stratumColumn?})
+//                  (a spec is {file, kind, sampleSize, stratumColumn?}; the
+//                  response also carries per-file `diagnostics` estimate
+//                  blocks the rows' disclosure renders)
 //     onChange:    () => run after a successful upload batch or delete
 //                  (the edit surface re-renders in place; the create page
 //                  reloads its draft)
@@ -77,6 +79,86 @@
                 document.querySelectorAll('tr[data-support-file]'));
         }
         function statusOf(row) { return row.querySelector('.js-dataset-status'); }
+
+        // ── The estimates disclosure ────────────────────────────────────────
+        //
+        // The server computes two estimates per dataset (Core's
+        // DatasetDiagnostics; docs/datasets.md) and serves them on the same
+        // GET/PUT the controls use, so the numbers move with every saved
+        // parameter edit.  They describe a band with two bad ends — more rows
+        // is fairer but more copyable — so the text is informational only:
+        // no thresholds, no warning styling.
+
+        function formatPercent(fraction) {
+            var pct = fraction * 100;
+            if (pct >= 99.95) return '100%';
+            return (pct >= 10 ? Math.round(pct) : pct.toFixed(1)) + '%';
+        }
+
+        function formatUnits(value) {
+            return value < 0.005 ? 'under 0.01' : value.toFixed(2);
+        }
+
+        function diagnosticsLines(report) {
+            var lines = [];
+            var overlap = report.overlap;
+            if (overlap) {
+                lines.push('Copying: two students share about '
+                    + Math.round(overlap.expectedSharedRows) + ' of their '
+                    + overlap.rowsPerStudent + ' rows ('
+                    + formatPercent(overlap.sharedFraction)
+                    + '); the unluckiest pair in a class of ' + report.classSize
+                    + ' shares about ' + Math.round(overlap.worstPairSharedRows) + '.');
+                var stratum = overlap.mostCopyableStratum;
+                if (stratum) {
+                    lines.push('Most copyable category: "' + stratum.value
+                        + '" — every student draws ' + stratum.rowsPerStudent
+                        + ' of the same ' + stratum.poolRows + ' pool rows ('
+                        + formatPercent(stratum.sharedFraction) + ' shared).');
+                }
+            }
+            (report.headlines || []).forEach(function (headline) {
+                if (headline.measure === 'wasserstein') {
+                    lines.push('Drift: ' + headline.column + ' sits about '
+                        + formatUnits(headline.median)
+                        + ' SD from the pool for a typical student (worst seed '
+                        + formatUnits(headline.worst) + '; any two students within about '
+                        + formatUnits(2 * headline.worst) + ' SD).');
+                } else {
+                    lines.push('Category drift: ' + headline.column + ' sits about '
+                        + formatUnits(headline.median)
+                        + ' total-variation from the pool (worst seed '
+                        + formatUnits(headline.worst) + ').');
+                }
+            });
+            if (report.divergenceMeasured === false) {
+                lines.push('Distribution drift was not measured — the file is too large to sample quickly.');
+            }
+            return lines;
+        }
+
+        // Paints each row's disclosure from the server's estimate blocks.  A
+        // row with no block (not a dataset, or a file the server could not
+        // read as text) hides the disclosure rather than showing an empty one.
+        function renderDiagnostics(reports) {
+            var byFile = {};
+            (reports || []).forEach(function (report) { byFile[report.file] = report; });
+            rows().forEach(function (row) {
+                var box = row.querySelector('.js-dataset-diagnostics');
+                if (!box) return;
+                var report = byFile[row.getAttribute('data-support-file')];
+                box.hidden = !report;
+                var body = row.querySelector('.js-dataset-diagnostics-body');
+                if (!report || !body) return;
+                body.textContent = '';
+                diagnosticsLines(report).forEach(function (line) {
+                    var item = document.createElement('span');
+                    item.className = 'dataset-diagnostics-line';
+                    item.textContent = line;
+                    body.appendChild(item);
+                });
+            });
+        }
 
         // Paints every row from the server's specs, so a row the edit didn't
         // name still ends up showing what the manifest holds.
@@ -192,15 +274,22 @@
             return value > 0 ? value : null;
         }
 
-        function fetchSpecs() {
+        function fetchState() {
             return ChickadeeUI.fetchJSON(config.datasetsURL(), { csrfToken: csrfToken })
-                .then(function (body) { return (body && body.datasets) || []; });
+                .then(function (body) { return body || {}; });
         }
 
-        // Restores the controls to what the server holds — used after a failed
-        // write so the page never shows a mark that was not saved.
+        // Paints controls and estimates together, from one server response.
+        function renderState(body) {
+            render((body && body.datasets) || []);
+            renderDiagnostics((body && body.diagnostics) || []);
+        }
+
+        // Restores the panel to what the server holds — after a failed write
+        // so the page never shows a mark that was not saved, and once at init
+        // so the estimates have a first paint.
         function resync() {
-            return fetchSpecs().then(render).catch(function () { /* advisory */ });
+            return fetchState().then(renderState).catch(function () { /* advisory */ });
         }
 
         // `spec` null clears the mark for `filename`.
@@ -229,7 +318,8 @@
         function commit(filename, spec, row) {
             queue = queue.then(function () {
                 ChickadeeUI.setStatus(statusOf(row), 'Saving…');
-                return fetchSpecs().then(function (current) {
+                return fetchState().then(function (state) {
+                    var current = (state && state.datasets) || [];
                     var next = current.filter(function (d) { return d.file !== filename; });
                     if (spec) next.push(merged(current, filename, spec));
                     return ChickadeeUI.fetchJSON(config.datasetsURL(), {
@@ -238,7 +328,7 @@
                         body: { datasets: next }
                     });
                 }).then(function (body) {
-                    render((body && body.datasets) || []);
+                    renderState(body);
                     ChickadeeUI.setStatus(statusOf(row), spec ? 'Saved' : 'Cleared', 'ok');
                 }).catch(function (e) {
                     ChickadeeUI.setStatus(statusOf(row), '');
@@ -267,6 +357,8 @@
                     if (field) field.hidden = true;
                     if (stratumField) stratumField.hidden = true;
                     if (blankField) blankField.hidden = true;
+                    var diagnostics = row.querySelector('.js-dataset-diagnostics');
+                    if (diagnostics) diagnostics.hidden = true;
                     commit(filename, null, row);
                     return;
                 }
@@ -300,6 +392,10 @@
                 commit(filename, specFor(row, filename, entered), row);
             }
         });
+
+        // First paint of the estimates: the controls are server-rendered, but
+        // the numbers come from the same GET the controls sync against.
+        resync();
     }
 
     window.initSupportFiles = function (config) {

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -211,6 +211,11 @@
                             <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
                             #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
+                            <details class="dataset-diagnostics js-dataset-diagnostics"
+                                     #if(!supportFile.isDataset):hidden#endif>
+                                <summary>Per-student estimates</summary>
+                                <span class="dataset-diagnostics-body js-dataset-diagnostics-body"></span>
+                            </details>
                         </div>
                     </td>
                     <td class="time">

--- a/Resources/Views/_course-item-row.leaf
+++ b/Resources/Views/_course-item-row.leaf
@@ -158,6 +158,22 @@
             #else:
             <span class="tier">—</span>
             #endif
+            #if(item.assignment.variantState == "failed"):
+            <div class="cell-subrow">
+                <span class="tier tier-closed" title="The reference solution was also graded against synthetic per-student seeds, and failed on some of them — a student holding one of those seeds would fail through no fault of their own.">#(item.assignment.variantSummaryText)</span>
+                #if(item.assignment.failedVariantSubmissionID):
+                <a href="/submissions/#(item.assignment.failedVariantSubmissionID)">View variant</a>
+                #endif
+            </div>
+            #elseif(item.assignment.variantState == "pending"):
+            <div class="cell-subrow">
+                <span class="tier" title="The reference solution is also being graded against synthetic per-student seeds.">#(item.assignment.variantSummaryText)</span>
+            </div>
+            #elseif(item.assignment.variantState == "passed"):
+            <div class="cell-subrow">
+                <span class="tier tier-open" title="The reference solution also passed against every synthetic per-student seed.">#(item.assignment.variantSummaryText)</span>
+            </div>
+            #endif
         </td>
         <td class="due-col col-hide-phone">#if(item.assignment.dueAt):#(item.assignment.dueAt)#else:—#endif</td>
         <td class="col-hide-phone nowrap">

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -211,6 +211,11 @@ Create Assignment
                             <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
                             #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
+                            <details class="dataset-diagnostics js-dataset-diagnostics"
+                                     #if(!supportFile.isDataset):hidden#endif>
+                                <summary>Per-student estimates</summary>
+                                <span class="dataset-diagnostics-body js-dataset-diagnostics-body"></span>
+                            </details>
                         </div>
                     </td>
                     <td class="time">

--- a/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
@@ -49,6 +49,24 @@ struct GetValidationResultTool: ContentTool {
         let timeout: Int
     }
 
+    /// One synthetic per-student variant of the validation batch
+    /// (multi-variant validation): the same reference solution graded against
+    /// a derived seed, so a solution that only works for some students'
+    /// material is visible here instead of failing a student.
+    struct VariantDTO: Encodable, Sendable {
+        let variantIndex: Int
+        /// The 64-hex seed this variant graded against — usable with
+        /// preview_personalization to reproduce the variant's material.
+        let seedHex: String
+        /// pending | passed | failed.
+        let status: String
+        /// Collection-level build status of the variant's run, when one exists.
+        let buildStatus: String?
+        /// Only the non-passing outcomes, so N variants stay readable; the
+        /// primary run's full grid is in `outcomes`.
+        let failingOutcomes: [OutcomeDTO]
+    }
+
     struct Output: Encodable, Sendable {
         let assignmentPublicID: String
         /// The assignment's current `validationStatus`: passed | failed |
@@ -70,6 +88,10 @@ struct GetValidationResultTool: ContentTool {
         /// content bug rather than version skew.
         let runnerID: String?
         let runnerVersion: String?
+        /// The current multi-variant batch, ordered by variant index.  Empty
+        /// when the assignment does not vary by student (no expressions and
+        /// no datasets) or no batch has been enqueued yet.
+        let variants: [VariantDTO]
     }
 
     static let name = "get_validation_result"
@@ -84,7 +106,11 @@ struct GetValidationResultTool: ContentTool {
         + "missing run returns the current validationStatus with empty outcomes. Also reports runnerID "
         + "and runnerVersion — which runner produced the result and the build it was running — so a "
         + "failure caused by a runner lagging behind the suite's requirements is distinguishable from "
-        + "a content bug."
+        + "a content bug. When the assignment varies by student (per-student expressions or datasets), "
+        + "`variants` reports the multi-variant batch: the same solution graded against derived "
+        + "per-student seeds, each with its failing outcomes — a failed variant means a student holding "
+        + "that seed would fail through no fault of their own, so fix the suite or solution until every "
+        + "variant passes."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -108,9 +134,11 @@ struct GetValidationResultTool: ContentTool {
             "counts": .object(["type": .array([.string("object"), .string("null")])]),
             "runnerID": .object(["type": .array([.string("string"), .string("null")])]),
             "runnerVersion": .object(["type": .array([.string("string"), .string("null")])]),
+            "variants": .object(["type": .string("array")]),
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("validationStatus"), .string("outcomes"),
+            .string("variants"),
         ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
@@ -143,6 +171,8 @@ struct GetValidationResultTool: ContentTool {
                 tool: Self.name, detail: "Could not read the validation result: \(error)")
         }
 
+        let variants = try await Self.variantBatch(for: assignment, context: context)
+
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard
@@ -150,7 +180,9 @@ struct GetValidationResultTool: ContentTool {
             let collection = try? decoder.decode(
                 TestOutcomeCollection.self, from: Data(collectionJSON.utf8))
         else {
-            return Self.empty(assignmentPublicID: assignment.publicID, validationStatus: status)
+            return Self.empty(
+                assignmentPublicID: assignment.publicID, validationStatus: status,
+                variants: variants)
         }
 
         let outcomes = collection.outcomes.map {
@@ -181,12 +213,65 @@ struct GetValidationResultTool: ContentTool {
             // The version carried on the result itself, so it is the build that
             // actually produced these outcomes rather than whatever that runner
             // happens to be running now.
-            runnerVersion: collection.runnerVersion)
+            runnerVersion: collection.runnerVersion,
+            variants: variants)
+    }
+
+    /// The current multi-variant batch for the assignment's setup, each
+    /// variant carrying only its non-passing outcomes.  Result access goes
+    /// through `MCPStudentDataBoundary.variantResult`, which re-applies the
+    /// validation filter on the way to the row.
+    private static func variantBatch(
+        for assignment: APIAssignment, context: ToolContext
+    ) async throws -> [VariantDTO] {
+        let batch = try await ValidationVariant.query(on: context.db)
+            .filter(\.$testSetupID == assignment.testSetupID)
+            .sort(\.$variantIndex)
+            .all()
+        guard !batch.isEmpty else { return [] }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        var dtos: [VariantDTO] = []
+        for variant in batch {
+            var buildStatus: String?
+            var failing: [OutcomeDTO] = []
+            if variant.status == ValidationVariant.Status.failed,
+                let result = try await MCPStudentDataBoundary.variantResult(
+                    for: variant, on: context.db),
+                let json = try? await result.loadCollectionJSON(on: context.db),
+                let collection = try? decoder.decode(
+                    TestOutcomeCollection.self, from: Data(json.utf8))
+            {
+                buildStatus = collection.buildStatus.rawValue
+                failing = collection.outcomes
+                    .filter { $0.status != .pass }
+                    .map {
+                        OutcomeDTO(
+                            testName: $0.testName,
+                            tier: $0.tier.rawValue,
+                            status: $0.status.rawValue,
+                            points: $0.points,
+                            shortResult: $0.shortResult,
+                            longResult: $0.longResult)
+                    }
+            }
+            dtos.append(
+                VariantDTO(
+                    variantIndex: variant.variantIndex,
+                    seedHex: variant.seedHex,
+                    status: variant.status,
+                    buildStatus: buildStatus,
+                    failingOutcomes: failing))
+        }
+        return dtos
     }
 
     /// The pending / no-result-yet response: the current status with no outcomes
     /// (mirrors validate_assignment's pending state).
-    private static func empty(assignmentPublicID: String, validationStatus: String) -> Output {
+    private static func empty(
+        assignmentPublicID: String, validationStatus: String, variants: [VariantDTO]
+    ) -> Output {
         Output(
             assignmentPublicID: assignmentPublicID,
             validationStatus: validationStatus,
@@ -197,6 +282,7 @@ struct GetValidationResultTool: ContentTool {
             outcomes: [],
             counts: nil,
             runnerID: nil,
-            runnerVersion: nil)
+            runnerVersion: nil,
+            variants: variants)
     }
 }

--- a/Sources/APIServer/MCP/Tools/MCPStudentDataBoundary.swift
+++ b/Sources/APIServer/MCP/Tools/MCPStudentDataBoundary.swift
@@ -62,4 +62,18 @@ enum MCPStudentDataBoundary {
             .sort(\.$receivedAt, .descending)
             .first()
     }
+
+    /// A validation variant's most recent result (multi-variant validation).
+    /// The variant row stores the submission id of one `kind == .validation`
+    /// run; resolving it back through the validation filter means this can
+    /// never yield a student row, even from a corrupted variant record.
+    static func variantResult(
+        for variant: ValidationVariant, on db: any Database
+    ) async throws -> APIResult? {
+        guard let submissionID = variant.submissionID,
+            let submission = try await validationSubmission(byID: submissionID, on: db),
+            let id = submission.id
+        else { return nil }
+        return try await latestResult(forSubmissionID: id, on: db)
+    }
 }

--- a/Sources/APIServer/Migrations/CreateValidationVariants.swift
+++ b/Sources/APIServer/Migrations/CreateValidationVariants.swift
@@ -1,0 +1,29 @@
+// APIServer/Migrations/CreateValidationVariants.swift
+//
+// The per-variant validation records (see `ValidationVariant`): one row per
+// synthetic seed the current validation batch graded the reference solution
+// against.  `submission_id` is `.setNull` on delete so retention pruning an
+// old validation submission leaves the recorded verdict standing.
+
+import Fluent
+
+struct CreateValidationVariants: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("validation_variants")
+            .id()
+            .field("test_setup_id", .string, .required)
+            .field("variant_index", .int, .required)
+            .field("seed_hex", .string, .required)
+            .field(
+                "submission_id", .string,
+                .references("submissions", "id", onDelete: .setNull)
+            )
+            .field("status", .string, .required)
+            .field("created_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("validation_variants").delete()
+    }
+}

--- a/Sources/APIServer/Models/ValidationVariant.swift
+++ b/Sources/APIServer/Models/ValidationVariant.swift
@@ -1,0 +1,79 @@
+// APIServer/Models/ValidationVariant.swift
+//
+// One synthetic per-student variant of an assignment's validation run.
+//
+// A validation submission grades the reference solution against the enqueuing
+// instructor's own seed — one variant of a per-student assignment.  When the
+// manifest varies by seed (`TestProperties.variesPerStudent`: a per-student
+// `=` expression or a dataset slice), that single run proves nothing about
+// the material other students receive: a solution that assumes a column is
+// never blank validates green and then fails for the student whose seed
+// blanked it.  So every validation enqueue also runs the solution against
+// `validationVariantCount` derived preflight seeds — the same seeds the
+// Files-panel estimates sample — and each of those runs is recorded here.
+//
+// Rows are the CURRENT batch only: a new enqueue deletes the setup's rows and
+// writes fresh ones, mirroring how `assignment.validationSubmissionID` always
+// points at the latest primary run.  The underlying variant submissions stay
+// in `submissions` as history like any other validation; `submission_id` is
+// `onDelete: .setNull` so retention pruning a submission leaves the recorded
+// verdict standing.
+//
+// Keyed by `test_setup_id` (not assignment id) because the draft flow
+// enqueues validation before the assignment row exists — the same reason
+// `submissions` itself is setup-keyed.
+
+import Fluent
+import Vapor
+
+final class ValidationVariant: Model, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context,
+    // never across unstructured concurrency.
+    static let schema = "validation_variants"
+
+    /// The per-run verdict vocabulary, mirroring the primary's
+    /// `validationStatus` subset a run can reach ("no-runner" is decided
+    /// before any run exists, so it never lands on a variant row).
+    enum Status {
+        static let pending = "pending"
+        static let passed = "passed"
+        static let failed = "failed"
+    }
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    /// 0-based position in the batch; the seed is
+    /// `DatasetDiagnostics.preflightSeed(variantIndex)`.
+    @Field(key: "variant_index")
+    var variantIndex: Int
+
+    /// The 64-hex seed this variant graded against — stored rather than
+    /// re-derived so the row still says what actually ran if the derivation
+    /// ever changes.
+    @Field(key: "seed_hex")
+    var seedHex: String
+
+    /// The `kind == .validation` submission that carried this variant's run.
+    @OptionalField(key: "submission_id")
+    var submissionID: String?
+
+    @Field(key: "status")
+    var status: String
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(testSetupID: String, variantIndex: Int, seedHex: String, submissionID: String?) {
+        self.testSetupID = testSetupID
+        self.variantIndex = variantIndex
+        self.seedHex = seedHex
+        self.submissionID = submissionID
+        self.status = Status.pending
+    }
+}

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -104,6 +104,21 @@ struct ResultRoutes: RouteCollection {
                         "Validation \(status) for assignment '\(assignment.title)' (submission \(collection.submissionID))"
                     )
                 }
+
+                // A per-variant run (multi-variant validation) is never the
+                // assignment's linked primary, so the two lookups are
+                // disjoint: this one records the verdict on the variant row
+                // the instructor surfaces read.
+                if let variant = try await ValidationVariant.query(on: req.db)
+                    .filter(\.$submissionID == collection.submissionID)
+                    .first()
+                {
+                    variant.status = status
+                    try await variant.save(on: req.db)
+                    req.logger.info(
+                        "Validation variant \(variant.variantIndex) \(status) for setup \(variant.testSetupID)"
+                    )
+                }
             }
 
             // Award class-wide badges when a student submission earns 100%.

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -281,11 +281,15 @@ extension AdminRoutes {
                     .filter(\.$submissionID ~~ subIDs).delete()
             }
 
-            // 3. Delete submission zip files then submission records.
+            // 3. Delete submission zip files then submission records (variant
+            // batches first — their FK is `.setNull`, so the other order
+            // leaves unlinked rows for setups that no longer exist).
             for sub in submissions {
                 try? FileManager.default.removeItem(atPath: sub.zipPath)
             }
             if !setupIDs.isEmpty {
+                try await ValidationVariant.query(on: db)
+                    .filter(\.$testSetupID ~~ setupIDs).delete()
                 try await APISubmission.query(on: db)
                     .filter(\.$testSetupID ~~ setupIDs).delete()
             }

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -19,10 +19,47 @@ struct AssignmentRow: Encodable {
     let sortOrder: Int?
     let validationStatus: String
     let validationSubmissionID: String?
+    /// Multi-variant validation rollup for the validation cell: "none" (the
+    /// assignment does not vary by student, or no batch has run yet) |
+    /// "pending" | "failed" | "passed".  A flat discriminator plus
+    /// pre-rendered text, because LeafKit 1.14.2 mis-parses compound
+    /// conditions and cannot do the arithmetic.
+    let variantState: String
+    let variantSummaryText: String  // e.g. "1 of 4 variants failed"; "" when none
+    /// The lowest-index failed variant's submission id, for the results link.
+    let failedVariantSubmissionID: String?
     let suiteCount: Int
     let createdAt: String
     let submittedStudentCount: Int?  // nil if unpublished; unique enrolled students who submitted at least once
     let vanityURL: String?  // e.g. "/CS101/lab-1-intro"; nil if unpublished or no active course
+}
+
+/// Aggregate of one setup's current validation-variant batch (multi-variant
+/// validation): the reference solution graded against N synthetic per-student
+/// seeds, on top of the primary run.  Fold-down for the listing row.
+struct ValidationVariantSummary {
+    let total: Int
+    let failed: Int
+    let pending: Int
+    let firstFailedSubmissionID: String?
+
+    /// The flat discriminator the template branches on.  Pending wins over
+    /// failed so a half-graded batch reads as still running rather than as a
+    /// settled verdict.
+    var state: String {
+        if total == 0 { return "none" }
+        if pending > 0 { return "pending" }
+        return failed > 0 ? "failed" : "passed"
+    }
+
+    var summaryText: String {
+        switch state {
+        case "pending": return "\(total) variants running"
+        case "failed": return "\(failed) of \(total) variants failed"
+        case "passed": return "\(total) variants passed"
+        default: return ""
+        }
+    }
 }
 
 /// One element of a section's unified item list on the instructor dashboard: a

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -22,9 +22,78 @@ struct DatasetsBody: Content {
 }
 
 /// The response of either GET or PUT — the specs as the manifest now holds
-/// them, which is what the Files panel renders its controls from.
+/// them, which is what the Files panel renders its controls from, plus the
+/// per-file estimates its disclosure shows.  Serving the estimates on the
+/// same response is what makes them live: every parameter edit is a PUT, so
+/// the numbers move with the controls without a second request.
 struct DatasetsResponse: Content {
     var datasets: [DatasetSpec]
+    var diagnostics: [DatasetFileDiagnostics]
+}
+
+/// One dataset's estimate block: closed-form overlap (can students copy?)
+/// and measured divergence headlines (are they doing the same exercise?).
+/// Both computed by Core's `DatasetDiagnostics` from the spec and the
+/// bundled file — estimates about the delivered bytes, never a change to
+/// them.  See docs/datasets.md.
+struct DatasetFileDiagnostics: Content {
+    var file: String
+    var overlap: DatasetOverlap
+    /// The worst column per measure (SDs of transport for numeric columns,
+    /// total variation for categorical).  Empty when nothing was measurable.
+    var headlines: [DatasetDivergenceHeadline]
+    /// False when the file was over the sampling ceiling, so only the
+    /// closed-form overlap is reported — stated rather than silently capped.
+    var divergenceMeasured: Bool
+    /// The class size the worst-pair estimate assumes, so the panel can say
+    /// it instead of implying a measured class.
+    var classSize: Int
+}
+
+/// Files above this size skip the divergence measurement — it materializes
+/// the pool once per preflight seed, and the panel is a live control, not a
+/// batch job.  Overlap is a single pass and is always reported.
+private let datasetDivergenceByteCeiling = 4 << 20
+
+/// The estimate blocks for every spec whose source file can be read as text.
+/// A file that cannot be read (or has no data rows) simply has no block —
+/// the panel hides the disclosure rather than showing an empty one.
+///
+/// CPU-bound (the divergence half materializes the pool `defaultSeedCount`
+/// times), so handlers call it through `runBlocking` rather than on the
+/// event loop.
+func datasetDiagnosticsReports(
+    zipPath: String, datasets: [DatasetSpec]
+) -> [DatasetFileDiagnostics] {
+    datasets.compactMap { spec in
+        guard let data = extractZipEntry(zipPath: zipPath, entryName: spec.file),
+            let text = String(data: data, encoding: .utf8),
+            let overlap = DatasetDiagnostics.overlap(spec: spec, sourceCSV: text)
+        else { return nil }
+        let measurable = data.count <= datasetDivergenceByteCeiling
+        let headlines =
+            measurable
+            ? DatasetDiagnostics.headlines(
+                of: DatasetDiagnostics.divergence(spec: spec, sourceCSV: text))
+            : []
+        return DatasetFileDiagnostics(
+            file: spec.file, overlap: overlap, headlines: headlines,
+            divergenceMeasured: measurable, classSize: DatasetDiagnostics.defaultClassSize)
+    }
+}
+
+/// The full panel payload for a setup: its specs plus their estimate blocks,
+/// computed off the event loop.  The one constructor every datasets handler
+/// uses, so the GET and PUT of both pairs cannot disagree about what the
+/// panel is told.
+func datasetsPanelResponse(req: Request, setup: APITestSetup) async throws -> DatasetsResponse {
+    let specs = datasetSpecs(inManifest: setup.manifest)
+    guard !specs.isEmpty else { return DatasetsResponse(datasets: [], diagnostics: []) }
+    let zipPath = setup.zipPath
+    let diagnostics = try await runBlocking(on: req) {
+        datasetDiagnosticsReports(zipPath: zipPath, datasets: specs)
+    }
+    return DatasetsResponse(datasets: specs, diagnostics: diagnostics)
 }
 
 /// Reads the dataset specs off a setup's manifest.  An undecodable manifest

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
@@ -119,7 +119,7 @@ extension DraftAssignmentRoutes {
     @Sendable
     func getDraftDatasets(req: Request) async throws -> DatasetsResponse {
         let setup = try await loadDraftSetupForRead(req)
-        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
+        return try await datasetsPanelResponse(req: req, setup: setup)
     }
 
     // MARK: - PUT /instructor/new/draft/datasets
@@ -129,7 +129,7 @@ extension DraftAssignmentRoutes {
         let setup = try await loadDraftSetupForWrite(req)
         let body = try req.content.decode(DatasetsBody.self)
         try await applyDatasetsEdit(setup: setup, datasets: body.datasets, on: req.db)
-        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
+        return try await datasetsPanelResponse(req: req, setup: setup)
     }
 
     // MARK: - GET /instructor/new/draft/files/item?draftID=<id>&name=<filename>

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -318,6 +318,34 @@ extension InstructorDashboardRoutes {
         return submitterSets.mapValues { $0.count }
     }
 
+    // MARK: - Validation-variant summaries
+
+    /// Aggregates each setup's current validation-variant batch (multi-variant
+    /// validation) for the listing: one query for the whole page, grouped in
+    /// memory — the batches are `validationVariantCount` rows per setup.
+    func loadValidationVariantSummaries(
+        req: Request, allSetupIDs: [String]
+    ) async throws -> [String: ValidationVariantSummary] {
+        guard !allSetupIDs.isEmpty else { return [:] }
+        let variants = try await ValidationVariant.query(on: req.db)
+            .filter(\.$testSetupID ~~ allSetupIDs)
+            .sort(\.$variantIndex)
+            .all()
+        var bySetup: [String: [ValidationVariant]] = [:]
+        for variant in variants {
+            bySetup[variant.testSetupID, default: []].append(variant)
+        }
+        return bySetup.mapValues { batch in
+            ValidationVariantSummary(
+                total: batch.count,
+                failed: batch.count { $0.status == ValidationVariant.Status.failed },
+                pending: batch.count { $0.status == ValidationVariant.Status.pending },
+                firstFailedSubmissionID: batch.first {
+                    $0.status == ValidationVariant.Status.failed && $0.submissionID != nil
+                }?.submissionID)
+        }
+    }
+
     // MARK: - Row construction
 
     /// Builds an `AssignmentRow` for each setup, joining the matching
@@ -327,6 +355,7 @@ extension InstructorDashboardRoutes {
         allSetups: [APITestSetup],
         assignmentBySetup: [String: APIAssignment],
         uniqueSubmittersBySetup: [String: Int],
+        variantSummariesBySetup: [String: ValidationVariantSummary],
         activeCourse: CourseContext?,
         fmt: DateFormatter
     ) -> [AssignmentRow] {
@@ -358,6 +387,8 @@ extension InstructorDashboardRoutes {
                 return VanityURLRoutes.vanityPath(courseCode: courseCode, assignmentSlug: assignment.slug)
             }()
 
+            let variants = variantSummariesBySetup[setupID]
+
             return AssignmentRow(
                 setupID: setupID,
                 assignmentID: assignment?.publicID,
@@ -368,6 +399,9 @@ extension InstructorDashboardRoutes {
                 sortOrder: assignment?.sortOrder,
                 validationStatus: validationStatus,
                 validationSubmissionID: validationSubmissionID,
+                variantState: variants?.state ?? "none",
+                variantSummaryText: variants?.summaryText ?? "",
+                failedVariantSubmissionID: variants?.firstFailedSubmissionID,
                 suiteCount: suiteCount,
                 createdAt: setup.createdAt.map { fmt.string(from: $0) } ?? "—",
                 submittedStudentCount: assignment != nil ? (uniqueSubmittersBySetup[setupID] ?? 0) : nil,

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -166,6 +166,8 @@ struct InstructorDashboardRoutes: RouteCollection {
             allSetups: allSetups,
             assignmentBySetup: assignmentBySetup,
             uniqueSubmittersBySetup: uniqueSubmittersBySetup,
+            variantSummariesBySetup: try await loadValidationVariantSummaries(
+                req: req, allSetupIDs: allSetupIDs),
             activeCourse: courseState.active,
             fmt: fmt
         )
@@ -507,6 +509,12 @@ struct InstructorDashboardRoutes: RouteCollection {
         if !submissionIDs.isEmpty {
             try await APIResult.query(on: req.db)
                 .filter(\.$submissionID ~~ submissionIDs)
+                .delete()
+            // Variant rows must go before their submissions: the FK is
+            // `.setNull`, so deleting the submissions first would leave the
+            // batch as unlinked rows for a setup that no longer exists.
+            try await ValidationVariant.query(on: req.db)
+                .filter(\.$testSetupID == setupID)
                 .delete()
             try await APISubmission.query(on: req.db)
                 .filter(\.$id ~~ submissionIDs)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
@@ -26,7 +26,7 @@ extension PublishedAssignmentRoutes {
     @Sendable
     func getDatasets(req: Request) async throws -> DatasetsResponse {
         let (_, setup) = try await loadAssignmentAndSetupForStaffRead(req)
-        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
+        return try await datasetsPanelResponse(req: req, setup: setup)
     }
 
     // MARK: - PUT /instructor/:assignmentID/datasets
@@ -39,6 +39,6 @@ extension PublishedAssignmentRoutes {
         // Read back rather than echoing the request: the response is what the
         // Files panel renders its controls from, so it has to be the state the
         // manifest now holds.
-        return DatasetsResponse(datasets: datasetSpecs(inManifest: setup.manifest))
+        return try await datasetsPanelResponse(req: req, setup: setup)
     }
 }

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -73,6 +73,20 @@ func enqueueRunnerValidationSubmission(
 
     try await materialized.saveClaimable(on: req.db)
 
+    // The primary run above grades the enqueuing instructor's own seed — ONE
+    // variant of a per-student assignment. When the manifest varies by seed,
+    // also grade the solution against the derived preflight seeds, so a
+    // solution that only works for some students' material fails validation
+    // instead of failing a student. Best-effort, after the primary is safely
+    // claimable: variant trouble must not block the save.
+    await enqueueValidationVariants(
+        req: req,
+        setupID: setupID,
+        solutionNotebookData: solutionNotebookData,
+        filename: sanitizedFilename,
+        priorValidationCount: priorCount + 1,
+        submitterUserID: resolvedSubmitterID)
+
     // Keep the server-side `shared/{setupID}/solution.py` in lockstep with the
     // reference solution, so a Global Input expression can compute an expected
     // value as `solution.<fn>(...)` — one source of truth — instead of a
@@ -109,6 +123,85 @@ func enqueueRunnerValidationSubmission(
     }
 
     return subID
+}
+
+/// How many synthetic per-student variants a validation batch grades, on top
+/// of the primary run against the instructor's own seed.  A constant, not
+/// configuration.  The seeds are `DatasetDiagnostics.preflightSeed(0..<n)` —
+/// the same derived seeds the Files-panel estimates sample — so a variant
+/// validation grades material the diagnostics already described.
+let validationVariantCount = 4
+
+/// Enqueues the per-variant validation runs for `setupID`, replacing the
+/// setup's previous variant batch outright — or just clearing it when the
+/// manifest no longer varies by student, so a stale batch cannot keep
+/// describing an assignment that stopped being per-student.
+///
+/// Each variant is an ordinary `kind == .validation` submission whose
+/// materialization is pinned to a preflight seed instead of a user's, so the
+/// whole delivery path — the `.grading` sidecar, `_ck_inputs.*`, and the
+/// per-student dataset slices `buildJobPayload` resolves from the cached
+/// `seedHex` — runs exactly as it would for a student holding that seed.
+///
+/// Best-effort like the rest of the validation trigger machinery: a failure
+/// logs and leaves at most a partial batch (rows are written per variant, so
+/// what did enqueue still reports), never blocking the instructor's save.
+func enqueueValidationVariants(
+    req: Request,
+    setupID: String,
+    solutionNotebookData: Data,
+    filename: String,
+    priorValidationCount: Int,
+    submitterUserID: UUID?
+) async {
+    do {
+        try await ValidationVariant.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .delete()
+
+        guard let setup = try await APITestSetup.find(setupID, on: req.db),
+            let manifestData = setup.manifest.data(using: .utf8),
+            let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData),
+            manifest.variesPerStudent
+        else { return }
+
+        let submissionsDir = req.application.submissionsDirectory
+        let ext = (filename as NSString).pathExtension
+        for index in 0..<validationVariantCount {
+            let seedHex = DatasetDiagnostics.preflightSeed(index)
+            let subID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
+            // Each variant gets its own stored copy: the `.grading` sidecar
+            // is derived from the submission's `zipPath`, so a shared file
+            // would make every variant's sidecar the same path.
+            let filePath = submissionsDir + "\(subID).\(ext)"
+            try await req.fileio.writeFile(.init(data: solutionNotebookData), at: filePath)
+
+            let submission = APISubmission(
+                id: subID,
+                testSetupID: setupID,
+                zipPath: filePath,
+                attemptNumber: priorValidationCount,
+                filename: filename,
+                userID: submitterUserID,
+                kind: APISubmission.Kind.validation)
+            let materialized = await materializeValidationGrading(
+                submission: submission,
+                setupID: setupID,
+                templateNotebookData: solutionNotebookData,
+                testSetupsDirectory: req.application.testSetupsDirectory,
+                app: req.application,
+                on: req.db,
+                variantSeedHex: seedHex)
+            try await materialized.saveClaimable(on: req.db)
+
+            try await ValidationVariant(
+                testSetupID: setupID, variantIndex: index, seedHex: seedHex,
+                submissionID: subID
+            ).save(on: req.db)
+        }
+    } catch {
+        req.logger.warning("enqueueValidationVariants for \(setupID): \(error)")
+    }
 }
 
 /// Proof that `materializeValidationGrading` ran for a validation submission:
@@ -148,6 +241,13 @@ struct MaterializedValidationSubmission {
 /// The stored `zipPath` keeps its `{{...}}` template, so `get_solution`, the
 /// editor, and re-validation by another user are unaffected.
 ///
+/// `variantSeedHex` pins the whole materialization to a synthetic per-student
+/// seed instead of the submitter's own (multi-variant validation).  With it
+/// set, the seed is cached even when the manifest has nothing to substitute —
+/// a dataset-only assignment personalizes through the seed alone, and the
+/// cached `seedHex` is exactly what `buildJobPayload` hands to
+/// `DatasetResolver`.
+///
 /// Best-effort: never throws out. On any failure the submission is left
 /// un-materialized — the download route then streams the template (grading
 /// fails clearly, but the worker never times out), and `buildJobPayload` falls
@@ -158,7 +258,8 @@ func materializeValidationGrading(
     templateNotebookData: Data,
     testSetupsDirectory: String,
     app: Application,
-    on db: any Database
+    on db: any Database,
+    variantSeedHex: String? = nil
 ) async -> MaterializedValidationSubmission {
     await resolveAndCacheValidationMaterialization(
         submission: submission,
@@ -166,7 +267,8 @@ func materializeValidationGrading(
         templateNotebookData: templateNotebookData,
         testSetupsDirectory: testSetupsDirectory,
         app: app,
-        on: db)
+        on: db,
+        variantSeedHex: variantSeedHex)
     return MaterializedValidationSubmission(submission: submission)
 }
 
@@ -179,7 +281,8 @@ private func resolveAndCacheValidationMaterialization(
     templateNotebookData: Data,
     testSetupsDirectory: String,
     app: Application,
-    on db: any Database
+    on db: any Database,
+    variantSeedHex: String? = nil
 ) async {
     do {
         guard let setup = try await APITestSetup.find(setupID, on: db),
@@ -187,21 +290,31 @@ private func resolveAndCacheValidationMaterialization(
             let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData)
         else { return }
 
-        // Non-personalized assignments: nothing to resolve or cache — the
-        // download route streams the stored zip exactly as before.
-        guard manifest.hasPersonalization else { return }
+        let seedHex: String?
+        if let variantSeedHex {
+            // A synthetic variant run: the seed IS the variant, so it must be
+            // cached even when there is nothing to substitute — a dataset-only
+            // manifest fails `hasPersonalization` yet still varies by seed.
+            seedHex = variantSeedHex
+        } else {
+            // Non-personalized assignments: nothing to resolve or cache — the
+            // download route streams the stored zip exactly as before.
+            guard manifest.hasPersonalization else { return }
 
-        // Resolve the per-(user, assignment) seed when we can. Literal variables
-        // substitute without a seed; only `=` expressions need one.
-        var seedHex: String?
-        if let userID = submission.userID,
-            let assignment = try await APIAssignment.query(on: db)
-                .filter(\.$testSetupID == setupID)
-                .first(),
-            let assignmentID = assignment.id
-        {
-            seedHex = try? await AssignmentSeedStore.ensureSeed(
-                userID: userID, assignmentID: assignmentID, on: db)
+            // Resolve the per-(user, assignment) seed when we can. Literal
+            // variables substitute without a seed; only `=` expressions need
+            // one.
+            var resolved: String?
+            if let userID = submission.userID,
+                let assignment = try await APIAssignment.query(on: db)
+                    .filter(\.$testSetupID == setupID)
+                    .first(),
+                let assignmentID = assignment.id
+            {
+                resolved = try? await AssignmentSeedStore.ensureSeed(
+                    userID: userID, assignmentID: assignmentID, on: db)
+            }
+            seedHex = resolved
         }
 
         let supportDir = testSetupsDirectory + "shared/\(setupID)/"

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -343,6 +343,7 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateCourseEnrollments())
     app.migrations.add(CreateTestSetups())
     app.migrations.add(CreateSubmissions())
+    app.migrations.add(CreateValidationVariants())
     app.migrations.add(CreateResults())
     app.migrations.add(CreateAssignments())
     app.migrations.add(CreatePerformanceIndexes())

--- a/Sources/Core/DatasetDiagnostics.swift
+++ b/Sources/Core/DatasetDiagnostics.swift
@@ -1,0 +1,209 @@
+// Core/DatasetDiagnostics.swift
+//
+// Instructor-facing estimates about a per-student dataset spec: how many rows
+// two students are expected to share (can they copy?), and — in
+// DatasetDivergence.swift — how far one student's slice drifts from the pool
+// (are they doing the same exercise?).  Both are read-only with respect to
+// delivery: nothing here alters a delivered byte, and no seed is ever chosen
+// or rejected to satisfy a diagnostic.
+//
+// The two halves have deliberately different dependency surfaces:
+//
+//   * Overlap is a function of SELECTION alone — a transform alters values
+//     inside a student's rows and never changes which rows they hold (pinned
+//     by `transformsNeverChangeTheRowSet` in DatasetDiagnosticsTests) — so it
+//     is closed form, behind an exhaustive switch over `DatasetKind`.  A new
+//     selection kind must answer here or this file does not compile.
+//   * Divergence is MEASURED, via `DatasetMaterializer.materialize`, so it
+//     covers every transform automatically, including ones not yet invented.
+//
+// The delivered-bytes determinism rules (`no Double`, no Dictionary
+// iteration) do not bind here — these are statistics ABOUT bytes, not bytes —
+// but the reported numbers still must not flicker between two computations
+// over the same spec, so sums run in file order and seeds are derived, never
+// random.
+
+import Foundation
+
+/// Closed-form estimate of how many rows two students' slices share.
+/// `Codable` because authoring surfaces serve it to the Files panel as-is.
+public struct DatasetOverlap: Sendable, Equatable, Codable {
+    /// Data rows in the instructor's pool.
+    public let poolRows: Int
+    /// Rows one student receives.  Equal to `poolRows` when the spec does not
+    /// reduce the file (no sample size, or one at least the pool's size).
+    public let rowsPerStudent: Int
+    /// Rows any two students are expected to share.
+    public let expectedSharedRows: Double
+    /// The fraction of ONE student's rows a peer is expected to also hold —
+    /// `expectedSharedRows / rowsPerStudent`, the reference class an
+    /// instructor thinks in.  Deliberately not Jaccard, whose union
+    /// denominator is a set neither student holds and which shrinks as
+    /// students diverge, understating copying risk.
+    public let sharedFraction: Double
+    /// Estimated shared rows for the *unluckiest* pair in a class of
+    /// `classSize` — the pair the instructor hears from.  An extreme-value
+    /// estimate over the class's C(C−1)/2 pairs, never below the mean and
+    /// never above `rowsPerStudent`.
+    public let worstPairSharedRows: Double
+    /// The stratum whose rows are most shared, for a stratified sample.  The
+    /// floor of one row per stratum makes a rare category the most copyable
+    /// part of the assignment — every student draws from the same few pool
+    /// rows — and that is invisible in the aggregate number, so it is
+    /// reported by name.  Nil for a plain row sample (or a stratified spec
+    /// that degrades to one).
+    public let mostCopyableStratum: Stratum?
+
+    /// Per-stratum overlap detail for `mostCopyableStratum`.
+    public struct Stratum: Sendable, Equatable, Codable {
+        /// The stratum column's value.
+        public let value: String
+        /// Pool rows carrying that value.
+        public let poolRows: Int
+        /// Rows of it each student receives (`apportion`'s allocation).
+        public let rowsPerStudent: Int
+        /// The fraction of one student's rows of this stratum a peer also
+        /// holds (`rowsPerStudent / poolRows`).
+        public let sharedFraction: Double
+    }
+}
+
+/// Estimates about a per-student dataset spec, for authoring surfaces.
+public enum DatasetDiagnostics {
+
+    /// Class size the worst-pair estimate assumes when a caller has nothing
+    /// better.  A constant, not configuration: the estimate moves with the
+    /// *logarithm* of the pair count, so being off by even a factor of two
+    /// barely moves the reported number.
+    public static let defaultClassSize = 100
+
+    /// Closed-form overlap for `spec` against the pool in `sourceCSV`, or nil
+    /// when the pool has no data rows to speak about.
+    ///
+    /// Mirrors `DatasetMaterializer`'s envelope decisions exactly — the same
+    /// line normalization, the same "keep everything" conditions, the same
+    /// degradation of an unusable stratified spec to a plain sample, and the
+    /// same `apportion` call for per-stratum allocations — so the estimate
+    /// describes the bytes that actually ship.
+    public static func overlap(
+        spec: DatasetSpec, sourceCSV: String, classSize: Int = defaultClassSize
+    ) -> DatasetOverlap? {
+        let (lines, _) = DatasetMaterializer.normalizedLines(of: sourceCSV)
+        guard lines.count > 1 else { return nil }
+        let poolRows = lines.count - 1
+
+        // The materializer keeps the whole file for a nil, non-positive, or
+        // not-actually-reducing sample size; every student then holds every
+        // row and the overlap is total.
+        let requested = spec.sampleSize ?? poolRows
+        let k = (requested > 0 && requested < poolRows) ? requested : poolRows
+
+        switch spec.kind {
+        case .rowSample:
+            return plainOverlap(poolRows: poolRows, k: k, classSize: classSize)
+        case .stratifiedSample:
+            guard k < poolRows,
+                let column = spec.stratumColumn, !column.isEmpty,
+                let columnIndex = DatasetMaterializer.splitCSVLine(lines[0]).firstIndex(of: column)
+            else {
+                // Delivery degrades this spec to a plain row sample (or the
+                // whole file); measure what ships, not what was asked for.
+                return plainOverlap(poolRows: poolRows, k: k, classSize: classSize)
+            }
+            return stratifiedOverlap(
+                lines: lines, poolRows: poolRows, k: k,
+                columnIndex: columnIndex, classSize: classSize)
+        }
+    }
+
+    /// Two independent size-`k` samples from a pool of `n` share a
+    /// hypergeometric number of rows: mean `k²/n`, variance
+    /// `k·(k/n)·(1−k/n)·(n−k)/(n−1)`.
+    private static func plainOverlap(poolRows: Int, k: Int, classSize: Int) -> DatasetOverlap {
+        let n = Double(poolRows)
+        let kk = Double(k)
+        let mean = kk * kk / n
+        let variance = hypergeometricVariance(poolRows: poolRows, take: k)
+        return DatasetOverlap(
+            poolRows: poolRows,
+            rowsPerStudent: k,
+            expectedSharedRows: mean,
+            sharedFraction: kk / n,
+            worstPairSharedRows: worstPair(
+                mean: mean, variance: variance, cap: kk, classSize: classSize),
+            mostCopyableStratum: nil)
+    }
+
+    /// Under stratification the shared count is a sum of independent
+    /// per-stratum hypergeometrics: mean `Σₛ kₛ²/Nₛ` with `kₛ` from the real
+    /// `apportion` call — never the `k²/N` shortcut, which Titu's lemma makes
+    /// a strict underestimate whenever allocation is non-proportional, and
+    /// the one-row-per-stratum floor is non-proportional by construction.
+    private static func stratifiedOverlap(
+        lines: [Substring], poolRows: Int, k: Int, columnIndex: Int, classSize: Int
+    ) -> DatasetOverlap {
+        // Strata in order of first appearance, exactly as
+        // `sampleStratifiedRows` builds them (a short row's missing value is
+        // the "" category), so the allocation below is the delivered one.
+        var strataOrder: [String] = []
+        var sizesByStratum: [String: Int] = [:]
+        for index in 1..<lines.count {
+            let fields = DatasetMaterializer.splitCSVLine(lines[index])
+            let value = columnIndex < fields.count ? fields[columnIndex] : ""
+            if sizesByStratum[value] == nil { strataOrder.append(value) }
+            sizesByStratum[value, default: 0] += 1
+        }
+        let sizes = strataOrder.map { sizesByStratum[$0] ?? 0 }
+        let allocation = DatasetMaterializer.apportion(
+            sampleSize: k, sizes: sizes, total: poolRows)
+
+        var mean = 0.0
+        var variance = 0.0
+        var copyable: DatasetOverlap.Stratum?
+        for (position, stratum) in strataOrder.enumerated() {
+            let size = sizes[position]
+            let take = min(allocation[position], size)
+            guard take > 0, size > 0 else { continue }
+            mean += Double(take) * Double(take) / Double(size)
+            variance += hypergeometricVariance(poolRows: size, take: take)
+            let fraction = Double(take) / Double(size)
+            if fraction > (copyable?.sharedFraction ?? 0) {
+                copyable = DatasetOverlap.Stratum(
+                    value: stratum, poolRows: size, rowsPerStudent: take,
+                    sharedFraction: fraction)
+            }
+        }
+        return DatasetOverlap(
+            poolRows: poolRows,
+            rowsPerStudent: k,
+            expectedSharedRows: mean,
+            sharedFraction: mean / Double(k),
+            worstPairSharedRows: worstPair(
+                mean: mean, variance: variance, cap: Double(k), classSize: classSize),
+            mostCopyableStratum: copyable)
+    }
+
+    /// Variance of the shared count between two independent size-`take`
+    /// samples of a `poolRows` pool.  Zero for a single-row pool (the row is
+    /// always shared) and for a whole-pool sample.
+    private static func hypergeometricVariance(poolRows: Int, take: Int) -> Double {
+        guard poolRows > 1 else { return 0 }
+        let n = Double(poolRows)
+        let kk = Double(take)
+        return kk * (kk / n) * (1 - kk / n) * ((n - kk) / (n - 1))
+    }
+
+    /// Extreme-value estimate of the maximum shared count over a class's
+    /// C(C−1)/2 pairs: `mean + σ·√(2·ln pairs)`, the standard Gumbel
+    /// approximation for the max of many roughly-normal draws.  The pairs are
+    /// not independent (each student appears in C−1 of them), so this is an
+    /// estimate — clamped to `[mean, cap]` so it can never claim more shared
+    /// rows than a student holds.
+    private static func worstPair(
+        mean: Double, variance: Double, cap: Double, classSize: Int
+    ) -> Double {
+        let pairs = classSize > 1 ? Double(classSize) * Double(classSize - 1) / 2 : 0
+        guard pairs >= 2, variance > 0 else { return mean }
+        return min(cap, mean + variance.squareRoot() * (2 * Foundation.log(pairs)).squareRoot())
+    }
+}

--- a/Sources/Core/DatasetDivergence.swift
+++ b/Sources/Core/DatasetDivergence.swift
@@ -1,0 +1,264 @@
+// Core/DatasetDivergence.swift
+//
+// The measured half of the dataset diagnostics (overlap, the closed-form
+// half, is in DatasetDiagnostics.swift).  Divergence answers "are students
+// doing the same exercise?": per column, how far a student's slice sits from
+// the instructor's pool, distributionally.
+//
+// It is measured, not derived — every sampled slice comes from
+// `DatasetMaterializer.materialize`, the exact call delivery makes — so it
+// covers every transform automatically, including kinds that do not exist
+// yet.  A fairness report about bytes other than the delivered ones would be
+// worse than no report.  The pool is parsed once and reused across seeds;
+// the slices are never approximated.
+//
+// Two measures, deliberately not collapsed into one number: numeric columns
+// get Wasserstein-1 in units of the pool's standard deviation ("SDs of
+// transport"), categorical columns get total variation distance (already
+// 0–1).  The two are not commensurable, and averaging across columns is
+// banned by design — one catastrophically skewed column must not hide
+// behind nineteen fine ones, so aggregation is max-and-name-the-column
+// (`headlines(of:)`).
+
+import Foundation
+
+/// One column's measured divergence between student slices and the pool,
+/// summarized over the preflight seeds.
+public struct DatasetColumnDivergence: Sendable, Equatable, Codable {
+    public enum Measure: String, Sendable, Equatable, Codable {
+        /// Wasserstein-1 in units of the pool's standard deviation (numeric).
+        case wasserstein
+        /// Total variation distance, 0–1 (categorical).
+        case totalVariation
+    }
+
+    public let column: String
+    public let measure: Measure
+    /// The median over the sampled seeds — a typical student.
+    public let median: Double
+    /// The maximum over the sampled seeds — an unlucky student.
+    public let worst: Double
+}
+
+/// The per-measure headline: the worst column, by name.  `0.11` alone is not
+/// actionable; `systolic 0.11 SD` is.  `Codable` because authoring surfaces
+/// serve it to the Files panel as-is.
+public struct DatasetDivergenceHeadline: Sendable, Equatable, Codable {
+    public let measure: DatasetColumnDivergence.Measure
+    public let column: String
+    public let median: Double
+    public let worst: Double
+}
+
+extension DatasetDiagnostics {
+
+    /// How many deterministic preflight seeds `divergence` samples by
+    /// default.  A constant, not configuration.
+    public static let defaultSeedCount = 20
+
+    /// The `index`-th preflight seed: a 64-hex string shaped like a real
+    /// per-(student, assignment) seed, derived — never random — so the
+    /// reported numbers cannot flicker between two computations over the same
+    /// spec, and so any consumer fanning out over synthetic variants (the
+    /// diagnostics here, multi-variant validation) exercises the same ones.
+    public static func preflightSeed(_ index: Int) -> String {
+        (0..<4).map { chunk in
+            String(format: "%016llx", fnv1a64("preflight|\(index)|\(chunk)"))
+        }.joined()
+    }
+
+    /// Per-column divergence between student slices and the pool, measured
+    /// over `seedCount` preflight seeds via `DatasetMaterializer.materialize`.
+    /// Columns are reported in header order.
+    ///
+    /// A column's distribution is that of its *observed* (non-empty) values:
+    /// a `missingValues` hole is thinning, not a value, and the question this
+    /// answers is whether the data a student sees looks like the pool —
+    /// which MCAR blanking preserves by design (pinned by the MCAR test).  A
+    /// column with nothing observed on either side contributes nothing.
+    public static func divergence(
+        spec: DatasetSpec, sourceCSV: String, seedCount: Int = defaultSeedCount
+    ) -> [DatasetColumnDivergence] {
+        guard seedCount > 0, let pool = ParsedColumns(csv: sourceCSV) else { return [] }
+
+        var samples: [[Double]] = Array(repeating: [], count: pool.names.count)
+        for seed in 0..<seedCount {
+            let materialized = DatasetMaterializer.materialize(
+                source: sourceCSV, spec: spec, seedHex: preflightSeed(seed))
+            guard let slice = ParsedColumns(csv: materialized) else { continue }
+            for index in pool.names.indices where index < slice.observed.count {
+                let observed = slice.observed[index]
+                guard !observed.isEmpty, !pool.observed[index].isEmpty else { continue }
+                if let numbers = pool.numbers[index] {
+                    let sliceNumbers = observed.compactMap(parseNumber)
+                    guard !sliceNumbers.isEmpty else { continue }
+                    let transport = wasserstein1(sliceNumbers, numbers)
+                    let sd = pool.standardDeviation[index]
+                    samples[index].append(sd > 0 ? transport / sd : 0)
+                } else {
+                    samples[index].append(totalVariation(observed, pool.observed[index]))
+                }
+            }
+        }
+
+        var results: [DatasetColumnDivergence] = []
+        for index in pool.names.indices {
+            let columnSamples = samples[index]
+            guard !columnSamples.isEmpty else { continue }
+            results.append(
+                DatasetColumnDivergence(
+                    column: pool.names[index],
+                    measure: pool.numbers[index] != nil ? .wasserstein : .totalVariation,
+                    median: median(of: columnSamples),
+                    worst: columnSamples.max() ?? 0))
+        }
+        return results
+    }
+
+    /// The worst column per measure (ties to the earlier column), Wasserstein
+    /// first.  Aggregating the two measures into one number would invent a
+    /// comparison that does not exist, so there are up to two headlines.
+    public static func headlines(of divergences: [DatasetColumnDivergence])
+        -> [DatasetDivergenceHeadline]
+    {
+        [.wasserstein, .totalVariation].compactMap { measure in
+            divergences
+                .filter { $0.measure == measure }
+                .max { $0.worst < $1.worst }
+                .map {
+                    DatasetDivergenceHeadline(
+                        measure: measure, column: $0.column,
+                        median: $0.median, worst: $0.worst)
+                }
+        }
+    }
+
+    // MARK: - Metrics
+
+    /// Wasserstein-1 between two 1-D empirical distributions: the area
+    /// between their quantile functions, computed exactly by walking both
+    /// sorted samples with breakpoints compared in integer arithmetic (units
+    /// of `1/(n·m)`), so the result is a pure function of the values.
+    /// Internal so the metric itself can be pinned on hand-computable cases.
+    static func wasserstein1(_ first: [Double], _ second: [Double]) -> Double {
+        guard !first.isEmpty, !second.isEmpty else { return 0 }
+        let a = first.sorted()
+        let b = second.sorted()
+        let n = a.count
+        let m = b.count
+        var total = 0.0
+        var i = 0
+        var j = 0
+        var position = 0  // consumed probability mass, in units of 1/(n·m)
+        while i < n, j < m {
+            let aEdge = (i + 1) * m
+            let bEdge = (j + 1) * n
+            let edge = min(aEdge, bEdge)
+            total += abs(a[i] - b[j]) * Double(edge - position)
+            position = edge
+            if aEdge == edge { i += 1 }
+            if bEdge == edge { j += 1 }
+        }
+        return total / Double(n * m)
+    }
+
+    /// Total variation distance between two categorical samples:
+    /// `½ Σ |p̂(v) − q̂(v)|` over the union of observed values, summed in
+    /// first-appearance order so the float sum is reproducible everywhere.
+    static func totalVariation(_ first: [String], _ second: [String]) -> Double {
+        guard !first.isEmpty, !second.isEmpty else { return 0 }
+        var order: [String] = []
+        var firstCounts: [String: Int] = [:]
+        var secondCounts: [String: Int] = [:]
+        for value in first {
+            if firstCounts[value] == nil { order.append(value) }
+            firstCounts[value, default: 0] += 1
+        }
+        for value in second {
+            if firstCounts[value] == nil, secondCounts[value] == nil { order.append(value) }
+            secondCounts[value, default: 0] += 1
+        }
+        let n = Double(first.count)
+        let m = Double(second.count)
+        var sum = 0.0
+        for value in order {
+            sum += abs(Double(firstCounts[value] ?? 0) / n - Double(secondCounts[value] ?? 0) / m)
+        }
+        return sum / 2
+    }
+
+    private static func median(of values: [Double]) -> Double {
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    /// A finite number parsed from a CSV field, or nil.  Shared with
+    /// `ParsedColumns.classify` so "is numeric" and "parse the slice" cannot
+    /// disagree about what counts as a number.
+    fileprivate static func parseNumber(_ raw: String) -> Double? {
+        guard let value = Double(raw.trimmingCharacters(in: .whitespaces)), value.isFinite
+        else { return nil }
+        return value
+    }
+}
+
+/// A parsed CSV, column-major: per column its observed (non-empty) raw
+/// values in file order, plus — when every observed value parses as a finite
+/// number — the parsed values and their population standard deviation.
+/// Parsed once per pool and reused across every sampled seed; the slices
+/// themselves always come from the real materializer.
+private struct ParsedColumns {
+    let names: [String]
+    /// Non-empty raw values per column, file order.
+    let observed: [[String]]
+    /// Parsed values per column; nil marks a categorical column.
+    let numbers: [[Double]?]
+    /// Population standard deviation per column (0 for categorical).
+    let standardDeviation: [Double]
+
+    init?(csv: String) {
+        let (lines, _) = DatasetMaterializer.normalizedLines(of: csv)
+        guard lines.count > 1 else { return nil }
+        let names = DatasetMaterializer.splitCSVLine(lines[0])
+        guard !names.isEmpty else { return nil }
+
+        var observed: [[String]] = Array(repeating: [], count: names.count)
+        for index in 1..<lines.count {
+            let fields = DatasetMaterializer.splitCSVLine(lines[index])
+            for column in names.indices where column < fields.count {
+                let value = fields[column]
+                if !value.isEmpty { observed[column].append(value) }
+            }
+        }
+
+        self.names = names
+        self.observed = observed
+        (numbers, standardDeviation) = Self.classify(observed)
+    }
+
+    /// A column is numeric when it has observed values and every one parses
+    /// as a finite number; anything else — including a numeric-looking column
+    /// with one "NA" — is categorical, where total variation is still a
+    /// sound answer.
+    private static func classify(_ observed: [[String]]) -> ([[Double]?], [Double]) {
+        var numbers: [[Double]?] = []
+        var deviations: [Double] = []
+        for values in observed {
+            let parsed = values.compactMap(DatasetDiagnostics.parseNumber)
+            guard !parsed.isEmpty, parsed.count == values.count else {
+                numbers.append(nil)
+                deviations.append(0)
+                continue
+            }
+            numbers.append(parsed)
+            let mean = parsed.reduce(0, +) / Double(parsed.count)
+            let squared = parsed.reduce(0) { $0 + ($1 - mean) * ($1 - mean) }
+            deviations.append((squared / Double(parsed.count)).squareRoot())
+        }
+        return (numbers, deviations)
+    }
+}

--- a/Sources/Core/DatasetDivergence.swift
+++ b/Sources/Core/DatasetDivergence.swift
@@ -118,7 +118,9 @@ extension DatasetDiagnostics {
     /// The worst column per measure (ties to the earlier column), Wasserstein
     /// first.  Aggregating the two measures into one number would invent a
     /// comparison that does not exist, so there are up to two headlines.
-    public static func headlines(of divergences: [DatasetColumnDivergence])
+    public static func headlines(
+        of divergences: [DatasetColumnDivergence]
+    )
         -> [DatasetDivergenceHeadline]
     {
         [.wasserstein, .totalVariation].compactMap { measure in

--- a/Sources/Core/Models/DatasetSpec.swift
+++ b/Sources/Core/Models/DatasetSpec.swift
@@ -25,7 +25,7 @@
 ///   exercise for that student; this is the fix for that, and the reason the
 ///   `set_dataset` advice "pick a sample size large enough that every category
 ///   still appears" exists.
-public enum DatasetKind: String, Codable, Sendable, Equatable {
+public enum DatasetKind: String, Codable, Sendable, Equatable, CaseIterable {
     case rowSample
     case stratifiedSample
 }

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -387,6 +387,20 @@ public struct TestProperties: Codable, Equatable, Sendable {
         hasExpressions || !globalVariables.isEmpty || sections.contains { !$0.variables.isEmpty }
     }
 
+    /// True when two students with different seeds can receive different
+    /// material: a per-student `=` expression, or a per-student dataset slice.
+    /// Literal-only personalization substitutes the same values for everyone,
+    /// so it does not count.
+    ///
+    /// This is the predicate multi-variant validation gates on — a validation
+    /// run against one seed proves nothing about the others exactly when this
+    /// is true.  Deliberately a SEPARATE predicate from `hasPersonalization`,
+    /// which also decides the worker download path's sidecar behaviour;
+    /// widening that one would change what the download route streams.
+    public var variesPerStudent: Bool {
+        hasExpressions || !datasets.isEmpty
+    }
+
     /// Instructor-authored achievements / goals / awards for this assignment —
     /// the generalized form of the hardcoded badge + class-achievement system.
     /// Server-evaluated and display-only; `runnerSanitized()` strips them so a

--- a/Tests/APITests/DatasetsRouteRoundTripTests.swift
+++ b/Tests/APITests/DatasetsRouteRoundTripTests.swift
@@ -442,6 +442,69 @@ import VaporTesting
         }
     }
 
+    // MARK: - The estimate blocks ride the same responses
+    //
+    // The Files panel's estimates disclosure renders from `diagnostics` on the
+    // GET/PUT it already uses — served on the same response so a saved
+    // parameter edit moves the numbers without a second request. Computed by
+    // Core's DatasetDiagnostics, which has its own suite; what is pinned here
+    // is the plumbing: the blocks describe the stored spec against the
+    // bundled file's real bytes, on both pairs.
+
+    private func fullResponse(_ path: String, _ fx: Fixture) async throws -> DatasetsResponse {
+        var response = DatasetsResponse(datasets: [], diagnostics: [])
+        try await app.asyncTest(
+            .GET, path,
+            beforeRequest: { req in req.headers.add(name: .cookie, value: fx.cookie) },
+            afterResponse: { res in
+                #expect(res.status == .ok, "GET \(path) — \(res.body.string)")
+                response = try res.content.decode(DatasetsResponse.self)
+            })
+        return response
+    }
+
+    @Test func datasetsResponsesCarryTheEstimateBlocks() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("g")
+            for path in [
+                "/instructor/\(fx.assignmentID)/datasets",
+                "/instructor/new/draft/datasets?draftID=\(fx.draftID)",
+            ] {
+                let putBody = try await put(
+                    path, fx,
+                    body: #"{"datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":2}]}"#,
+                    expect: .ok, "marking a bundled file is accepted")
+                #expect(
+                    putBody.contains("\"diagnostics\""),
+                    "\(path): the PUT response carries the estimates for its live repaint")
+
+                let state = try await fullResponse(path, fx)
+                let block = try #require(
+                    state.diagnostics.first, "\(path): a marked CSV gets an estimate block")
+                #expect(block.file == "cases.csv")
+                // Two of the fixture's three rows: shared fraction k/N = 2/3,
+                // expected shared k²/N = 4/3 — the numbers describe the real
+                // bundled bytes, not a placeholder.
+                #expect(block.overlap.poolRows == 3)
+                #expect(block.overlap.rowsPerStudent == 2)
+                #expect(abs(block.overlap.sharedFraction - 2.0 / 3.0) < 1e-9)
+                #expect(abs(block.overlap.expectedSharedRows - 4.0 / 3.0) < 1e-9)
+                #expect(block.divergenceMeasured)
+                #expect(block.classSize == DatasetDiagnostics.defaultClassSize)
+                // `id` is numeric (Wasserstein), `ward` categorical (TV) —
+                // one headline per measure, each naming its column.
+                #expect(block.headlines.count == 2)
+                #expect(block.headlines.map(\.measure) == [.wasserstein, .totalVariation])
+
+                try await put(
+                    path, fx, body: #"{"datasets":[]}"#, expect: .ok, "clearing the mark")
+                #expect(
+                    try await fullResponse(path, fx).diagnostics.isEmpty,
+                    "\(path): no marked file, no estimate blocks")
+            }
+        }
+    }
+
     // MARK: - Two specs for one file are incoherent on either pair
 
     @Test func duplicateSpecsForOneFileAreRejected() async throws {

--- a/Tests/APITests/MCP/GetValidationResultToolTests.swift
+++ b/Tests/APITests/MCP/GetValidationResultToolTests.swift
@@ -247,4 +247,68 @@ import Vapor
             }
         }
     }
+
+    // MARK: - Multi-variant batch
+
+    @Test func reportsTheVariantBatchWithFailingOutcomesOnly() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+
+            // A failed variant with a stored run: one passing and one failing
+            // outcome, of which only the failing one should surface.
+            try await makeTestSubmission(
+                on: app, id: "sub_var0", setupID: "setup_val", userID: testerID(on: app),
+                kind: APISubmission.Kind.validation)
+            try await makeTestResult(
+                on: app, submissionID: "sub_var0",
+                collectionJSON: collectionJSON(
+                    submissionID: "sub_var0",
+                    outcomes: [
+                        outcome("loads", .pass, short: "ok"),
+                        outcome(
+                            "mean is close", .fail, short: "off by 4.2",
+                            long: "expected 121.3, got 125.5"),
+                    ]))
+            let failed = ValidationVariant(
+                testSetupID: "setup_val", variantIndex: 0,
+                seedHex: DatasetDiagnostics.preflightSeed(0), submissionID: "sub_var0")
+            failed.status = ValidationVariant.Status.failed
+            try await failed.save(on: app.db)
+
+            // A still-running variant: reported by status alone.
+            try await makeTestSubmission(
+                on: app, id: "sub_var1", setupID: "setup_val", userID: testerID(on: app),
+                kind: APISubmission.Kind.validation, status: "pending")
+            try await ValidationVariant(
+                testSetupID: "setup_val", variantIndex: 1,
+                seedHex: DatasetDiagnostics.preflightSeed(1), submissionID: "sub_var1"
+            ).save(on: app.db)
+
+            let output = try await run(app, publicID: assignment.publicID)
+            #expect(output.variants.count == 2)
+
+            let first = try #require(output.variants.first)
+            #expect(first.variantIndex == 0)
+            #expect(first.seedHex == DatasetDiagnostics.preflightSeed(0))
+            #expect(first.status == "failed")
+            #expect(first.buildStatus == "passed")
+            #expect(first.failingOutcomes.map(\.testName) == ["mean is close"])
+            #expect(first.failingOutcomes.first?.shortResult == "off by 4.2")
+
+            let second = try #require(output.variants.last)
+            #expect(second.variantIndex == 1)
+            #expect(second.status == "pending")
+            #expect(second.failingOutcomes.isEmpty)
+        }
+    }
+
+    @Test func variantsAreEmptyWhenNoBatchExists() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await run(app, publicID: assignment.publicID)
+            #expect(output.variants.isEmpty)
+        }
+    }
 }

--- a/Tests/APITests/MCP/MCPLeastPrivilegeGrantSyncTests.swift
+++ b/Tests/APITests/MCP/MCPLeastPrivilegeGrantSyncTests.swift
@@ -25,13 +25,15 @@ import Testing
     }
 
     /// Student-data tables the MCP read path queries: the two the boundary
-    /// accessors filter to validation rows, plus the collection-blob side
-    /// table `loadCollectionJSON` joins in. Grown deliberately by hand — a new
+    /// accessors filter to validation rows, the collection-blob side table
+    /// `loadCollectionJSON` joins in, and the multi-variant validation batch
+    /// `get_validation_result` reports. Grown deliberately by hand — a new
     /// table here must come with a grant AND an RLS policy in the SQL file.
     private static let readTables: [String] = [
         APISubmission.schema,
         APIResult.schema,
         APIResultCollection.schema,
+        ValidationVariant.schema,
     ]
 
     @Test func everyMCPReadTableHasSelectGrant() throws {

--- a/Tests/APITests/ValidationVariantTests.swift
+++ b/Tests/APITests/ValidationVariantTests.swift
@@ -1,0 +1,305 @@
+// Tests/APITests/ValidationVariantTests.swift
+//
+// Multi-variant validation: every validation enqueue on an assignment that
+// varies by student also grades the reference solution against
+// `validationVariantCount` derived preflight seeds, recorded as
+// `ValidationVariant` rows.
+//
+// The load-bearing fixture is a DATASET-ONLY manifest — `hasPersonalization`
+// false, `variesPerStudent` true — because that is exactly the combination
+// the single-run validation path skips (`materializeValidationGrading`
+// returns early), which used to mean a dataset assignment validated only
+// against the instructor's own slice.  What these assert end to end: the
+// batch is enqueued with each variant's seed pinned in its materialization,
+// a claimed variant job delivers that seed's dataset slice, and the worker's
+// result lands on the variant row rather than on the assignment's primary
+// status.
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+@Suite(.serialized, .timeLimit(.minutes(3))) final class ValidationVariantTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-valvariants")
+        app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
+    }
+
+    private let workerSecret = "variant-worker-secret"
+
+    /// Dataset-only: nothing to substitute (`hasPersonalization` false), yet
+    /// the material varies by seed (`variesPerStudent` true).
+    private let datasetManifest = """
+        {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],\
+        "testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null,\
+        "datasets":[{"file":"cases.csv","kind":"rowSample","sampleSize":2}]}
+        """
+
+    private let plainManifest = """
+        {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],\
+        "testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}
+        """
+
+    private let poolCSV = "id,ward\n1,A\n2,B\n3,A\n4,B\n"
+
+    private let solutionNotebook =
+        #"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#
+
+    private struct Fixture {
+        let setupID: String
+        let submitterID: UUID
+        let assignmentPublicID: String
+    }
+
+    /// Course + instructor + a worker-graded setup whose shared directory
+    /// holds the dataset pool, plus the published assignment row.
+    private func fixture(_ tag: String, manifest: String? = nil) async throws -> Fixture {
+        let course = try await makeTestCourse(on: app, code: "VV\(tag)")
+        let courseID = try course.requireID()
+        let user = try await makeTestUser(on: app, username: "vv_inst_\(tag)", role: "instructor")
+        let userID = try user.requireID()
+        try await makeTestEnrollment(on: app, userID: userID, courseID: courseID)
+
+        let setupID = "vvsetup_\(tag)"
+        try await makeTestSetup(
+            on: app, id: setupID, courseID: courseID, manifest: manifest ?? datasetManifest)
+        let sharedDir = app.testSetupsDirectory + "shared/\(setupID)/"
+        try FileManager.default.createDirectory(
+            atPath: sharedDir, withIntermediateDirectories: true)
+        try poolCSV.write(toFile: sharedDir + "cases.csv", atomically: true, encoding: .utf8)
+
+        let assignment = try await makeTestAssignment(
+            on: app, testSetupID: setupID, courseID: courseID, title: "Variant Lab \(tag)")
+        return Fixture(
+            setupID: setupID, submitterID: userID, assignmentPublicID: assignment.publicID)
+    }
+
+    /// Drives the real enqueue door (the one all five validation triggers
+    /// call), returning the primary submission's id.
+    private func enqueue(_ fx: Fixture) async throws -> String {
+        let req = Request(application: app, on: app.eventLoopGroup.any())
+        return try await enqueueRunnerValidationSubmission(
+            req: req,
+            setupID: fx.setupID,
+            solutionNotebookData: Data(solutionNotebook.utf8),
+            filename: "solution.ipynb",
+            submitterUserID: fx.submitterID)
+    }
+
+    private func variantRows(_ setupID: String) async throws -> [ValidationVariant] {
+        try await ValidationVariant.query(on: app.db)
+            .filter(\.$testSetupID == setupID)
+            .sort(\.$variantIndex)
+            .all()
+    }
+
+    // MARK: - Enqueue
+
+    @Test func enqueuePinsAVariantBatchForADatasetOnlyAssignment() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("a")
+            let primaryID = try await enqueue(fx)
+
+            let rows = try await variantRows(fx.setupID)
+            #expect(rows.count == validationVariantCount)
+            for (index, row) in rows.enumerated() {
+                #expect(row.variantIndex == index)
+                #expect(row.seedHex == DatasetDiagnostics.preflightSeed(index))
+                #expect(row.status == ValidationVariant.Status.pending)
+
+                let submissionID = try #require(row.submissionID)
+                let submission = try #require(
+                    try await APISubmission.find(submissionID, on: app.db))
+                #expect(submission.kind == APISubmission.Kind.validation)
+                // The whole point: the variant's seed is pinned in its
+                // materialization, so `buildJobPayload` resolves the datasets
+                // against the variant's seed rather than the submitter's.
+                let materialization = try #require(submission.decodedMaterialization())
+                #expect(materialization.seedHex == DatasetDiagnostics.preflightSeed(index))
+                #expect(
+                    materialization.inputs.isEmpty,
+                    "dataset-only: the seed is the variant; there are no expression inputs")
+            }
+
+            // The primary run keeps its long-standing dataset-only behaviour —
+            // un-materialized, graded against the submitter's own seed.
+            let primary = try #require(try await APISubmission.find(primaryID, on: app.db))
+            #expect(primary.materializationJSON == nil)
+
+            let validations = try await APISubmission.query(on: app.db)
+                .filter(\.$testSetupID == fx.setupID)
+                .filter(\.$kind == APISubmission.Kind.validation)
+                .count()
+            #expect(validations == validationVariantCount + 1)
+        }
+    }
+
+    @Test func reEnqueueReplacesTheBatchAndANonVaryingManifestClearsIt() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("b")
+            _ = try await enqueue(fx)
+            let firstBatch = try await variantRows(fx.setupID).compactMap(\.submissionID)
+
+            _ = try await enqueue(fx)
+            let secondRows = try await variantRows(fx.setupID)
+            #expect(secondRows.count == validationVariantCount, "replaced, not appended")
+            let secondBatch = Set(secondRows.compactMap(\.submissionID))
+            #expect(secondBatch.isDisjoint(with: firstBatch), "a fresh batch of runs")
+
+            // The manifest stops varying: the next enqueue must clear the
+            // batch, or a stale verdict keeps describing an assignment that is
+            // no longer per-student.
+            let setup = try #require(try await APITestSetup.find(fx.setupID, on: app.db))
+            setup.manifest = plainManifest
+            try await setup.save(on: app.db)
+            _ = try await enqueue(fx)
+            #expect(try await variantRows(fx.setupID).isEmpty)
+        }
+    }
+
+    // MARK: - Claim: the variant job delivers the variant's material
+
+    @Test func aClaimedVariantJobCarriesItsSeedAndItsDatasetSlice() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("c")
+            _ = try await enqueue(fx)
+            let rows = try await variantRows(fx.setupID)
+            let seedBySubmission = Dictionary(
+                uniqueKeysWithValues: rows.compactMap { row in
+                    row.submissionID.map { ($0, row.seedHex) }
+                })
+
+            // Claim every pending job (primary + variants); collect the Jobs.
+            var claimed: [String: Job] = [:]
+            let path = "/api/v1/worker/request"
+            for attempt in 0..<(validationVariantCount + 1) {
+                let body = try ByteBuffer(
+                    data: JSONEncoder().encode(
+                        WorkerActivityPayload(
+                            workerID: "vv-worker-\(attempt)", hostname: "vv.local",
+                            runnerVersion: "runner-tests/1.0", maxConcurrentJobs: 1,
+                            activeJobs: 0, profile: nil)))
+                try await app.asyncTest(
+                    .POST, path,
+                    beforeRequest: { req in
+                        req.headers = workerHMACHeaders(
+                            method: .POST, path: path, body: body, workerSecret: self.workerSecret)
+                        req.body = body
+                    },
+                    afterResponse: { res in
+                        #expect(res.status == .ok, "claim \(attempt) — \(res.status)")
+                        let job = try res.content.decode(Job.self)
+                        claimed[job.submissionID] = job
+                    })
+            }
+
+            let spec = DatasetSpec(file: "cases.csv", kind: .rowSample, sampleSize: 2)
+            for (submissionID, seedHex) in seedBySubmission {
+                let job = try #require(claimed[submissionID], "variant \(submissionID) was claimable")
+                #expect(job.assignmentSeed == seedHex)
+                let files = try #require(job.personalizedFiles)
+                #expect(
+                    files["cases.csv"]
+                        == DatasetMaterializer.materialize(
+                            source: poolCSV, spec: spec, seedHex: seedHex),
+                    "the job delivers the slice a student holding this seed would get")
+            }
+        }
+    }
+
+    // MARK: - Result ingestion
+
+    @Test func aVariantResultLandsOnTheVariantRowNotTheAssignment() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture("d")
+            _ = try await enqueue(fx)
+            let rows = try await variantRows(fx.setupID)
+            let failing = try #require(rows.first?.submissionID)
+            let passing = try #require(rows.dropFirst().first?.submissionID)
+
+            try await postResult(submissionID: failing, setupID: fx.setupID, pass: false)
+            try await postResult(submissionID: passing, setupID: fx.setupID, pass: true)
+
+            let updated = try await variantRows(fx.setupID)
+            #expect(updated.first?.status == ValidationVariant.Status.failed)
+            #expect(updated.dropFirst().first?.status == ValidationVariant.Status.passed)
+            #expect(
+                updated.dropFirst(2).allSatisfy {
+                    $0.status == ValidationVariant.Status.pending
+                })
+
+            // A variant is never the assignment's linked primary, so the
+            // assignment's own validationStatus must not move.
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db)
+                    .filter(\.$publicID == fx.assignmentPublicID)
+                    .first())
+            #expect(assignment.validationStatus == nil)
+        }
+    }
+
+    private func postResult(submissionID: String, setupID: String, pass: Bool) async throws {
+        let outcome = TestOutcome(
+            testName: "t1", testClass: nil, tier: .pub,
+            status: pass ? .pass : .fail,
+            shortResult: pass ? "ok" : "wrong answer", longResult: nil,
+            executionTimeMs: 1, memoryUsageBytes: nil, attemptNumber: 1,
+            isFirstPassSuccess: pass)
+        let collection = TestOutcomeCollection(
+            submissionID: submissionID, testSetupID: setupID, attemptNumber: 1,
+            buildStatus: .passed, compilerOutput: nil, outcomes: [outcome],
+            totalTests: 1, passCount: pass ? 1 : 0, failCount: pass ? 0 : 1,
+            errorCount: 0, timeoutCount: 0, executionTimeMs: 5,
+            runnerVersion: "runner-tests/1.0", timestamp: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let body = try ByteBuffer(data: encoder.encode(collection))
+        let path = "/api/v1/worker/results"
+        try await app.asyncTest(
+            .POST, path,
+            beforeRequest: { req in
+                req.headers = workerHMACHeaders(
+                    method: .POST, path: path, body: body, workerSecret: self.workerSecret)
+                req.body = body
+            },
+            afterResponse: { res in
+                #expect(res.status == .ok, "posting result for \(submissionID)")
+            })
+    }
+
+}
+
+/// The pure fold-down the listing row renders — no app, so a separate struct
+/// suite (the class suite above builds an `Application` per test instance,
+/// and a test that skips `withApp` would leak it into a deinit assertion).
+@Suite struct ValidationVariantSummaryTests {
+
+    @Test func variantSummaryFoldsTheBatchForTheListingRow() {
+        let pendingWins = ValidationVariantSummary(
+            total: 4, failed: 1, pending: 2, firstFailedSubmissionID: "sub_x")
+        #expect(pendingWins.state == "pending")
+        #expect(pendingWins.summaryText == "4 variants running")
+
+        let failed = ValidationVariantSummary(
+            total: 4, failed: 2, pending: 0, firstFailedSubmissionID: "sub_x")
+        #expect(failed.state == "failed")
+        #expect(failed.summaryText == "2 of 4 variants failed")
+
+        let passed = ValidationVariantSummary(
+            total: 4, failed: 0, pending: 0, firstFailedSubmissionID: nil)
+        #expect(passed.state == "passed")
+        #expect(passed.summaryText == "4 variants passed")
+
+        let none = ValidationVariantSummary(
+            total: 0, failed: 0, pending: 0, firstFailedSubmissionID: nil)
+        #expect(none.state == "none")
+        #expect(none.summaryText.isEmpty)
+    }
+}

--- a/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
+++ b/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
@@ -39,6 +39,19 @@ function makeInput(value = '', disabled = false) {
   };
 }
 
+/// The estimates disclosure body: collects appended line elements, and
+/// clears them when the control resets `textContent`.
+function makeDiagnosticsBody() {
+  const el = makeInput();
+  el.children = [];
+  el.appendChild = (child) => { el.children.push(child); };
+  Object.defineProperty(el, 'textContent', {
+    set(value) { if (value === '') el.children = []; },
+    get() { return el.children.map((c) => c.textContent).join('\n'); },
+  });
+  return el;
+}
+
 /// One `tr[data-support-file]` carrying the control's six elements.
 function makeRow(filename) {
   const parts = {
@@ -51,6 +64,8 @@ function makeRow(filename) {
     '.js-dataset-blank-columns': makeInput(),
     '.js-dataset-blank-percent': makeInput(),
     '.js-dataset-status': makeInput(),
+    '.js-dataset-diagnostics': makeInput(),
+    '.js-dataset-diagnostics-body': makeDiagnosticsBody(),
   };
   const row = {
     filename,
@@ -68,7 +83,7 @@ function makeRow(filename) {
   return row;
 }
 
-function load({ specs = [] } = {}) {
+function load({ specs = [], diagnostics = null } = {}) {
   const puts = [];
   const bodyHandlers = {};
   let stored = specs.slice();
@@ -79,9 +94,15 @@ function load({ specs = [] } = {}) {
     getElementById: () => null,
     body: { addEventListener(type, fn) { (bodyHandlers[type] ||= []).push(fn); } },
     addEventListener() {},
+    createElement: (tag) => ({ tagName: tag, className: '', textContent: '' }),
     querySelector: () => null,
     querySelectorAll: (sel) => (sel === 'tr[data-support-file]' ? rows : []),
   };
+
+  // The server serves an estimate block per marked file on the same GET/PUT
+  // the controls use; the mock mirrors that by deriving them from whatever is
+  // currently stored (a caller passes `diagnostics` as a per-spec factory).
+  const blocks = () => (diagnostics ? stored.map(diagnostics).filter(Boolean) : []);
 
   const sandbox = { document: doc, Promise, JSON, Error, Object, Array, Math, parseInt, setTimeout };
   sandbox.ChickadeeUI = {
@@ -99,7 +120,7 @@ function load({ specs = [] } = {}) {
         puts.push(body);
         stored = body.datasets.slice();
       }
-      return Promise.resolve({ datasets: stored });
+      return Promise.resolve({ datasets: stored, diagnostics: blocks() });
     },
   };
   sandbox.window = { ChickadeeUI: sandbox.ChickadeeUI };
@@ -280,6 +301,110 @@ test('a re-render disables the fields for a spec the panel cannot represent', as
   // Still disabled, and still not showing half of a two-step spec.
   assert.equal(row.querySelector('.js-dataset-blank-columns').disabled, true);
   assert.equal(row.querySelector('.js-dataset-blank-columns').value, '');
+});
+
+// ── The estimates disclosure ────────────────────────────────────────────────
+
+const sampleBlock = (spec) => ({
+  file: spec.file,
+  overlap: {
+    poolRows: 6388,
+    rowsPerStudent: spec.sampleSize || 6388,
+    expectedSharedRows: 39.1,
+    sharedFraction: 0.078,
+    worstPairSharedRows: 63.2,
+    mostCopyableStratum: spec.stratumColumn
+      ? { value: 'D', poolRows: 5, rowsPerStudent: 2, sharedFraction: 0.4 }
+      : null,
+  },
+  headlines: [
+    { measure: 'wasserstein', column: 'systolic', median: 0.037, worst: 0.061 },
+    { measure: 'totalVariation', column: 'ward', median: 0.02, worst: 0.05 },
+  ],
+  divergenceMeasured: true,
+  classSize: 100,
+});
+
+test('the estimates paint on init from the GET, one line per fact', async () => {
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
+    diagnostics: sampleBlock,
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  await settle();
+
+  assert.equal(row.querySelector('.js-dataset-diagnostics').hidden, false);
+  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
+  assert.match(text, /39 of their 500 rows \(7\.8%\)/);
+  assert.match(text, /unluckiest pair in a class of 100 shares about 63/);
+  assert.match(text, /systolic sits about 0\.04 SD/);
+  assert.match(text, /any two students within about 0\.12 SD/);
+  assert.match(text, /ward sits about 0\.02 total-variation/);
+  assert.equal(h.puts.length, 0, 'the first paint is a read, not a write');
+});
+
+test('a stratified block names its most copyable category', async () => {
+  const h = load({
+    specs: [{
+      file: 'cases.csv', kind: 'stratifiedSample', sampleSize: 500, stratumColumn: 'ward',
+    }],
+    diagnostics: sampleBlock,
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  await settle();
+
+  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
+  assert.match(text, /Most copyable category: "D"/);
+  assert.match(text, /2 of the same 5 pool rows \(40% shared\)/);
+});
+
+test('the estimates repaint from the PUT response when a parameter changes', async () => {
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
+    diagnostics: (spec) => ({
+      ...sampleBlock(spec),
+      overlap: { ...sampleBlock(spec).overlap, rowsPerStudent: spec.sampleSize },
+    }),
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-size').value = '900';
+  await change(h, row, '.js-dataset-size');
+  await settle();
+
+  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
+  assert.match(text, /of their 900 rows/, 'the numbers follow the saved edit');
+});
+
+test('a row without an estimate block hides the disclosure', async () => {
+  // The server sends no block for an unreadable file (and for an unmarked
+  // one); an empty disclosure would read as a broken panel.
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
+    diagnostics: null,
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  await settle();
+
+  assert.equal(row.querySelector('.js-dataset-diagnostics').hidden, true);
+});
+
+test('an unmeasured divergence says so instead of showing nothing', async () => {
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
+    diagnostics: (spec) => ({
+      ...sampleBlock(spec), headlines: [], divergenceMeasured: false,
+    }),
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  await settle();
+
+  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
+  assert.match(text, /not measured — the file is too large/);
 });
 
 test('a stratified spec keeps its kind when only the blanking changes', async () => {

--- a/Tests/CoreTests/DatasetDiagnosticsTests.swift
+++ b/Tests/CoreTests/DatasetDiagnosticsTests.swift
@@ -1,0 +1,334 @@
+// Tests/CoreTests/DatasetDiagnosticsTests.swift
+//
+// The drift protection for the dataset diagnostics (DatasetDiagnostics.swift /
+// DatasetDivergence.swift).  The load-bearing three:
+//
+//   * Completeness via `allCases` — a selection kind nobody wrote an overlap
+//     formula for, or a transform kind nobody decided a row-set answer for,
+//     fails here instead of quietly inheriting a plausible number.
+//   * Analytic vs Monte Carlo — the compiler can check a formula exists,
+//     never that it is right; simulated pairs check the value.
+//   * Transforms do not change the row set — the theorem that licenses
+//     overlap ignoring transforms entirely, which is what keeps this test
+//     matrix linear instead of exponential.  If a row-dropping transform ever
+//     ships, this fails, and the decomposition — not the test — needs
+//     revisiting.
+//
+// The statistical tests use deterministic inputs (fixed seeds, fixed pools)
+// with tolerance assertions, so they are exactly reproducible and cannot
+// flake.  A failure means a wrong formula; re-derive it rather than widening
+// the tolerance.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite(.timeLimit(.minutes(2))) struct DatasetDiagnosticsTests {
+
+    // MARK: - Fixture
+
+    /// 200 unique rows: `id` 0–199, `ward` A×120 / B×60 / C×15 / D×5 (a
+    /// deliberately rare stratum), `score` a spread of integers.
+    private let pool: String = {
+        var lines = ["id,ward,score"]
+        for i in 0..<200 {
+            let ward = i < 120 ? "A" : i < 180 ? "B" : i < 195 ? "C" : "D"
+            lines.append("\(i),\(ward),\(50 + (i * 37) % 100)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }()
+
+    private func plainSpec(_ size: Int?) -> DatasetSpec {
+        DatasetSpec(file: "cases.csv", sampleSize: size)
+    }
+
+    private func stratifiedSpec(_ size: Int?, column: String = "ward") -> DatasetSpec {
+        DatasetSpec(
+            file: "cases.csv", kind: .stratifiedSample, sampleSize: size, stratumColumn: column)
+    }
+
+    private func dataRowIDs(spec: DatasetSpec, seedHex: String) -> [Substring] {
+        let materialized = DatasetMaterializer.materialize(
+            source: pool, spec: spec, seedHex: seedHex)
+        let (lines, _) = DatasetMaterializer.normalizedLines(of: materialized)
+        return lines.dropFirst().map { line in line.prefix(while: { $0 != "," }) }
+    }
+
+    private func simulatedMeanSharedRows(spec: DatasetSpec, pairs: Int) -> Double {
+        var total = 0
+        for pair in 0..<pairs {
+            let a = Set(dataRowIDs(spec: spec, seedHex: "mc|\(pair)|a"))
+            let b = Set(dataRowIDs(spec: spec, seedHex: "mc|\(pair)|b"))
+            total += a.intersection(b).count
+        }
+        return Double(total) / Double(pairs)
+    }
+
+    // MARK: - 1. Completeness via allCases
+
+    @Test(arguments: DatasetKind.allCases)
+    func everySelectionKindAnswersTheOverlapFormula(kind: DatasetKind) throws {
+        // Exhaustive switch: a new selection kind fails to compile here (and
+        // in `DatasetDiagnostics.overlap`) until someone decides its formula.
+        let spec: DatasetSpec
+        switch kind {
+        case .rowSample: spec = plainSpec(40)
+        case .stratifiedSample: spec = stratifiedSpec(40)
+        }
+        let overlap = try #require(DatasetDiagnostics.overlap(spec: spec, sourceCSV: pool))
+        #expect(overlap.poolRows == 200)
+        #expect(overlap.rowsPerStudent == 40)
+        #expect(overlap.expectedSharedRows > 0)
+        #expect(overlap.sharedFraction > 0 && overlap.sharedFraction <= 1)
+        #expect(overlap.worstPairSharedRows >= overlap.expectedSharedRows)
+        #expect(overlap.worstPairSharedRows <= Double(overlap.rowsPerStudent))
+    }
+
+    @Test(arguments: DatasetTransform.Kind.allCases)
+    func everyTransformKindHasADecidedRowSetAnswer(kind: DatasetTransform.Kind) {
+        // Exhaustive switch: adding a transform kind forces a decision about
+        // which columns a representative step touches — and the row-set test
+        // below then holds it to "transforms never change which rows a
+        // student holds".
+        let transform: DatasetTransform
+        switch kind {
+        case .missingValues:
+            transform = DatasetTransform(kind: .missingValues, columns: ["score"], rate: 0.5)
+        }
+        let with = DatasetSpec(file: "cases.csv", sampleSize: 40, transforms: [transform])
+        for seed in 0..<5 {
+            let seedHex = DatasetDiagnostics.preflightSeed(seed)
+            #expect(
+                dataRowIDs(spec: plainSpec(40), seedHex: seedHex)
+                    == dataRowIDs(spec: with, seedHex: seedHex),
+                "transform kind \(kind) changed the row set under seed \(seed)")
+        }
+    }
+
+    // MARK: - 2. Analytic vs Monte Carlo
+
+    @Test func plainOverlapMatchesSimulatedPairs() throws {
+        let overlap = try #require(DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool))
+        // Two 40-row samples of a 200-row pool: mean k²/N = 8 exactly.
+        #expect(abs(overlap.expectedSharedRows - 8) < 1e-9)
+        #expect(abs(overlap.sharedFraction - 0.2) < 1e-9)
+
+        // 400 simulated pairs: σ ≈ 2.27 ⇒ standard error ≈ 0.11, so a 0.5
+        // tolerance is ~4.4 standard errors — and the seeds are fixed, so
+        // the observed mean is one number forever.
+        let simulated = simulatedMeanSharedRows(spec: plainSpec(40), pairs: 400)
+        #expect(abs(simulated - overlap.expectedSharedRows) < 0.5)
+    }
+
+    @Test func stratifiedOverlapMatchesSimulatedPairsAndHandComputedAllocation() throws {
+        let overlap = try #require(
+            DatasetDiagnostics.overlap(spec: stratifiedSpec(40), sourceCSV: pool))
+        // Hamilton with a one-row floor over sizes [120, 60, 15, 5] at k = 40
+        // allocates [23, 12, 3, 2], so Σ kₛ²/Nₛ = 23²/120 + 12²/60 + 9/15
+        // + 4/5 = 985/120 — checkable by hand, independent of the code.
+        #expect(abs(overlap.expectedSharedRows - 985.0 / 120.0) < 1e-9)
+
+        let simulated = simulatedMeanSharedRows(spec: stratifiedSpec(40), pairs: 400)
+        #expect(abs(simulated - overlap.expectedSharedRows) < 0.5)
+    }
+
+    // MARK: - 3. The rare-stratum consequence, by name
+
+    @Test func theRareStratumIsReportedAsTheMostCopyable() throws {
+        let overlap = try #require(
+            DatasetDiagnostics.overlap(spec: stratifiedSpec(40), sourceCSV: pool))
+        let stratum = try #require(overlap.mostCopyableStratum)
+        // Every student takes 2 of ward D's 5 pool rows: a 40% pairwise
+        // share on that stratum against 20% overall — stratification made
+        // the rare category the most copyable part of the assignment.
+        #expect(stratum.value == "D")
+        #expect(stratum.poolRows == 5)
+        #expect(stratum.rowsPerStudent == 2)
+        #expect(abs(stratum.sharedFraction - 0.4) < 1e-9)
+        #expect(
+            DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool)?
+                .mostCopyableStratum == nil,
+            "a plain row sample has no strata to report")
+    }
+
+    // MARK: - 4. Theorems as tests
+
+    @Test(arguments: [8, 20, 40, 100])
+    func stratifiedOverlapIsNeverBelowPlainAtEqualSampleSize(size: Int) throws {
+        // Titu's lemma: Σ kₛ²/Nₛ ≥ k²/N, equality only under exactly
+        // proportional allocation — which the one-row floor prevents, so a
+        // violation is definitely a bug, not a tolerance question.
+        let plain = try #require(
+            DatasetDiagnostics.overlap(spec: plainSpec(size), sourceCSV: pool))
+        let stratified = try #require(
+            DatasetDiagnostics.overlap(spec: stratifiedSpec(size), sourceCSV: pool))
+        #expect(stratified.expectedSharedRows >= plain.expectedSharedRows - 1e-9)
+    }
+
+    @Test func moreRowsMeansMoreOverlapAndLessDivergence() throws {
+        let small = try #require(DatasetDiagnostics.overlap(spec: plainSpec(20), sourceCSV: pool))
+        let large = try #require(DatasetDiagnostics.overlap(spec: plainSpec(100), sourceCSV: pool))
+        #expect(small.expectedSharedRows < large.expectedSharedRows)
+        #expect(small.sharedFraction < large.sharedFraction)
+
+        func scoreMedian(_ size: Int) throws -> Double {
+            let divergences = DatasetDiagnostics.divergence(
+                spec: plainSpec(size), sourceCSV: pool)
+            return try #require(divergences.first { $0.column == "score" }).median
+        }
+        #expect(try scoreMedian(20) > scoreMedian(100))
+    }
+
+    // MARK: - 5. Overlap is selection-only
+
+    @Test func overlapIgnoresTransformsBecauseTheyPreserveTheRowSet() {
+        let blanked = DatasetSpec(
+            file: "cases.csv", sampleSize: 40,
+            transforms: [DatasetTransform(kind: .missingValues, columns: ["score"], rate: 0.5)])
+        #expect(
+            DatasetDiagnostics.overlap(spec: blanked, sourceCSV: pool)
+                == DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool))
+    }
+
+    // MARK: - 6. Envelope cases mirror the materializer
+
+    @Test func aWholeFileSpecMeansTotalOverlap() throws {
+        for spec in [plainSpec(nil), plainSpec(0), plainSpec(200), plainSpec(5000)] {
+            let overlap = try #require(DatasetDiagnostics.overlap(spec: spec, sourceCSV: pool))
+            #expect(overlap.rowsPerStudent == 200)
+            #expect(abs(overlap.sharedFraction - 1) < 1e-9)
+            #expect(abs(overlap.expectedSharedRows - 200) < 1e-9)
+            #expect(abs(overlap.worstPairSharedRows - 200) < 1e-9)
+        }
+    }
+
+    @Test func aDegradedStratifiedSpecReportsWhatActuallyShips() {
+        // An unknown column falls back to a plain row sample at delivery
+        // (authoring refuses it, but the file can change under a saved spec)
+        // — the estimate must describe those bytes, not the intended strata.
+        let degraded = stratifiedSpec(40, column: "nope")
+        #expect(
+            DatasetDiagnostics.overlap(spec: degraded, sourceCSV: pool)
+                == DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool))
+    }
+
+    @Test func aHeaderOnlyPoolHasNothingToEstimate() {
+        #expect(DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: "id,ward\n") == nil)
+        #expect(DatasetDiagnostics.divergence(spec: plainSpec(40), sourceCSV: "id,ward\n").isEmpty)
+    }
+
+    // MARK: - 7. The Wasserstein metric itself, by hand
+
+    @Test func wassersteinIsPinnedOnHandComputableCases() {
+        // Equal sizes: the mean absolute difference of order statistics.
+        #expect(abs(DatasetDiagnostics.wasserstein1([0, 1, 2, 3], [0, 1, 2, 7]) - 1) < 1e-12)
+        // Unequal sizes, by the quantile-function integral: [0,1] vs
+        // [0,0,3] → segments 0·⅓ + 0·⅙ + 1·⅙ + 2·⅓ = ⅚.
+        #expect(abs(DatasetDiagnostics.wasserstein1([0, 1], [0, 0, 3]) - 5.0 / 6.0) < 1e-12)
+        // Identical distributions at different sample sizes transport nothing.
+        #expect(DatasetDiagnostics.wasserstein1([1, 2], [1, 1, 2, 2]) == 0)
+        // Two point masses transport their distance.
+        #expect(abs(DatasetDiagnostics.wasserstein1([2.5], [4]) - 1.5) < 1e-12)
+        // Order must not matter beyond sorting.
+        #expect(
+            DatasetDiagnostics.wasserstein1([3, 1, 2], [9, 4, 6])
+                == DatasetDiagnostics.wasserstein1([1, 2, 3], [4, 6, 9]))
+    }
+
+    @Test func totalVariationIsPinnedOnHandComputableCases() {
+        #expect(
+            abs(
+                DatasetDiagnostics.totalVariation(["a", "a", "b", "b"], ["a", "b", "b", "b"])
+                    - 0.25) < 1e-12)
+        #expect(DatasetDiagnostics.totalVariation(["a", "b"], ["b", "a"]) == 0)
+        #expect(abs(DatasetDiagnostics.totalVariation(["a"], ["b"]) - 1) < 1e-12)
+    }
+
+    // MARK: - 8. Divergence
+
+    @Test func divergenceClassifiesColumnsAndReportsInHeaderOrder() {
+        let divergences = DatasetDiagnostics.divergence(spec: plainSpec(40), sourceCSV: pool)
+        #expect(divergences.map(\.column) == ["id", "ward", "score"])
+        #expect(divergences.map(\.measure) == [.wasserstein, .totalVariation, .wasserstein])
+        for divergence in divergences {
+            #expect(divergence.median >= 0)
+            #expect(divergence.worst >= divergence.median)
+        }
+    }
+
+    @Test func mcarBlankingDoesNotBiasTheObservedDistribution() throws {
+        // `missingValues` thins a column without biasing it: the divergence
+        // of the observed (non-blank) values must sit within sampling noise
+        // of the unblanked spec's.  A future transform that *does* bias
+        // fails here — the right moment to decide whether that is a bug or a
+        // property it must declare.
+        let blanked = DatasetSpec(
+            file: "cases.csv", sampleSize: 100,
+            transforms: [DatasetTransform(kind: .missingValues, columns: ["score"], rate: 0.3)])
+        func scoreDivergence(_ spec: DatasetSpec) throws -> DatasetColumnDivergence {
+            try #require(
+                DatasetDiagnostics.divergence(spec: spec, sourceCSV: pool)
+                    .first { $0.column == "score" })
+        }
+        let without = try scoreDivergence(plainSpec(100))
+        let with = try scoreDivergence(blanked)
+        #expect(abs(with.median - without.median) < 0.1)
+
+        // And the thinning is real: 30% of the 100-row sample is blanked.
+        let materialized = DatasetMaterializer.materialize(
+            source: pool, spec: blanked, seedHex: DatasetDiagnostics.preflightSeed(0))
+        let (lines, _) = DatasetMaterializer.normalizedLines(of: materialized)
+        let observedScores = lines.dropFirst().count { line in
+            !(DatasetMaterializer.splitCSVLine(line).last ?? "").isEmpty
+        }
+        #expect(observedScores == 70)
+    }
+
+    @Test func headlinesNameTheWorstColumnPerMeasureAndNeverAverage() {
+        let divergences = [
+            DatasetColumnDivergence(column: "id", measure: .wasserstein, median: 0.02, worst: 0.05),
+            DatasetColumnDivergence(
+                column: "systolic", measure: .wasserstein, median: 0.08, worst: 0.31),
+            DatasetColumnDivergence(
+                column: "ward", measure: .totalVariation, median: 0.11, worst: 0.19),
+        ]
+        let headlines = DatasetDiagnostics.headlines(of: divergences)
+        #expect(headlines.count == 2)
+        #expect(headlines.first?.measure == .wasserstein)
+        #expect(headlines.first?.column == "systolic")
+        #expect(abs((headlines.first?.worst ?? 0) - 0.31) < 1e-12)
+        #expect(headlines.last?.measure == .totalVariation)
+        #expect(headlines.last?.column == "ward")
+        #expect(
+            DatasetDiagnostics.headlines(of: Array(divergences.prefix(2))).count == 1,
+            "a measure with no columns yields no headline")
+    }
+
+    // MARK: - 9. Deterministic seeds
+
+    @Test func preflightSeedsAreDerivedAndPinned() {
+        // Random preflight seeds would make the reported numbers flicker on
+        // every page load, so an instructor could not tell whether their own
+        // edit moved them.  The literal pin also catches an accidental
+        // derivation change, which would silently re-map every multi-variant
+        // consumer onto different variants.
+        #expect(
+            DatasetDiagnostics.preflightSeed(0)
+                == "b0577888b859ff94b0577988b85a0147b0577a88b85a02fab0577b88b85a04ad")
+        #expect(DatasetDiagnostics.preflightSeed(1).count == 64)
+        #expect(DatasetDiagnostics.preflightSeed(0) != DatasetDiagnostics.preflightSeed(1))
+    }
+
+    @Test func twoRunsOverTheSameSpecAgreeExactly() {
+        let spec = DatasetSpec(
+            file: "cases.csv", kind: .stratifiedSample, sampleSize: 40, stratumColumn: "ward",
+            transforms: [DatasetTransform(kind: .missingValues, columns: ["score"], rate: 0.2)])
+        #expect(
+            DatasetDiagnostics.divergence(spec: spec, sourceCSV: pool)
+                == DatasetDiagnostics.divergence(spec: spec, sourceCSV: pool))
+        #expect(
+            DatasetDiagnostics.overlap(spec: spec, sourceCSV: pool)
+                == DatasetDiagnostics.overlap(spec: spec, sourceCSV: pool))
+    }
+}

--- a/Tests/CoreTests/TestPropertiesPersonalizationTests.swift
+++ b/Tests/CoreTests/TestPropertiesPersonalizationTests.swift
@@ -47,4 +47,29 @@ import Testing
         #expect(!manifest.hasExpressions)
         #expect(manifest.hasPersonalization)
     }
+
+    // `variesPerStudent` answers a third question — "can two seeds receive
+    // different material?" — and is what multi-variant validation gates on.
+    // Deliberately separate from `hasPersonalization`, whose answer also
+    // steers the worker download path.
+
+    @Test func aDatasetVariesPerStudentWithoutBeingPersonalization() {
+        let manifest = TestProperties(datasets: [DatasetSpec(file: "cases.csv", sampleSize: 5)])
+        #expect(manifest.variesPerStudent)
+        #expect(
+            !manifest.hasPersonalization,
+            "a dataset substitutes nothing — the download path must not change")
+    }
+
+    @Test func expressionsVaryPerStudentButLiteralsDoNot() {
+        #expect(TestProperties(globalExpressions: [expr]).variesPerStudent)
+        #expect(
+            TestProperties(
+                sections: [TestSuiteSection(id: "s1", name: "S1", expressions: [expr])]
+            ).variesPerStudent)
+        #expect(
+            !TestProperties(globalVariables: [literal]).variesPerStudent,
+            "every student gets the same literal, so one validation run covers them all")
+        #expect(!TestProperties().variesPerStudent)
+    }
 }

--- a/changelog.d/dataset-diagnostics-and-variant-validation.md
+++ b/changelog.d/dataset-diagnostics-and-variant-validation.md
@@ -1,0 +1,20 @@
+### Added
+
+- **Per-student dataset estimates in the Files panel.** Each marked dataset row
+  gains a collapsed "Per-student estimates" disclosure answering the two
+  questions the parameters could not: how many rows two students share
+  (closed-form overlap, with the unluckiest pair in a class and — for a
+  stratified sample — the most copyable category by name), and how far a
+  student's slice drifts from the pool (per-column Wasserstein-1 in pool-SD
+  units for numeric columns, total variation for categorical, measured through
+  the real materializer over derived preflight seeds). The numbers recompute on
+  every saved parameter edit and never alter a delivered byte.
+- **Multi-variant validation.** On an assignment that varies by student (a
+  per-student `=` expression or a per-student dataset), every validation
+  enqueue now also grades the reference solution against four derived
+  per-student seeds — the same preflight seeds the estimates sample — so a
+  solution that only works for some students' material fails validation
+  instead of failing a student. Per-variant verdicts appear under the
+  validation cell on the instructor assignments list (with a link to the
+  failing variant's per-test results) and in the MCP `get_validation_result`
+  tool, which reports each variant's seed and its failing outcomes.

--- a/deploy/sql/mcp-least-privilege-role.sql
+++ b/deploy/sql/mcp-least-privilege-role.sql
@@ -56,6 +56,17 @@ GRANT SELECT ON users, course_enrollments TO chickadee_mcp;
 --    table result_collections".
 GRANT SELECT ON submissions, results, result_collections TO chickadee_mcp;
 
+--    validation_variants (multi-variant validation) records the per-variant
+--    verdicts of the instructor's reference-solution runs against synthetic
+--    seeds — no student identity or grade in any column, and every linked
+--    submission is a validation run by construction. get_validation_result
+--    reads it to report the batch. Deployments that applied this file before
+--    the table existed must re-run this section, or every
+--    get_validation_result call fails with "permission denied for table
+--    validation_variants". Writes (enqueue, verdict ingestion, cleanup) all
+--    run on the main (owner) pool, so SELECT is the only grant needed.
+GRANT SELECT ON validation_variants TO chickadee_mcp;
+
 ALTER TABLE submissions ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS mcp_validation_submissions ON submissions;
 CREATE POLICY mcp_validation_submissions ON submissions
@@ -80,6 +91,21 @@ CREATE POLICY mcp_validation_result_collections ON result_collections
         JOIN submissions s ON s.id = r.submission_id
         WHERE r.id = result_collections.result_id AND s.kind = 'validation'
     ));
+
+-- A variant row with a pruned (NULL) submission keeps its recorded verdict
+-- visible; a linked one must resolve to a validation submission — through
+-- this role's own submissions policy, so a row somehow pointing at a student
+-- submission is invisible rather than a leak.
+ALTER TABLE validation_variants ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS mcp_validation_variant_rows ON validation_variants;
+CREATE POLICY mcp_validation_variant_rows ON validation_variants
+    FOR SELECT TO chickadee_mcp
+    USING (
+        submission_id IS NULL OR EXISTS (
+            SELECT 1 FROM submissions s
+            WHERE s.id = validation_variants.submission_id AND s.kind = 'validation'
+        )
+    );
 
 -- 5. Everything else is DENIED by omission — no GRANT is issued, so the role
 --    cannot touch any of these student-data tables:

--- a/docs/compliance/data-flow-inventory.md
+++ b/docs/compliance/data-flow-inventory.md
@@ -75,7 +75,7 @@ Classification column references `policy46-classification.md`.
 | `get_achievements` | manifest achievements | composable awards (badges/goals/records), built-in defaults until curated | No | Confidential |
 | `preview_personalization` | manifest; `python3` eval | resolved per-seed values for the *previewed* seed | No (synthetic/instructor) | Restricted |
 | `validate_assignment` | enqueues run; status | `passed`/`failed`/`no-runner` | No | Confidential |
-| `get_validation_result` | validation submission + its result | per-test outcomes; **`submissionID`/`userID` dropped** (`GetValidationResultTool.swift:18-24`) | No (instructor reference run) | Restricted |
+| `get_validation_result` | validation submission + its result; `validation_variants` batch | per-test outcomes; per-variant verdicts + synthetic seeds + failing outcomes (all reference-solution runs); **`submissionID`/`userID` dropped** (`GetValidationResultTool.swift:18-24`) | No (instructor reference run; variant seeds are derived constants, not student seeds) | Restricted |
 | `update_assignment` | assignment | echo of saved metadata | No | Confidential |
 | `set_grading_mode` | assignment, setup | echo of mode | No | Confidential |
 | `update_suite` | manifest | reconciled suite state | No | Restricted |

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -657,8 +657,9 @@ through.
 whitespace, letter case, `2024-01-02` vs `02/01/2024`) — is the natural next
 transform, and the most pedagogically honest of the set: real health data
 arrives like this, and it is **answer-preserving**, so correct parsing yields
-the same result the pool would. It is also the only transform safe to author
-before multi-variant validation exists, for that reason.
+the same result the pool would. (It was once the only transform safe to author
+without multi-variant validation, for that reason; that gate exists now — see
+below — so the ordering constraint is gone.)
 
 `numericJitter` is **not** implemented, and the recommendation is against it.
 `rowSample` already delivers anti-copying, so jitter buys little pedagogy while
@@ -668,19 +669,58 @@ in this cohort is 128" reports a number existing nowhere outside their own file.
 Whether an assignment's prose must disclose that its data is derived is a policy
 call for the maintainer, not a decision this design should make quietly.
 
-### The gap this leaves: validation still exercises one variant
+### Multi-variant validation — closing the one-variant gap
 
-`hasPersonalization` counts expressions and variables, not `datasets`, so
-`materializeValidationGrading` returns early for a dataset-only assignment and
-validation grades against the **instructor's own** seed. For selection that is
-tolerable — the solution sees real rows, just fewer. For derivation it is not: a
-solution that assumes a column is never empty validates green and then fails for
-the students whose seed blanked it.
+A validation submission grades the reference solution against the enqueuing
+instructor's own seed — one variant of a per-student assignment. That used to
+be the whole story: `hasPersonalization` counts expressions and variables, not
+`datasets`, so `materializeValidationGrading` returned early for a dataset-only
+assignment and validation proved nothing about the material other students
+receive. For selection that was tolerable — the solution sees real rows, just
+fewer. For derivation it was not: a solution that assumes a column is never
+empty validated green and then failed for the students whose seed blanked it.
 
-This is why `missingValues` has no UI yet. Multi-variant validation — running the
-reference solution against N seeds and reporting per-variant results — is the
-gate that has to come before an instructor can reach for a transform from the
-Files panel.
+Every validation enqueue on an assignment that **varies by student** now also
+grades the solution against `validationVariantCount` (4) synthetic seeds. The
+pieces, and the decisions inside them:
+
+- **The gate is a new predicate, `TestProperties.variesPerStudent`** — a
+  per-student `=` expression or a per-student dataset. Deliberately *not* a
+  widening of `hasPersonalization`, whose answer also steers the worker
+  download path's sidecar behaviour; and literal-only personalization does not
+  count, because every seed receives identical material and N identical runs
+  prove nothing the first one did not.
+- **The seeds are `DatasetDiagnostics.preflightSeed(0..<4)`** — the same
+  derived seeds the Files-panel estimates sample, so the variant a validation
+  grades is material the diagnostics already described. Derived, never random,
+  pinned by test.
+- **A variant is an ordinary `kind == .validation` submission** whose
+  `SubmissionMaterialization` is pinned to the variant seed
+  (`materializeValidationGrading(variantSeedHex:)`). Nothing downstream is
+  new: the `.grading` sidecar, `_ck_inputs.*`, and the dataset slices
+  `buildJobPayload` resolves from the cached `seedHex` all behave exactly as
+  they would for a student holding that seed. With a variant seed the
+  materialization is cached even when there is nothing to substitute — the
+  dataset-only case the primary path deliberately skips.
+- **The batch is recorded in `validation_variants`** (one row per variant:
+  index, seed, submission id, verdict), keyed by test setup because the draft
+  flow enqueues validation before the assignment row exists. Each enqueue
+  *replaces* the setup's batch — and clears it outright when the manifest
+  stops varying, so a stale verdict cannot keep describing an assignment that
+  is no longer per-student. Result ingestion writes each verdict onto its
+  variant row; the assignment's own `validationStatus` still reflects only
+  the primary run.
+- **Surfaces.** The instructor assignments list shows the batch under the
+  validation cell ("4 variants passed" / "1 of 4 variants failed", linking to
+  the failing variant's per-test results — an ordinary submission page). MCP
+  `get_validation_result` reports the batch with each variant's seed and, for
+  failed variants, only its non-passing outcomes.
+- **A failed variant does not (yet) block opening the assignment.** The open
+  gate still reads `validationStatus == "passed"`, i.e. the primary run.
+  Display-first is deliberate for the first release: hard-blocking on variant
+  failures would retroactively freeze existing dataset assignments mid-course
+  the next time they are edited. Revisit once a term's worth of variant
+  verdicts shows the false-positive rate is what it should be (zero).
 
 ### Build slices
 
@@ -765,6 +805,78 @@ twice, and `set_dataset` drops any existing spec for the file before appending
 its own — two specs for one file would disagree about how many rows a student
 gets, and which one won would be a detail of whichever consumer folded the
 array.
+
+## Diagnostics — how different is each student's data?
+
+Two estimates about a dataset spec, shown in the Files panel and recomputed on
+every saved parameter edit. Both are **read-only with respect to delivery**:
+they describe the delivered bytes and never alter one — in particular, no seed
+is ever reject-sampled to satisfy a tolerance, because a slice that depends on
+an acceptance criterion silently changes for every student when the threshold
+moves.
+
+**Overlap — can students copy?** Closed form, per selection kind, behind an
+exhaustive switch over `DatasetKind` (now `CaseIterable` so the completeness
+guard can iterate it):
+
+- `rowSample`: two size-`k` samples of an `N`-row pool share `k²/N` rows in
+  expectation; the reported *shared fraction* is `k/N` — the fraction of one
+  student's rows a peer also holds. Deliberately not Jaccard, whose union
+  denominator is a set neither student has and which shrinks as students
+  diverge, understating copying risk.
+- `stratifiedSample`: `Σₛ kₛ²/Nₛ`, with `kₛ` from the real `apportion` call —
+  never the `k/N` shortcut, which Titu's lemma makes a strict underestimate
+  whenever allocation is non-proportional, and the one-row-per-stratum floor
+  is non-proportional by construction. The consequence worth knowing: **a rare
+  category with 5 pool rows and 2 rows per student is 40% shared** — turning
+  on stratification to protect a rare category makes that category the most
+  copyable part of the assignment. It is invisible in the aggregate number, so
+  the panel names the most copyable stratum explicitly.
+- The worst pair in a class (the pair the instructor hears from) is an
+  extreme-value estimate over the class's C(C−1)/2 pairs, clamped to
+  `[mean, k]`; class size is a stated constant, not configuration.
+
+**Divergence — are students doing the same exercise?** Measured, not derived:
+every sampled slice comes from `DatasetMaterializer.materialize` — the exact
+call delivery makes — over 20 **derived** preflight seeds
+(`DatasetDiagnostics.preflightSeed`, pinned by test so the numbers cannot
+flicker between page loads). Because it measures the shipped bytes, it covers
+every transform automatically, including kinds that do not exist yet. Per
+column: Wasserstein-1 in units of the pool's SD for numeric columns (an exact
+quantile-function integral — a sort, not an optimal-transport solve), total
+variation for categorical. A column's distribution is that of its *observed*
+(non-empty) values: a `missingValues` hole is thinning, not a value, which is
+exactly what MCAR blanking preserves — pinned by the MCAR test. Aggregation is
+max-and-name-the-column, never a mean (an average over 20 columns hides one
+catastrophically skewed column behind 19 fine ones), and the two measures stay
+two headlines because SD-units and TV are not commensurable.
+
+**The asymmetry is the architecture.** Overlap is a function of *selection*
+alone — transforms alter values inside a student's rows and never change which
+rows they hold — so it is closed-form per kind and a new selection kind must
+answer a formula (the `allCases` completeness test fails until it does, and an
+analytic-vs-Monte-Carlo test checks the formula is *right*, not merely
+present). Divergence has no per-kind logic at all. The row-set theorem that
+licenses this split is itself a test (`transformsNeverChangeTheRowSet`); a
+future row-dropping transform fails it, at which point the decomposition — not
+the test — needs revisiting.
+
+**The surface** is the Files panel, not the validation report — a live
+parameter estimate wants to live where the parameters are, moving as the
+instructor edits the row count (multi-variant validation shares the preflight
+seeds but answers a different question at a different time). Each dataset row
+carries a collapsed "Per-student estimates" disclosure; the estimate blocks
+ride the same GET/PUT the controls already use (`DatasetsResponse.diagnostics`,
+computed off the event loop), so a saved edit repaints the numbers with no
+second request. The two estimates pull in opposite directions — more rows per
+student is fairer but more copyable — so the text is deliberately
+informational: no thresholds, no warnings, and no gating on either number
+(instructors may legitimately want to *maximize* divergence). Files above a
+stated byte ceiling skip the divergence sampling and say so; overlap, a single
+pass, is always reported.
+
+`numericJitter` stays dead (see above), and these diagnostics do not assume
+it.
 
 ## Train/test splits & grader-only files (option B)
 


### PR DESCRIPTION
Lands the dataset-diagnostics handoff (all three slices) and then closes the gap that handoff explicitly left open: validation exercising only one variant of a per-student assignment. Four commits, one per concern.

## 1. `feat(datasets)` — closed-form overlap + measured divergence (Core)

Two estimates about a dataset spec, read-only with respect to delivery (no byte changes, no reject-sampled seeds):

- **Overlap** ("can students copy?") is closed form behind an exhaustive switch over `DatasetKind` (now `CaseIterable`). Plain sampling: shared fraction `k/N`, expected shared `k²/N`, hypergeometric worst-pair estimate over a class's pairs. Stratified: `Σₛ kₛ²/Nₛ` computed from the **real `apportion` allocation** — never the `k/N` shortcut, which Titu's lemma makes a strict underestimate under the one-row-per-stratum floor — plus the **most copyable stratum by name**, since a rare 5-row category at 2 rows/student is 40% shared and invisible in the aggregate.
- **Divergence** ("are students doing the same exercise?") is measured, not derived: 20 derived preflight seeds (`DatasetDiagnostics.preflightSeed`, literal-pinned by test), each slice from the real `DatasetMaterializer.materialize`, so every transform — including future ones — is covered automatically. Per column: exact quantile-integral Wasserstein-1 in pool-SD units (numeric) or total variation (categorical), over observed (non-blank) values. Aggregation is max-and-name-the-column; the two measures stay two headlines.

The handoff's seven drift-protection tests are all present; the load-bearing three are completeness via `allCases`, analytic-vs-Monte-Carlo agreement per selection kind (400 simulated pairs against the formula, plus a hand-computed `985/120` pin for the stratified allocation), and transforms-never-change-the-row-set — the theorem that licenses overlap ignoring transforms and keeps the test matrix linear.

## 2. `feat(ui)` — the estimates disclosure in the Files panel

Surface decision (recorded in `docs/datasets.md`): the Files panel, because a live parameter estimate wants to be where the parameters are. Each marked dataset row gains a collapsed "Per-student estimates" `<details>`; the blocks ride the same datasets GET/PUT the controls already use (`DatasetsResponse.diagnostics`, computed off the event loop via `runBlocking`), so every saved edit repaints the numbers without a second request. One JS implementation for both authoring pages. No thresholds and no warning styling — the band has two bad ends (more rows is fairer but more copyable), so the text is informational. Files above a 4 MB ceiling skip divergence sampling *and say so*; overlap is always reported.

## 3. `feat(validation)` — multi-variant validation

The known gap: `hasPersonalization` doesn't count `datasets`, so `materializeValidationGrading` returned early and a dataset-only assignment validated against the instructor's own seed alone — a solution assuming a column is never blank validated green and failed a student.

- New predicate `TestProperties.variesPerStudent` (expressions or datasets; deliberately **not** a widening of `hasPersonalization`, which also steers the worker download path; false for literal-only personalization, where N runs prove nothing one didn't).
- Every validation enqueue (all five doors funnel through `enqueueRunnerValidationSubmission`) also grades the solution against **4 preflight seeds — the same seeds the diagnostics sample**. Each variant is an ordinary `kind == "validation"` submission whose `SubmissionMaterialization` pins the variant seed (`materializeValidationGrading(variantSeedHex:)`), now cached even with nothing to substitute — so the `.grading` sidecar, `_ck_inputs.*`, and `buildJobPayload`'s dataset resolution behave exactly as for a student holding that seed.
- Verdicts land on a new `validation_variants` table (batch replaced per enqueue, cleared when the manifest stops varying, swept on assignment/course deletion). Result ingestion writes per-variant status; the assignment's `validationStatus` still reflects only the primary run.
- Surfaces: the instructor assignments list shows the batch under the validation cell ("4 variants passed" / "1 of 4 variants failed" with a link to the failing variant's per-test results); MCP `get_validation_result` gains a `variants` array (seed, status, failing outcomes only), with result access routed through `MCPStudentDataBoundary`.
- **Deploy note:** `deploy/sql/mcp-least-privilege-role.sql` gains the `validation_variants` SELECT grant + RLS policy (the #1176 permission-denied class); the grant-sync test now pins the table. Deployments using the `chickadee_mcp` role must re-run that section.
- Deliberate scope choice: a failed variant does **not** yet block opening the assignment — hard-blocking would retroactively freeze live dataset assignments on their next edit. Recorded in the docs with the revisit condition.

## 4. `docs` — design record + changelog fragment

`docs/datasets.md` gains the diagnostics section and replaces the stale one-variant-gap section with the shipped design. One `changelog.d/` fragment covers both features (previewed with `assemble-release.sh --dry-run` → lands as 0.5.135). `VERSION`/`ChickadeeVersion`/`CHANGELOG.md` untouched.

## Testing

- New: `DatasetDiagnosticsTests` (18), `ValidationVariantTests` (4 end-to-end through the real enqueue door, worker HMAC claim, and results ingestion — including the claim-side assertion that a variant job delivers byte-identical `DatasetMaterializer` output for its seed), `ValidationVariantSummaryTests`, variant cases in `GetValidationResultToolTests`, `variesPerStudent` cases in `TestPropertiesPersonalizationTests`, estimate-block round-trip in `DatasetsRouteRoundTripTests`, 5 new JS panel tests (13 total in that file, all green).
- `format-lint` surface run locally: swift-format, SwiftLint `--strict` (0 violations), `check-styles`, `check-css-vars`, `check-design-tokens`, `check-class-resolution`, eslint, `no-language-defaults` — all green.
- Render tests prove templates resolve, not page behaviour: the Files-panel disclosure and the variant chips have **not** had a manual browser pass in this session — worth a click-through on a real assignment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcLvzjV8ZnS1qbCkjnfGRE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcLvzjV8ZnS1qbCkjnfGRE)_