### PR TITLE
feat(ui): price the vocabulary above the token layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1133,6 +1133,35 @@ the `format-lint` CI job) — keep them green:
 - **The nginx maintenance page mirrors the palette by value** —
   `scripts/check-maintenance-palette.sh` fails when a colour there stops
   existing in `styles.css`.
+- **Do not invent a second way to say something the UI already says.** The
+  token guards prove a value is on the palette and the class-resolution guard
+  proves a name has a rule; neither can see a component that duplicates one in
+  the vocabulary under a different name, and until v0.5.137 the *global* sheet
+  had no budget at all — so the cheapest way to add a second spelling was to
+  skip the page block and put it in `styles.css`. That is how a pair of
+  estimate chips shipped as chips in the changelog, the commit message and
+  their own CSS comment, under a name sharing nothing with `.chip`, past a
+  fully green `format-lint`. `scripts/check-ui-vocabulary.sh` now prices it:
+  the count of global classes [docs/ui-design.md](docs/ui-design.md) does not
+  name is a shrink-only ratchet, `cursor` and `text-decoration` values are a
+  closed **affordance registry** (a new one is a rulebook edit, not a CSS
+  line), and hover text written in a template is capped at 20 words.
+- **Chrome is not prose, and a tooltip is not a disclosure.** Labels and chips
+  are two-or-three-word noun phrases; a `title` is one phrase; a note under a
+  control is one sentence; **anything longer goes in `docs/` and the UI links
+  there**. A hover title is invisible on touch, unsearchable, and read
+  inconsistently by screen readers, so it may never hold the only copy of
+  something a reader needs. The rules and the cheapest-first table of
+  interaction idioms — on the page → `<details>` → row popover → modal — are
+  in ui-design.md under "Interaction idioms" and "UI copy". The script only
+  reads templates, so prose assembled in Swift or JS needs its own budget
+  assertion (`datasetEstimateTitleWordCap` is the worked example).
+- **Run the `ui-review` agent on any change touching `Resources/Views/`,
+  `Public/styles.css`, or a page-wiring `Public/*.js`.** It reviews the layer
+  the guards structurally cannot: whether a construct duplicates the
+  vocabulary, whether the idiom is the lightest that fits, and whether the
+  copy is at house length. Green guards are necessary, not sufficient — every
+  style regression so far has been mechanically legal.
 
 Run `scripts/check-styles.sh` locally before pushing UI changes (it runs all
 of the above — same as the CI `format-lint` job). The visual-regression

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -2072,16 +2072,12 @@ code { font-family: var(--font-mono); font-size: .9em; }
    cannot represent — it steps aside rather than rendering a partial view it
    would then save over. */
 .dataset-note { font-style: italic; color: var(--gray-600); }
-/* Per-row estimate chips: student-to-student similarity and drift from the
-   pool (docs/datasets.md), one concise number each, painted by
-   support-files.js from the datasets GET/PUT.  The how-it-is-measured
-   detail rides each chip's hover title — cursor plus dotted underline as
-   the affordance.  A band with two bad ends rather than a threshold, so
-   never styled as a warning.  Inherits the control row's size and colour;
-   an empty chip (before the first fetch lands) takes no space. */
-.dataset-estimates { display: inline-flex; gap: .5rem; }
-.dataset-estimate { cursor: help; text-decoration: underline dotted; text-underline-offset: .15em; }
-.dataset-estimate:empty { display: none; }
+/* The per-row estimates — student-to-student similarity and drift from the
+   pool (docs/datasets.md) — are plain chips, painted by support-files.js
+   from the datasets GET/PUT.  They carry no styling of their own: a chip is
+   already the vocabulary's neutral tag, and these describe a band with two
+   bad ends rather than a threshold, so there is no status colour to add.
+   Each chip is hidden until its number lands. */
 
 /* Pattern-family editor body internals. */
 .label-note { color: var(--gray-600); font-weight: 400; }

--- a/Public/support-files.js
+++ b/Public/support-files.js
@@ -86,9 +86,16 @@
         // and drift from the pool — served as ready-made display strings on
         // the same GET/PUT the controls use, so the numbers move with every
         // saved parameter edit and the wording lives in one tested place
-        // server-side (DatasetEditHelpers).  The how-it-is-measured detail
-        // rides each chip's hover title.  A row with no block (not a dataset,
-        // or a file the server could not read as text) hides the chips.
+        // server-side (DatasetEditHelpers).  A row with no block (not a
+        // dataset, or a file the server could not read as text) hides the
+        // chips, as does a chip whose number is not measurable.
+        function paintChip(chip, text, title) {
+            if (!chip) return;
+            chip.textContent = text || '';
+            chip.title = title || '';
+            chip.hidden = !text;
+        }
+
         function renderDiagnostics(reports) {
             var byFile = {};
             (reports || []).forEach(function (report) { byFile[report.file] = report; });
@@ -97,16 +104,10 @@
                 if (!box) return;
                 var report = byFile[row.getAttribute('data-support-file')];
                 box.hidden = !report;
-                var similarity = row.querySelector('.js-dataset-similarity');
-                var drift = row.querySelector('.js-dataset-drift');
-                if (similarity) {
-                    similarity.textContent = report ? report.similarityDisplay : '';
-                    similarity.title = report ? report.similarityTitle : '';
-                }
-                if (drift) {
-                    drift.textContent = report ? report.driftDisplay : '';
-                    drift.title = report ? report.driftTitle : '';
-                }
+                paintChip(row.querySelector('.js-dataset-similarity'),
+                    report && report.similarityDisplay, report && report.similarityTitle);
+                paintChip(row.querySelector('.js-dataset-drift'),
+                    report && report.driftDisplay, report && report.driftTitle);
             });
         }
 

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -211,10 +211,10 @@
                             <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
                             #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
-                            <span class="dataset-estimates js-dataset-estimates"
+                            <span class="chip-row js-dataset-estimates"
                                   #if(!supportFile.isDataset):hidden#endif>
-                                <span class="dataset-estimate js-dataset-similarity"></span>
-                                <span class="dataset-estimate js-dataset-drift"></span>
+                                <span class="chip js-dataset-similarity" hidden></span>
+                                <span class="chip js-dataset-drift" hidden></span>
                             </span>
                         </div>
                     </td>
@@ -319,7 +319,7 @@
                 <input class="form-input input-compact suite-default-limit-input"
                        type="number" min="1" max="600" step="1"
                        id="suite-default-time-limit" value="#(timeLimitSeconds)"
-                       title="Seconds each test may run before it is killed and recorded as a timeout. Individual tests can override this in the test editor.">
+                       title="Seconds a test may run before it times out. Individual tests can override this.">
                 s
                 <span id="suite-default-limit-status" class="upload-status-inline" role="status" aria-live="polite"></span>
             </label>

--- a/Resources/Views/_assignment-edit-body.leaf
+++ b/Resources/Views/_assignment-edit-body.leaf
@@ -319,7 +319,7 @@
                 <input class="form-input input-compact suite-default-limit-input"
                        type="number" min="1" max="600" step="1"
                        id="suite-default-time-limit" value="#(timeLimitSeconds)"
-                       title="Seconds a test may run before it times out. Individual tests can override this.">
+                       title="Seconds before a test times out, unless the test sets its own limit.">
                 s
                 <span id="suite-default-limit-status" class="upload-status-inline" role="status" aria-live="polite"></span>
             </label>

--- a/Resources/Views/_course-item-row.leaf
+++ b/Resources/Views/_course-item-row.leaf
@@ -155,6 +155,7 @@
             #endif
             #elseif(item.assignment.validationStatus == "no-runner"):
             <span class="tier tier-closed" title="No runner could grade this when it was last saved, so validation did not run.">no runner</span>
+            <div class="cell-subrow">Ask an admin for a compatible runner, then re-save.</div>
             #else:
             <span class="tier">—</span>
             #endif

--- a/Resources/Views/_course-item-row.leaf
+++ b/Resources/Views/_course-item-row.leaf
@@ -154,13 +154,13 @@
             </div>
             #endif
             #elseif(item.assignment.validationStatus == "no-runner"):
-            <span class="tier tier-closed" title="No compatible runner was available when the assignment was last saved. Validation was not enqueued — ask an admin to start a compatible runner, then re-save the assignment.">no runner</span>
+            <span class="tier tier-closed" title="No runner could grade this when it was last saved, so validation did not run.">no runner</span>
             #else:
             <span class="tier">—</span>
             #endif
             #if(item.assignment.variantState == "failed"):
             <div class="cell-subrow">
-                <span class="tier tier-closed" title="The reference solution was also graded against synthetic per-student seeds, and failed on some of them — a student holding one of those seeds would fail through no fault of their own.">#(item.assignment.variantSummaryText)</span>
+                <span class="tier tier-closed" title="The solution failed on some per-student variants; those students would fail too.">#(item.assignment.variantSummaryText)</span>
                 #if(item.assignment.failedVariantSubmissionID):
                 <a href="/submissions/#(item.assignment.failedVariantSubmissionID)">View variant</a>
                 #endif

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -211,10 +211,10 @@ Create Assignment
                             <span class="dataset-note">Derivation steps authored by an agent — edit them with set_dataset.</span>
                             #endif
                             <span class="upload-status-inline js-dataset-status" role="status" aria-live="polite"></span>
