### PR TITLE
docs: inventory the fitness functions, and name the one real gap

### DIFF
--- a/changelog.d/fitness-function-inventory.md
+++ b/changelog.d/fitness-function-inventory.md
@@ -1,0 +1,14 @@
+### Added
+
+- **`docs/fitness-functions.md`** — an inventory of the automated checks that
+  hold the architecture, sorted by the Building Evolutionary Architectures
+  taxonomy (atomic vs holistic, triggered vs continual). No new machinery: the
+  point is that nothing answered "what governs this?" in one place, and the
+  taxonomy makes one real gap visible. `RouteAuthorizationMatrixTests` walks
+  the **live route table**, so routes are discovered — but it crosses every
+  route with exactly two personas, and `.ta` appears nowhere in it, leaving the
+  TA boundary on eight hand-written spot tests. A new instructor-only route
+  that forgets its floor passes both. That is the "enumerated rather than
+  discovered, fails open" shape the language work was built to escape, on the
+  dimension where the failure mode is cross-course access rather than a
+  mis-rendered test.

--- a/docs/fitness-functions.md
+++ b/docs/fitness-functions.md
@@ -1,0 +1,127 @@
+# Fitness functions — what governs this codebase
+
+An inventory of the automated checks that hold Chickadee's architecture, using
+the vocabulary from [Building Evolutionary Architectures][beas]. Two reasons it
+is worth writing down: the checks are spread across 31 scripts, ~333 Swift test
+files, 51 docs and a dozen workflows, so nothing answers *"what governs this?"*
+in one place; and the taxonomy sorts them in a way that makes a real gap
+visible.
+
+Nothing here is new machinery. Chickadee invented these independently and the
+best of them are better articulated than the literature's examples — what the
+vocabulary adds is a way to see which **kinds** are thin.
+
+[beas]: https://nealford.com/books/buildingevolutionaryarchitectures.html
+
+## The vocabulary, in one paragraph
+
+A **fitness function** is an objective test of an architectural characteristic.
+Two axes matter here. **Atomic** functions test one dimension in isolation; a
+**holistic** one tests dimensions *interacting*, which is where defects
+actually live once each part is individually correct. **Triggered** functions
+run on an event — a commit, a PR; **continual** ones run against production
+continuously.
+
+## What Chickadee has
+
+### Atomic + triggered — the bulk, and effectively airtight
+
+The `scripts/check-*.sh` family (palette, type/radius/spacing scales, CSS var
+resolution, class resolution, component vocabulary, maintenance-page palette,
+vendored-kernel integrity, wasm size, version), the six shrink-only ratchets,
+`no-language-defaults.sh`, `no-new-xctest.sh`, SwiftLint at `--strict`,
+swift-format, ESLint, and most of the ~3,000 tests.
+
+These carry a property most codebases' linters do not: **ratchets**, which
+encode a *direction of travel* rather than a threshold. `PAGE_STYLE_BASELINE`
+does not say page CSS must be under N lines; it says it may only shrink. That
+is a fitness function over time, and it is why the widget-layer audit actually
+converged.
+
+As of #1448 they also have a self-test: `scripts/check-guards.sh` requires
+every guard to be **seen to fail** on a fixture reproducing the defect it
+exists to catch. A fitness function nobody has watched fail is a hypothesis.
+
+### Holistic + triggered — fewer, and the best work here
+
+- **`LanguageConformanceMatrixTests`** — every capability asserted for every
+  `AssignmentLanguage.allCases`, with the per-language glue in one exhaustive
+  switch so *the compiler produces the worklist*. Written because the previous
+  test hand-listed `[.python, .r]` and would have silently kept testing two.
+- **`LanguagePipelineWalkTests`** — one end-to-end walk per language along
+  resolve → render family → render check → write inputs → normalize notebook,
+  asserting each stage against the language **the first step resolved**. Its
+  header states the holistic case exactly: *"every defect sat in the JOINT
+  between stages, where something asked 'which language is this?' and answered
+  Python."*
+- **`RouteAuthorizationMatrixTests`** — walks the *live route table*
+  (`app.routes.all`), substitutes real fixture IDs, and asserts every
+  parameterized `/instructor` and `/courses` route denies a student of the
+  owning course and staff of a different course. Route enumeration is
+  discovered, so a new route the matrix does not know fails loudly.
+- **`MCPAuthorizationCoverageTests`** — scans every tool's source and fails the
+  build if one skips authorization.
+- **`Tools/visual-regression/run-repaint-probe.sh`** — the seam where the
+  shared filter, sort, poll and icon sprite meet, which a screenshot cannot
+  catch because both sides would agree.
+- The editor and browser-grading smokes, which boot real kernels because
+  *"only a real kernel proves any of this."*
+
+### Continual — present, but not treated as fitness functions
+
+- The `chickadee-deployer` daemon health-gates each blue-green cutover and
+  **auto-rolls-back if the new version degrades**. That is a continual fitness
+  function in the literal sense: a production measurement with an automated
+  corrective action.
+- `get_health_alerts`, the queue/runner/metrics surface, and the browser
+  diagnostics table are continual measurements.
+
+The gap is not that these are missing — it is that they are **operational
+plumbing rather than governed invariants**. No document states what degradation
+triggers a rollback, nobody reviews the thresholds when the system changes, and
+they are not in any list of things that hold the architecture. Compare the
+triggered side, where every rule has a named guard, a baseline, and a doc.
+
+## The gap worth acting on
+
+**The route table is discovered. The role dimension is hand-listed.**
+
+`RouteAuthorizationMatrixTests` crosses *every* route with exactly two
+personas: a student of the owning course, and an instructor of a different
+course. `CourseRole.allCases` is `student < ta < instructor`, and **`.ta`
+appears zero times in that matrix.** The TA boundary — the rule that a TA may
+author content and grade but may *not* manage enrollment, deadlines, archival
+or staff — rests on eight hand-written spot tests in `TARoleRouteTests`.
+
+So a new instructor-only route that forgets its `.instructor` floor passes both:
+the matrix denies students and cross-course staff, and a TA of the owning course
+is neither; the spot suite only covers routes someone remembered to add. That is
+precisely the *"enumerated rather than discovered, fails open"* shape the
+language work was built to escape — on the one dimension where the failure mode
+is cross-course access to student data rather than a mis-rendered test.
+
+**The fix is small, because both halves already exist**: the matrix already
+discovers routes and already knows how to build enrolled personas. Crossing the
+discovered route table with `CourseRole.allCases` — asserting each route's
+declared floor rather than a fixed pair — turns eight remembered cases into a
+derived matrix, and makes a new role (or a new route) fail loudly instead of
+quietly.
+
+Two smaller ones, recorded rather than argued:
+
+- **No holistic function covers `MCPMode × scope × tool`.** The pieces are
+  guarded individually (`MCPModeScopeContractTests`, `MCPConfigTests`,
+  `MCPAuthorizationCoverageTests`); the product is not walked.
+- **The continual functions have no stated contract.** Writing down what the
+  deployer treats as degradation, and reviewing it when the system changes,
+  would make it a governed invariant rather than a script's default.
+
+## The rule this suggests
+
+The language dimension got a matrix and a walk because it hurt repeatedly. That
+is the honest history — these were bought with pain, not foresight. The cheap
+generalization: **when a dimension is enumerable (`allCases`) and crosses more
+than two subsystems, derive the matrix rather than remembering the cases.** The
+compiler produces the worklist; the matrix produces the definition of done.
+
+Everything else in this document is inventory. That sentence is the finding.

