### PR TITLE
ci: the UI-vocabulary guard ships with its fixtures

### DIFF
--- a/changelog.d/ui-vocabulary-fixtures.md
+++ b/changelog.d/ui-vocabulary-fixtures.md
@@ -1,0 +1,12 @@
+### Added
+
+- **The UI-vocabulary guard now ships with its fixtures.** Its three rules —
+  the catalog ratchet, the affordance registry (`cursor` and
+  `text-decoration`), and the 20-word hover-text cap — each gain a fixture in
+  `scripts/guard-fixtures/`, so each is now *seen to fail* on the defect it
+  exists to catch. The four defects are the ones that actually shipped in
+  0.5.136: a global component the rulebook does not name, `cursor: help`, a
+  dotted underline, and a paragraph in a `title`. The guard and the self-test
+  harness landed in separate PRs and could only meet on `main`; this is the
+  rule those PRs established — a guard ships with its fixture — paying its own
+  tax. 22 fixtures total.

--- a/scripts/guard-fixtures/ui-vocabulary-catalog.fixture
+++ b/scripts/guard-fixtures/ui-vocabulary-catalog.fixture
@@ -1,0 +1,10 @@
+# A new component in the GLOBAL sheet was free until v0.5.137: the page-style
+# ratchet prices only a page-local copy. This is the rule that would have
+# caught the estimate chips shipping under a name sharing nothing with .chip.
+guard="scripts/check-ui-vocabulary.sh"
+files="Public/styles.css"
+description="a global component the rulebook does not name"
+expect="the rulebook does not name"
+apply() {
+    printf '\n.ck-guard-fixture-uncatalogued { display: inline-flex; }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/ui-vocabulary-cursor-affordance.fixture
+++ b/scripts/guard-fixtures/ui-vocabulary-cursor-affordance.fixture
@@ -1,0 +1,9 @@
+# `cursor: help` is the exact value that shipped in 0.5.136 as a private
+# "hover me" convention, in a UI that already had four ways to reveal detail.
+guard="scripts/check-ui-vocabulary.sh"
+files="Public/styles.css"
+description="an unregistered cursor affordance"
+expect="unregistered cursor affordance"
+apply() {
+    printf '\n.ck-guard-fixture-cursor { cursor: help; }\n' >> Public/styles.css
+}

--- a/scripts/guard-fixtures/ui-vocabulary-hover-prose.fixture
+++ b/scripts/guard-fixtures/ui-vocabulary-hover-prose.fixture
@@ -1,0 +1,11 @@
+# A title attribute holds a phrase. The estimates shipped with ~50-word
+# paragraphs in theirs, against a codebase median of 7 words.
+guard="scripts/check-ui-vocabulary.sh"
+files="Resources/Views/login.leaf"
+description="hover text over the word budget"
+expect="hover text over"
+apply() {
+    printf '<p title="%s">guard fixture</p>\n' \
+        "Two students share about eight of their forty rows, which is the expected overlap between two independent forty-row samples drawn from the same two-hundred-row pool of cases." \
+        >> Resources/Views/login.leaf
+}

--- a/scripts/guard-fixtures/ui-vocabulary-text-decoration-affordance.fixture
+++ b/scripts/guard-fixtures/ui-vocabulary-text-decoration-affordance.fixture
@@ -1,0 +1,9 @@
+# The dotted underline that travelled with `cursor: help`. Registered values
+# are none / underline / line-through; anything else is a new idiom.
+guard="scripts/check-ui-vocabulary.sh"
+files="Public/styles.css"
+description="an unregistered text-decoration affordance"
+expect="unregistered text-decoration affordance"
+apply() {
+    printf '\n.ck-guard-fixture-underline { text-decoration: underline dotted; }\n' >> Public/styles.css
+}


### PR DESCRIPTION
## Why

`scripts/check-ui-vocabulary.sh` (#1445) has three rules and no fixtures. `scripts/check-guards.sh` (#1448) requires every guard to be **seen to fail** on the defect it exists to catch. The guard and the harness landed in separate PRs and could only meet on `main` — this is that meeting, and it's the rule #1448 established (*a guard ships with its fixture*) paying its own tax.

## What

Four fixtures, one per rule. The defects are not invented — they are exactly what shipped in 0.5.136:

| Fixture | Defect | Rule proved |
|---|---|---|
| `ui-vocabulary-catalog` | a global class the rulebook does not name | catalog ratchet |
| `ui-vocabulary-cursor-affordance` | `cursor: help` | affordance registry |
| `ui-vocabulary-text-decoration-affordance` | `text-decoration: underline dotted` | affordance registry |
| `ui-vocabulary-hover-prose` | a ~28-word `title` | hover-text cap |

**22 fixtures** total, all green — meaning each of those four rules has now been observed failing rather than assumed to work.

## Scope

Four fixture files plus a changelog fragment. No guard, script or source changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NC5C3Qt5wyG5XpzXWJyHz)_