### PR TITLE
fix(ci): point the mutation sweep at swift-ci, and stop a total wipeout reading as clean

### DIFF
--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -67,11 +67,14 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     container:
-      # The same image worker-tests uses, so the interpreters available here
-      # match what CI normally grades with. This matters more than it looks: a
-      # missing interpreter makes its tests SKIP rather than fail, and every
-      # mutant they covered then survives and reads as a hole that is not there.
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-CI, not plain swift. The -ci image is the one carrying python3,
+      # lua5.4, octave and r-base; the plain image is the toolchain alone. Run 1
+      # of this workflow died in under a second on all ten shards because it
+      # named the wrong one, and the whole sweep is worthless on an image
+      # missing interpreters anyway: a missing interpreter makes its tests SKIP
+      # rather than fail, so every mutant they covered survives and reads as a
+      # hole that is not there.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -137,6 +140,14 @@ jobs:
                 })
               : [];
 
+            // The EXPECTED shard count, so a run where every shard died cannot be
+            // mistaken for a clean sweep. Run 1 did exactly that: all ten shards
+            // failed, no artifact was uploaded, `dirs` came back empty, and this
+            // job reported success and filed nothing. Absence of findings is only
+            // meaningful against a known denominator.
+            const expected = JSON.parse(
+              fs.readFileSync('Tools/mutation/config.json', 'utf8')).shardCount;
+
             let survivors = 0, phantoms = 0, killed = 0, missing = [];
             const sections = [];
 
@@ -155,11 +166,19 @@ jobs:
             // A shard that produced nothing is reported, never silently dropped:
             // partial coverage that reads as complete is the failure mode this
             // whole exercise exists to avoid.
-            const shardCount = dirs.length + missing.length;
+            for (let i = 0; i < expected; i++) {
+              if (!dirs.some(d => Number(d.split('-').pop()) === i)) missing.push(String(i));
+            }
+            missing = [...new Set(missing)].sort((a, b) => Number(a) - Number(b));
+
+            // sections.length, not dirs.length: an artifact can exist and still
+            // carry no report (the shard died after uploading an empty dir), and
+            // counting those as covered is the same lie in smaller print.
             const header = [
               `## Mutation sweep — logic tier`,
               '',
-              `**${killed} killed, ${survivors} survived** across ${dirs.length} shard(s)`
+              `**${killed} killed, ${survivors} survived** across `
+                + `${sections.length} of ${expected} shard(s)`
                 + (phantoms ? `, plus ${phantoms} phantom mutant(s) filtered out.` : '.'),
               '',
             ];
@@ -170,6 +189,14 @@ jobs:
                 '> means nothing. Check the job logs.',
                 '',
               );
+            }
+
+            if (missing.length === expected) {
+              core.summary.addRaw(header.join('\n')).write();
+              core.setFailed(
+                `Every shard (${expected}) produced no report. This is a tooling `
+                + 'failure, not a clean sweep — nothing was mutated. Check the shard logs.');
+              return;
             }
 
             if (survivors === 0 && missing.length === 0) {

--- a/changelog.d/mutation-sweep-image-fix.md
+++ b/changelog.d/mutation-sweep-image-fix.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **The weekly mutation sweep now names the image that has the interpreters.**
+  Run 1 died on all ten shards in under a second: the workflow asked for
+  `swift:6.3-noble`, the toolchain-only image, where the runner's own
+  `python3 not on PATH` guard fires immediately. It now uses `swift-ci:6.3-noble`
+  like `api-tests` and `worker-tests`.
+- **A sweep where every shard dies no longer reports success.** The aggregator
+  counted only the artifacts it found, so ten failed shards produced an empty
+  list, zero survivors, and a green job that filed nothing — the exact "partial
+  coverage reads as clean" failure the sweep is built to prevent, in its most
+  complete form. It now compares against the expected shard count from
+  `Tools/mutation/config.json`, fails the job when nothing reported at all, and
+  counts shards that actually produced a report rather than shards that uploaded
+  a directory.


### PR DESCRIPTION
Run 1 of the weekly sweep ([32177759107](https://github.com/JimWallace/Chickadee/actions/runs/32177759107)) failed on all ten shards in under a second. Two defects, and the second is worse than the first.

## 1. Wrong image — my mistake, twice

The workflow asked for `swift:6.3-noble`, the toolchain-only image, instead of `swift-ci:6.3-noble`, which carries `python3`, `lua5.4`, `octave` and `r-base`. The runner's own guard fired instantly:

```
python3 not on PATH
```

I fixed exactly this in `swift-tests.yml` earlier today and failed to carry it into the workflow I'd written *before* learning there were two images.

The image matters well beyond startup: **a missing interpreter makes its tests skip rather than fail**, so a sweep on the wrong image would report every mutant those tests covered as a survivor — fictional holes, at scale, in a report designed to be trusted.

## 2. The aggregator called a total failure a clean sweep

With every shard dead, no artifact was uploaded, the directory listing came back empty, and the job computed zero survivors, filed nothing, and reported **success**.

That is the "partial coverage reads as complete" failure this sweep exists to prevent, arrived at in its most complete form. The guard I wrote only handled *some* shards going missing; it never considered all of them. Absence of findings is only meaningful against a known denominator, and there wasn't one.

Now it:
- reads the expected shard count from `Tools/mutation/config.json`;
- marks every shard with no report as missing, by index;
- **fails the job** when that is all of them, rather than filing nothing quietly;
- counts shards that actually produced a report rather than shards that uploaded a directory — an artifact can exist and still be empty.

Both paths simulated against the real aggregator code:

| case | result |
|---|---|
| 10 of 10 missing | `setFailed: Every shard (10) produced no report…`, no issue filed |
| 2 of 10 reported | issue filed: *"128 killed, 39 survived across 2 of 10 shard(s)"* + ⚠️ naming shards 1,2,4,5,6,7,8,9 |

## After merge

The sweep needs re-dispatching to get a real first result; the Tuesday 06:00 UTC cron is unaffected either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_0136amKs8tbCmVhi4cMSY1en)_