### PR TITLE
refactor(ui): dataset estimates become two glanceable chips

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2072,15 +2072,16 @@ code { font-family: var(--font-mono); font-size: .9em; }
    cannot represent — it steps aside rather than rendering a partial view it
    would then save over. */
 .dataset-note { font-style: italic; color: var(--gray-600); }
-/* Per-row estimates disclosure: how many rows two students share and how far
-   a slice drifts from the pool (docs/datasets.md).  A band with two bad ends
-   rather than a threshold, so the text is informational and never styled as
-   a warning.  Takes the full row width so it wraps under the inline
-   controls; the `hidden` attribute hides it (no display override here). */
-.dataset-diagnostics { flex-basis: 100%; font-size: var(--text-sm); color: var(--gray-600); }
-.dataset-diagnostics > summary { cursor: pointer; color: var(--gray-500); }
-.dataset-diagnostics-body { display: flex; flex-direction: column; gap: .15rem; margin-top: .25rem; }
-.dataset-diagnostics-line { display: block; }
+/* Per-row estimate chips: student-to-student similarity and drift from the
+   pool (docs/datasets.md), one concise number each, painted by
+   support-files.js from the datasets GET/PUT.  The how-it-is-measured
+   detail rides each chip's hover title — cursor plus dotted underline as
+   the affordance.  A band with two bad ends rather than a threshold, so
+   never styled as a warning.  Inherits the control row's size and colour;
+   an empty chip (before the first fetch lands) takes no space. */
+.dataset-estimates { display: inline-flex; gap: .5rem; }
+.dataset-estimate { cursor: help; text-decoration: underline dotted; text-underline-offset: .15em; }
+.dataset-estimate:empty { display: none; }
 
 /* Pattern-family editor body internals. */
 .label-note { color: var(--gray-600); font-weight: 400; }

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -12,8 +12,8 @@
 //     deleteURL:   (name) => DELETE target for one stored support file
 //     datasetsURL: () => GET/PUT target for {datasets: [DatasetSpec]}
 //                  (a spec is {file, kind, sampleSize, stratumColumn?}; the
-//                  response also carries per-file `diagnostics` estimate
-//                  blocks the rows' disclosure renders)
+//                  response also carries per-file `diagnostics` blocks of
+//                  ready-made display strings the rows' estimate chips paint)
 //     onChange:    () => run after a successful upload batch or delete
 //                  (the edit surface re-renders in place; the create page
 //                  reloads its draft)
@@ -80,83 +80,33 @@
         }
         function statusOf(row) { return row.querySelector('.js-dataset-status'); }
 
-        // ── The estimates disclosure ────────────────────────────────────────
+        // ── The estimate chips ──────────────────────────────────────────────
         //
