### PR TITLE
ci: every guard must be seen to fail

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -19,6 +19,23 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Every guard must be SEEN to fail. Its own job rather than a step inside
+  # format-lint: each fixture re-runs a whole guard, so the suite costs
+  # minutes, and paying that in wall-clock beside format-lint is free while
+  # paying it inside format-lint is not.
+  guard-self-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Every guard fails on its own defect
+        run: scripts/check-guards.sh
+
   format-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -449,6 +466,7 @@ jobs:
   swift-tests-gate:
     needs:
       - format-lint
+      - guard-self-tests
       - build
       - core-tests
       - api-tests

--- a/changelog.d/guard-self-tests.md
+++ b/changelog.d/guard-self-tests.md
@@ -1,0 +1,22 @@
+### Added
+
+- **Every guard is now proved to fail on its own defect.** The house rule —
+  "a check never seen to fail is not a check" — was the one discipline here
+  with nothing enforcing it, and the cost is on the record four times: a
+  regression test matching a wiring string after the wiring went dead, the
+  repaint probe's filter assertion passing against a dead poll, the S5 guard
+  matching its own documentation, and a hover-budget test that passed three
+  times while exercising nothing. `scripts/check-guards.sh` runs each fixture
+  in `scripts/guard-fixtures/` — a guard, a defect that guard exists to catch,
+  and the message it must produce — and **fails the build if the guard
+  passes**. 18 fixtures cover the token, name and idiom layers: raw colours,
+  off-scale font sizes, radii and spacing, undefined and hardcoded-fallback
+  CSS vars, unresolved classes, inline styles in templates and in JS-built
+  HTML, native `alert()` in both, inline `<script>`, native `confirm()`,
+  icon geometry outside the sprite, retired button modifiers, page blocks
+  re-defining global selectors, page-local sorters, and JS-written colour.
+  Its own runner refuses an empty fixture set, checks each guard is green on
+  the clean tree before trusting any result, asserts the *expected message*
+  rather than just a non-zero exit (so a defect tripping a neighbouring rule
+  is not mistaken for coverage), and restores every file it touches on all
+  exit paths. Runs as its own CI job and joins the merge gate.

