### PR TITLE
ci: put the mutation-testing tool on trial before adopting it

### DIFF
--- a/.github/workflows/mutation-probe.yml
+++ b/.github/workflows/mutation-probe.yml
@@ -1,0 +1,238 @@
+name: Mutation-testing probe (macOS)
+
+# DIAGNOSTIC harness — NOT a required gate, and NOT yet a mutation run against
+# Chickadee. This puts the TOOL on trial before we point it at the codebase.
+#
+# Why it exists. The recurring defect in this repo is verification that passes
+# while proving nothing — a test asserting against dead wiring, a probe filtering
+# a dead poll, a guard matching its own documentation, and (in #1445) a
+# word-budget test that passed three times while exercising nothing. Mutation
+# testing is the industrial answer to exactly that: mutate the source, and any
+# mutant the suite fails to kill is a hole in the suite.
+#
+# Why a probe first. Muter was measured on Linux (Swift 6.3, SwiftPM) and it
+# FAILS SILENTLY there, which is the worst possible failure for a verification
+# tool. Measured, not inferred:
+#
+#   * It builds and runs once `autoreleasepool` (Darwin-only, one call site in
+#     DiscoverMutationPoints.swift) is shimmed.
+#   * It copies the whole project with no exclusions, so a present `.build` is
+#     copied too and SwiftPM's absolute-path module cache poisons the copy
+#     ("missing required module 'SwiftShims'"). `exclude:` filters mutation
+#     targets, not the copy.
+#   * With `.build` removed it completes — and reports 0%, every mutant
+#     surviving. That is false: applying one of those mutations by hand makes
+#     the suite fail. Its rewriter emitted the scaffolding (`import class
+#     Foundation.ProcessInfo`) into its working copy but inserted NO mutation
+#     switches, so every "mutant" ran the unmutated binary.
+#
+# So the question this answers is narrow and worth money: does Muter actually
+# discriminate on macOS, where it is developed and supported? If yes, a weekly
+# scheduled run against Chickadee is worth building (macOS runners are free for
+# public repositories, which this is). If no, the tool is not adoptable at all
+# and we stop here rather than reading a fabricated score.
+#
+# The probe is a throwaway package with one STRONG test that pins a boundary and
+# one WEAK test that never exercises its second condition. A working mutation
+# tool must kill at least one mutant and let at least one survive. The
+# assertion is deliberately that shape rather than an exact score: which
+# replacement a relational operator gets is Muter's business, but discriminating
+# at all is the property under test.
+#
+# Step 4 establishes GROUND TRUTH without Muter — it applies the mutation by
+# hand and requires the suite to fail. Without that, a green probe would only
+# prove Muter agreed with itself, which is the very failure mode being chased.
+
+on:
+  workflow_dispatch:
+    inputs:
+      muter_ref:
+        description: "Muter commit/tag to build (default: the commit measured on Linux)"
+        default: "7f1f258"
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Does Muter discriminate on macOS?
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Toolchain
+        run: |
+          swift --version
+          xcodebuild -version || true
+
+      - name: Build Muter from source
+        run: |
+          git clone https://github.com/muter-mutation-testing/muter.git "$RUNNER_TEMP/muter"
+          cd "$RUNNER_TEMP/muter"
+          git checkout "${{ inputs.muter_ref }}"
+          git log -1 --format='muter @ %h %ad %s' --date=short
+          # --product muter: Muter's own test target does not build standalone.
+          swift build -c release --product muter
+          "$RUNNER_TEMP/muter/.build/release/muter" --version
+
+      - name: Write the probe package
+        run: |
+          PROBE="$RUNNER_TEMP/probe"
+          mkdir -p "$PROBE/Sources/Probe" "$PROBE/Tests/ProbeTests"
+
+          cat > "$PROBE/Package.swift" <<'EOF'
+          // swift-tools-version: 6.0
+          import PackageDescription
+
+          let package = Package(
+              name: "Probe",
+              targets: [
+                  .target(name: "Probe"),
+                  .testTarget(name: "ProbeTests", dependencies: ["Probe"]),
+              ]
+          )
+          EOF
+
+          cat > "$PROBE/Sources/Probe/Probe.swift" <<'EOF'
+          public struct Probe {
+              public static func isAdult(age: Int) -> Bool {
+                  age >= 18
+              }
+
+              public static func canVote(age: Int, registered: Bool) -> Bool {
+                  age >= 18 && registered
+              }
+          }
+          EOF
+
+          cat > "$PROBE/Tests/ProbeTests/ProbeTests.swift" <<'EOF'
+          import Testing
+
+          @testable import Probe
+
+          @Suite struct ProbeTests {
+              /// STRONG: pins the boundary, so any relational mutation of
+              /// `>=` must fail this.
+              @Test func adultBoundaryIsPinned() {
+                  #expect(Probe.isAdult(age: 18) == true)
+                  #expect(Probe.isAdult(age: 17) == false)
+              }
+
+              /// WEAK on purpose: only ever passes `registered: true`, so
+              /// flipping `&&` to `||` cannot be observed. This is the
+              /// vacuous-test shape the whole exercise is about.
+              @Test func votingIsChecked() {
+                  #expect(Probe.canVote(age: 40, registered: true) == true)
+              }
+          }
+          EOF
+
+          # Muter's config. `executable` must be an absolute path to a real
+          # swift; Muter derives the build system from its last path component.
+          cat > "$PROBE/muter.conf.yml" <<EOF
+          executable: $(command -v swift)
+          arguments:
+            - test
+          exclude:
+            - .build
+          mutationTestTimeout: 300
+          EOF
+          cat "$PROBE/muter.conf.yml"
+
+      - name: Baseline — the probe suite passes unmutated
+        working-directory: ${{ runner.temp }}/probe
+        run: swift test
+
+      - name: Ground truth — the mutation really is killable, without Muter
+        working-directory: ${{ runner.temp }}/probe
+        run: |
+          # Establishes the oracle independently. If a hand-applied mutation
+          # does NOT fail the suite, the probe itself is broken and Muter's
+          # answer means nothing either way.
+          cp Sources/Probe/Probe.swift /tmp/probe-original.swift
+          sed -i '' 's/age >= 18$/age > 18/' Sources/Probe/Probe.swift
+          grep -n 'age > 18' Sources/Probe/Probe.swift
+
+          if swift test > /tmp/mutated-run.log 2>&1; then
+            echo "::error::Ground truth FAILED: the suite passed with a mutation applied by hand."
+            echo "The probe is not discriminating, so this run cannot judge Muter."
+            tail -30 /tmp/mutated-run.log
+            cp /tmp/probe-original.swift Sources/Probe/Probe.swift
+            exit 1
+          fi
+          echo "Ground truth OK: the hand-applied mutation fails the suite."
+          cp /tmp/probe-original.swift Sources/Probe/Probe.swift
+
+          # Clean the build tree: Muter copies the project wholesale, and a
+          # SwiftPM build cache carries absolute paths that break in the copy.
+          rm -rf .build
+          swift test > /dev/null 2>&1 || { echo "::error::restore failed"; exit 1; }
+          rm -rf .build
+
+      - name: Run Muter
+        id: muter
+        working-directory: ${{ runner.temp }}/probe
+        run: |
+          # Muter's own exit code must not preempt the verdict: a low score is
+          # a RESULT, not a failure, and the next step is the judge. A genuine
+          # crash still surfaces there as zero mutant outcomes.
+          set +e
+          "$RUNNER_TEMP/muter/.build/release/muter" run \
+            --skip-coverage --skip-update-check -f plain \
+            2>&1 | tee "$RUNNER_TEMP/muter-report.txt"
+          echo "muter exit status: ${PIPESTATUS[0]}"
+
+      - name: Verdict — did Muter discriminate?
+        run: |
+          REPORT="$RUNNER_TEMP/muter-report.txt"
+          killed=$(grep -c 'mutant killed' "$REPORT" || true)
+          survived=$(grep -c 'mutant survived' "$REPORT" || true)
+          builderr=$(grep -c 'build error' "$REPORT" || true)
+
+          echo "killed=$killed survived=$survived build_errors=$builderr"
+          {
+            echo "### Muter probe on macOS"
+            echo ""
+            echo "| outcome | count |"
+            echo "|---|---:|"
+            echo "| mutants killed | $killed |"
+            echo "| mutants survived | $survived |"
+            echo "| build errors | $builderr |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$killed" -eq 0 ] && [ "$survived" -eq 0 ]; then
+            echo "::error::Muter produced no mutant outcomes at all — it crashed, or"
+            echo "discovered nothing. This is a tooling failure, not a measurement."
+            echo "**Verdict: Muter produced no result.**" >> "$GITHUB_STEP_SUMMARY"
+            tail -40 "$REPORT"
+            exit 1
+          fi
+
+          if [ "$killed" -eq 0 ]; then
+            echo "::error::Muter killed NOTHING. The strong test pins the boundary and a"
+            echo "hand-applied mutation was proven to fail the suite in the previous step,"
+            echo "so a 0% score here means Muter is not inserting mutants — the same"
+            echo "silent failure measured on Linux. Do NOT adopt it."
+            echo "**Verdict: Muter does NOT work here.**" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if [ "$survived" -eq 0 ]; then
+            echo "::error::Muter reported every mutant killed, including the one the WEAK"
+            echo "test cannot observe. That is not credible; treat the report as suspect."
+            echo "**Verdict: implausible — every mutant killed.**" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "Muter discriminates: it killed the mutant the strong test covers and let"
+          echo "the one the weak test cannot observe survive."
+          echo "**Verdict: Muter works on macOS — a weekly run against Chickadee is worth building.**" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the Muter report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: muter-probe-report
+          path: ${{ runner.temp }}/muter-report.txt
+          if-no-files-found: warn