-        // The server computes two estimates per dataset (Core's
-        // DatasetDiagnostics; docs/datasets.md) and serves them on the same
-        // GET/PUT the controls use, so the numbers move with every saved
-        // parameter edit.  They describe a band with two bad ends — more rows
-        // is fairer but more copyable — so the text is informational only:
-        // no thresholds, no warning styling.
-
-        function formatPercent(fraction) {
-            var pct = fraction * 100;
-            if (pct >= 99.95) return '100%';
-            return (pct >= 10 ? Math.round(pct) : pct.toFixed(1)) + '%';
-        }
-
-        function formatUnits(value) {
-            return value < 0.005 ? 'under 0.01' : value.toFixed(2);
-        }
-
-        function diagnosticsLines(report) {
-            var lines = [];
-            var overlap = report.overlap;
-            if (overlap) {
-                lines.push('Copying: two students share about '
-                    + Math.round(overlap.expectedSharedRows) + ' of their '
-                    + overlap.rowsPerStudent + ' rows ('
-                    + formatPercent(overlap.sharedFraction)
-                    + '); the unluckiest pair in a class of ' + report.classSize
-                    + ' shares about ' + Math.round(overlap.worstPairSharedRows) + '.');
-                var stratum = overlap.mostCopyableStratum;
-                if (stratum) {
-                    lines.push('Most copyable category: "' + stratum.value
-                        + '" — every student draws ' + stratum.rowsPerStudent
-                        + ' of the same ' + stratum.poolRows + ' pool rows ('
-                        + formatPercent(stratum.sharedFraction) + ' shared).');
-                }
-            }
-            (report.headlines || []).forEach(function (headline) {
-                if (headline.measure === 'wasserstein') {
-                    lines.push('Drift: ' + headline.column + ' sits about '
-                        + formatUnits(headline.median)
-                        + ' SD from the pool for a typical student (worst seed '
-                        + formatUnits(headline.worst) + '; any two students within about '
-                        + formatUnits(2 * headline.worst) + ' SD).');
-                } else {
-                    lines.push('Category drift: ' + headline.column + ' sits about '
-                        + formatUnits(headline.median)
-                        + ' total-variation from the pool (worst seed '
-                        + formatUnits(headline.worst) + ').');
-                }
-            });
-            if (report.divergenceMeasured === false) {
-                lines.push('Distribution drift was not measured — the file is too large to sample quickly.');
-            }
-            return lines;
-        }
-
-        // Paints each row's disclosure from the server's estimate blocks.  A
-        // row with no block (not a dataset, or a file the server could not
-        // read as text) hides the disclosure rather than showing an empty one.
+        // Two concise numbers per dataset row — student-to-student similarity
+        // and drift from the pool — served as ready-made display strings on
+        // the same GET/PUT the controls use, so the numbers move with every
+        // saved parameter edit and the wording lives in one tested place
+        // server-side (DatasetEditHelpers).  The how-it-is-measured detail
+        // rides each chip's hover title.  A row with no block (not a dataset,
+        // or a file the server could not read as text) hides the chips.
         function renderDiagnostics(reports) {
             var byFile = {};
             (reports || []).forEach(function (report) { byFile[report.file] = report; });
             rows().forEach(function (row) {
-                var box = row.querySelector('.js-dataset-diagnostics');
+                var box = row.querySelector('.js-dataset-estimates');
                 if (!box) return;
                 var report = byFile[row.getAttribute('data-support-file')];
                 box.hidden = !report;
-                var body = row.querySelector('.js-dataset-diagnostics-body');
-                if (!report || !body) return;
-                body.textContent = '';
-                diagnosticsLines(report).forEach(function (line) {
-                    var item = document.createElement('span');
-                    item.className = 'dataset-diagnostics-line';
-                    item.textContent = line;
-                    body.appendChild(item);
-                });
+                var similarity = row.querySelector('.js-dataset-similarity');
+                var drift = row.querySelector('.js-dataset-drift');
+                if (similarity) {
+                    similarity.textContent = report ? report.similarityDisplay : '';
+                    similarity.title = report ? report.similarityTitle : '';
+                }
+                if (drift) {
+                    drift.textContent = report ? report.driftDisplay : '';
+                    drift.title = report ? report.driftTitle : '';
+                }
             });
         }
 
@@ -357,8 +307,8 @@
                     if (field) field.hidden = true;
                     if (stratumField) stratumField.hidden = true;
                     if (blankField) blankField.hidden = true;
-                    var diagnostics = row.querySelector('.js-dataset-diagnostics');
-                    if (diagnostics) diagnostics.hidden = true;
+                    var estimates = row.querySelector('.js-dataset-estimates');
+                    if (estimates) estimates.hidden = true;
                     commit(filename, null, row);
                     return;
                 }

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -211,11 +211,11 @@
                             <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
                             #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
-                            <details class="dataset-diagnostics js-dataset-diagnostics"
-                                     #if(!supportFile.isDataset):hidden#endif>
-                                <summary>Per-student estimates</summary>
-                                <span class="dataset-diagnostics-body js-dataset-diagnostics-body"></span>
-                            </details>
+                            <span class="dataset-estimates js-dataset-estimates"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                <span class="dataset-estimate js-dataset-similarity"></span>
+                                <span class="dataset-estimate js-dataset-drift"></span>
+                            </span>
                         </div>
                     </td>
                     <td class="time">

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -211,11 +211,11 @@ Create Assignment
                             <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
                             #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
-                            <details class="dataset-diagnostics js-dataset-diagnostics"
-                                     #if(!supportFile.isDataset):hidden#endif>
-                                <summary>Per-student estimates</summary>
-                                <span class="dataset-diagnostics-body js-dataset-diagnostics-body"></span>
-                            </details>
+                            <span class="dataset-estimates js-dataset-estimates"
+                                  #if(!supportFile.isDataset):hidden#endif>
+                                <span class="dataset-estimate js-dataset-similarity"></span>
+                                <span class="dataset-estimate js-dataset-drift"></span>
+                            </span>
                         </div>
                     </td>
                     <td class="time">

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -31,23 +31,23 @@ struct DatasetsResponse: Content {
     var diagnostics: [DatasetFileDiagnostics]
 }
 