-                            <span class="dataset-estimates js-dataset-estimates"
+                            <span class="chip-row js-dataset-estimates"
                                   #if(!supportFile.isDataset):hidden#endif>
-                                <span class="dataset-estimate js-dataset-similarity"></span>
-                                <span class="dataset-estimate js-dataset-drift"></span>
+                                <span class="chip js-dataset-similarity" hidden></span>
+                                <span class="chip js-dataset-drift" hidden></span>
                             </span>
                         </div>
                     </td>

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -23,7 +23,7 @@ struct DatasetsBody: Content {
 
 /// The response of either GET or PUT — the specs as the manifest now holds
 /// them, which is what the Files panel renders its controls from, plus the
-/// per-file estimates its disclosure shows.  Serving the estimates on the
+/// per-file estimates its chips show.  Serving the estimates on the
 /// same response is what makes them live: every parameter edit is a PUT, so
 /// the numbers move with the controls without a second request.
 struct DatasetsResponse: Content {
@@ -96,12 +96,12 @@ func datasetEstimateSummary(
     else { return nil }
 
     var similarityTitle =
-        "Rows a typical pair of students both hold, of \(overlap.rowsPerStudent). "
+        "Rows a typical pair shares, of \(overlap.rowsPerStudent). "
         + "Unluckiest pair of \(DatasetDiagnostics.defaultClassSize): "
         + "\(Int(overlap.worstPairSharedRows.rounded()))."
     if let stratum = overlap.mostCopyableStratum {
         similarityTitle +=
-            " Most shared: \"\(stratum.value)\" "
+            " Most shared: \"\(hoverName(stratum.value))\" "
             + "(\(estimatePercentText(stratum.sharedFraction)))."
     }
 
@@ -130,9 +130,32 @@ private func driftChip(
     }
 
     let title =
-        "Worst column \"\(worst.column)\", in \(estimateMeasureName(worst.measure)). "
+        "Worst column \"\(hoverName(worst.column))\", "
+        + "in \(estimateMeasureName(worst.measure)). "
         + "0 is identical; \(estimateUnitsText(worst.worst)) on an unlucky variant."
     return ("drift \(estimateUnitsText(worst.median))", title)
+}
+
+/// A column name or category value, bounded for a hover title.
+///
+/// Both titles interpolate identifiers out of the instructor's own CSV, and
+/// `datasetEstimateTitleWordCap` is a WORD budget, so an unbounded name is a
+/// silent breach waiting for the first course whose stratum is "Type 2
+/// Diabetes" or whose column is "Systolic Blood Pressure" — the test fixture's
+/// one-letter wards cannot see it.  Bounding the name here keeps both titles
+/// within budget by construction rather than by anyone remembering: the base
+/// sentences interpolate only numbers, so with this cap the longest either can
+/// reach is 18 words.  A prefix is the right trim — the reader is matching it
+/// against a column list they already have, so the first words identify it.
+func hoverName(_ raw: String, words wordLimit: Int = 3, characters charLimit: Int = 32) -> String {
+    let parts = raw.split(whereSeparator: \.isWhitespace)
+    var name =
+        parts.count > wordLimit
+        ? parts.prefix(wordLimit).joined(separator: " ") + "…" : raw
+    if name.count > charLimit {
+        name = name.prefix(charLimit).trimmingCharacters(in: .whitespaces) + "…"
+    }
+    return name
 }
 
 /// A fraction as chip-sized percent text: whole percents from 10% up, one

--- a/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/DatasetEditHelpers.swift
@@ -33,9 +33,11 @@ struct DatasetsResponse: Content {
 
 /// One dataset's estimate chips: two concise numbers the row shows inline —
 /// student-to-student similarity (closed-form overlap) and drift from the
-/// pool (measured divergence) — with the how-it-is-measured detail carried
-/// in each chip's hover title.  Display strings are built HERE, server-side,
-/// so the wording lives in one tested place and the page JS only paints.
+/// pool (measured divergence).  Each title is a PHRASE naming what its number
+/// measures, within `datasetEstimateTitleWordCap`; how the estimates are
+/// computed is in docs/datasets.md, because a hover title is not a place a
+/// reader can be sent.  Display strings are built HERE, server-side, so the
+/// wording lives in one tested place and the page JS only paints.
 /// Computed by Core's `DatasetDiagnostics`; estimates about the delivered
 /// bytes, never a change to them.  See docs/datasets.md.
 struct DatasetFileDiagnostics: Content {
@@ -49,6 +51,14 @@ struct DatasetFileDiagnostics: Content {
     var driftDisplay: String
     var driftTitle: String
 }
+
+/// The word budget for a chip's hover title, matching the cap
+/// `scripts/check-ui-vocabulary.sh` enforces on titles written in templates.
+/// These are assembled from measured numbers rather than written in markup,
+/// so the script cannot see them and `DatasetEstimateSummaryTests` holds the
+/// same line instead.  A tooltip is hover-only and unsearchable: it names
+/// what the number is, and docs/datasets.md explains it.
+let datasetEstimateTitleWordCap = 20
 
 /// Files above this size skip the divergence measurement — it materializes
 /// the pool once per preflight seed, and the panel is a live control, not a
@@ -86,16 +96,13 @@ func datasetEstimateSummary(
     else { return nil }
 
     var similarityTitle =
-        "Two students share about \(Int(overlap.expectedSharedRows.rounded())) of their "
-        + "\(overlap.rowsPerStudent) rows — the expected overlap between independent "
-        + "\(overlap.rowsPerStudent)-row samples of the \(overlap.poolRows)-row pool. "
-        + "The unluckiest pair in a class of \(DatasetDiagnostics.defaultClassSize) shares "
-        + "about \(Int(overlap.worstPairSharedRows.rounded())) rows."
+        "Rows a typical pair of students both hold, of \(overlap.rowsPerStudent). "
+        + "Unluckiest pair of \(DatasetDiagnostics.defaultClassSize): "
+        + "\(Int(overlap.worstPairSharedRows.rounded()))."
     if let stratum = overlap.mostCopyableStratum {
         similarityTitle +=
-            " Most shared category: \"\(stratum.value)\" — every student draws "
-            + "\(stratum.rowsPerStudent) of its \(stratum.poolRows) pool rows "
-            + "(\(estimatePercentText(stratum.sharedFraction)) shared)."
+            " Most shared: \"\(stratum.value)\" "
+            + "(\(estimatePercentText(stratum.sharedFraction)))."
     }
 
     let drift = driftChip(for: spec, sourceCSV: sourceCSV, measurable: divergenceMeasurable)
@@ -108,36 +115,23 @@ func datasetEstimateSummary(
 }
 
 /// The drift chip: the worst column's *typical* (median-over-variants)
-/// normalized distance from the pool, as one number.  The column, the
-/// measure and its unit, the unlucky-variant value, and the other measure's
-/// worst column (when both kinds exist) all ride the title.
+/// normalized distance from the pool, as one number.  The title names that
+/// column and its measure and gives the unlucky-variant value; the per-column
+/// table behind it is not something a tooltip can carry, so it is not tried.
 private func driftChip(
     for spec: DatasetSpec, sourceCSV: String, measurable: Bool
 ) -> (display: String, title: String) {
     guard measurable else {
-        return (
-            "drift —",
-            "Distribution drift was not measured — the file is too large to sample quickly."
-        )
+        return ("drift —", "Not measured: the file is too large to sample quickly.")
     }
     let columns = DatasetDiagnostics.divergence(spec: spec, sourceCSV: sourceCSV)
     guard let worst = columns.max(by: { $0.median < $1.median }) else {
-        return ("drift —", "No measurable columns — nothing observed to compare to the pool.")
+        return ("drift —", "No measurable columns to compare against the pool.")
     }
 
-    var title =
-        "How far a student's data drifts from the pool's distribution, measured over "
-        + "\(DatasetDiagnostics.defaultSeedCount) sampled variants; 0 means identical. "
-        + "Worst column: \"\(worst.column)\" — typically \(estimateUnitsText(worst.median)) "
-        + "\(estimateMeasureName(worst.measure)) from the pool, "
-        + "\(estimateUnitsText(worst.worst)) on an unlucky variant."
-    if let other = columns.filter({ $0.measure != worst.measure })
-        .max(by: { $0.median < $1.median })
-    {
-        title +=
-            " Also: \"\(other.column)\" at \(estimateUnitsText(other.median)) "
-            + "\(estimateMeasureName(other.measure))."
-    }
+    let title =
+        "Worst column \"\(worst.column)\", in \(estimateMeasureName(worst.measure)). "
+        + "0 is identical; \(estimateUnitsText(worst.worst)) on an unlucky variant."
     return ("drift \(estimateUnitsText(worst.median))", title)
 }
 
@@ -159,8 +153,11 @@ func estimateUnitsText(_ value: Double) -> String {
 
 private func estimateMeasureName(_ measure: DatasetColumnDivergence.Measure) -> String {
     switch measure {
+    // Both are bare noun phrases so a caller can set them in one sentence
+    // frame: one used to lead with "in" and read as a fragment wherever the
+    // other read as a unit.
     case .wasserstein: return "pool standard deviations (Wasserstein-1)"
-    case .totalVariation: return "in total-variation distance (0–1)"
+    case .totalVariation: return "total-variation distance (0–1)"
     }
 }
 

--- a/Tests/APITests/DatasetEstimateSummaryTests.swift
+++ b/Tests/APITests/DatasetEstimateSummaryTests.swift
@@ -4,7 +4,7 @@
 // (DatasetEditHelpers.datasetEstimateSummary).  The underlying statistics
 // have their own suite in CoreTests (DatasetDiagnosticsTests); what is
 // pinned here is the display layer the page JS paints verbatim — one
-// concise number per chip, the how-it-is-measured detail in the title —
+// concise number per chip, a phrase naming what it measures in the title —
 // so a wording regression is caught in Swift rather than in a browser.
 
 import Foundation
@@ -35,23 +35,49 @@ import Testing
 
         // 40 of 200 rows: k/N = 20%, expected shared k²/N = 8.
         #expect(summary.similarityDisplay == "similarity 20%")
-        #expect(summary.similarityTitle.contains("about 8 of their 40 rows"))
-        #expect(summary.similarityTitle.contains("200-row pool"))
-        #expect(summary.similarityTitle.contains("class of 100"))
+        #expect(summary.similarityTitle.contains("of 40"))
+        #expect(summary.similarityTitle.contains("Unluckiest pair of 100"))
         #expect(
-            !summary.similarityTitle.contains("Most shared category"),
+            !summary.similarityTitle.contains("Most shared"),
             "a plain sample has no strata to name")
 
-        // One number; the column, measure and unlucky-variant value ride the
-        // title.
+        // One number; the worst column, its measure and the unlucky-variant
+        // value ride the title.
         #expect(summary.driftDisplay.wholeMatch(of: /drift (\d+\.\d{2}|<0\.01)/) != nil)
-        #expect(summary.driftTitle.contains("Worst column: \""))
-        #expect(summary.driftTitle.contains("sampled variants"))
+        #expect(summary.driftTitle.contains("Worst column \""))
         #expect(summary.driftTitle.contains("on an unlucky variant"))
-        // The fixture has numeric and categorical columns, so both measures
-        // are named across the title.
-        #expect(summary.driftTitle.contains("pool standard deviations"))
-        #expect(summary.driftTitle.contains("total-variation"))
+    }
+
+    /// The chips' titles are assembled from measured numbers in Swift, so
+    /// `scripts/check-ui-vocabulary.sh` — which reads templates — cannot see
+    /// them.  This holds the same budget on the path the script cannot reach,
+    /// across every branch that produces a title.
+    @Test(arguments: [true, false]) func everyTitleStaysWithinTheHoverBudget(
+        measurable: Bool
+    ) throws {
+        for spec in [
+            DatasetSpec(file: "cases.csv", sampleSize: 40),
+            DatasetSpec(file: "cases.csv", sampleSize: nil),
+            DatasetSpec(
+                file: "cases.csv", kind: .stratifiedSample, sampleSize: 40,
+                stratumColumn: "ward"),
+        ] {
+            let summary = try #require(
+                datasetEstimateSummary(
+                    for: spec, sourceCSV: pool, divergenceMeasurable: measurable))
+            for (label, title) in [
+                ("similarity", summary.similarityTitle), ("drift", summary.driftTitle),
+            ] {
+                let words = title.split(whereSeparator: \.isWhitespace).count
+                #expect(
+                    words <= datasetEstimateTitleWordCap,
+                    """
+                    the \(label) title is \(words) words, over the \
+                    \(datasetEstimateTitleWordCap)-word hover budget — a tooltip holds a \
+                    phrase, and the explanation belongs in docs/datasets.md: \(title)
+                    """)
+            }
+        }
     }
 
     @Test func aStratifiedSampleNamesItsMostSharedCategory() throws {
@@ -63,8 +89,7 @@ import Testing
                 sourceCSV: pool, divergenceMeasurable: true))
         // The one-row floor makes rare ward D the most copyable part: every
         // student draws 2 of its 5 pool rows.
-        #expect(summary.similarityTitle.contains("Most shared category: \"D\""))
-        #expect(summary.similarityTitle.contains("2 of its 5 pool rows (40% shared)"))
+        #expect(summary.similarityTitle.contains("Most shared: \"D\" (40%)"))
     }
 
     @Test func aWholeFileSpecIsTotalSimilarity() throws {

--- a/Tests/APITests/DatasetEstimateSummaryTests.swift
+++ b/Tests/APITests/DatasetEstimateSummaryTests.swift
@@ -48,6 +48,57 @@ import Testing
         #expect(summary.driftTitle.contains("on an unlucky variant"))
     }
 