--- a/docs/handoff-authorization-matrix.md
+++ b/docs/handoff-authorization-matrix.md
@@ -1,0 +1,115 @@
+# Handoff — derive the authorization matrix over `CourseRole.allCases`
+
+**Status: not started. This is the whole task.** The finding is in
+[fitness-functions.md](fitness-functions.md); this is how to act on it.
+
+## The defect
+
+`Tests/APITests/RouteAuthorizationMatrixTests.swift` walks the **live route
+table** (`app.routes.all`), takes every parameterized route under `/instructor`
+and `/courses`, substitutes real fixture IDs, and asserts each route denies:
+
+1. a **student** of the course that owns the resources, and
+2. **staff (an instructor) of a different course**.
+
+Routes are therefore *discovered* — a new route with an unknown path parameter
+fails the walk until someone adds a fixture value. That half is right and should
+not be disturbed.
+
+The role dimension is not. `CourseRole` is `student < ta < instructor`, and
+**`.ta` appears zero times in that file.** The TA boundary — a TA may author
+content and grade, but may **not** manage enrollment, deadlines, archival or
+staff — rests on **eight hand-written spot tests** in
+`Tests/APITests/TARoleRouteTests.swift`.
+
+So an instructor-only route that forgets its `.instructor` floor passes both:
+
+- the matrix denies students and cross-course staff, and **a TA of the owning
+  course is neither**;
+- the spot suite only covers routes someone remembered to write a test for.
+
+This is the *"enumerated rather than discovered, fails open"* shape the language
+work was built to escape (`LanguageConformanceMatrixTests`' header tells that
+story). It sits on the dimension where the failure mode is cross-course access
+to student data rather than a mis-rendered test.
+
+## The design problem — read this before writing code
+
+The existing matrix works because its expected outcome is **uniform**: every
+route denies both personas. A TA is *allowed* on most `/instructor` routes and
+denied on a few, so there is no single expected outcome. The matrix needs to
+know **each route's declared floor**, and the route table does not carry it.
+
+Three ways to get it, in ascending order of how much they are worth:
+
+1. **Scan the handler source for `requireCourseRole(atLeast:)`.** Cheap and
+   fragile — it infers the invariant from an implementation detail, and a route
+   whose gate is spelled differently reads as having no floor. This is the
+   option that quietly fails open. Do not pick it.
+2. **A declared floor map in the test**, keyed by route, with exhaustiveness
+   enforced by the discovered route table: a route with no declared floor
+   **fails** until someone declares it. Routes stay discovered, floors are
+   stated once, and a new route cannot be forgotten. This is the recommended
+   option — it is honest that a floor is a human judgement while keeping the
+   fails-closed property.
+3. **Declare the floor at route registration** so the test reads it off the
+   route rather than off a parallel map. The principled end state: the
+   invariant lives with the route it governs and cannot drift from it. More
+   invasive; worth proposing separately if (2) proves annoying to maintain.
+
+**Pick (2) unless you find a reason not to, and say why in the PR.**
+
+## What to build
+
+In `RouteAuthorizationMatrixTests`:
+
+- Add a **third persona** to `fixture()`: a user with a `.ta` enrollment in
+  OWNED. The existing fixture already shows the shape — `loginUser`, then an
+  `APICourseEnrollment(userID:courseID:role:)`. Note the existing outsider is
+  deliberately a *global student with a per-course role*, which also proves
+  authority is per-course; keep that property.
+- Add the declared-floor map, and fail on any walked route missing an entry,
+  with the offending route named — mirroring how an unknown path parameter
+  already fails.
+- For each walked route, assert the TA persona is **denied** where the floor is
+  `.instructor` and **not denied** where it is `.ta`. "Not denied" is the
+  weaker assertion — a 200 is not required, only that it is not 401/403/404 for
+  an authorization reason — so be careful the negative case is meaningful and
+  not passing on an unrelated 404.
+- Then delete from `TARoleRouteTests` only what the matrix now covers, and say
+  in the PR what you removed and why. Leave anything asserting *behaviour*
+  rather than *authorization*.
+
+## How to know it is done
+
+The repo's own rule applies and is not optional: **watch it fail.** A guard
+never seen to fail is a hypothesis.
+
+- Remove the `.instructor` floor from one genuinely instructor-only route (a
+  deadline, archival, enrollment or staff-management route) and confirm the
+  matrix goes red, naming that route.
+- Add a new route with a floor and no map entry; confirm it fails until
+  declared.
+- Restore both, confirm green.
+
+Consider adding a fixture to `scripts/guard-fixtures/` if the check can be
+expressed as a defect + expected message (see `scripts/check-guards.sh`) — but
+this is a Swift test, so the equivalent discipline is the two failure
+demonstrations above, recorded in the PR description.
+
+## Traps this codebase has already paid for
+
+- **A test that hand-lists cases fails open.** That is the entire reason this
+  task exists; do not replace one hand-list with another.
+- **A weak proxy is not the contract.** `DatasetsRouteRoundTripTests` once
+  asserted a field's visibility by searching a whole table row for the string
+  `hidden`, which silently became a different question the moment anything else
+  in the row rendered hidden. Assert the specific thing.
+- **`.serialized` matters here.** This suite is DB-backed and already carries
+  it; keep it.
+
+## Definition of done
+
+A new `/instructor` route cannot be added without declaring its floor, and a
+route whose floor is wrong fails a named test — without anyone remembering to
+write a test for it.