-/// One dataset's estimate block: closed-form overlap (can students copy?)
-/// and measured divergence headlines (are they doing the same exercise?).
-/// Both computed by Core's `DatasetDiagnostics` from the spec and the
-/// bundled file — estimates about the delivered bytes, never a change to
-/// them.  See docs/datasets.md.
+/// One dataset's estimate chips: two concise numbers the row shows inline —
+/// student-to-student similarity (closed-form overlap) and drift from the
+/// pool (measured divergence) — with the how-it-is-measured detail carried
+/// in each chip's hover title.  Display strings are built HERE, server-side,
+/// so the wording lives in one tested place and the page JS only paints.
+/// Computed by Core's `DatasetDiagnostics`; estimates about the delivered
+/// bytes, never a change to them.  See docs/datasets.md.
 struct DatasetFileDiagnostics: Content {
     var file: String
-    var overlap: DatasetOverlap
-    /// The worst column per measure (SDs of transport for numeric columns,
-    /// total variation for categorical).  Empty when nothing was measurable.
-    var headlines: [DatasetDivergenceHeadline]
-    /// False when the file was over the sampling ceiling, so only the
-    /// closed-form overlap is reported — stated rather than silently capped.
-    var divergenceMeasured: Bool
-    /// The class size the worst-pair estimate assumes, so the panel can say
-    /// it instead of implying a measured class.
-    var classSize: Int
+    /// The whole chip text, e.g. "similarity 8%": the fraction of one
+    /// student's rows a peer is expected to also hold.
+    var similarityDisplay: String
+    var similarityTitle: String
+    /// The whole chip text, e.g. "drift 0.04" — the worst column's typical
+    /// distance from the pool — or "drift —" when nothing was measurable.
+    var driftDisplay: String
+    var driftTitle: String
 }
 
 /// Files above this size skip the divergence measurement — it materializes