+    /// A pool whose stratum values and column names are the multi-word text a
+    /// real course has ("Type 2 Diabetes", "Systolic Blood Pressure"), which
+    /// is the axis `pool`'s one-letter wards cannot exercise: the budget is
+    /// counted in WORDS, so a title that fits for ward "D" can breach it for a
+    /// three-word category with no code change at all.
+    /// The long-named stratum is the one the summary will actually name, and
+    /// making that true takes more than making it rare: `mostCopyableStratum`
+    /// is the highest take/size ratio, which only favours a small stratum once
+    /// the one-row floor OVER-allocates it — that is, once its proportional
+    /// share falls below one row.  At 30 of 120 that means fewer than four
+    /// rows, so this stratum has two.  A first draft gave it five, the floor
+    /// never engaged, a three-word category was named instead, and the test
+    /// passed against a completely unbounded name.
+    private let wordyPool: String = {
+        var lines = ["patient id,Primary Diagnosis Group,Mean Systolic Blood Pressure Reading mmHg"]
+        let groups = ["Type 2 Diabetes", "Asthma", "Chronic Kidney Disease Stage 3 Dialysis"]
+        for i in 0..<120 {
+            lines.append("\(i),\(groups[i < 70 ? 0 : i < 118 ? 1 : 2]),\(90 + (i * 31) % 60)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }()
+
+    @Test func aMultiWordStratumAndColumnStayWithinTheBudget() throws {
+        let summary = try #require(
+            datasetEstimateSummary(
+                for: DatasetSpec(
+                    file: "cases.csv", kind: .stratifiedSample, sampleSize: 30,
+                    stratumColumn: "Primary Diagnosis Group"),
+                sourceCSV: wordyPool, divergenceMeasurable: true))
+
+        for (label, title) in [
+            ("similarity", summary.similarityTitle), ("drift", summary.driftTitle),
+        ] {
+            let words = title.split(whereSeparator: \.isWhitespace).count
+            #expect(
+                words <= datasetEstimateTitleWordCap,
+                "the \(label) title is \(words) words on real-world names: \(title)")
+        }
+        // The clause still identifies the category — bounded, not dropped.
+        #expect(summary.similarityTitle.contains("Most shared: \""))
+    }
+
+    @Test func aBoundedHoverNameKeepsItsIdentifyingPrefix() {
+        #expect(hoverName("Asthma") == "Asthma", "a short name is untouched")
+        #expect(hoverName("Type 2 Diabetes") == "Type 2 Diabetes", "three words fit")
+        #expect(hoverName("Chronic Kidney Disease Stage 3 Dialysis") == "Chronic Kidney Disease…")
+        #expect(
+            hoverName(String(repeating: "x", count: 50)).count <= 33,
+            "one very long token is bounded by the character cap, not the word cap")
+    }
+
     /// The chips' titles are assembled from measured numbers in Swift, so
     /// `scripts/check-ui-vocabulary.sh` — which reads templates — cannot see
     /// them.  This holds the same budget on the path the script cannot reach,

--- a/Tests/APITests/DatasetsRouteRoundTripTests.swift
+++ b/Tests/APITests/DatasetsRouteRoundTripTests.swift
@@ -253,6 +253,20 @@ import VaporTesting
         return String(rest[..<end.lowerBound])
     }
 
+    /// Whether the ONE element carrying `hook` is hidden — read off that
+    /// element's own open tag rather than by searching the whole row, which
+    /// silently became a different question the moment any other element in
+    /// the row started rendering hidden (the estimate chips, which begin
+    /// hidden and appear when their numbers arrive).
+    private func isHidden(_ hook: String, in row: String) throws -> Bool {
+        let at = try #require(row.range(of: hook), "no element carrying \(hook)")
+        let opened = try #require(
+            row[..<at.lowerBound].lastIndex(of: "<"), "\(hook) is not inside a tag")
+        let closed = try #require(
+            row[at.upperBound...].firstIndex(of: ">"), "the tag holding \(hook) never closes")
+        return row[opened...closed].contains("hidden")
+    }
+
     @Test func editPageRendersTheDatasetControlFromTheStoredSpec() async throws {
         try await withApp(app) { _ in
             let fx = try await fixture("e")
@@ -266,12 +280,16 @@ import VaporTesting
             #expect(marked.contains("js-dataset-toggle"))
             #expect(marked.contains("checked"), "a marked file renders a checked toggle")
             #expect(marked.contains("value=\"25\""), "and its stored row count")
-            #expect(marked.contains("hidden") == false, "and shows the row-count field")
+            #expect(
+                try isHidden("js-dataset-size-field", in: marked) == false,
+                "and shows the row-count field")
 
             let plain = try rowMarkup(for: "notes.txt", in: html)
             #expect(plain.contains("js-dataset-toggle"))
             #expect(plain.contains("checked") == false, "an unmarked file renders an unchecked toggle")
-            #expect(plain.contains("hidden"), "and keeps its row-count field hidden")
+            #expect(
+                try isHidden("js-dataset-size-field", in: plain),
+                "and keeps its row-count field hidden")
         }
     }
 