--- a/.github/workflows/mutation-probe.yml
+++ b/.github/workflows/mutation-probe.yml
@@ -43,15 +43,14 @@ name: Mutation-testing probe (macOS)
 # hand and requires the suite to fail. Without that, a green probe would only
 # prove Muter agreed with itself, which is the very failure mode being chased.
 
-# Runs on a PR that touches this file, so the verdict is available BEFORE the
-# probe is merged — `workflow_dispatch` alone can only be triggered from the
-# default branch, which would mean merging an unevaluated tool evaluation. The
-# path filter keeps it off every unrelated PR; it is diagnostic, not a gate, so
-# not running is the correct outcome elsewhere.
+# ANSWERED 2026-08-18, negative: run 32141581986 on macos-latest reported
+# killed=0 survived=3 — 0%, the same fabricated score measured on Linux, and on
+# a run whose ground-truth step had just proven the mutation killable by hand.
+# The defect is therefore NOT platform-specific. Kept on manual dispatch so the
+# question can be re-asked cheaply against a future Muter release; it ran on a
+# `pull_request` trigger to get the first answer without merging an unevaluated
+# tool evaluation, and that trigger is removed now the answer is in.
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/mutation-probe.yml"
   workflow_dispatch:
     inputs:
       muter_ref:
@@ -195,7 +194,7 @@ jobs:
           REPORT="$RUNNER_TEMP/muter-report.txt"
           killed=$(grep -c 'mutant killed' "$REPORT" || true)
           survived=$(grep -c 'mutant survived' "$REPORT" || true)