@@ -55,9 +55,9 @@ struct DatasetFileDiagnostics: Content {
 /// batch job.  Overlap is a single pass and is always reported.
 private let datasetDivergenceByteCeiling = 4 << 20
 
-/// The estimate blocks for every spec whose source file can be read as text.
+/// The estimate chips for every spec whose source file can be read as text.
 /// A file that cannot be read (or has no data rows) simply has no block —
-/// the panel hides the disclosure rather than showing an empty one.
+/// the panel hides the chips rather than showing empty ones.
 ///
 /// CPU-bound (the divergence half materializes the pool `defaultSeedCount`
 /// times), so handlers call it through `runBlocking` rather than on the
@@ -67,18 +67,100 @@ func datasetDiagnosticsReports(
 ) -> [DatasetFileDiagnostics] {
     datasets.compactMap { spec in
         guard let data = extractZipEntry(zipPath: zipPath, entryName: spec.file),
-            let text = String(data: data, encoding: .utf8),
-            let overlap = DatasetDiagnostics.overlap(spec: spec, sourceCSV: text)
+            let text = String(data: data, encoding: .utf8)
         else { return nil }
-        let measurable = data.count <= datasetDivergenceByteCeiling
-        let headlines =
-            measurable
-            ? DatasetDiagnostics.headlines(
-                of: DatasetDiagnostics.divergence(spec: spec, sourceCSV: text))
-            : []
-        return DatasetFileDiagnostics(
-            file: spec.file, overlap: overlap, headlines: headlines,
-            divergenceMeasured: measurable, classSize: DatasetDiagnostics.defaultClassSize)
+        return datasetEstimateSummary(
+            for: spec, sourceCSV: text,
+            divergenceMeasurable: data.count <= datasetDivergenceByteCeiling)
+    }
+}
+
+/// Builds one file's two chips from its spec and source text, or nil when
+/// the pool has no data rows to estimate.  Pure given its inputs — the
+/// zip-reading and the byte ceiling live in `datasetDiagnosticsReports` —
+/// so the wording and number formatting are testable on plain strings.
+func datasetEstimateSummary(
+    for spec: DatasetSpec, sourceCSV: String, divergenceMeasurable: Bool
+) -> DatasetFileDiagnostics? {
+    guard let overlap = DatasetDiagnostics.overlap(spec: spec, sourceCSV: sourceCSV)
+    else { return nil }
+
+    var similarityTitle =
+        "Two students share about \(Int(overlap.expectedSharedRows.rounded())) of their "
+        + "\(overlap.rowsPerStudent) rows — the expected overlap between independent "
+        + "\(overlap.rowsPerStudent)-row samples of the \(overlap.poolRows)-row pool. "
+        + "The unluckiest pair in a class of \(DatasetDiagnostics.defaultClassSize) shares "
+        + "about \(Int(overlap.worstPairSharedRows.rounded())) rows."
+    if let stratum = overlap.mostCopyableStratum {
+        similarityTitle +=
+            " Most shared category: \"\(stratum.value)\" — every student draws "
+            + "\(stratum.rowsPerStudent) of its \(stratum.poolRows) pool rows "
+            + "(\(estimatePercentText(stratum.sharedFraction)) shared)."
+    }
+
+    let drift = driftChip(for: spec, sourceCSV: sourceCSV, measurable: divergenceMeasurable)
+    return DatasetFileDiagnostics(
+        file: spec.file,
+        similarityDisplay: "similarity \(estimatePercentText(overlap.sharedFraction))",
+        similarityTitle: similarityTitle,
+        driftDisplay: drift.display,
+        driftTitle: drift.title)
+}
+
+/// The drift chip: the worst column's *typical* (median-over-variants)
+/// normalized distance from the pool, as one number.  The column, the
+/// measure and its unit, the unlucky-variant value, and the other measure's
+/// worst column (when both kinds exist) all ride the title.
+private func driftChip(
+    for spec: DatasetSpec, sourceCSV: String, measurable: Bool
+) -> (display: String, title: String) {
+    guard measurable else {
+        return (
+            "drift —",
+            "Distribution drift was not measured — the file is too large to sample quickly."
+        )
+    }
+    let columns = DatasetDiagnostics.divergence(spec: spec, sourceCSV: sourceCSV)
+    guard let worst = columns.max(by: { $0.median < $1.median }) else {
+        return ("drift —", "No measurable columns — nothing observed to compare to the pool.")
+    }
+
+    var title =
+        "How far a student's data drifts from the pool's distribution, measured over "
+        + "\(DatasetDiagnostics.defaultSeedCount) sampled variants; 0 means identical. "
+        + "Worst column: \"\(worst.column)\" — typically \(estimateUnitsText(worst.median)) "
+        + "\(estimateMeasureName(worst.measure)) from the pool, "
+        + "\(estimateUnitsText(worst.worst)) on an unlucky variant."
+    if let other = columns.filter({ $0.measure != worst.measure })
+        .max(by: { $0.median < $1.median })
+    {
+        title +=
+            " Also: \"\(other.column)\" at \(estimateUnitsText(other.median)) "
+            + "\(estimateMeasureName(other.measure))."
+    }
+    return ("drift \(estimateUnitsText(worst.median))", title)
+}
+
+/// A fraction as chip-sized percent text: whole percents from 10% up, one
+/// decimal below, and a floor marker rather than a misleading "0%".
+func estimatePercentText(_ fraction: Double) -> String {
+    let percent = fraction * 100
+    if percent >= 99.95 { return "100%" }
+    if percent >= 10 { return "\(Int(percent.rounded()))%" }
+    if percent >= 0.1 { return String(format: "%.1f%%", percent) }
+    return "<0.1%"
+}
+
+/// A normalized divergence as chip-sized text: two decimals, with a floor
+/// marker rather than a "0.00" that would claim identical distributions.
+func estimateUnitsText(_ value: Double) -> String {
+    value < 0.005 ? "<0.01" : String(format: "%.2f", value)
+}
+
+private func estimateMeasureName(_ measure: DatasetColumnDivergence.Measure) -> String {
+    switch measure {
+    case .wasserstein: return "pool standard deviations (Wasserstein-1)"
+    case .totalVariation: return "in total-variation distance (0–1)"
     }
 }
 

--- a/Tests/APITests/DatasetEstimateSummaryTests.swift
+++ b/Tests/APITests/DatasetEstimateSummaryTests.swift
@@ -1,0 +1,114 @@
+// Tests/APITests/DatasetEstimateSummaryTests.swift
+//
+// The wording and number formatting of the Files panel's two estimate chips
+// (DatasetEditHelpers.datasetEstimateSummary).  The underlying statistics
+// have their own suite in CoreTests (DatasetDiagnosticsTests); what is
+// pinned here is the display layer the page JS paints verbatim — one
+// concise number per chip, the how-it-is-measured detail in the title —
+// so a wording regression is caught in Swift rather than in a browser.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+@testable import Core
+
+@Suite struct DatasetEstimateSummaryTests {
+
+    /// 200 unique rows: `id` 0–199, `ward` A×120 / B×60 / C×15 / D×5 (a
+    /// deliberately rare stratum), `score` a spread of integers — the same
+    /// shape as the CoreTests fixture.
+    private let pool: String = {
+        var lines = ["id,ward,score"]
+        for i in 0..<200 {
+            let ward = i < 120 ? "A" : i < 180 ? "B" : i < 195 ? "C" : "D"
+            lines.append("\(i),\(ward),\(50 + (i * 37) % 100)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }()
+
+    @Test func aPlainSampleGetsBothChipsWithTheDetailInTheTitles() throws {
+        let summary = try #require(
+            datasetEstimateSummary(
+                for: DatasetSpec(file: "cases.csv", sampleSize: 40),
+                sourceCSV: pool, divergenceMeasurable: true))
+
+        // 40 of 200 rows: k/N = 20%, expected shared k²/N = 8.
+        #expect(summary.similarityDisplay == "similarity 20%")
+        #expect(summary.similarityTitle.contains("about 8 of their 40 rows"))
+        #expect(summary.similarityTitle.contains("200-row pool"))
+        #expect(summary.similarityTitle.contains("class of 100"))
+        #expect(
+            !summary.similarityTitle.contains("Most shared category"),
+            "a plain sample has no strata to name")
+
+        // One number; the column, measure and unlucky-variant value ride the
+        // title.
+        #expect(summary.driftDisplay.wholeMatch(of: /drift (\d+\.\d{2}|<0\.01)/) != nil)
+        #expect(summary.driftTitle.contains("Worst column: \""))
+        #expect(summary.driftTitle.contains("sampled variants"))
+        #expect(summary.driftTitle.contains("on an unlucky variant"))
+        // The fixture has numeric and categorical columns, so both measures
+        // are named across the title.
+        #expect(summary.driftTitle.contains("pool standard deviations"))
+        #expect(summary.driftTitle.contains("total-variation"))
+    }
+
+    @Test func aStratifiedSampleNamesItsMostSharedCategory() throws {
+        let summary = try #require(
+            datasetEstimateSummary(
+                for: DatasetSpec(
+                    file: "cases.csv", kind: .stratifiedSample, sampleSize: 40,
+                    stratumColumn: "ward"),
+                sourceCSV: pool, divergenceMeasurable: true))
+        // The one-row floor makes rare ward D the most copyable part: every
+        // student draws 2 of its 5 pool rows.
+        #expect(summary.similarityTitle.contains("Most shared category: \"D\""))
+        #expect(summary.similarityTitle.contains("2 of its 5 pool rows (40% shared)"))
+    }
+
+    @Test func aWholeFileSpecIsTotalSimilarity() throws {
+        let summary = try #require(
+            datasetEstimateSummary(
+                for: DatasetSpec(file: "cases.csv", sampleSize: nil),
+                sourceCSV: pool, divergenceMeasurable: true))
+        #expect(summary.similarityDisplay == "similarity 100%")
+    }
+
+    @Test func anUnmeasurableFileSaysSoInsteadOfShowingNothing() throws {
+        let summary = try #require(
+            datasetEstimateSummary(
+                for: DatasetSpec(file: "cases.csv", sampleSize: 40),
+                sourceCSV: pool, divergenceMeasurable: false))
+        #expect(summary.driftDisplay == "drift —")
+        #expect(summary.driftTitle.contains("too large"))
+        #expect(
+            summary.similarityDisplay == "similarity 20%",
+            "overlap is closed form and stays reported")
+    }
+
+    @Test func aHeaderOnlyPoolHasNoChips() {
+        #expect(
+            datasetEstimateSummary(
+                for: DatasetSpec(file: "cases.csv", sampleSize: 40),
+                sourceCSV: "id,ward\n", divergenceMeasurable: true) == nil)
+    }
+
+    // MARK: - Number formatting
+
+    @Test func percentTextRoundsByMagnitudeAndNeverClaimsZero() {
+        #expect(estimatePercentText(1.0) == "100%")
+        #expect(estimatePercentText(0.9996) == "100%")
+        #expect(estimatePercentText(0.47) == "47%")
+        #expect(estimatePercentText(0.078) == "7.8%")
+        #expect(estimatePercentText(0.001) == "0.1%")
+        #expect(estimatePercentText(0.0004) == "<0.1%")
+    }
+
+    @Test func unitsTextUsesTwoDecimalsAndAFloorMarker() {
+        #expect(estimateUnitsText(0.037) == "0.04")
+        #expect(estimateUnitsText(1.5) == "1.50")
+        #expect(estimateUnitsText(0.004) == "<0.01")
+        #expect(estimateUnitsText(0) == "<0.01")
+    }
+}