@@ -288,11 +306,11 @@ import VaporTesting
             #expect(marked.contains("js-dataset-toggle"))
             #expect(marked.contains("checked"))
             #expect(marked.contains("value=\"8\""))
-            #expect(marked.contains("hidden") == false)
+            #expect(try isHidden("js-dataset-size-field", in: marked) == false)
 
             let plain = try rowMarkup(for: "notes.txt", in: html)
             #expect(plain.contains("checked") == false)
-            #expect(plain.contains("hidden"))
+            #expect(try isHidden("js-dataset-size-field", in: plain))
         }
     }
 
@@ -487,7 +505,7 @@ import VaporTesting
                 // placeholder.  Wording itself is pinned in
                 // DatasetEstimateSummaryTests; this is the plumbing.
                 #expect(block.similarityDisplay == "similarity 67%")
-                #expect(block.similarityTitle.contains("3-row pool"))
+                #expect(block.similarityTitle.contains("Unluckiest pair"))
                 #expect(block.driftDisplay.hasPrefix("drift "))
                 #expect(block.driftTitle.contains("Worst column"))
 

--- a/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
+++ b/Tests/BrowserRunnerJSTests/support-files-datasets.test.mjs
@@ -292,18 +292,19 @@ test('a re-render disables the fields for a spec the panel cannot represent', as
 
 // ── The estimate chips ──────────────────────────────────────────────────────
 //
-// The server sends ready-made display strings (the wording is pinned in
-// Swift, in DatasetEstimateSummaryTests); what the JS owes is painting them
-// into the two chips — textContent for the number, title for the hover
-// detail — and hiding the chips when a row has no block.
+// The server sends ready-made display strings (the wording and its word
+// budget are pinned in Swift, in DatasetEstimateSummaryTests); what the JS
+// owes is painting them into the two chips — textContent for the number,
+// title for the phrase — and hiding a chip whose number did not arrive, so
+// an empty chip never renders as a blank tag.
 
 const sampleBlock = (spec) => ({
   file: spec.file,
   similarityDisplay: 'similarity 7.8%',
-  similarityTitle: 'Two students share about 39 of their '
-    + (spec.sampleSize || 6388) + ' rows.',
+  similarityTitle: 'Rows a typical pair of students both hold, of '
+    + (spec.sampleSize || 6388) + '.',
   driftDisplay: 'drift 0.04',
-  driftTitle: 'Worst column: "systolic" - typically 0.04 pool standard deviations.',
+  driftTitle: 'Distance from the pool, worst column "systolic".',
 });
 
 test('the chips paint on init from the GET, number plus hover title', async () => {
@@ -318,11 +319,32 @@ test('the chips paint on init from the GET, number plus hover title', async () =
   assert.equal(row.querySelector('.js-dataset-estimates').hidden, false);
   const similarity = row.querySelector('.js-dataset-similarity');
   assert.equal(similarity.textContent, 'similarity 7.8%');
-  assert.match(similarity.title, /39 of their 500 rows/);
+  assert.equal(similarity.hidden, false);
+  assert.match(similarity.title, /both hold, of 500/);
   const drift = row.querySelector('.js-dataset-drift');
   assert.equal(drift.textContent, 'drift 0.04');
-  assert.match(drift.title, /Worst column: "systolic"/);
+  assert.match(drift.title, /worst column "systolic"/);
   assert.equal(h.puts.length, 0, 'the first paint is a read, not a write');
+});
+
+test('a chip with no number of its own hides rather than rendering blank', async () => {
+  // Overlap is closed-form and always reported; drift is skipped on a file
+  // too large to sample. The row still shows what it knows.
+  const h = load({
+    specs: [{ file: 'cases.csv', kind: 'rowSample', sampleSize: 500 }],
+    diagnostics: (spec) => ({
+      ...sampleBlock(spec), driftDisplay: '', driftTitle: '',
+    }),
+  });
+  const row = h.rows[0];
+  row.querySelector('.js-dataset-toggle').checked = true;
+  await settle();
+
+  assert.equal(row.querySelector('.js-dataset-estimates').hidden, false);
+  assert.equal(row.querySelector('.js-dataset-similarity').hidden, false);
+  const drift = row.querySelector('.js-dataset-drift');
+  assert.equal(drift.hidden, true);
+  assert.equal(drift.title, '', 'a hidden chip carries no stale title');
 });
 
 test('the chips repaint from the PUT response when a parameter changes', async () => {
@@ -337,7 +359,7 @@ test('the chips repaint from the PUT response when a parameter changes', async (
   await settle();
 
   assert.match(
-    row.querySelector('.js-dataset-similarity').title, /of their 900 rows/,
+    row.querySelector('.js-dataset-similarity').title, /both hold, of 900/,
     'the numbers follow the saved edit');
 });
 

--- a/changelog.d/ui-vocabulary-guard.md
+++ b/changelog.d/ui-vocabulary-guard.md
@@ -17,6 +17,14 @@
   row-anchored popover → modal) and a **UI copy** budget, whose rule is that
   anything longer than a phrase belongs in `docs/` with the interface linking
   to it. A `ui-review` agent covers the judgement the guards cannot reach.
+  The catalog debt this exposed was paid down in the same pass: the shorthand
+  the doc used for component families (`.modal-head/-body/-foot`) is spelled
+  out so the names are greppable, and the site navigation and the
+  drag-to-reorder vocabulary — one grip, one in-flight class, one set of drop
+  cues, shared across the two reorder surfaces — are catalogued for the first
+  time. There is no dead CSS to remove: every rule in the global sheet is
+  reached by a template, by page JS, by a Leaf-interpolated class family, or
+  by the vendored CodeMirror bundle.
 
 ### Changed
 

--- a/changelog.d/ui-vocabulary-guard.md
+++ b/changelog.d/ui-vocabulary-guard.md
@@ -1,0 +1,33 @@
+### Added
+
+- **The UI rulebook now covers which interaction to reach for, and how much
+  text it may carry — and CI enforces the mechanical half.**
+  `scripts/check-ui-vocabulary.sh` joins the `format-lint` job with three
+  rules. The count of classes in `Public/styles.css` that
+  `docs/ui-design.md` does not name is a **shrink-only ratchet**, so a new
+  global component costs a catalog entry, paid in the PR that adds it: the
+  page-style ratchet already priced a page-local copy, but the global sheet
+  carried no budget at all, which made "put it in `styles.css`" the cheapest
+  way to add a second spelling of an existing component. `cursor` and
+  `text-decoration` values are a closed **affordance registry** — adding a way
+  to signal that an element is interactive is now a rulebook edit rather than
+  a line in a rule body. Hover text written in a template is capped at 20
+  words. `docs/ui-design.md` gains the two sections it never had: an
+  **interaction-idiom** table (cheapest first: on the page → `<details>` →
+  row-anchored popover → modal) and a **UI copy** budget, whose rule is that
+  anything longer than a phrase belongs in `docs/` with the interface linking
+  to it. A `ui-review` agent covers the judgement the guards cannot reach.
+
+### Changed
+
+- **The per-student dataset estimates are plain chips.** They shipped as a
+  private variant with a dotted underline and `cursor: help`, carrying
+  50-word explanatory paragraphs in their hover titles — a fifth way to reveal
+  detail in a UI that had four, and a second kind of chip beside `.chip`,
+  which every guard passed. They now use `.chip`/`.chip-row`, each title is a
+  phrase naming what its number measures, and the method they used to explain
+  is in `docs/datasets.md`. Three over-long hover titles elsewhere (the
+  no-runner and failed-variant badges, the default time limit) were cut to a
+  sentence. The numbers, and the thirteen components that had reached
+  `styles.css` without ever reaching the catalog, are unchanged and now
+  documented.

--- a/changelog.d/ui-vocabulary-guard.md
+++ b/changelog.d/ui-vocabulary-guard.md
@@ -36,6 +36,11 @@
   phrase naming what its number measures, and the method they used to explain
   is in `docs/datasets.md`. Three over-long hover titles elsewhere (the
   no-runner and failed-variant badges, the default time limit) were cut to a
-  sentence. The numbers, and the thirteen components that had reached
-  `styles.css` without ever reaching the catalog, are unchanged and now
-  documented.
+  sentence, and the "no runner" badge — the one validation state whose only
+  remedy lived in a tooltip — gains the same on-page follow-up line its
+  `failed` and `pending` siblings already had. A hover title assembled from an
+  instructor's own column names and category values is now bounded to a
+  fixed number of words, so a course whose stratum is "Type 2 Diabetes"
+  cannot silently breach the budget the same release introduced. The numbers,
+  and the thirteen components that had reached `styles.css` without ever
+  reaching the catalog, are unchanged and now documented.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -883,16 +883,27 @@ the test — needs revisiting.
 parameter estimate wants to live where the parameters are, moving as the
 instructor edits the row count (multi-variant validation shares the preflight
 seeds but answers a different question at a different time). Each dataset row
-shows **two inline chips, one concise number each**: `similarity NN%` (the
-fraction of one student's rows a peer is expected to also hold — a
-student-to-student similarity score) and `drift 0.NN` (the worst column's
-typical normalized distance from the pool). Everything else — the expected
-shared-row count, the unluckiest pair, the most-shared category under
-stratification, which column drifts and in which measure, the unlucky-variant
-value — rides each chip's hover title. This replaced a first-release
-disclosure full of prose sentences, on maintainer feedback: the numbers are
-for glancing at while dragging a row count, and the method belongs behind a
-mouse-over, not in the row. The display strings are built server-side in one
+shows **two chips, one concise number each**: `similarity NN%` (the fraction
+of one student's rows a peer is expected to also hold — a student-to-student
+similarity score) and `drift 0.NN` (the worst column's typical normalized
+distance from the pool). Each chip's `title` is a phrase naming what its
+number measures, within the same word budget the rest of the UI's hover text
+keeps (`datasetEstimateTitleWordCap`); **how the numbers are computed is here,
+in this section, and nowhere in the interface** — the formulas are above, and
+the arithmetic behind each chip is below.
+
+That took two corrections to arrive at. The first release put the estimates
+in a per-row disclosure of prose sentences, which was too heavy for a control
+row. The replacement moved the same prose into hover titles and gave the chips
+a private dotted-underline-and-`cursor: help` treatment, which was worse in a
+way the first version was not: it was a fifth way to reveal detail in a UI
+that had four, and a second kind of chip in a UI whose vocabulary already had
+`.chip`. They are plain chips now, and the sentences are in this file. The
+general rule that came out of it is in
+[ui-design.md](ui-design.md) under "Interaction idioms" and "UI copy", and
+`scripts/check-ui-vocabulary.sh` enforces the mechanical half.
+
+The display strings are built server-side in one
 tested place (`DatasetEditHelpers.datasetEstimateSummary`), and the blocks
 ride the same GET/PUT the controls already use
 (`DatasetsResponse.diagnostics`, computed off the event loop), so a saved
@@ -908,8 +919,17 @@ The drift chip's single number is the max across columns of the *median*
 normalized divergence, whatever that column's measure — a deliberate
 softening of the two-headline rule above for the glanceable layer only: SD
 units and TV still are not commensurable, so the chip never mixes them
-arithmetically (no averaging), and the title always names the column, the
-measure, and the other measure's worst column when both kinds exist.
+arithmetically (no averaging), and the title names the column and its measure
+so the number is never read as a bare quantity. The per-column table, and the
+second measure's worst column when both kinds exist, are not in the interface
+at all — a tooltip cannot carry a table, and the numbers a row needs while an
+instructor drags a slider are the two on the chips.
+
+The similarity chip reads `k²/N` over `k` — the expected overlap between two
+independent `k`-row samples of an `N`-row pool — and its title gives the
+unluckiest pair in a class of `DatasetDiagnostics.defaultClassSize` and, under
+stratification, the most-shared category by name. Those are the two facts an
+instructor acts on; the derivation is the "Overlap" subsection above.
 
 `numericJitter` stays dead (see above), and these diagnostics do not assume
 it.

--- a/docs/handoff-page-scaffolds.md
+++ b/docs/handoff-page-scaffolds.md
@@ -1,0 +1,101 @@
+# Handoff — make the compliant page the easy one to start from
+
+**Status: not started.** This is the additive half of the UI-language work.
+
+## The question behind it
+
+*"How do we lock down the UI language and keep shipping features without
+reining in random changes all the time?"*
+
+The honest diagnosis: **every investment in this codebase's UI language is
+subtractive.** Guards say *no* — not that colour, not that class, not a second
+chip, not a paragraph in a tooltip. There is nothing **additive** that says
+*start here*. A new page is assembled by reading a 500-line rulebook and
+imitating whichever existing page the author happened to open, and then the
+guards argue with the result.
+
+That is why drift keeps arriving through the front door. The token guards are
+airtight and the vocabulary is now priced (#1445), but neither makes the
+compliant thing the *cheapest* thing to begin.
+
+Note what this is **not**: the "vertical slice" advice from the article that
+prompted the question is about *sequencing work* (DB → server → UI, one feature
+at a time), and this project is well past needing that. The thing worth having
+is a **scaffold**, and it is genuinely absent.
+
+## What exists, and what is missing
+
+[ui-design.md](ui-design.md) defines **seven page archetypes** in a table:
+Admin tabbed, Instructor tabbed, Titlebar page, Plain student page, Auth box,
+Body-partial shim, Full-bleed app. Each row lists three example pages.
+
+- The table **describes** skeletons in prose. It does not **provide** one.
+- No example is designated canonical — three are listed, so an author picks
+  whichever they open, and any drift in that page propagates.
+- **Nothing checks archetype conformance.** Grep `archetype` across `scripts/`
+  and `Tests/`: zero hits. `CLAUDE.md` asserts "Pages follow a named archetype"
+  as though enforced; the only mechanism it cites is `PAGE_STYLE_BASELINE`,
+  which counts CSS lines and knows nothing about shape.
+
+So the archetype is the single most-repeated UI concept in the rulebook and the
+least enforced thing in the repo.
+
+## The work, cheapest first
+
+**1. Name a canonical exemplar per archetype (small, do this first).**
+Pick one existing page per row — the one that best embodies the skeleton — and
+mark it in the table as *the* reference. No new files. The value is that
+"copy `admin-alerts.leaf`" becomes a real instruction instead of "read the
+skeleton column and infer".
+
+**2. Guard the exemplars (small, and it is what makes (1) stick).**
+A structural test asserting each exemplar still matches its archetype: the
+tabbed ones open with the right partial and start sections at `<h2>`, the
+titlebar one has `.page-titlebar` with a single `<h1>`, the auth box uses
+`.auth-box`, exactly one `<h1>` per non-tabbed page, `_flash` is the only
+banner source. `Tests/APITests/ListFilterMarkupTests.swift` is the pattern to
+copy — it walks tags backwards from a match rather than grepping the document,
+which is the right technique here for the same reason (a scanner cannot tell
+markup from prose about markup, and this codebase has been bitten by that four
+times).
+
+Guarding the exemplar is deliberately weaker than guarding every page. It is
+also achievable, and it means the thing authors copy cannot rot.
+
+**3. Consider a component gallery (larger, decide after 1–2).**
+A single page rendering every component in the vocabulary from the real
+stylesheet — chips, tiers, buttons in their two sizes, the filter, the modal
+shell, the popover, the stat tiles. It makes the vocabulary *discoverable at
+the point of use* rather than by reading a document, and it doubles as a visual
+baseline for the whole component set. Add it to
+`Tools/visual-regression/pages.mjs` if built.
+
+Do not start here. It is the most appealing and the least certain: if authors
+do not open it, it is a page to maintain for nothing. Earn it with (1) and (2).
+
+**4. Make the guards point at the alternative (small, high leverage).**
+`scripts/check-ui-vocabulary.sh` currently says "reuse what is there" without
+saying *what*. Error messages that name the nearest existing component turn a
+refusal into a redirect. This is the cheapest way to make the subtractive layer
+feel additive, and it needs no new machinery.
+
+## Judgement calls to make deliberately
+
+- **Do not add an eighth archetype** to solve a layout problem. The rulebook
+  says so and means it; if a page genuinely does not fit, that is a
+  conversation, not a new row.
+- **Resist generating scaffolds.** A `new-page.sh` that stamps out a template is
+  tempting and creates a second source of truth that drifts from the exemplar.
+  Prefer "copy this page" over "run this generator" until there is evidence the
+  copying is the bottleneck.
+- **A scaffold is not a rule.** Nothing here should become a guard that fails an
+  existing page for not being the exemplar. The point is to lower the cost of
+  starting right, not to add a new way to be wrong.
+
+## Definition of done
+
+An author asking "how do I start a new instructor page?" gets a one-line answer
+naming a file to copy, and that file cannot silently stop being a good example.
+
+Run the `ui-review` agent on whatever you build — it reviews the layer the
+guards structurally cannot, which is the layer this work lives in.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -141,6 +141,18 @@ The audit that produced this rule found sixteen page-local names for "a row
 of action buttons" and four pill implementations; the page-style ratchet
 (below) now makes the private copy the expensive option.
 
+For a while it made only the *page-local* copy expensive.  The global sheet
+carried no budget at all, so the cheapest way to add a second spelling of a
+component was to skip the page block and put it in `Public/styles.css` — and
+thirteen components went in without ever reaching this list, followed by a
+pair of estimate chips that were chips in the changelog, in the commit
+message and in their own CSS comment, under a name that shared nothing with
+`.chip`.  Every guard passed.  `scripts/check-ui-vocabulary.sh` now prices
+the global sheet the same way: the count of classes in it that this catalog
+does not name is a shrink-only ratchet, so a new global component costs a
+catalog entry, paid here, where review sees it beside the component it would
+duplicate.
+
 - **Buttons** — one grammar (UI audit S6):
   - a form's primary submit is `btn btn-primary`; secondary actions beside it
     are `btn`;
@@ -221,18 +233,97 @@ of action buttons" and four pill implementations; the page-style ratchet
   `ChickadeeSortableTable.apply(table)`.  Never hand-roll a sorter or a sort
   glyph — the guard fails on both.
 - **`.diagnostics-cards`** + `.diagnostic-card/-label/-value` — stat tiles.
-- **`.chip`**, `.chip-row` — neutral tags.  `.tier` + `.tier-*` — status
+  `.diagnostics-section` wraps a group of them under one heading.
+- **`.chip`**, `.chip-row` — neutral tags.  A chip is the answer for a short
+  labelled value beside a control; it carries no status colour, so if the
+  value needs one it is a `.tier`, not a chip.  `.chip-ok` / `.chip-err` add
+  pass/fail colouring to an inline count.  `.tier` + `.tier-*` — status
   badges (defined variants only: open/closed/extended/preview/unpublished).
 - **`.text-muted`**, `.card-meta`, `.fine-print` — muted text.
   `.text-error` / `.text-ok` / `.text-quiet` — status-line colours
   (`ChickadeeUI.setStatus` toggles them; nothing writes `el.style.color`).
+  `.empty` — the "nothing here yet" line a list renders in place of rows.
 - **`.ext-details`/`.ext-panel`/`.ext-field-*`** — inline set/clear popover
-  forms.
+  forms.  `.popover-panel` is the same shape for a row-anchored panel that
+  is not a set/clear form; `app.js` floats both.
 - **`.card`**, `.notice-box`, `.error-box` — surfaces and callouts.
+  `.standin-panel` — the placeholder a panel shows while its content is
+  unavailable.  `.detail-grid` — label/value pairs in a two-column grid.
+- **`.page-heading`**, `.titlebar-subtitle` — a heading and its subtitle
+  inside `.page-titlebar`.  `.section-gap` adds the standard gap between
+  stacked sections.
+- **`.icon`** — every inline SVG, referencing a `<symbol>` in `_icons.leaf`
+  by `<use href="#i-…">`.  Geometry may not appear anywhere else.
+- **`.textarea-mono`**, `.form-stack` (+ `--wide`) — a monospace textarea and
+  the stacked form column that usually holds one.
 
 If two pages need the same rule, it belongs in `Public/styles.css`, not
 copied into both `<style>` blocks — the duplicate-selector guard fails CI on
 copies, and the page-style ratchet fails CI on growth.
+
+## Interaction idioms
+
+The component vocabulary answers "what class do I write".  This answers the
+question before it: **which of the ways this UI already has of doing a thing
+is the right one** — and the default answer is that there are enough.  A
+page that introduces a fifth way to reveal detail has not added a feature;
+it has made the other four less meaningful.
+
+Reaching for detail, cheapest first.  Pick the first one that fits:
+
+| The reader | Idiom |
+|---|---|
+| should just see it | put it on the page — a `.chip` for a value, `.field-note` under a control, `.card-meta` under a title |
+| wants it occasionally | `<details>` + `.accordion-caret`, closed by default |
+| is acting on one row | `.ext-details`/`.ext-panel`, or `.popover-panel` |
+| must decide before anything else happens | `.modal-card` — the only blocking shape, and only for a decision |
+| wants a reminder of what a control is | `title` — a phrase, and never the only copy of something they need |
+
+The affordances that say an element is interactive are a **closed registry**,
+enforced by `scripts/check-ui-vocabulary.sh`:
+
+- `cursor` — `pointer` (activates), `not-allowed` (disabled), `grab` /
+  `grabbing` (drag to reorder), `col-resize` (the workbench splitter),
+  `default` (deliberately not interactive).
+- `text-decoration` — `underline` (a link), `line-through` (superseded),
+  `none`.
+
+Adding a value is allowed and sometimes right, but it is an edit to this
+list and to that script, with the reasoning in the PR — not a line in a rule
+body.  The registry exists because `cursor: help` and a dotted underline
+arrived together as a private convention for "hover me", in a codebase that
+already had four ways to reveal detail and no fifth one it needed.
+
+Two things a hover title is not.  It is **not a disclosure**: no touch
+device shows it, no in-page search finds it, and screen readers treat it
+inconsistently, so anything a reader actually needs must exist somewhere
+else.  And it is **not a docs page**: if the answer runs to sentences, the
+sentences go in `docs/`, and the UI links there.
+
+## UI copy
+
+Chrome is not prose.  A label names a thing; it does not explain it.  The
+[authoring-voice guide](../CLAUDE.md) governs assignment *content* — what
+instructors and students read as course material — and this is its
+counterpart for the interface around it.
+
+- **Labels and chips: a noun phrase.**  Two or three words.  `similarity
+  20%`, not `Students share about 20% of their rows with each other`.
+- **Hover titles: one phrase, 20 words maximum**, enforced by
+  `scripts/check-ui-vocabulary.sh` for titles written in templates and by a
+  word-budget assertion for any assembled server-side (see
+  `datasetEstimateTitleWordCap`).  Name what the number is.  Do not derive
+  it, qualify it, or give its worked example.
+- **Notes under a control: one sentence**, in `.field-note` or
+  `.field-help`, and only when the control's own label cannot carry it.
+- **Everything longer belongs in `docs/`.**  A measurement's method, a
+  band's two bad ends, why a default is what it is — these are real and
+  worth writing down, in a file a reader can link to, search, and correct.
+
+The test for a number the UI shows: an instructor should be able to read it
+at a glance and know whether to act.  If it needs a paragraph before it means
+anything, the paragraph is not the fix — either show a number that speaks for
+itself, or move it out of the control row.
 
 ## Timestamps
 

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -167,7 +167,7 @@ duplicate.
 - **`.form`**, `.form--wide`, `.form-input`, `.form-error`, `.form-flush`,
   `.inline-form` — forms and the inline error banner (never native
   `alert()`).
-- **`.modal-overlay` / `.modal-card`** (+ `--confirm`) — the one blocking
+- **`.modal-overlay`** / **`.modal-card`** (+ `.modal-card--confirm`) — the one blocking
   dialog shape.  A destructive action asks with `data-confirm="…"` in
   markup (app.js handles it) or `await ChickadeeUI.confirmAction(msg)`
   where there is no element to mark; both render the same themed
@@ -215,8 +215,9 @@ duplicate.
   `.input-attention` (amber), `.input-invalid` (red), `.input-computed`
   (muted), `.input-ref-ok` / `.input-ref-broken` (italic green/red `$name`
   refs).  Editors toggle these classes; they never write the colours.
-- **`.modal-overlay`**, `.modal-card`, `.modal-head/-body/-foot`,
-  `.modal-title/-close/-status/-desc` — the one modal shell
+- **`.modal-overlay`**, `.modal-card`, `.modal-card--confirm`, `.modal-head`,
+  `.modal-body`, `.modal-foot`, `.modal-title`, `.modal-close`,
+  `.modal-status`, `.modal-desc` — the one modal shell
   (test-editor-modal.js).  `hidden` does the showing and hiding.
 - **`.editor-stack`**, `.editor-cm-mount`, `.cell-stack`, `.cell-title`,
   `.cell-actions` — editor-built layout: vertical field stacks, the
@@ -232,7 +233,8 @@ duplicate.
   `data-sort-tiebreak="<key>"` the tie-break; a page that repaints rows calls
   `ChickadeeSortableTable.apply(table)`.  Never hand-roll a sorter or a sort
   glyph — the guard fails on both.
-- **`.diagnostics-cards`** + `.diagnostic-card/-label/-value` — stat tiles.
+- **`.diagnostics-cards`** + `.diagnostic-card`, `.diagnostic-label`,
+  `.diagnostic-value` — stat tiles.
   `.diagnostics-section` wraps a group of them under one heading.
 - **`.chip`**, `.chip-row` — neutral tags.  A chip is the answer for a short
   labelled value beside a control; it carries no status colour, so if the
@@ -246,6 +248,25 @@ duplicate.
 - **`.ext-details`/`.ext-panel`/`.ext-field-*`** — inline set/clear popover
   forms.  `.popover-panel` is the same shape for a row-anchored panel that
   is not a set/clear form; `app.js` floats both.
+- **`.nav`**, `.nav-brand`, `.nav-brand-logo`, `.nav-link` — the site header
+  in `base.leaf`, on every page.  `.nav-user`, `.nav-username`,
+  `.nav-dropdown`, `.nav-dropdown-toggle`, `.nav-dropdown-caret`,
+  `.nav-dropdown-menu`, `.nav-dropdown-item`, `.nav-dropdown-item-active` —
+  the account menu; `app.js` toggles `.open` on the `.nav-dropdown`, and the
+  caret and menu follow from that one class.  This is the only pop-out menu
+  shape outside `.popover-panel` and the modal shell — a page needing a third
+  is a conversation, not a new rule.
+- **Drag to reorder** — one vocabulary, two surfaces.  The grip is
+  `.section-drag-handle` (course sections, test sections) or
+  `.suite-drag-handle` (suite rows); the row in flight takes
+  `.section-dragging` or `.suite-row-dragging`; the target cue is
+  `.drop-before` / `.drop-after` for "land beside this" and `.drop-adopt` for
+  "become a child of this", with `.suite-root-drop` the empty tail target and
+  `.drop-hover` its lit state.  `.section-dragging` is deliberately shared —
+  `assignments.js` and `suite-table.js` both apply it to a `.section-block`.
+  A third reorder surface reuses these; it does not mint a third grip.
+- **`.drop-zone`** (+ `.drag-over`, `.drop-filename`) — file-drop upload
+  targets.  Unrelated to the reorder cues above despite the shared verb.
 - **`.card`**, `.notice-box`, `.error-box` — surfaces and callouts.
   `.standin-panel` — the placeholder a panel shows while its content is
   unavailable.  `.detail-grid` — label/value pairs in a two-column grid.
@@ -529,7 +550,18 @@ tell you.
   A scale with exceptions is just the old sprawl with extra steps.
 - **New repeated pattern** (a third page grows the same card/banner/table
   flavour) → hoist it into `styles.css` as a named component and note it in
-  the component vocabulary above.
+  the component vocabulary above.  The note is not optional bookkeeping:
+  `scripts/check-ui-vocabulary.sh` counts the classes in the global sheet
+  this catalog does not name and fails on growth, so the entry is what pays
+  for the component.  Before writing it, search the catalog for the
+  *concept* — a duplicate arrives under a name that shares nothing with its
+  twin, which is why the guard cannot find it for you.
+- **New interaction idiom** (a `cursor`, a `text-decoration`, a way to
+  reveal detail that is not in the table above) → this is a rulebook edit
+  and a change to the affordance registry in that script, with the reasoning
+  in the PR description.  Reach for it last: the table is ordered
+  cheapest-first, and a fifth way to reveal detail makes the other four less
+  meaningful.
 - **New page** → pick an archetype, assemble it from the vocabulary, and add
   it to `Tools/visual-regression/pages.mjs` if it introduces a new shape
   (commit the CI bootstrap capture as its baseline in the same PR).

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -459,6 +459,14 @@ fi
 # ── 5. Class names must resolve ──────────────────────────────────────────────
 scripts/check-class-resolution.sh || status=1
 
+# ── 6. The vocabulary above the token layer ──────────────────────────────────
+# Guard 4 compares selector TEXT and guard 4b prices a page-local copy, so
+# between them a second spelling of an existing component is free as long as
+# it is spelled differently and lives in the global sheet. This prices that,
+# plus the two things nothing else looks at: the affordances that tell a user
+# an element is interactive, and how much prose a tooltip carries.
+scripts/check-ui-vocabulary.sh || status=1
+
 if [ "$status" -eq 0 ]; then
   echo "check-styles: OK (no disallowed inline styles; alert()s within baseline; no duplicated selectors; ratchets within baseline)"
 fi

--- a/scripts/check-ui-vocabulary.sh
+++ b/scripts/check-ui-vocabulary.sh
@@ -57,7 +57,7 @@ status=0
 #
 # Shrink-only.  Lower it in the PR that earns it; headroom left behind gets
 # spent by the next person adding a copy.
-CATALOG_BASELINE=298
+CATALOG_BASELINE=262
 
 # Comment stripper.  A scanner cannot tell a selector from prose about a
 # selector, and this codebase has been bitten by that three times (the

--- a/scripts/check-ui-vocabulary.sh
+++ b/scripts/check-ui-vocabulary.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# UI vocabulary guard (pure grep/sed/awk — runs in the Swift CI container
+# alongside the other format-lint steps; invoked from check-styles.sh).
+#
+# The token guards (check-design-tokens.sh, check-css-vars.sh) prove a value
+# routes through the palette.  check-class-resolution.sh proves a name has a
+# rule.  Guard 4 in check-styles.sh proves two selectors are not literally the
+# same text.  None of them can see the layer above: a SECOND way to say
+# something the vocabulary already says.
+#
+# That layer had exactly one source of pressure — PAGE_STYLE_BASELINE, which
+# makes a page-local re-implementation expensive — and it has a hole the width
+# of the global sheet: a new component costs nothing if you put it in
+# Public/styles.css, which carries no budget at all.  Everything below is what
+# went through that hole, generalized.  Three rules:
+#
+#   1. CATALOG.  A class with a rule in the global sheet should be named in
+#      the component vocabulary in docs/ui-design.md.  That rule is already
+#      written there ("a genuinely new pattern must be ADDED to it (and to
+#      this list) rather than approximated privately") and was already
+#      drifting — thirteen shipped components had never been added.  This is
+#      a shrink-only ratchet, not an absolute: the point is not to document
+#      every historical name, it is that the NEXT one costs a catalog entry,
+#      paid in the PR that adds it, where review sees the new component next
+#      to the one it would duplicate.
+#
+#   2. AFFORDANCES.  A closed allowlist of the property values that tell a
+#      user what an element DOES — the pointer over a target, the dotted
+#      underline promising a definition.  Guard 4c in check-styles.sh is a
+#      blocklist of idioms already consolidated, so it can only ever catch a
+#      repeat; this is the same idea pointed forwards.  A value outside the
+#      list is a new interaction idiom, and adding one should be a decision
+#      with a paragraph behind it rather than a line in a rule body.
+#
+#   3. HOVER PROSE.  A title attribute is a hover-only, touch-hostile,
+#      unsearchable, screen-reader-inconsistent channel.  It holds a phrase.
+#      When it holds sentences, the sentences belong on the page or in the
+#      docs, and the guard's job is to make that trade visible at the moment
+#      it is made.
+#
+# Scope: Public/styles.css + Resources/Views/*.leaf.  Rule 2 also reads page
+# <style> blocks, since an idiom hides just as well in one.
+#
+# The three of these together would have failed the change that prompted
+# them; see docs/ui-design.md "Interaction idioms" and "UI copy".
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+sheet="Public/styles.css"
+rulebook="docs/ui-design.md"
+status=0
+
+# ── 1. Component catalog ─────────────────────────────────────────────────────
+#
+# Shrink-only.  Lower it in the PR that earns it; headroom left behind gets
+# spent by the next person adding a copy.
+CATALOG_BASELINE=298
+
+# Comment stripper.  A scanner cannot tell a selector from prose about a
+# selector, and this codebase has been bitten by that three times (the
+# handoff doc's rule 5).  It must span lines: the sheet's comments run to
+# paragraphs, and a line-at-a-time strip leaves every line but the first,
+# which is how a version string in prose first registered as a class here.
+strip_css_comments() {
+  awk '
+    {
+      line = $0; out = ""
+      while (length(line)) {
+        if (incomment) {
+          p = index(line, "*/")
+          if (p == 0) { line = "" } else { line = substr(line, p + 2); incomment = 0 }
+        } else {
+          p = index(line, "/*")
+          if (p == 0) { out = out line; line = "" }
+          else { out = out substr(line, 1, p - 1); line = substr(line, p + 2); incomment = 1 }
+        }
+      }
+      print out
+    }
+  ' "$1"
+}
+
+# Classes carrying a rule in the global sheet.
+sheet_classes="$(
+  strip_css_comments "$sheet" \
+    | tr '}' '\n' \
+    | sed 's/{.*$//' \
+    | grep -oE '\.[a-zA-Z][A-Za-z0-9_-]*' \
+    | sed 's/^\.//' \
+    | grep -vE '^js-' \
+    | sort -u
+)"
+
+# Names the rulebook accounts for, either exactly or as a documented family
+# (a tier-* entry covers every tier variant).  The catalog writes a class both
+# with and without its leading dot, and sometimes several to a span (a class
+# ORDER is quoted as one run of names), so every identifier-shaped token
+# inside backticks counts.  That over-matches slightly — an attribute name in
+# backticks can collide with a class name — and it errs in the safe direction:
+# a spurious match understates the count, which only ever makes the ratchet
+# stricter for the next change.
+doc_tokens="$(
+  grep -oE '`[^`]+`' "$rulebook" \
+    | tr -d '`' | tr ' ' '\n' \
+    | sed -e 's/^\.//' -e 's/[,;:()]*$//' \
+    | grep -E '^[a-zA-Z][A-Za-z0-9_-]*(-\*)?$' \
+    | sort -u || true
+)"
+doc_names="$(grep -v -- '-\*$' <<<"$doc_tokens" || true)"
+doc_families="$(grep -- '-\*$' <<<"$doc_tokens" | sed 's/-\*$//' || true)"
+
+undocumented="$(
+  awk -v names="$doc_names" -v fams="$doc_families" '
+    BEGIN {
+      n = split(names, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") known[a[i]] = 1
+      m = split(fams,  b, "\n"); for (i = 1; i <= m; i++) if (b[i] != "") family[++fc] = b[i]
+    }
+    {
+      if ($0 in known) next
+      for (i = 1; i <= fc; i++) if (index($0, family[i] "-") == 1) next
+      print
+    }
+  ' <<<"$sheet_classes"
+)"
+
+catalog_count="$(printf '%s' "$undocumented" | grep -c . || true)"
+
+if [ "$catalog_count" -gt "$CATALOG_BASELINE" ]; then
+  status=1
+  echo "ERROR: the global stylesheet grew a component the rulebook does not name."
+  echo "       Undocumented classes in $sheet: $catalog_count (baseline $CATALOG_BASELINE)."
+  echo
+  echo "       A new component in the global sheet is currently free — the page-style"
+  echo "       ratchet only prices a page-local one. This is that price. Either add the"
+  echo "       new name to the component vocabulary in $rulebook (and check, while you"
+  echo "       are there, that it is not a second spelling of something already in the"
+  echo "       catalog), or reuse what is there."
+  echo
+  echo "       Undocumented names, for the diff:"
+  printf '%s\n' "$undocumented" | sed 's/^/  /'
+  echo
+elif [ "$catalog_count" -lt "$CATALOG_BASELINE" ]; then
+  status=1
+  echo "ERROR: undocumented-component count dropped to $catalog_count (baseline $CATALOG_BASELINE)."
+  echo "       Lower CATALOG_BASELINE in scripts/check-ui-vocabulary.sh to $catalog_count"
+  echo "       in this PR — headroom left behind gets spent by the next copy."
+  echo
+fi
+
+# ── 2. Affordance registry ───────────────────────────────────────────────────
+#
+# Each entry is an interaction the UI already makes. Extending this list is
+# allowed and sometimes right — but it is a rulebook edit, not a CSS edit, so
+# that the question "does this UI need a fifth way to signal something?" gets
+# asked out loud. Keep in sync with the registry in docs/ui-design.md.
+CURSOR_REGISTRY="pointer not-allowed grab grabbing default col-resize"
+TEXT_DECORATION_REGISTRY="none underline line-through"
+
+style_sources=("$sheet")
+while IFS= read -r f; do style_sources+=("$f"); done < <(ls Resources/Views/*.leaf 2>/dev/null || true)
+
+check_affordance() {
+  local prop="$1" registry="$2" label="$3"
+  local found
+  found="$(
+    grep -nE "(^|[;{[:space:]])${prop}[[:space:]]*:" "${style_sources[@]}" 2>/dev/null \
+      | grep -v '^\s*/\*' \
+      | sed -E "s/^([^:]+:[0-9]+):.*${prop}[[:space:]]*:[[:space:]]*([^;}!]*).*/\1|\2/" \
+      | sed -E 's/[[:space:]]+$//' \
+      | awk -F'|' -v reg="$registry" '
+          BEGIN { n = split(reg, a, " "); for (i = 1; i <= n; i++) ok[a[i]] = 1 }
+          { v = $2; gsub(/^[ \t]+|[ \t]+$/, "", v); if (!(v in ok) && v != "") print $1 "  " v }
+        ' || true
+  )"
+  if [ -n "$found" ]; then
+    status=1
+    echo "ERROR: unregistered $label affordance."
+    echo "       Registered values: $registry"
+    printf '%s\n' "$found" | sed 's/^/  /'
+    echo
+    echo "       A value outside the registry is a new way of telling a user what an"
+    echo "       element does. If the UI genuinely needs one, add it to the registry in"
+    echo "       $rulebook and to this script in the same PR, with the reasoning in the"
+    echo "       PR description. If it does not, reuse the affordance already in use."
+    echo
+  fi
+}
+
+check_affordance "cursor" "$CURSOR_REGISTRY" "cursor"
+check_affordance "text-decoration" "$TEXT_DECORATION_REGISTRY" "text-decoration"
+
+# ── 3. Hover prose budget ────────────────────────────────────────────────────
+#
+# A phrase, not a paragraph. The cap is deliberately generous — it is a
+# backstop against sentences accumulating in a tooltip, not a style opinion
+# about any particular string.
+TITLE_WORD_CAP=20
+
+long_titles="$(
+  awk -v cap="$TITLE_WORD_CAP" '
+    FNR == 1 { inscript = 0 }
+    /<script/ { inscript = 1 } /<\/script>/ { inscript = 0 }
+    inscript { next }
+    {
+      line = $0
+      while (match(line, /title="[^"]*"/)) {
+        t = substr(line, RSTART + 7, RLENGTH - 8)
+        line = substr(line, RSTART + RLENGTH)
+        # Leaf interpolation renders to unknown length; the budget is on the
+        # prose an author wrote, so a value-bearing title is out of scope.
+        if (t ~ /#\(/) continue
+        n = split(t, w, /[ \t]+/)
+        words = 0
+        for (i = 1; i <= n; i++) if (w[i] != "") words++
+        if (words > cap) printf "%s:%d  (%d words)  %s\n", FILENAME, FNR, words, t
+      }
+    }
+  ' Resources/Views/*.leaf 2>/dev/null || true
+)"
+
+if [ -n "$long_titles" ]; then
+  status=1
+  echo "ERROR: hover text over $TITLE_WORD_CAP words."
+  printf '%s\n' "$long_titles" | sed 's/^/  /'
+  echo
+  echo "       A title attribute is hover-only: no touch device shows it, no search"
+  echo "       finds it, and screen readers treat it inconsistently. It can hold a"
+  echo "       phrase. Anything a reader must have belongs in the page — a note under"
+  echo "       the control, a docs link — and anything they must not have can go."
+  echo
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "check-ui-vocabulary: OK (catalog at $catalog_count/$CATALOG_BASELINE; affordances registered; hover text within $TITLE_WORD_CAP words)"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Why

The 0.5.136 dataset estimates were right in substance and wrong in style, and **every CI guard passed on them**. That is not an oversight — it is structural, and worth stating precisely before the fix:

- `.chip` and `.chip-row` are in the component vocabulary (`docs/ui-design.md`). #1444 shipped `.dataset-estimates` / `.dataset-estimate` — called chips in the changelog, in the commit message and in their own CSS comment — sharing no styling with either.
- `cursor: help` and `text-decoration: underline dotted` each appear **exactly once in the codebase**: a private "hover me" convention, in a UI that already had four ways to reveal detail.
- The hover titles ran ~50 words of explanatory prose. The median `title=` in this codebase is 7 words.
- `docs/ui-ratchet-handoff.md` already requires that a new pattern be added to the catalog "in the same PR". #1444 did not touch `docs/ui-design.md` — and neither had thirteen components before it.

The reason nothing caught it: the guards are airtight at the token layer and blind above it. `PAGE_STYLE_BASELINE` is the only pressure against re-implementing a component, and it prices a **page-local** copy only. `Public/styles.css` carries no budget of any kind, so the cheapest way to add a second spelling of an existing component is to skip the page block and put it in the global sheet. The audit predicted this in so many words: "the drift now lives in the layer those guards cannot see."

## What changed

**`scripts/check-ui-vocabulary.sh`**, wired into `check-styles.sh` (so it runs in `format-lint`). Three rules:

| Rule | Kind | Catches |
|---|---|---|
| **Catalog** | shrink-only ratchet (298) | a global class `ui-design.md` does not name — a new component now costs a catalog entry, paid where review sees it beside the one it would duplicate |
| **Affordances** | closed allowlist | a `cursor` / `text-decoration` value outside the registry. Guard 4c blocklists idioms *already* consolidated, so it only ever catches a repeat; this is the same idea pointed forwards |
| **Hover prose** | absolute cap (20 words) | a `title=` in a template that has become a paragraph |

**`docs/ui-design.md`** gains the two sections it has never had. The rulebook was exclusively about *which token, which class, which archetype* — it had no guidance on which interaction to reach for, or how much text one may carry:

- **Interaction idioms** — a cheapest-first table (on the page → `<details>` → row-anchored popover → modal), the affordance registry, and why a hover title is neither a disclosure nor a docs page.
- **UI copy** — labels and chips are two-or-three-word noun phrases, a `title` is one phrase, a note is one sentence, and **anything longer belongs in `docs/` with the interface linking to it**.

Plus catalog entries for the thirteen components that had reached the global sheet without one.

**`.claude/agents/ui-review.md`** — the taste layer no script reaches: does this duplicate the vocabulary, is it the lightest idiom that fits, is the copy at house length, could an instructor act on it at a glance. `CLAUDE.md` points at it for any change touching `Resources/Views/`, `Public/styles.css`, or a page-wiring `Public/*.js`.

**The estimates themselves** are now plain `.chip`s inside a `.chip-row`, hidden until their number lands, with phrase-length titles; the method they used to explain moved into `docs/datasets.md`. Three over-long titles elsewhere (no-runner and failed-variant badges, the default time limit) are cut to a sentence. The numbers and the statistics are untouched.

## Verification

Watching the guard fail is the point, so it was tested by reintroducing the exact pattern that shipped. All four failure modes fire, and the tree restores clean:

```
ERROR: the global stylesheet grew a component the rulebook does not name.
  dataset-estimate
  dataset-estimates
ERROR: unregistered cursor affordance.
ERROR: unregistered text-decoration affordance.
ERROR: hover text over 20 words.
  Resources/Views/assignment-new.leaf:214  (26 words)  Two students share about 8 of their 40 rows, ...
```

Both ratchet directions were also exercised: the guard demanded the baseline be lowered to its floor once the catalog debt was paid.

Local gate, all green: `check-styles.sh`, `lint.sh`, `swiftlint.sh` (0 violations, 1041 files), `eslint.sh`, `node --test Tests/BrowserRunnerJSTests/*.mjs` (532 pass), and the Swift suites for the changed surface.

Two things found while doing it, both instances of documented traps:

- My first comment-stripper was line-at-a-time, so `v0.4.x` in a multi-line CSS comment registered as a class — the "a scanner cannot tell markup from prose about markup" trap, on its fourth outing. It spans lines now.
- `DatasetsRouteRoundTripTests` asserted a field's visibility by searching the **whole row** for the string `hidden`. That silently became a different question the moment any other element in the row rendered hidden. It reads the field's own open tag now.

## Limits, stated plainly

The script reads templates, so prose assembled in Swift or JS is invisible to it — which is exactly how the over-long tooltip shipped. That path needs its own budget assertion; `datasetEstimateTitleWordCap` + `DatasetEstimateSummaryTests` is the worked example, and the `ui-review` agent covers the general case. No script computes taste: these rules catch *recurrence* and make a novel misstep visible at the moment it is made. They do not decide whether a chip was the right answer.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NC5C3Qt5wyG5XpzXWJyHz)_