--- a/scripts/check-guards.sh
+++ b/scripts/check-guards.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Guard self-test: every guard must be SEEN to fail.
+#
+# The house rule is already written — "a check never seen to fail is not a
+# check" (docs/ui-ratchet-handoff.md) — and it is the one discipline here with
+# nothing enforcing it. The cost of that gap is on the record four times: a
+# regression test matching a wiring string after the wiring went dead, the
+# repaint probe's filter assertion passing against a dead poll, the S5 guard
+# matching its own documentation, and a hover-budget test that passed three
+# times while exercising nothing. Each read as coverage. None was.
+#
+# This closes it mechanically. Each fixture in scripts/guard-fixtures/ names a
+# guard, a defect that guard exists to catch, and the message it must produce.
+# The runner applies the defect, runs the guard, and FAILS THE BUILD IF THE
+# GUARD PASSES. A guard that stops catching its own defect — because a regex
+# drifted, a path moved, a rule was refactored into a no-op — is then a red
+# build rather than a quiet false negative.
+#
+# Two design points worth keeping.
+#
+#   * The expected MESSAGE is asserted, not just the exit status. A fixture
+#     that trips a different rule in the same script would otherwise look like
+#     a pass, and the guard under test would still be dead.
+#   * A fixture edits the real tree and restores it. Only the files it declares
+#     are touched, they are restored on every exit path including a failed
+#     assertion or an interrupt, and the runner refuses to start if any of them
+#     is already modified — so a dirty working tree is never silently reverted.
+#
+# Fixture format (scripts/guard-fixtures/NAME.fixture, sourced):
+#
+#     guard="scripts/check-design-tokens.sh"   # the guard to run
+#     files="Public/styles.css"                # files apply() modifies
+#     description="a raw hex colour in a rule body"
+#     expect="colour literal"                  # substring its output must have
+#     apply() { ... }                          # introduce the defect
+#
+# Adding a rule to a guard means adding a fixture. That is the price of the
+# rule, and it is the cheapest possible: proving once that the thing you just
+# wrote can fail.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+fixture_dir="scripts/guard-fixtures"
+backup_dir="$(mktemp -d)"
+current_files=""
+status=0
+passed=0
+failed=0
+
+restore_current() {
+    [ -z "$current_files" ] && return 0
+    for f in $current_files; do
+        if [ -f "$backup_dir/$(echo "$f" | tr '/' '_')" ]; then
+            cp "$backup_dir/$(echo "$f" | tr '/' '_')" "$f"
+        fi
+    done
+    current_files=""
+}
+
+cleanup() {
+    restore_current
+    rm -rf "$backup_dir"
+}
+trap cleanup EXIT INT TERM
+
+if [ ! -d "$fixture_dir" ]; then
+    echo "ERROR: no fixture directory at $fixture_dir"
+    exit 1
+fi
+
+fixtures=("$fixture_dir"/*.fixture)
+if [ ! -e "${fixtures[0]}" ]; then
+    echo "ERROR: $fixture_dir contains no fixtures."
+    echo "       An empty self-test suite reports success while proving nothing,"
+    echo "       which is the exact failure this script exists to prevent."
+    exit 1
+fi
+
+echo "check-guards: ${#fixtures[@]} fixtures"
+
+# Pre-flight: every guard under test must be GREEN on the clean tree, once.
+# A guard already failing would make every result below meaningless — a red
+# run would prove nothing about the fixture that "caused" it. Hoisted out of
+# the loop because the umbrella guard costs seconds and fixtures restore the
+# tree, so one clean run covers them all.
+guards_under_test="$(
+    for f in "${fixtures[@]}"; do
+        # shellcheck disable=SC1090
+        ( source "$f"; printf '%s\n' "$guard" )
+    done | sort -u
+)"
+for g in $guards_under_test; do
+    if ! "./$g" >/dev/null 2>&1; then
+        echo
+        echo "ERROR: $g already fails on the clean tree."
+        echo "       Fix that first; until then no fixture result means anything."
+        exit 1
+    fi
+done
+echo "pre-flight: $(wc -w <<<"$guards_under_test" | tr -d ' ') guards green on the clean tree"
+echo
+
+for fixture in "${fixtures[@]}"; do
+    name="$(basename "$fixture" .fixture)"
+
+    # Read the fixture's metadata in a subshell so one fixture cannot leak
+    # variables or an apply() into the next.
+    meta="$(
+        # shellcheck disable=SC1090
+        source "$fixture"
+        printf '%s\n%s\n%s\n%s\n' "$guard" "$files" "$description" "$expect"
+    )"
+    guard="$(sed -n 1p <<<"$meta")"
+    files="$(sed -n 2p <<<"$meta")"
+    description="$(sed -n 3p <<<"$meta")"
+    expect="$(sed -n 4p <<<"$meta")"
+
+    if [ ! -x "$guard" ] && [ ! -f "$guard" ]; then
+        echo "✘ $name — names a guard that does not exist: $guard"
+        failed=$((failed + 1)); status=1; continue
+    fi
+
+    # Refuse to touch a file the working tree has already modified.
+    dirty=""
+    for f in $files; do
+        if [ ! -f "$f" ]; then
+            dirty="$f (missing)"
+            break
+        fi
+        if ! git diff --quiet -- "$f" 2>/dev/null || ! git diff --cached --quiet -- "$f" 2>/dev/null; then
+            dirty="$f (modified)"
+            break
+        fi
+    done
+    if [ -n "$dirty" ]; then
+        echo "✘ $name — refusing to run: $dirty"
+        echo "    This fixture edits and restores that file; commit or stash first."
+        failed=$((failed + 1)); status=1; continue
+    fi
+
+    for f in $files; do
+        cp "$f" "$backup_dir/$(echo "$f" | tr '/' '_')"
+    done
+    current_files="$files"
+
+    ( # shellcheck disable=SC1090
+      source "$fixture"; apply )
+
+    out="$("./$guard" 2>&1)"
+    code=$?
+    restore_current
+
+    if [ "$code" -eq 0 ]; then
+        echo "✘ $name — $guard PASSED with the defect applied."
+        echo "    defect: $description"
+        echo "    This guard no longer catches what it exists to catch."
+        failed=$((failed + 1)); status=1
+    elif ! grep -qF -- "$expect" <<<"$out"; then
+        echo "✘ $name — $guard failed, but not with its own message."
+        echo "    defect:   $description"
+        echo "    expected: $expect"
+        echo "    The defect tripped a different rule, so the rule under test"
+        echo "    is still unproven."
+        printf '%s\n' "$out" | sed 's/^/      /' | head -12
+        failed=$((failed + 1)); status=1
+    else
+        echo "✔ $name — $description"
+        passed=$((passed + 1))
+    fi
+done
+
+echo
+if [ "$status" -eq 0 ]; then
+    echo "check-guards: OK ($passed guards seen to fail on their own defect)"
+else
+    echo "check-guards: $failed of $((passed + failed)) fixtures did not prove their guard"
+fi
+exit "$status"

--- a/scripts/check-guards.sh
+++ b/scripts/check-guards.sh
@@ -124,17 +124,34 @@ for fixture in "${fixtures[@]}"; do
     fi
 
     # Refuse to touch a file the working tree has already modified.
+    #
+    # `git diff --quiet` exits 0 clean, 1 differing, and >1 on an ERROR — and
+    # an error is routine in CI, where the container runs as root against a
+    # workspace owned by another uid and git refuses the repository as
+    # "dubious ownership". Treating every non-zero as "modified" made this
+    # refuse all 18 fixtures on a pristine checkout. When git cannot answer,
+    # proceed: the backup/restore below is what actually protects the file,
+    # and this check only exists to avoid confusing results mid-edit.
     dirty=""
+    git_mute=""
     for f in $files; do
         if [ ! -f "$f" ]; then
             dirty="$f (missing)"
             break
         fi
-        if ! git diff --quiet -- "$f" 2>/dev/null || ! git diff --cached --quiet -- "$f" 2>/dev/null; then
+        git diff --quiet -- "$f" 2>/dev/null; unstaged=$?
+        git diff --cached --quiet -- "$f" 2>/dev/null; staged=$?
+        if [ "$unstaged" -gt 1 ] || [ "$staged" -gt 1 ]; then
+            git_mute="yes"
+        elif [ "$unstaged" -eq 1 ] || [ "$staged" -eq 1 ]; then
             dirty="$f (modified)"
             break
         fi
     done
+    if [ -n "$git_mute" ] && [ -z "${git_mute_warned:-}" ]; then
+        echo "note: git cannot report file status here; relying on backup/restore."
+        git_mute_warned=1
+    fi
     if [ -n "$dirty" ]; then
         echo "✘ $name — refusing to run: $dirty"
         echo "    This fixture edits and restores that file; commit or stash first."

--- a/scripts/guard-fixtures/class-resolution-unresolved.fixture
+++ b/scripts/guard-fixtures/class-resolution-unresolved.fixture
@@ -1,0 +1,9 @@
+# A class with no rule is either a typo or dead markup; both render fine and
+# so are invisible to the render tests.
+guard="scripts/check-class-resolution.sh"
+files="Resources/Views/login.leaf"
+description="a class name with no stylesheet rule"
+expect="resolve"
+apply() {
+    printf '<div class="ck-guard-fixture-no-such-rule">x</div>\n' >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/css-vars-hex-fallback.fixture
+++ b/scripts/guard-fixtures/css-vars-hex-fallback.fixture
@@ -1,0 +1,9 @@
+# var(--x, #hex) looks safe and is not: the fallback is off-palette and has
+# no dark-mode value, so it fires exactly when the token is missing.
+guard="scripts/check-css-vars.sh"
+files="Public/styles.css"
+description="a hardcoded colour fallback in a var() reference"
+expect="fallback"
+apply() {
+    printf '\n.ck-guard-fixture { color: var(--gray-600, #333333); }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/css-vars-undefined.fixture
+++ b/scripts/guard-fixtures/css-vars-undefined.fixture
@@ -1,0 +1,8 @@
+# A var(--x) with no declaration renders as nothing rather than erroring.
+guard="scripts/check-css-vars.sh"
+files="Public/styles.css"
+description="a var() reference to an undeclared custom property"
+expect="undefined"
+apply() {
+    printf '\n.ck-guard-fixture { color: var(--ck-guard-fixture-never-declared); }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/design-tokens-font-size.fixture
+++ b/scripts/guard-fixtures/design-tokens-font-size.fixture
@@ -1,0 +1,9 @@
+# 26 distinct font sizes had accumulated before the type scale. A literal
+# reintroduces a step outside it.
+guard="scripts/check-design-tokens.sh"
+files="Public/styles.css"
+description="a font-size literal outside the type scale"
+expect="font-size"
+apply() {
+    printf '\n.ck-guard-fixture { font-size: 0.83rem; }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/design-tokens-radius.fixture
+++ b/scripts/guard-fixtures/design-tokens-radius.fixture
@@ -1,0 +1,8 @@
+# 18 distinct border radii had accumulated before the radius scale.
+guard="scripts/check-design-tokens.sh"
+files="Public/styles.css"
+description="a border-radius literal outside the radius scale"
+expect="border-radius"
+apply() {
+    printf '\n.ck-guard-fixture { border-radius: 0.37rem; }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/design-tokens-raw-colour.fixture
+++ b/scripts/guard-fixtures/design-tokens-raw-colour.fixture
@@ -1,0 +1,10 @@
+# A raw colour literal in a rule body bypasses the palette and so bypasses
+# dark mode. The historical bug: a hardcoded #d4edda success banner rendering
+# invisible-text-on-dark.
+guard="scripts/check-design-tokens.sh"
+files="Public/styles.css"
+description="a raw hex colour in a rule body"
+expect="colour literal"
+apply() {
+    printf '\n.ck-guard-fixture { color: #ff0000; }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/design-tokens-spacing.fixture
+++ b/scripts/guard-fixtures/design-tokens-spacing.fixture
@@ -1,0 +1,9 @@
+# Spacing is a shrink-only lattice, not a scale: a value off it is a new step
+# nobody agreed to.
+guard="scripts/check-design-tokens.sh"
+files="Public/styles.css"
+description="a spacing value off the lattice"
+expect="spacing"
+apply() {
+    printf '\n.ck-guard-fixture { padding: 0.37rem; }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/styles-icon-geometry.fixture
+++ b/scripts/guard-fixtures/styles-icon-geometry.fixture
@@ -1,0 +1,9 @@
+# Icon geometry lives only in _icons.leaf; every other use references a
+# <symbol>. Sixteen copies of one trash can is what this prevents.
+guard="scripts/check-styles.sh"
+files="Resources/Views/login.leaf"
+description="inline SVG geometry outside the icon sprite"
+expect="inline SVG geometry outside the icon sprite"
+apply() {
+    printf '<svg><path d="M1 1 L2 2"/></svg>\n' >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/styles-inline-script.fixture
+++ b/scripts/guard-fixtures/styles-inline-script.fixture
@@ -1,0 +1,14 @@
+# JS inside a template <script> block is invisible to ESLint, CodeQL and
+# node --check. Page behaviour belongs in a Public/*.js file.
+guard="scripts/check-styles.sh"
+files="Resources/Views/login.leaf"
+description="a multi-line inline script in a template"
+expect="multi-line inline <script>"
+apply() {
+    {
+        printf '<script>\n'
+        printf 'var ckGuardFixture = 1;\n'
+        printf 'console.log(ckGuardFixture);\n'
+        printf '</script>\n'
+    } >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/styles-inline-style-attribute.fixture
+++ b/scripts/guard-fixtures/styles-inline-style-attribute.fixture
@@ -1,0 +1,10 @@
+# An inline style= bypasses every token guard: the value never routes through
+# the palette or the scales. Only display:none and custom-prop assignments
+# are allowed.
+guard="scripts/check-styles.sh"
+files="Resources/Views/login.leaf"
+description="an inline style attribute in a template"
+expect="disallowed inline style"
+apply() {
+    printf '<p style="margin-top: 3px">guard fixture</p>\n' >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/styles-js-built-inline-style.fixture
+++ b/scripts/guard-fixtures/styles-js-built-inline-style.fixture
@@ -1,0 +1,13 @@
+# The inline-style rule has to hold inside JS-built HTML strings too, which
+# the template scanner cannot see. The idiomatic form here is a single-quoted
+# JS string carrying a double-quoted attribute.
+guard="scripts/check-styles.sh"
+files="Public/app.js"
+description="a style attribute inside a JS-built HTML string"
+expect="inside a JS-built HTML string"
+apply() {
+    cat >> Public/app.js <<'JSEOF'
+
+function ckGuardFixture2() { return '<div style="margin:1px"></div>'; }
+JSEOF
+}

--- a/scripts/guard-fixtures/styles-js-writes-colour.fixture
+++ b/scripts/guard-fixtures/styles-js-writes-colour.fixture
@@ -1,0 +1,9 @@
+# JS may toggle a class or set a custom property. A colour written from JS
+# never routes through the palette and has no dark-mode value.
+guard="scripts/check-styles.sh"
+files="Public/app.js"
+description="a colour written via .style from JS"
+expect="colour/typography property written via .style"
+apply() {
+    printf '\nfunction ckGuardFixture(el) { el.style.color = "red"; }\n' >> Public/app.js
+}

--- a/scripts/guard-fixtures/styles-native-alert-js.fixture
+++ b/scripts/guard-fixtures/styles-native-alert-js.fixture
@@ -1,0 +1,9 @@
+# The template ratchet alone was leaky: externalizing page JS moves code out
+# of the template glob, so the same rule has to hold for Public/*.js.
+guard="scripts/check-styles.sh"
+files="Public/app.js"
+description="a native alert() in first-party JS"
+expect="new native alert() in first-party JS"
+apply() {
+    printf '\nfunction ckGuardFixture() { alert("x"); }\n' >> Public/app.js
+}

--- a/scripts/guard-fixtures/styles-native-alert-template.fixture
+++ b/scripts/guard-fixtures/styles-native-alert-template.fixture
@@ -1,0 +1,9 @@
+# Native alert() is at zero: errors surface through the inline .form-error
+# banner (ChickadeeUI.showActionError).
+guard="scripts/check-styles.sh"
+files="Resources/Views/login.leaf"
+description="a native alert() in a template"
+expect="new native alert() in a template"
+apply() {
+    printf '<a href="#" onclick="alert(1)">guard fixture</a>\n' >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/styles-native-confirm.fixture
+++ b/scripts/guard-fixtures/styles-native-confirm.fixture
@@ -1,0 +1,9 @@
+# Destructive confirmation goes through ChickadeeUI.confirmAction (or the
+# data-confirm seam); the native dialog is at zero and stays there.
+guard="scripts/check-styles.sh"
+files="Resources/Views/login.leaf"
+description="a native confirm() in a template"
+expect="native confirm()"
+apply() {
+    printf '<form onsubmit="return confirm(%s)"></form>\n' "'sure?'" >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/styles-page-local-sorter.fixture
+++ b/scripts/guard-fixtures/styles-page-local-sorter.fixture
@@ -1,0 +1,9 @@
+# Six hand-rolled sorters in three markup dialects is what the shared
+# component replaced; a page-local sorter forks it back.
+guard="scripts/check-styles.sh"
+files="Resources/Views/admin-audit.leaf"
+description="a page-local table sorter"
+expect="re-implements the shared sortable-table idiom"
+apply() {
+    printf '<p>function sortByHeader(a, b) {}</p>\n' >> Resources/Views/admin-audit.leaf
+}

--- a/scripts/guard-fixtures/styles-page-redefines-global.fixture
+++ b/scripts/guard-fixtures/styles-page-redefines-global.fixture
@@ -1,0 +1,9 @@
+# A page block re-defining a global selector forks the component: the page
+# and the sheet drift apart and only one of them is reviewed.
+guard="scripts/check-styles.sh"
+files="Resources/Views/admin-audit.leaf"
+description="a page style block re-defining a global selector"
+expect="re-defines a selector from the global sheet"
+apply() {
+    printf '<style>\n.btn { padding: 1rem; }\n</style>\n' >> Resources/Views/admin-audit.leaf
+}

--- a/scripts/guard-fixtures/styles-retired-button-modifier.fixture
+++ b/scripts/guard-fixtures/styles-retired-button-modifier.fixture
@@ -1,0 +1,10 @@
+# btn-tiny and action-btn-tight were second sizes for jobs btn-compact and
+# action-btn-icon already did. A name with no rule is caught by
+# check-class-resolution; a name someone re-adds a rule for is caught here.
+guard="scripts/check-styles.sh"
+files="Resources/Views/login.leaf"
+description="a retired button size modifier"
+expect="retired button size modifier"
+apply() {
+    printf '<button type="button" class="btn btn-tiny">guard fixture</button>\n' >> Resources/Views/login.leaf
+}


### PR DESCRIPTION
## Why

*"A check never seen to fail is not a check"* has been the house rule since the UI-ratchet epic closed, and it's the one discipline here with **nothing enforcing it**. The cost is on the record four times:

- a regression test matching a wiring string in page HTML after the wiring went dead
- the repaint probe's filter assertion passing against a dead poll
- the S5 guard matching its own documentation
- a hover-budget test in #1445 that passed **three times** while exercising nothing

Each read as coverage. None was. This is also the fallback from #1447 — mutation testing would have targeted the same defect, but Muter reports a fabricated 0% on both platforms and isn't adoptable.

## What it does

`scripts/check-guards.sh` runs each fixture in `scripts/guard-fixtures/` — a guard, a defect that guard exists to catch, and the message it must produce. It applies the defect and **fails the build if the guard passes**. A guard that stops catching its own defect — a drifted regex, a moved path, a rule refactored into a no-op — becomes a red build instead of a quiet false negative.

**18 fixtures**, across the token, name and idiom layers:

| Layer | Covered |
|---|---|
| Tokens | raw hex colour, off-scale `font-size`, off-scale `border-radius`, off-lattice spacing |
| CSS vars | undefined `var()`, hardcoded colour fallback |
| Names | unresolved class, retired button modifier |
| Templates | inline `style=`, native `alert()`, native `confirm()`, multi-line inline `<script>`, icon geometry outside the sprite |
| JS | native `alert()`, colour written via `.style`, `style=` inside a JS-built HTML string |
| Page CSS | page block re-defining a global selector, page-local table sorter |

## Four properties of the runner are load-bearing

- **The expected message is asserted**, not just a non-zero exit. A fixture that trips a *neighbouring* rule in the same script would otherwise look like proof while the rule under test stayed dead.
- **Each guard is checked green on the clean tree first**, once, before any fixture runs. A guard already failing would make every result below meaningless.
- **An empty fixture directory is an error.** A self-test suite reporting success while proving nothing is the exact failure being prevented.
- **Fixtures edit the real tree and restore it** — only declared files, on every exit path including interrupt, and refusing to start if any is already modified, so a dirty working tree is never silently reverted.

## It caught its author on the first attempt

Writing the fixtures found one defect immediately — in a *fixture*, not a guard. The JS-built-inline-style case got its `printf` escaping wrong, so the string landing in the file (`style=\\"`) was not the string the guard looks for (`style="`). It "passed" while testing nothing, and the harness reported the guard as unproven. Rewritten the way real code is written, the guard catches it.

That's the failure mode this exists for, reproduced by accident on day one.

## One real gap found, not fixed here

Rule 3e matches `style="…"` in JS. A double-quoted JS string carrying an *escaped* attribute — `"<div style=\"x\"></div>"` — evades it, because after `style=` comes a backslash. Narrow (the idiomatic form in this codebase is a single-quoted JS string), and widening the regex risks false positives, so it's flagged rather than changed. Worth a follow-up decision.

## Cost and wiring

~100s. Its **own CI job** rather than a step inside `format-lint`: each fixture re-runs a whole guard, so paying that in wall-clock beside `format-lint` is free while paying it inside is not. Joins `swift-tests-gate`.

The clean-tree pre-check is hoisted out of the loop — it was 2 runs per fixture and the suite timed out at 2 minutes; it's now 1 run per fixture plus one per distinct guard.

## Not covered

`check-version`, `check-env-vendored-sync`, `check-xeus-vendored`, `check-runner-wasm-size` — each needs vendored bytes or a version bump to fixture honestly, and a dishonest fixture is worse than none. `check-ui-vocabulary`'s three rules land with that guard in #1445, on the principle this PR establishes: **a guard ships with its fixture.**

---
_Generated by [Claude Code](https://claude.ai/code/session_013NC5C3Qt5wyG5XpzXWJyHz)_