### PR DESCRIPTION
## Why

Chickadee's automated checks are spread across 31 scripts, ~333 Swift test files, 51 docs and a dozen workflows. Nothing answers *"what governs this?"* in one place.

Borrowing the [Building Evolutionary Architectures][beas] taxonomy is worth doing **not for validation** — the best of these are better articulated than the literature's own examples — but because sorting by *kind* makes a gap visible that the current organization hides.

[beas]: https://nealford.com/books/buildingevolutionaryarchitectures.html

## What the inventory shows

| Kind | State |
|---|---|
| **Atomic + triggered** | Airtight. The `check-*.sh` family, six ratchets, SwiftLint/swift-format/ESLint, most of ~3,000 tests. Carries something most linters don't: ratchets encode a *direction of travel*, not a threshold — which is why the widget audit converged. Now self-tested by #1448. |
| **Holistic + triggered** | Where the best work is: `LanguageConformanceMatrixTests`, `LanguagePipelineWalkTests`, `RouteAuthorizationMatrixTests`, `MCPAuthorizationCoverageTests`, the repaint probe, the real-kernel smokes. |
| **Continual** | Exists but ungoverned. The deployer health-gates each cutover and **auto-rolls-back on degradation** — a continual fitness function in the literal sense — but no document states what counts as degradation and nobody reviews it when the system changes. It's operational plumbing, not a governed invariant. |