--- a/Tests/APITests/DatasetsRouteRoundTripTests.swift
+++ b/Tests/APITests/DatasetsRouteRoundTripTests.swift
@@ -482,19 +482,14 @@ import VaporTesting
                 let block = try #require(
                     state.diagnostics.first, "\(path): a marked CSV gets an estimate block")
                 #expect(block.file == "cases.csv")
-                // Two of the fixture's three rows: shared fraction k/N = 2/3,
-                // expected shared k²/N = 4/3 — the numbers describe the real
-                // bundled bytes, not a placeholder.
-                #expect(block.overlap.poolRows == 3)
-                #expect(block.overlap.rowsPerStudent == 2)
-                #expect(abs(block.overlap.sharedFraction - 2.0 / 3.0) < 1e-9)
-                #expect(abs(block.overlap.expectedSharedRows - 4.0 / 3.0) < 1e-9)
-                #expect(block.divergenceMeasured)
-                #expect(block.classSize == DatasetDiagnostics.defaultClassSize)
-                // `id` is numeric (Wasserstein), `ward` categorical (TV) —
-                // one headline per measure, each naming its column.
-                #expect(block.headlines.count == 2)
-                #expect(block.headlines.map(\.measure) == [.wasserstein, .totalVariation])
+                // Two of the fixture's three rows: shared fraction k/N = 2/3
+                // — the chip describes the real bundled bytes, not a
+                // placeholder.  Wording itself is pinned in
+                // DatasetEstimateSummaryTests; this is the plumbing.
+                #expect(block.similarityDisplay == "similarity 67%")
+                #expect(block.similarityTitle.contains("3-row pool"))
+                #expect(block.driftDisplay.hasPrefix("drift "))
+                #expect(block.driftTitle.contains("Worst column"))
 
                 try await put(
                     path, fx, body: #"{"datasets":[]}"#, expect: .ok, "clearing the mark")

--- a/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
+++ b/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
@@ -39,19 +39,6 @@ function makeInput(value = '', disabled = false) {
   };
 }
 