-          builderr=$(grep -c 'build error' "$REPORT" || true)
+          builderr=$(grep -c 'build error$' "$REPORT" || true)
 
           echo "killed=$killed survived=$survived build_errors=$builderr"
           {

--- a/.github/workflows/mutation-probe.yml
+++ b/.github/workflows/mutation-probe.yml
@@ -43,7 +43,15 @@ name: Mutation-testing probe (macOS)
 # hand and requires the suite to fail. Without that, a green probe would only
 # prove Muter agreed with itself, which is the very failure mode being chased.
 
+# Runs on a PR that touches this file, so the verdict is available BEFORE the
+# probe is merged — `workflow_dispatch` alone can only be triggered from the
+# default branch, which would mean merging an unevaluated tool evaluation. The
+# path filter keeps it off every unrelated PR; it is diagnostic, not a gate, so
+# not running is the correct outcome elsewhere.
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/mutation-probe.yml"
   workflow_dispatch:
     inputs:
       muter_ref:
@@ -69,7 +77,7 @@ jobs:
         run: |
           git clone https://github.com/muter-mutation-testing/muter.git "$RUNNER_TEMP/muter"
           cd "$RUNNER_TEMP/muter"
-          git checkout "${{ inputs.muter_ref }}"
+          git checkout "${{ inputs.muter_ref || '7f1f258' }}"
           git log -1 --format='muter @ %h %ad %s' --date=short
           # --product muter: Muter's own test target does not build standalone.
           swift build -c release --product muter

--- a/docs/handoff-mutation-testing.md
+++ b/docs/handoff-mutation-testing.md
@@ -1,0 +1,105 @@
+# Handoff — re-evaluating mutation testing
+
+**Status: closed, negative, dormant.** Nothing to build today. This exists so
+the question can be re-asked in ten minutes instead of re-investigated in a day.
+Tracking issue: **#1447**. Measurements: [mutation-testing-spike.md](mutation-testing-spike.md).
+
+## Why we wanted it
+
+The recurring defect in this codebase is **verification that passes while
+proving nothing** — four instances on the record, including a hover-budget test
+that passed three times while exercising nothing. Mutation testing is the
+industrial instrument for exactly that: mutate the source, and any mutant the
+suite fails to kill is a hole in the suite.
+
+That motivation has not changed. Only the tooling failed.
+
+## What was measured — do not redo this
+
+[Muter](https://github.com/muter-mutation-testing/muter) @ `7f1f258`, on both
+platforms, reports a **fabricated 0%**: it discovers mutants correctly, inserts
+none, and reports every one as "survived".
+
+| | Linux (Swift 6.3, SwiftPM) | macOS (`macos-latest`, Xcode toolchain) |
+|---|---|---|
+| Mutants discovered | 3, correct operators and lines | 3, correct operators and lines |
+| Result | 0 killed, 3 survived | 0 killed, 3 survived |
+
+The macOS run is the decisive one: the step immediately before it applies the
+mutation **by hand** and requires the suite to fail. In one run — the mutant is
+provably killable, and Muter says it survived.
+
+**Mechanism**, inspected in Muter's own working copy: the "mutated" source
+carries its scaffolding (`import class Foundation.ProcessInfo`) and **no
+mutation switches** — the function bodies are byte-identical. Schemata live in
+`[CodeBlockItemListSyntax: MutationSchemata]`, a dictionary keyed by SwiftSyntax
+nodes, and `MutationSwitch.apply` returns the original syntax untouched whenever
+that lookup is empty.
+
+Two incidental findings, if you do revisit:
+
+- **Linux needs one shim.** `autoreleasepool` is Darwin-only, one call site
+  (`DiscoverMutationPoints.swift:83`). Shimmed, Muter builds and runs on Linux.
+- **A warm `.build` breaks it.** Muter `copyItem`s the whole project with *no
+  exclusions*, and SwiftPM's absolute-path module cache poisons the copy
+  (`missing required module 'SwiftShims'`). `exclude:` filters mutation
+  *targets*, not the copy. Delete `.build` first; the cost is a cold build.
+
+**The version boundary was NOT isolated.** Two environments differing in OS,
+architecture and compiler agree on the result, so "it needs Swift 6.3 support"
+is a guess. Trigger on observed behaviour, not a version number.
+
+## How to re-ask the question
+
+**Actions → "Mutation-testing probe (macOS)" → Run workflow.** Manual dispatch,
+free on this public repo, ~10 minutes. One run answers it.
+
+The probe is built to distrust the tool, and both properties are load-bearing:
+
+- **It establishes ground truth without Muter** — a step applies the mutation
+  by hand and requires the suite to fail. Without it, a green probe would only
+  prove Muter agreed with itself.
+- **It asserts a shape, not a score.** One strong test pinning a boundary, one
+  weak test that cannot observe its mutant. It fails on 0% (inserted nothing),
+  on 100% (implausible), and on no outcomes at all (crashed).
+
+If you rewrite it, keep both. They are the difference between a probe and a
+rubber stamp.
+
+## When it is worth re-running
+
+A Muter release mentioning schemata or mutant insertion, swift-syntax 602+, or
+Swift 6.3+ support. Watching the repo's releases is cheaper than watching the
+issue tracker.
+
+## If it works
+
+Do **not** point it at the whole codebase. The shape:
+
+- **Scoped** — `--files-to-mutate` over the week's changed files. A full
+  campaign across ~3,000 tests with a cold build per run is not affordable even
+  on free minutes.
+- **Scheduled**, not per-PR.
+- **A report, never a gate.** A surviving mutant is a question for a human;
+  failing a build on a mutation score punishes the wrong thing.
+
+Ask before building the weekly job — it is a standing commitment of CI time and
+attention, not a one-off.
+
+## The alternative, already assessed
+
+[ericodx/swift-mutation-testing](https://github.com/ericodx/swift-mutation-testing)
+does not build on Linux (`no such module 'CryptoKit'`, Apple-only). Its design
+is better on paper — schematization rather than rebuild-per-mutant, and explicit
+support for both XCTest and **Swift Testing**, which matters because every test
+here is Swift Testing — but porting off CryptoKit to swift-crypto is real work,
+and it is less actively maintained. Reconsider only if Muter stays broken and
+the appetite survives.
+
+## What shipped instead
+
+`scripts/check-guards.sh` + `scripts/guard-fixtures/` — every guard must be
+**seen to fail** on a fixture reproducing the defect it exists to catch. Same
+target, no platform question, no external dependency. Mutation testing would
+extend that discipline from the guard layer to the unit layer; it does not
+replace it.

--- a/docs/mutation-testing-spike.md
+++ b/docs/mutation-testing-spike.md
@@ -1,0 +1,93 @@
+# Mutation testing — spike (2026-08)
+
+**Status: open, gated on one macOS probe run.** Nothing is adopted. Run the
+`Mutation-testing probe (macOS)` workflow (`workflow_dispatch`) and read its
+verdict before spending anything further.
+
+## Why we looked
+
+The recurring defect in this codebase is not an untested path — it is
+**verification that passes while proving nothing**. Four independent instances
+are on record: a regression test matching a wiring string in page HTML after the
+wiring went dead, the repaint probe's filter assertion passing against a dead
+poll, the S5 guard matching its own documentation, and — in #1445, the PR that
+prompted this — a hover-budget test that passed three times while exercising
+nothing (the fixture picked a one-word category, then the allocation floor never
+engaged, then both titles landed at exactly the cap).
+
+The house rule already exists — *"a check never seen to fail is not a check"*
+([ui-ratchet-handoff.md](ui-ratchet-handoff.md)) — and it is the one discipline
+here with no enforcement behind it. Mutation testing is the industrial form of
+that rule: change the source, and any mutant the suite fails to kill is a hole
+in the suite.
+
+## What was measured
+
+Both candidate tools were built and run on this repo's own platform (Linux,
+Swift 6.3, SwiftPM). Neither works there.
+
+### Muter ([muter-mutation-testing/muter](https://github.com/muter-mutation-testing/muter), @ 7f1f258, 2026-07-21)
+
+Its README badge says macos | linux; its FAQ says macOS only. Measured, the
+executable **does** build and run on Linux after one shim — but it then fails
+**silently and confidently**, which for a verification tool is the worst
+available outcome.
+
+| finding | detail |
+|---|---|
+| Builds on Linux | after shimming `autoreleasepool` (Darwin-only, one call site, `DiscoverMutationPoints.swift:83`) |
+| Discovery works | SwiftSyntax analysis found the right mutants at the right lines |
+| The copy is poisoned | it `copyItem`s the whole project with **no exclusions**, so a present `.build` comes too and SwiftPM's absolute-path module cache breaks the copy (`missing required module 'SwiftShims'`). `exclude:` filters mutation *targets*, not the copy. Deleting `.build` first is the workaround, at the cost of a cold build per run |
+| **It inserts no mutants** | its rewriter wrote the scaffolding (`import class Foundation.ProcessInfo`) into its working copy and emitted **no mutation switches** — the function bodies are byte-identical to the originals. Every "mutant" therefore ran the unmutated binary |
+| **The score is fabricated** | it reported 0%, all mutants surviving. Applying one of those same mutations by hand makes the suite fail, so the mutants it called "survived" are ones the tests demonstrably kill |
+
+The mechanism behind the empty rewrite: schemata are held in
+`[CodeBlockItemListSyntax: MutationSchemata]` — a dictionary keyed by
+**SwiftSyntax nodes** — and `MutationSwitch.apply` returns the original syntax
+untouched whenever the lookup yields nothing. Whether that lookup fails only on
+Linux, or generally against current toolchains, is exactly what the macOS probe
+settles. Muter pins `swift-syntax from: 601.0.0` (resolved 601.0.1) while the
+toolchain here is 6.3.
+
+### swift-mutation-testing ([ericodx/swift-mutation-testing](https://github.com/ericodx/swift-mutation-testing), 2026-05-24)
+
+Does not build on Linux at all: `no such module 'CryptoKit'` (Apple-only). That
+is a real port to swift-crypto, not a shim. Its design is the better one on
+paper — schematization (build once, switch mutants at runtime) rather than
+rebuild-per-mutant, and explicit support for **both XCTest and Swift Testing**,
+which matters because every test here is Swift Testing. It is also less actively
+maintained than Muter and declares `platforms: [.macOS(.v15)]`. Worth
+reconsidering only if the Muter probe fails and the appetite survives.
+
+## The probe, and why it is shaped this way
+
+`.github/workflows/mutation-probe.yml` — manual dispatch, macOS runner, **free**
+because this repository is public. It puts the *tool* on trial, not the
+codebase: a throwaway package with one **strong** test pinning a boundary and
+one **weak** test that never exercises its second condition. A working mutation
+tool must kill at least one and let at least one survive.
+
+Two design points worth keeping if this is ever rewritten:
+
+- **It establishes ground truth without Muter.** A step applies the mutation by
+  hand and *requires* the suite to fail. Without it, a green probe would only
+  prove Muter agreed with itself — the very failure being chased.
+- **The assertion is a shape, not a score.** Which replacement a relational
+  operator receives is Muter's business; discriminating at all is the property
+  under test. It fails on 0% (inserted nothing), on 100% (implausible — the weak
+  test cannot observe its mutant), and on no outcomes at all (crashed).
+
+## What happens next, by verdict
+
+- **Muter discriminates** → build the weekly scheduled run. Scope it with
+  `--files-to-mutate` against the week's changed files rather than the whole
+  tree; a full campaign over ~3,000 tests with a cold build per run is not
+  affordable even on free minutes. It is a report, never a gate — a surviving
+  mutant is a question for a human, not a build failure.
+- **Muter does not discriminate** → it is not adoptable, and the finding is
+  worth an upstream issue since the failure is silent. Fall back to **guard
+  self-tests**: every `scripts/check-*.sh` ships a fixture it must reject, with
+  a meta-check that runs them. That targets the same defect, has no platform
+  question, and is a day's work. It is what #1445 did by hand — reintroduce the
+  shipped pattern, watch four rules fire, restore — which is the only reason
+  that guard is trusted.

--- a/docs/mutation-testing-spike.md
+++ b/docs/mutation-testing-spike.md
@@ -1,8 +1,14 @@
 # Mutation testing — spike (2026-08)
 
-**Status: open, gated on one macOS probe run.** Nothing is adopted. Run the
-`Mutation-testing probe (macOS)` workflow (`workflow_dispatch`) and read its
-verdict before spending anything further.
+**Status: CLOSED, negative. Muter is not adoptable.** The macOS probe ran
+(2026-08-18, run 32141581986, `macos-latest`) and reported **killed=0,
+survived=3 — 0%**, the same fabricated score measured on Linux, on a run whose
+ground-truth step had just proven by hand that one of those mutants is
+killable. **The defect is not platform-specific.** The workflow stays on manual
+dispatch so the question can be re-asked cheaply against a future release.
+
+Do not read a Muter score from either platform as a measurement of this test
+suite. The fallback — guard self-tests — is in `scripts/check-guards.sh`.
 
 ## Why we looked
 
@@ -77,9 +83,26 @@ Two design points worth keeping if this is ever rewritten:
   under test. It fails on 0% (inserted nothing), on 100% (implausible — the weak
   test cannot observe its mutant), and on no outcomes at all (crashed).
 
+## The verdict, and why the probe was worth building
+
+Muter reported 0% on macOS with Xcode's own toolchain — the platform it is
+developed and supported on. Every step before the verdict passed, including the
+one that applies the mutation by hand and requires the suite to fail, so the run
+establishes both halves: the mutant is killable, and Muter says it survived.
+
+That is the whole argument for putting the tool on trial first. Pointed straight
+at Chickadee, Muter would have reported a catastrophic mutation score for a
+well-tested suite, every "finding" would have been noise, and the number would
+have looked like a measurement. A weekly job publishing that would have been
+worse than no job at all — the failure mode is a confident wrong answer, which
+is the exact defect class the tool was being bought to catch.
+
+The probe cost one workflow file and one run on a free runner.
+
 ## What happens next, by verdict
 
-- **Muter discriminates** → build the weekly scheduled run. Scope it with
+- ~~**Muter discriminates** → build the weekly scheduled run. Scope it with~~
+  *(did not happen — see above)* Scope it with
   `--files-to-mutate` against the week's changed files rather than the whole
   tree; a full campaign over ~3,000 tests with a cold build per run is not
   affordable even on free minutes. It is a report, never a gate — a surviving


### PR DESCRIPTION
## Why

Mutation testing is the industrial answer to this repo's most-repeated defect — **verification that passes while proving nothing**. Four instances are on record: a regression test matching a wiring string after the wiring went dead, the repaint probe's filter assertion passing against a dead poll, the S5 guard matching its own documentation, and in #1445 a hover-budget test that passed three times while exercising nothing.

The house rule already exists — *"a check never seen to fail is not a check"* — and it's the one discipline here with no enforcement behind it.

## What was measured

Both candidate tools were built and run on this repo's own platform (Linux, Swift 6.3, SwiftPM). **Neither works there.**

**Muter** builds and runs once `autoreleasepool` (Darwin-only, one call site) is shimmed, and its discovery is correct — right mutants, right lines. Then it reports **0%, every mutant surviving.** That is false: applying one of those same mutations by hand makes the suite fail.

The cause, from its working copy: the rewriter emitted its scaffolding (`import class Foundation.ProcessInfo`) and **no mutation switches at all** — the function bodies are byte-identical to the originals, so every "mutant" ran the unmutated binary. Mechanically, schemata live in `[CodeBlockItemListSyntax: MutationSchemata]` (a dictionary keyed by SwiftSyntax *nodes*) and `MutationSwitch.apply` returns the original syntax whenever that lookup is empty. Separately, it `copyItem`s the whole project with no exclusions, so a present `.build` poisons the copy via SwiftPM's absolute-path module cache (`missing required module 'SwiftShims'`).

**swift-mutation-testing** doesn't build on Linux at all — `no such module 'CryptoKit'`. Its design is better on paper (schematization rather than rebuild-per-mutant; explicit Swift Testing support, which matters because every test here is Swift Testing) but that's a real port, not a shim.

## What this adds

A **manual-dispatch macOS probe** that puts the *tool* on trial rather than the codebase. macOS runners are free here — the repository is public — so the only cost is deciding to look.

A silently fabricated score is the worst failure available to a verification tool, and it's the same defect class the tool would be bought to catch. So the probe is built to distrust it. Two properties worth keeping if it's ever rewritten:

- **It establishes ground truth without Muter.** One step applies the mutation by hand and *requires* the suite to fail. Without that, a green probe would only prove Muter agreed with itself.
- **It asserts a shape, not a score.** The throwaway package has one **strong** test pinning a boundary and one **weak** test that never exercises its second condition, so a working tool must kill at least one mutant and let at least one survive. It fails on 0% (inserted nothing), on 100% (implausible — the weak test can't observe its mutant), and on no outcomes at all (crashed).

## How to run it

Actions → **Mutation-testing probe (macOS)** → Run workflow. ~10–15 min. The verdict lands in the job summary; the full Muter report uploads as an artifact.

## What it decides

- **Discriminates** → build the weekly scheduled run, scoped with `--files-to-mutate` against the week's changed files (a full campaign over ~3,000 tests with a cold build per run isn't affordable even on free minutes). A report, never a gate — a surviving mutant is a question for a human.
- **Doesn't** → Muter isn't adoptable, the silent failure is worth an upstream issue, and the fallback is **guard self-tests**: every `scripts/check-*.sh` ships a fixture it must reject. Same defect targeted, no platform question, a day's work.

No schedule and no run against Chickadee yet — that's the follow-up the verdict earns or refuses. `docs/mutation-testing-spike.md` carries the measurements and both branches.

## Note

Not a required check, and it touches nothing outside `.github/workflows/` and `docs/`. Independent of #1445.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NC5C3Qt5wyG5XpzXWJyHz)_