## The gap worth acting on

**The route table is discovered. The role dimension is hand-listed.**

`RouteAuthorizationMatrixTests` walks the live route table (`app.routes.all`) and asserts every parameterized `/instructor` and `/courses` route denies:

1. a student of the owning course, and
2. staff of a *different* course.

`CourseRole` is `student < ta < instructor`. **`.ta` appears zero times in that matrix.** The TA boundary — a TA may author and grade but may *not* manage enrollment, deadlines, archival or staff — rests on **eight hand-written spot tests** in `TARoleRouteTests`.

So a new instructor-only route that forgets its `.instructor` floor passes both: the matrix denies students and cross-course staff, and *a TA of the owning course is neither*; the spot suite only covers routes someone remembered.

That is precisely the *"enumerated rather than discovered, fails open"* shape the language work was built to escape — on the one dimension where the failure mode is cross-course access to student data rather than a mis-rendered test.

**Both halves of the fix already exist.** The matrix discovers routes and knows how to build enrolled personas; crossing them with `CourseRole.allCases` and asserting each route's declared floor turns eight remembered cases into a derived matrix. Not done here — this PR is the finding, deliberately separate from the change.

Two smaller ones recorded rather than argued: no holistic function covers `MCPMode × scope × tool` (the pieces are guarded, the product isn't walked), and the continual functions have no stated contract.

## The rule it suggests

The language dimension got a matrix and a walk because it hurt repeatedly — bought with pain, not foresight. The cheap generalization:

> When a dimension is enumerable (`allCases`) and crosses more than two subsystems, **derive** the matrix rather than remembering the cases. The compiler produces the worklist; the matrix produces the definition of done.

Everything else in the document is inventory. That sentence is the finding.

## Scope

Docs only — one new file plus a changelog fragment. No code, no CI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NC5C3Qt5wyG5XpzXWJyHz)_