-/// The estimates disclosure body: collects appended line elements, and
-/// clears them when the control resets `textContent`.
-function makeDiagnosticsBody() {
-  const el = makeInput();
-  el.children = [];
-  el.appendChild = (child) => { el.children.push(child); };
-  Object.defineProperty(el, 'textContent', {
-    set(value) { if (value === '') el.children = []; },
-    get() { return el.children.map((c) => c.textContent).join('\n'); },
-  });
-  return el;
-}
-
 /// One `tr[data-support-file]` carrying the control's six elements.
 function makeRow(filename) {
   const parts = {
@@ -64,8 +51,9 @@ function makeRow(filename) {
     '.js-dataset-blank-columns': makeInput(),
     '.js-dataset-blank-percent': makeInput(),
     '.js-dataset-status': makeInput(),
-    '.js-dataset-diagnostics': makeInput(),
-    '.js-dataset-diagnostics-body': makeDiagnosticsBody(),
+    '.js-dataset-estimates': makeInput(),
+    '.js-dataset-similarity': makeInput(),
+    '.js-dataset-drift': makeInput(),
   };
   const row = {
     filename,
@@ -94,7 +82,6 @@ function load({ specs = [], diagnostics = null } = {}) {
     getElementById: () => null,
     body: { addEventListener(type, fn) { (bodyHandlers[type] ||= []).push(fn); } },
     addEventListener() {},
-    createElement: (tag) => ({ tagName: tag, className: '', textContent: '' }),
     querySelector: () => null,
     querySelectorAll: (sel) => (sel === 'tr[data-support-file]' ? rows : []),
   };
@@ -303,29 +290,23 @@ test('a re-render disables the fields for a spec the panel cannot represent', as
   assert.equal(row.querySelector('.js-dataset-blank-columns').value, '');
 });
 
-// ── The estimates disclosure ────────────────────────────────────────────────
+// ── The estimate chips ──────────────────────────────────────────────────────
+//
+// The server sends ready-made display strings (the wording is pinned in
+// Swift, in DatasetEstimateSummaryTests); what the JS owes is painting them
+// into the two chips — textContent for the number, title for the hover
+// detail — and hiding the chips when a row has no block.
 
 const sampleBlock = (spec) => ({
   file: spec.file,
-  overlap: {
-    poolRows: 6388,
-    rowsPerStudent: spec.sampleSize || 6388,
-    expectedSharedRows: 39.1,
-    sharedFraction: 0.078,
-    worstPairSharedRows: 63.2,
-    mostCopyableStratum: spec.stratumColumn
-      ? { value: 'D', poolRows: 5, rowsPerStudent: 2, sharedFraction: 0.4 }
-      : null,
-  },
-  headlines: [
-    { measure: 'wasserstein', column: 'systolic', median: 0.037, worst: 0.061 },
-    { measure: 'totalVariation', column: 'ward', median: 0.02, worst: 0.05 },
-  ],
-  divergenceMeasured: true,
-  classSize: 100,
+  similarityDisplay: 'similarity 7.8%',
+  similarityTitle: 'Two students share about 39 of their '
+    + (spec.sampleSize || 6388) + ' rows.',
+  driftDisplay: 'drift 0.04',
+  driftTitle: 'Worst column: "systolic" - typically 0.04 pool standard deviations.',
 });
 
-test('the estimates paint on init from the GET, one line per fact', async () => {
+test('the chips paint on init from the GET, number plus hover title', async () => {
   const h = load({
     specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
     diagnostics: sampleBlock,
@@ -334,39 +315,20 @@ test('the estimates paint on init from the GET, one line per fact', async () => 
   row.querySelector('.js-dataset-toggle').checked = true;
   await settle();
 
-  assert.equal(row.querySelector('.js-dataset-diagnostics').hidden, false);
-  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
-  assert.match(text, /39 of their 500 rows \(7\.8%\)/);
-  assert.match(text, /unluckiest pair in a class of 100 shares about 63/);
-  assert.match(text, /systolic sits about 0\.04 SD/);
-  assert.match(text, /any two students within about 0\.12 SD/);
-  assert.match(text, /ward sits about 0\.02 total-variation/);
+  assert.equal(row.querySelector('.js-dataset-estimates').hidden, false);
+  const similarity = row.querySelector('.js-dataset-similarity');
+  assert.equal(similarity.textContent, 'similarity 7.8%');
+  assert.match(similarity.title, /39 of their 500 rows/);
+  const drift = row.querySelector('.js-dataset-drift');
+  assert.equal(drift.textContent, 'drift 0.04');
+  assert.match(drift.title, /Worst column: "systolic"/);
   assert.equal(h.puts.length, 0, 'the first paint is a read, not a write');
 });
 
-test('a stratified block names its most copyable category', async () => {
-  const h = load({
-    specs: [{
-      file: 'cases.csv', kind: 'stratifiedSample', sampleSize: 500, stratumColumn: 'ward',
-    }],
-    diagnostics: sampleBlock,
-  });
-  const row = h.rows[0];
-  row.querySelector('.js-dataset-toggle').checked = true;
-  await settle();
-
-  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
-  assert.match(text, /Most copyable category: "D"/);
-  assert.match(text, /2 of the same 5 pool rows \(40% shared\)/);
-});
-
-test('the estimates repaint from the PUT response when a parameter changes', async () => {
+test('the chips repaint from the PUT response when a parameter changes', async () => {
   const h = load({
     specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
-    diagnostics: (spec) => ({
-      ...sampleBlock(spec),
-      overlap: { ...sampleBlock(spec).overlap, rowsPerStudent: spec.sampleSize },
-    }),
+    diagnostics: sampleBlock,
   });
   const row = h.rows[0];
   row.querySelector('.js-dataset-toggle').checked = true;
@@ -374,37 +336,25 @@ test('the estimates repaint from the PUT response when a parameter changes', asy
   await change(h, row, '.js-dataset-size');
   await settle();
 
-  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
-  assert.match(text, /of their 900 rows/, 'the numbers follow the saved edit');
+  assert.match(
+    row.querySelector('.js-dataset-similarity').title, /of their 900 rows/,
+    'the numbers follow the saved edit');
 });
 
-test('a row without an estimate block hides the disclosure', async () => {
+test('a row without an estimate block hides and empties the chips', async () => {
   // The server sends no block for an unreadable file (and for an unmarked
-  // one); an empty disclosure would read as a broken panel.
+  // one); a stale number would read as a live estimate.
   const h = load({
     specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
     diagnostics: null,
   });
   const row = h.rows[0];
   row.querySelector('.js-dataset-toggle').checked = true;
+  row.querySelector('.js-dataset-similarity').textContent = 'similarity 7.8%';
   await settle();
 
-  assert.equal(row.querySelector('.js-dataset-diagnostics').hidden, true);
-});
-
-test('an unmeasured divergence says so instead of showing nothing', async () => {
-  const h = load({
-    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
-    diagnostics: (spec) => ({
-      ...sampleBlock(spec), headlines: [], divergenceMeasured: false,
-    }),
-  });
-  const row = h.rows[0];
-  row.querySelector('.js-dataset-toggle').checked = true;
-  await settle();
-
-  const text = row.querySelector('.js-dataset-diagnostics-body').textContent;
-  assert.match(text, /not measured — the file is too large/);
+  assert.equal(row.querySelector('.js-dataset-estimates').hidden, true);
+  assert.equal(row.querySelector('.js-dataset-similarity').textContent, '');
 });
 
 test('a stratified spec keeps its kind when only the blanking changes', async () => {

--- a/changelog.d/compact-dataset-estimates.md
+++ b/changelog.d/compact-dataset-estimates.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The dataset estimates are now two glanceable chips, not a disclosure.**
+  Each marked dataset row shows `similarity NN%` — the fraction of one
+  student's rows a peer is expected to also hold, a student-to-student
+  similarity score — and `drift 0.NN`, the worst column's typical normalized
+  distance from the pool, inline beside the controls. The full detail (shared
+  row counts, the unluckiest pair, the most-shared category under
+  stratification, which column drifts in which measure) moved into each
+  chip's mouse-over title. The first release's collapsed "Per-student
+  estimates" panel of prose sentences is gone.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -883,15 +883,33 @@ the test — needs revisiting.
 parameter estimate wants to live where the parameters are, moving as the
 instructor edits the row count (multi-variant validation shares the preflight
 seeds but answers a different question at a different time). Each dataset row
-carries a collapsed "Per-student estimates" disclosure; the estimate blocks
-ride the same GET/PUT the controls already use (`DatasetsResponse.diagnostics`,
-computed off the event loop), so a saved edit repaints the numbers with no
-second request. The two estimates pull in opposite directions — more rows per
-student is fairer but more copyable — so the text is deliberately
-informational: no thresholds, no warnings, and no gating on either number
-(instructors may legitimately want to *maximize* divergence). Files above a
-stated byte ceiling skip the divergence sampling and say so; overlap, a single
-pass, is always reported.
+shows **two inline chips, one concise number each**: `similarity NN%` (the
+fraction of one student's rows a peer is expected to also hold — a
+student-to-student similarity score) and `drift 0.NN` (the worst column's
+typical normalized distance from the pool). Everything else — the expected
+shared-row count, the unluckiest pair, the most-shared category under
+stratification, which column drifts and in which measure, the unlucky-variant
+value — rides each chip's hover title. This replaced a first-release
+disclosure full of prose sentences, on maintainer feedback: the numbers are
+for glancing at while dragging a row count, and the method belongs behind a
+mouse-over, not in the row. The display strings are built server-side in one
+tested place (`DatasetEditHelpers.datasetEstimateSummary`), and the blocks
+ride the same GET/PUT the controls already use
+(`DatasetsResponse.diagnostics`, computed off the event loop), so a saved
+edit repaints the numbers with no second request. The two estimates pull in
+opposite directions — more rows per student is fairer but more copyable — so
+the chips are deliberately informational: no thresholds, no warnings, and no
+gating on either number (instructors may legitimately want to *maximize*
+divergence). Files above a stated byte ceiling skip the divergence sampling
+and the drift chip says so (`drift —`); overlap, a single pass, is always
+reported.
+
+The drift chip's single number is the max across columns of the *median*
+normalized divergence, whatever that column's measure — a deliberate
+softening of the two-headline rule above for the glanceable layer only: SD
+units and TV still are not commensurable, so the chip never mixes them
+arithmetically (no averaging), and the title always names the column, the
+measure, and the other measure's worst column when both kinds exist.
 
 `numericJitter` stays dead (see above), and these diagnostics do not assume
 it.


### PR DESCRIPTION
Redesign of the dataset estimates surface shipped in #1443, on maintainer feedback: the collapsed "Per-student estimates" disclosure was too heavyweight and too much text, and the numbers should not live behind a drop-down.

## What changed

Each marked dataset row now shows **two inline chips**, one concise number each, beside the existing controls:

- **`similarity NN%`** — the fraction of one student's rows a peer is expected to also hold (the closed-form overlap, i.e. a student-to-student similarity score). Percent formatting: whole percents from 10% up, one decimal below, `<0.1%` floor.
- **`drift 0.NN`** — the worst column's *typical* (median-over-variants) normalized distance from the pool, or `drift —` when the file is over the sampling ceiling.

Everything that used to be prose lines — expected shared-row counts, the unluckiest pair in a class, the most-shared category under stratification, which column drifts in which measure and its unlucky-variant value — now rides each chip's **hover title** (`cursor: help`, dotted underline as the affordance).

## How

- Display strings are built **server-side in one tested place** (`datasetEstimateSummary` in `DatasetEditHelpers.swift`); the page JS only paints `textContent` and `title`. Wording is pinned by the new `DatasetEstimateSummaryTests`.
- The wire shape of `DatasetsResponse.diagnostics` changed from raw overlap/headline structs to the four display strings. Same endpoints, same repaint-on-save flow.
- The drift chip's single number is the max across columns of the median normalized divergence, whatever that column's measure. SD-units and total variation are still never mixed arithmetically — the softening of the two-headline rule is confined to the glanceable layer, and the title always names the column and measure (and the other measure's worst column when both kinds exist).
- Core's `DatasetDiagnostics` / `DatasetDivergence` are untouched; so is multi-variant validation.

## Tests

- `DatasetEstimateSummaryTests` (new): chip wording and number formatting — plain/stratified/whole-file/unmeasurable cases, percent and unit formatting edges.
- `DatasetsRouteRoundTripTests` updated to the new wire shape (real-bytes plumbing assertion: 2-of-3-row fixture → `similarity 67%`).
- JS tests rewritten for the chip markup: paint-on-init, repaint-from-PUT, hide-and-empty when a row has no block.
- `format-lint` gates all green locally (swift-format, SwiftLint `--strict`, check-styles, eslint).

Render tests prove the templates resolve; the chips' look (wrapping in the flex row, tooltip affordance) has not had a manual browser pass — worth one glance on the edit page after deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcLvzjV8ZnS1qbCkjnfGRE)_