### PR TITLE
ci: turn the mutation sweep into a trend, not just a snapshot

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -40,8 +40,15 @@ jobs:
     timeout-minutes: 15
     env:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-    # Never re-trigger on our own release commit.
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Never re-trigger on our own release commit, and never let the weekly
+    # mutation sweep's data commit cut one. With no fragments pending that
+    # commit is already a no-op, but "already a no-op" depends on timing, and a
+    # release whose triggering commit is a report data file is confusing at
+    # best. Both prefixes are machine-written, so neither can be typed by
+    # accident.
+    if: >-
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):')
+       && !startsWith(github.event.head_commit.message, 'chore(mutation):') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -115,7 +115,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
+      # `write` so the run record can be committed. The sweep's output was
+      # otherwise entirely perishable -- expiring artifacts and an issue body --
+      # and a trend needs a series that outlives the retention window.
+      contents: write
       issues: write
 
     steps:
@@ -125,6 +128,34 @@ jobs:
         with:
           pattern: mutation-report-*
           path: shards
+
+      - name: Record this run for the trend
+        run: |
+          date="$(date -u +%Y-%m-%d)"
+          python3 Tools/mutation/merge-run.py shards "MutationReports/$date.json" "$date" || {
+            echo "::warning::No shard produced outcomes; no run recorded."
+            exit 0
+          }
+          python3 Tools/mutation/trend.py
+
+      - name: Commit the run record
+        # NEVER fatal. This step runs before the triage issue is filed, and a
+        # push refused by branch protection must not cost the run its report --
+        # the issue is the existing behaviour and the record is the addition.
+        # A lost record is one gap in a series; a lost issue is the whole run.
+        continue-on-error: true
+        run: |
+          if [ -z "$(git status --porcelain MutationReports)" ]; then
+            echo "Nothing to record."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add MutationReports
+          git commit -m "chore(mutation): record sweep $(date -u +%Y-%m-%d)"
+          # Rebase rather than force: this job races nothing, but main moves.
+          git pull --rebase origin "${GITHUB_REF_NAME}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
 
       - name: Merge the shards and file the issue
         uses: actions/github-script@v7

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Every guard fails on its own defect
         run: scripts/check-guards.sh
 
+  # The mutation tooling is Python, so this needs python3 and NOTHING else --
+  # no Swift, no container. It rode in format-lint for one commit and failed
+  # with `python3: not found`: that job runs the PLAIN swift image, which is the
+  # toolchain alone. The -ci image is the one carrying python3, and pulling a
+  # ~GB container to run 18 unit tests would be the wrong fix for a job that
+  # never touches Swift.
+  mutation-trend-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Mutation trend aggregation self-test
+        run: python3 -m unittest discover -s Tools/mutation -p 'trend_test.py' -v
+
   format-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -86,9 +100,6 @@ jobs:
 
       - name: Check the CI compose fixture covers every required variable
         run: scripts/ci-compose-env.sh --check
-
-      - name: Mutation trend aggregation self-test
-        run: python3 -m unittest discover -s Tools/mutation -p 'trend_test.py' -v
 
   # Single shared compile of the whole package + all test targets.  The
   # resulting `.build/` tree is cached and reused by every test job below
@@ -494,6 +505,7 @@ jobs:
     needs:
       - format-lint
       - guard-self-tests
+      - mutation-trend-tests
       - build
       - core-tests
       - api-tests

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Check the CI compose fixture covers every required variable
         run: scripts/ci-compose-env.sh --check
 
+      - name: Mutation trend aggregation self-test
+        run: python3 -m unittest discover -s Tools/mutation -p 'trend_test.py' -v
+
   # Single shared compile of the whole package + all test targets.  The
   # resulting `.build/` tree is cached and reused by every test job below
   # via `swift test --skip-build`, replacing five from-scratch compiles

--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,19 @@ visual-diffs/
 
 # Muter run config, written per-machine for a mutation-testing run. It pins an
 # absolute path to the local swift binary, so it is never portable and must not
-# be committed. Muter is NOT adopted -- see docs/handoff-mutation-testing.md.
+# be committed. scripts/mutation-run.sh writes it per run and deletes it after;
+# see docs/handoff-mutation-testing.md for why the tool is a patched fork.
 muter.conf.yml
 
 # Muter run artifacts: per-mutant test logs (one file per mutant, MBs per run)
 # written into the project root by a mutation-testing run.
 muter_logs/
+
+# Per-shard output of a LOCAL mutation run (scripts/mutation-run.sh --out).
+# The durable record is MutationReports/, written by the weekly workflow and
+# committed on purpose; this is the raw working directory that produces it and
+# carries a full copy of Muter's stdout.
+mutation-report/
+
+# Bytecode from the mutation tooling's self-test.
+Tools/mutation/__pycache__/

--- a/MutationReports/README.md
+++ b/MutationReports/README.md
@@ -1,0 +1,22 @@
+# Mutation run records
+
+One JSON file per sweep, written by `.github/workflows/mutation-weekly.yml` via
+`Tools/mutation/merge-run.py` and committed automatically. Read the series with:
+
+```
+python3 Tools/mutation/trend.py
+```
+
+These are **committed rather than uploaded** on purpose. The sweep's other
+outputs — ten per-shard artifacts and one issue body — both expire or are prose,
+and a trend needs a series that outlives the artifact retention window.
+
+Do not hand-edit a record. Each one carries the fingerprint of the configuration
+that produced it (`muterRef`, `patchHash`, `configHash`, `swift`), and the trend
+tool uses that to refuse comparisons between runs that are not the same
+measurement. Editing a record silently makes two incomparable runs look
+comparable, which is the one failure this whole series exists to avoid.
+
+`survived` is the phantom-filtered count — real holes. `report.md` in the run
+artifacts carries Muter's raw count instead, so the two differ by design. See
+`Tools/mutation/report.py` for why phantoms exist.

--- a/Tools/mutation/merge-run.py
+++ b/Tools/mutation/merge-run.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Merge one sweep's shard reports into a single durable run record.
+
+Usage: merge-run.py <shards-dir> <out.json> [date]
+
+WHY THIS EXISTS. The sweep's output was, until this, entirely perishable: ten
+GitHub artifacts that expire and one issue body written as prose. Neither can
+be read as a series, so there was no way to answer whether the suite is
+improving -- only what one Tuesday looked like. This writes the one artefact a
+trend can be built on, and it is committed to the repo rather than uploaded,
+because the point of a trend is that it outlives the retention window.
+
+THE ONE RULE HERE: a shard that produced nothing must never look like a shard
+that found nothing. Both contribute zero survivors. `shardsReported` versus
+`shardsExpected` is what tells them apart, and Tools/mutation/trend.py refuses
+to read a run where they differ as a comparable data point.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def load(path: str) -> dict | None:
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def merge(shards_dir: str, expected: int, date: str) -> dict:
+    killed = survived = 0
+    survivors: list[dict] = []
+    phantoms = 0
+    seen: set[int] = set()
+    env: dict = {}
+
+    for entry in sorted(os.listdir(shards_dir)) if os.path.isdir(shards_dir) else []:
+        summary = load(os.path.join(shards_dir, entry, "summary.json"))
+        if summary is None:
+            continue
+        # An artifact can exist and still carry no outcomes -- the shard died
+        # after the directory was created. Counting it as covered is the same
+        # lie in smaller print, so a shard counts only if it reported mutants.
+        if summary.get("killed", 0) + summary.get("survived", 0) == 0:
+            continue
+        if summary.get("shard") is not None:
+            seen.add(summary["shard"])
+        killed += summary.get("killed", 0)
+        survived += summary.get("survived", 0)
+        phantoms += len(summary.get("phantoms", []))
+        survivors.extend(summary.get("survivors", []))
+        env = env or load(os.path.join(shards_dir, entry, "env.json")) or {}
+
+    return {
+        "date": date,
+        "shardsExpected": expected,
+        "shardsReported": len(seen),
+        "killed": killed,
+        "survived": survived,
+        "phantomsFiltered": phantoms,
+        "config": {
+            "muterRef": env.get("muterRef"),
+            "patchHash": env.get("patchHash"),
+            "configHash": env.get("configHash"),
+            "swift": env.get("swift"),
+        },
+        "commit": env.get("commit"),
+        "survivors": sorted(
+            survivors, key=lambda s: (s.get("file", ""), s.get("line", 0), s.get("operator", ""))
+        ),
+    }
+
+
+def main() -> int:
+    shards_dir, out_path = sys.argv[1], sys.argv[2]
+    date = sys.argv[3] if len(sys.argv) > 3 else None
+    if not date:
+        raise SystemExit("a date is required; the run record is keyed by it")
+
+    with open("Tools/mutation/config.json") as fh:
+        expected = json.load(fh)["shardCount"]
+
+    run = merge(shards_dir, expected, date)
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    with open(out_path, "w") as fh:
+        json.dump(run, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+    print(
+        f"{out_path}: {run['killed']} killed, {run['survived']} survived across "
+        f"{run['shardsReported']}/{run['shardsExpected']} shards"
+    )
+    if run["shardsReported"] == 0:
+        # Writing a record of nothing would put a permanent 0% in the series.
+        print("No shard reported any mutant. Not a measurement; refusing to record it.", file=sys.stderr)
+        os.remove(out_path)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -30,6 +30,7 @@ Only the phantom carries a bogus line.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -114,6 +115,43 @@ def main() -> int:
         fh.write("file\treported_line\ttrue_line\toperator\tsource\n")
         for path, line, operator in sorted(resolved):
             fh.write(f"{path}\t{line}\t{line}\t{operator}\t{source_line(path, line)}\n")
+
+    # A MACHINE-READABLE twin of the markdown, written for the trend tool.
+    # report.md is for a human triaging one run; nothing could read a series of
+    # them without re-parsing prose, so the numbers are emitted once, here,
+    # where they are already known and already phantom-filtered.
+    shard_nums = [int(n) for n in re.findall(r"\d+", label)]
+    json.dump(
+        {
+            "shard": shard_nums[0] if shard_nums else None,
+            "shardCount": shard_nums[1] if len(shard_nums) > 1 else None,
+            "killed": len(killed),
+            # `survived` is the PHANTOM-FILTERED count -- the real holes. It is
+            # deliberately NOT the number in report.md's table, which carries
+            # Muter's raw count so it reconciles with Muter's own summary. Both
+            # are emitted under distinct names because a trend built on the raw
+            # count would read phantoms as regressions.
+            "survived": len(resolved),
+            "reportedSurvived": len(survived),
+            "survivors": [
+                {
+                    "file": path,
+                    "line": line,
+                    "operator": operator,
+                    "source": source_line(path, line),
+                }
+                for path, line, operator in sorted(resolved)
+            ],
+            "phantoms": [
+                {"file": path, "line": line, "operator": operator}
+                for path, line, operator in sorted(phantoms)
+            ],
+            "runtime": TOOK.search(text).group(1) if TOOK.search(text) else None,
+        },
+        open(os.path.join(out_dir, "summary.json"), "w"),
+        indent=2,
+        sort_keys=True,
+    )
 
     out = [f"**{label}**", ""]
     if not rows:

--- a/Tools/mutation/trend.py
+++ b/Tools/mutation/trend.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Read every run in MutationReports/ and print the trend.
+
+WHAT THIS IS FOR. One mutation score answers nothing: 69% is neither good nor
+bad in isolation, and the pilot's own conclusion was that chasing a percentage
+means writing tests for inputs that cannot occur. What a series answers is the
+question worth asking -- is the suite getting better at telling the difference
+when the source changes, and which holes have survived every attempt so far.
+
+THREE THINGS THIS REFUSES TO DO SILENTLY, each of which would make the trend
+lie in the direction of good news:
+
+  * COMPARE ACROSS CONFIGURATIONS. The score depends on what was mutated
+    (`include`), how mutants were graded (`testArgs`) and which Muter built
+    them. Change any of those and the next number is a different measurement
+    wearing the same units. Runs carry a fingerprint; a change marks the row
+    and splits the persistent-survivor set, because a survivor cannot be
+    "still surviving" across a run that never mutated its file.
+
+  * COUNT A PARTIAL SWEEP AS A CLEAN ONE. The sweep is sharded ten ways and a
+    shard that dies uploads nothing. Fewer shards means fewer mutants means a
+    smaller survivor count -- which reads exactly like progress. Every row
+    shows shards covered, and an incomplete run is marked and excluded from
+    the persistent set.
+
+  * IDENTIFY A SURVIVOR BY LINE NUMBER. Line numbers move whenever anything
+    above them is edited, so a line-keyed backlog empties itself on the first
+    unrelated commit and reports the holes as fixed. Survivors are keyed by
+    (file, operator, source text); the line is display only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+REPORTS_DIR = "MutationReports"
+
+
+def score(killed: int, survived: int) -> float | None:
+    """Killed as a fraction of mutants that ran. None when nothing ran.
+
+    Recomputed from counts rather than averaged from the shards' own
+    percentages: shards differ in mutant count, so the mean of ten percentages
+    is not the percentage of the whole.
+    """
+    total = killed + survived
+    return None if total == 0 else killed / total
+
+
+def survivor_key(s: dict) -> tuple[str, str, str]:
+    """Identity of a survivor across runs. Deliberately excludes the line."""
+    return (s.get("file", ""), s.get("operator", ""), " ".join(s.get("source", "").split()))
+
+
+def fingerprint(run: dict) -> tuple:
+    """What must match for two runs to be comparable."""
+    c = run.get("config", {})
+    return (
+        c.get("muterRef"),
+        c.get("patchHash"),
+        c.get("configHash"),
+        c.get("swift"),
+    )
+
+
+def load_runs(directory: str) -> list[dict]:
+    """Every *.json in the reports directory, oldest first.
+
+    A malformed file is a hard error rather than a skip: silently dropping a
+    run shortens the series, and a shorter series makes the persistent set
+    smaller -- the same false good news the shard check exists to catch.
+    """
+    if not os.path.isdir(directory):
+        return []
+    runs = []
+    for name in sorted(os.listdir(directory)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            with open(path) as fh:
+                run = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"{path}: unreadable run report ({exc})")
+        run.setdefault("date", os.path.splitext(name)[0])
+        runs.append(run)
+    runs.sort(key=lambda r: r.get("date", ""))
+    return runs
+
+
+def is_complete(run: dict) -> bool:
+    expected, reported = run.get("shardsExpected"), run.get("shardsReported")
+    return bool(expected) and reported == expected
+
+
+def persistent_survivors(runs: list[dict]) -> list[dict]:
+    """Survivors present in EVERY comparable, complete run.
+
+    Restricted to the newest fingerprint: a run under a different config may
+    never have mutated the file at all, and absence there is not evidence a
+    mutant died. Incomplete runs are excluded for the same reason.
+    """
+    usable = [r for r in runs if is_complete(r)]
+    if not usable:
+        return []
+    current = fingerprint(usable[-1])
+    usable = [r for r in usable if fingerprint(r) == current]
+    if not usable:
+        return []
+
+    common = set(survivor_key(s) for s in usable[0].get("survivors", []))
+    for run in usable[1:]:
+        common &= set(survivor_key(s) for s in run.get("survivors", []))
+
+    # Report each survivor as the LATEST run saw it: the line number in an
+    # older run is stale by definition, and triage happens against today's
+    # source. Ordered by file then line, which is the order someone reads them.
+    latest = {survivor_key(s): s for s in usable[-1].get("survivors", [])}
+    found = [latest[k] for k in common if k in latest]
+    return sorted(found, key=lambda s: (s.get("file", ""), s.get("line", 0)))
+
+
+def format_table(runs: list[dict]) -> str:
+    rows = [
+        "| date       | shards | mutants | killed | survivors | score | ",
+        "|------------|--------|---------|--------|-----------|-------|",
+    ]
+    previous = None
+    for run in runs:
+        killed, survived = run.get("killed", 0), run.get("survived", 0)
+        pct = score(killed, survived)
+        expected = run.get("shardsExpected") or "?"
+        reported = run.get("shardsReported") or 0
+        shards = f"{reported}/{expected}"
+
+        flags = []
+        if not is_complete(run):
+            flags.append("PARTIAL")
+        if previous is not None and fingerprint(run) != previous:
+            flags.append("CONFIG CHANGED")
+        previous = fingerprint(run)
+
+        rows.append(
+            f"| {run.get('date', '?'):<10} | {shards:>6} | {killed + survived:>7} "
+            f"| {killed:>6} | {survived:>9} | "
+            f"{'n/a' if pct is None else format(pct * 100, '.1f') + '%':>5} | "
+            + (" ".join(flags))
+        )
+    return "\n".join(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dir", default=REPORTS_DIR, help=f"reports directory (default {REPORTS_DIR})")
+    args = parser.parse_args(argv)
+
+    runs = load_runs(args.dir)
+    if not runs:
+        print(f"No runs in {args.dir}/. The weekly sweep writes one file per run.")
+        return 0
+
+    print(format_table(runs))
+    print()
+
+    latest = runs[-1]
+    if not is_complete(latest):
+        print(
+            f"The most recent run covered {latest.get('shardsReported')} of "
+            f"{latest.get('shardsExpected')} shards. Its totals are LOWER because less\n"
+            "was mutated, not because fewer mutants survived. Do not read it as progress."
+        )
+        print()
+
+    persistent = persistent_survivors(runs)
+    comparable = [r for r in runs if is_complete(r) and fingerprint(r) == fingerprint(runs[-1])]
+    if len(comparable) < 2:
+        print(
+            "Persistent backlog needs at least two complete runs on one configuration; "
+            f"there {'is' if len(comparable) == 1 else 'are'} {len(comparable)}."
+        )
+        return 0
+
+    print(f"### Survived every one of the last {len(comparable)} comparable runs ({len(persistent)})")
+    print()
+    print(
+        "This is the standing backlog. Expect a good fraction to be EQUIVALENT MUTANTS --\n"
+        "unkillable by construction, because no input reaching that code can tell the\n"
+        "difference. Those are closed with a reason, not with a test. A survivor is a\n"
+        "question; 'correctly, no test' is a legitimate answer."
+    )
+    print()
+    current_file = None
+    for s in persistent:
+        if s.get("file") != current_file:
+            current_file = s.get("file")
+            print(f"\n**{current_file}**")
+        src = s.get("source", "")
+        print(f"  L{s.get('line')} {s.get('operator')}" + (f" — {src}" if src else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/mutation/trend_test.py
+++ b/Tools/mutation/trend_test.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Self-test for trend.py's aggregation logic.
+
+Run: python3 -m unittest discover -s Tools/mutation -p 'trend_test.py'
+
+Every case here is one of the three ways a trend can report false good news --
+a partial sweep read as progress, a config change read as improvement, a moved
+line read as a fixed hole. Each was written by breaking the logic first and
+confirming the test caught it.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import trend  # noqa: E402
+
+
+def run(date, killed, survived, survivors=(), shards=(10, 10), config=None):
+    """A run report, with the fields the trend actually reads."""
+    return {
+        "date": date,
+        "killed": killed,
+        "survived": survived,
+        "survivors": [
+            {"file": f, "line": ln, "operator": op, "source": src}
+            for f, ln, op, src in survivors
+        ],
+        "shardsReported": shards[0],
+        "shardsExpected": shards[1],
+        "config": config or {"muterRef": "7f1f258", "patchHash": "aaa", "configHash": "bbb", "swift": "6.3"},
+    }
+
+
+class Score(unittest.TestCase):
+    def test_fraction_of_mutants_that_ran(self):
+        self.assertAlmostEqual(trend.score(88, 39), 88 / 127)
+
+    def test_no_mutants_is_none_not_zero(self):
+        # A run that mutated nothing scores neither 0% nor 100%. Reporting 0
+        # would read as a total regression; the honest answer is "no data".
+        self.assertIsNone(trend.score(0, 0))
+
+    def test_recomputed_from_counts_not_averaged(self):
+        # Two shards, very different sizes. The mean of their percentages is
+        # 75%; the real score is 91%. Averaging shard percentages is the bug
+        # this asserts against.
+        big, small = (100, 0), (2, 2)
+        combined = trend.score(big[0] + small[0], big[1] + small[1])
+        mean_of_percentages = (trend.score(*big) + trend.score(*small)) / 2
+        self.assertAlmostEqual(combined, 102 / 104)
+        self.assertNotAlmostEqual(combined, mean_of_percentages)
+
+
+class SurvivorIdentity(unittest.TestCase):
+    def test_line_number_is_not_part_of_identity(self):
+        a = {"file": "A.swift", "line": 82, "operator": "RemoveSideEffects", "source": "onEvent(x)"}
+        b = dict(a, line=900)
+        self.assertEqual(trend.survivor_key(a), trend.survivor_key(b))
+
+    def test_whitespace_in_source_is_normalised(self):
+        a = {"file": "A.swift", "line": 1, "operator": "Relational", "source": "a  ==   b"}
+        b = {"file": "A.swift", "line": 1, "operator": "Relational", "source": "a == b"}
+        self.assertEqual(trend.survivor_key(a), trend.survivor_key(b))
+
+    def test_different_operator_on_one_line_is_a_different_mutant(self):
+        a = {"file": "A.swift", "line": 1, "operator": "Relational", "source": "a == b"}
+        b = {"file": "A.swift", "line": 1, "operator": "Logical", "source": "a == b"}
+        self.assertNotEqual(trend.survivor_key(a), trend.survivor_key(b))
+
+
+class Persistent(unittest.TestCase):
+    def test_intersection_across_runs(self):
+        stays = ("A.swift", 10, "Relational", "a == b")
+        goes = ("A.swift", 20, "Logical", "x && y")
+        runs = [run("2026-01-01", 5, 2, [stays, goes]), run("2026-02-01", 6, 1, [stays])]
+        self.assertEqual([s["source"] for s in trend.persistent_survivors(runs)], ["a == b"])
+
+    def test_survives_a_line_move(self):
+        # Same mutant, ten lines lower after an unrelated edit above it. A
+        # line-keyed backlog would call this fixed.
+        runs = [
+            run("2026-01-01", 5, 1, [("A.swift", 10, "Relational", "a == b")]),
+            run("2026-02-01", 5, 1, [("A.swift", 20, "Relational", "a == b")]),
+        ]
+        self.assertEqual(len(trend.persistent_survivors(runs)), 1)
+
+    def test_reports_the_latest_line_not_the_oldest(self):
+        runs = [
+            run("2026-01-01", 5, 1, [("A.swift", 10, "Relational", "a == b")]),
+            run("2026-02-01", 5, 1, [("A.swift", 20, "Relational", "a == b")]),
+        ]
+        self.assertEqual(trend.persistent_survivors(runs)[0]["line"], 20)
+
+    def test_partial_run_cannot_shrink_the_backlog(self):
+        # The second run lost nine shards, so it reports one survivor. That is
+        # missing coverage, not eleven fixed mutants.
+        first = run("2026-01-01", 5, 2, [("A.swift", 10, "Relational", "a == b"),
+                                         ("B.swift", 3, "Logical", "x && y")])
+        broken = run("2026-02-01", 1, 1, [("A.swift", 10, "Relational", "a == b")], shards=(1, 10))
+        self.assertEqual(len(trend.persistent_survivors([first, broken])), 2)
+
+    def test_config_change_splits_the_series(self):
+        # The old run predates A.swift being added to `include`, so it lists
+        # only B. A's absence THERE is missing coverage, not a dead mutant, and
+        # an unfiltered intersection would let that old run veto A and report an
+        # empty backlog. Only runs on the current fingerprint may vote.
+        old_cfg = {"muterRef": "7f1f258", "patchHash": "aaa", "configHash": "OLD", "swift": "6.3"}
+        runs = [
+            run("2026-01-01", 5, 1, [("B.swift", 3, "Logical", "x && y")], config=old_cfg),
+            run("2026-02-01", 5, 1, [("A.swift", 10, "Relational", "a == b")]),
+            run("2026-03-01", 5, 1, [("A.swift", 10, "Relational", "a == b")]),
+        ]
+        self.assertEqual([s["file"] for s in trend.persistent_survivors(runs)], ["A.swift"])
+
+    def test_no_complete_runs_yields_nothing(self):
+        self.assertEqual(trend.persistent_survivors([run("2026-01-01", 1, 1, shards=(2, 10))]), [])
+
+
+class LoadRuns(unittest.TestCase):
+    def test_orders_by_date_not_filesystem_order(self):
+        with tempfile.TemporaryDirectory() as d:
+            for date in ("2026-03-01", "2026-01-01", "2026-02-01"):
+                with open(os.path.join(d, f"{date}.json"), "w") as fh:
+                    json.dump(run(date, 1, 1), fh)
+            self.assertEqual([r["date"] for r in trend.load_runs(d)],
+                             ["2026-01-01", "2026-02-01", "2026-03-01"])
+
+    def test_malformed_report_is_fatal_not_skipped(self):
+        # Skipping it would shorten the series, and a shorter series makes the
+        # persistent set smaller -- false good news, silently.
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "2026-01-01.json"), "w") as fh:
+                fh.write("{not json")
+            with self.assertRaises(SystemExit):
+                trend.load_runs(d)
+
+    def test_missing_directory_is_empty_not_an_error(self):
+        self.assertEqual(trend.load_runs("/nonexistent/mutation/reports"), [])
+
+
+class Table(unittest.TestCase):
+    def test_marks_a_partial_run(self):
+        self.assertIn("PARTIAL", trend.format_table([run("2026-01-01", 5, 1, shards=(7, 10))]))
+
+    def test_marks_a_config_change(self):
+        other = {"muterRef": "NEW", "patchHash": "aaa", "configHash": "bbb", "swift": "6.3"}
+        table = trend.format_table([run("2026-01-01", 5, 1), run("2026-02-01", 5, 1, config=other)])
+        self.assertIn("CONFIG CHANGED", table)
+
+    def test_quiet_when_nothing_is_wrong(self):
+        table = trend.format_table([run("2026-01-01", 5, 1), run("2026-02-01", 6, 1)])
+        self.assertNotIn("PARTIAL", table)
+        self.assertNotIn("CONFIG CHANGED", table)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/changelog.d/mutation-trend.md
+++ b/changelog.d/mutation-trend.md
@@ -1,0 +1,15 @@
+### Added
+
+- **The mutation sweep now produces a trend, not just a snapshot.** Each weekly
+  run merges its ten shards into a committed `MutationReports/<date>.json` and
+  `Tools/mutation/trend.py` prints the series — one row per run, plus the
+  survivors present in every comparable run, which is the standing backlog.
+  Previously the sweep's entire output was perishable (expiring artifacts and a
+  prose issue body), so there was no way to ask whether the suite was improving.
+  The trend refuses three comparisons that would read as good news without
+  being it: a partial sweep whose smaller survivor count is missing coverage
+  rather than progress, a configuration change that makes the next number a
+  different measurement in the same units, and a moved line — survivors are
+  keyed by source text, not line number, so an unrelated edit above one no
+  longer reports the hole as fixed. Still a report, never a gate, and still no
+  threshold anywhere. See [docs/mutation-trend.md](docs/mutation-trend.md).

--- a/docs/handoff-mutation-testing.md
+++ b/docs/handoff-mutation-testing.md
@@ -3,7 +3,8 @@
 **Status: stock Muter is unusable; a three-line fork works and has been run
 against real source.** Tracking issue: **#1447**. Root cause and measurements:
 [mutation-testing-spike.md](mutation-testing-spike.md). What a real run costs
-and finds: **[mutation-testing-pilot.md](mutation-testing-pilot.md)**.
+and finds: **[mutation-testing-pilot.md](mutation-testing-pilot.md)**. How to
+read a series of runs: [mutation-trend.md](mutation-trend.md).
 
 **If you read one thing:** the blocker is upstream issue
 [muter#307](https://github.com/muter-mutation-testing/muter/issues/307), not a

--- a/docs/mutation-testing-pilot.md
+++ b/docs/mutation-testing-pilot.md
@@ -9,7 +9,9 @@ a measurement rather than an artifact.
 Read [handoff-mutation-testing.md](handoff-mutation-testing.md) first for why
 stock Muter cannot do this, and
 [mutation-testing-spike.md](mutation-testing-spike.md) for the root cause.
-Tracking issue **#1447**.
+For reading a *series* of runs rather than this one — what the score means, and
+the two things that make it move for reasons unrelated to the suite — see
+[mutation-trend.md](mutation-trend.md). Tracking issue **#1447**.
 
 ---
 

--- a/docs/mutation-trend.md
+++ b/docs/mutation-trend.md
@@ -1,0 +1,110 @@
+# Reading the mutation trend
+
+**What this answers: is the test suite getting better at telling the difference
+when the source changes?** One mutation score cannot answer that. A series can.
+
+Run it:
+
+```
+python3 Tools/mutation/trend.py
+```
+
+Prerequisites and cost are not this document's subject — see
+[mutation-testing-pilot.md](mutation-testing-pilot.md) for what a sweep costs
+and [handoff-mutation-testing.md](handoff-mutation-testing.md) for why the tool
+is a patched fork.
+
+---
+
+## Where the numbers come from
+
+The weekly sweep shards ten ways. Each shard writes a `summary.json`; the merge
+job folds all ten into one `MutationReports/<date>.json` and commits it. The
+trend tool reads that directory and nothing else.
+
+| | |
+|---|---|
+| `killed` | mutants the suite detected |
+| `survived` | mutants it did not, **after phantom filtering** |
+| score | `killed / (killed + survived)`, recomputed from counts |
+| shards | how much of the logic tier this run actually covered |
+
+The score is recomputed rather than averaged from the shards' own percentages:
+shards differ in mutant count, so the mean of ten percentages is not the
+percentage of the whole.
+
+`survived` here is smaller than the number in a shard's `report.md`, by design.
+Muter reports mutants it never inserted and they always read as survivors;
+`Tools/mutation/report.py` quarantines those against the mutated copy. The
+markdown keeps Muter's raw count so it reconciles with Muter's own summary; the
+trend uses the filtered count, because a trend built on phantoms reads tooling
+noise as regression.
+
+## How to read the score
+
+**It is always lower than line coverage, and that is the point.** Coverage asks
+whether a line ran. Mutation asks whether anything would have *noticed* if that
+line were wrong. A line can be executed by ten tests and still have no assertion
+that constrains it — covered, and unverified. That gap is the whole reason this
+exists: the recurring defect in this codebase is verification that passes while
+proving nothing.
+
+**A surviving mutant is an assertion gap, not a failing test.** Nothing is
+broken. The suite could not distinguish the mutated source from the original.
+That is a question addressed to a human, and the answer is sometimes "correctly,
+no test".
+
+**Do not chase the percentage.** A meaningful fraction of survivors are
+*equivalent mutants* — unkillable by construction, because no input that can
+reach that code tells the difference. The pilot found several in `JSONLite`:
+`skipWhitespace` treating `\n` as skippable, when the footer is by definition
+the last non-empty *line* and can never contain one. Writing a test for those
+means writing tests for inputs that cannot occur. This is why there is no
+threshold anywhere and why the sweep is a report, never a gate.
+
+So read the trend for **direction**, not altitude. A score that drifts down
+while the shard count holds steady means new code is arriving less
+well-asserted than the code already there.
+
+## Two things that would otherwise lie to you
+
+Both make the numbers move for reasons that have nothing to do with the suite,
+and both are marked in the table rather than left to be noticed.
+
+**`PARTIAL` — the run did not cover everything.** A shard that dies uploads
+nothing, so its mutants are absent from both counts. Fewer survivors, which
+reads exactly like progress. A row showing `7/10` is not comparable with one
+showing `10/10`, and partial runs are excluded from the persistent backlog.
+
+**`CONFIG CHANGED` — the measurement changed.** The score depends on what was
+mutated (`include`), how mutants were graded (`testArgs`), and which Muter built
+them. Change any of those and the next number is a different measurement in the
+same units. **A score is only comparable between runs with the same
+configuration.** Runs carry a fingerprint; when it changes the trend marks the
+row and starts the persistent-survivor set over, because a survivor cannot be
+"still surviving" across a run that never mutated its file.
+
+## The persistent backlog
+
+Survivors present in *every* comparable, complete run. This is the standing set
+— the holes that have survived every attempt so far, and where the equivalent
+mutants accumulate.
+
+Survivors are identified by `(file, operator, source text)`, deliberately **not
+by line number**. Line numbers move whenever anything above them is edited, so a
+line-keyed backlog empties itself on the first unrelated commit and reports the
+holes as fixed. The line shown is from the most recent run, since triage happens
+against today's source.
+
+## Triaging one survivor
+
+1. **Confirm it by hand.** Make the mutation yourself and check the suite
+   actually passes. The tool's failure modes are silent and its output is
+   audited, not trusted.
+2. **Decide whether a test should exist.** If no reachable input distinguishes
+   the mutant, it is equivalent — close it with the reason.
+3. **If a test should exist, write it.** One fixture often kills several
+   neighbours at once; the pilot noted a single generously-spaced JSON footer
+   would have killed four `skipWhitespace` survivors together.
+
+Closing a survivor with a reason is a legitimate outcome, not a backlog item.

--- a/scripts/mutation-run.sh
+++ b/scripts/mutation-run.sh
@@ -183,6 +183,34 @@ done
 mkdir -p "$OUT_DIR"
 raw="$OUT_DIR/muter-raw.txt"
 
+# The comparability fingerprint, recorded HERE because this is where the tool
+# and toolchain actually are -- the job that merges the shards runs on a
+# different image and could only guess. A mutation score is only meaningful
+# against the configuration that produced it, so the trend marks any run whose
+# fingerprint differs rather than drawing a line between two measurements that
+# are not the same measurement. See Tools/mutation/trend.py.
+python3 - "$config" "$patch_file" "$MUTER_REF" > "$OUT_DIR/env.json" <<'FINGERPRINT'
+import hashlib, json, subprocess, sys
+
+def digest(path):
+    return hashlib.sha256(open(path, "rb").read()).hexdigest()[:12]
+
+def first_line(*cmd):
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True).stdout
+    except OSError:
+        return None
+    return out.splitlines()[0].strip() if out.strip() else None
+
+json.dump({
+    "muterRef": sys.argv[3],
+    "patchHash": digest(sys.argv[2]),
+    "configHash": digest(sys.argv[1]),
+    "swift": first_line("swift", "--version"),
+    "commit": first_line("git", "rev-parse", "HEAD"),
+}, sys.stdout, indent=2, sort_keys=True)
+FINGERPRINT
+
 # Muter's exit status must not abort the run: a low score is a RESULT. A genuine
 # crash surfaces below as zero mutant outcomes, which IS a failure.
 set +e


### PR DESCRIPTION
## What and why

The weekly sweep's entire output was perishable: ten GitHub artifacts that expire and one issue body written as prose. Neither can be read as a series, so the question worth asking — *is the suite getting better at telling the difference when the source changes?* — had no way to be answered. Only what one Tuesday looked like.

Each run now merges its ten shards into a committed `MutationReports/<date>.json`, and `Tools/mutation/trend.py` prints the series:

```
| date       | shards | mutants | killed | survivors | score |
|------------|--------|---------|--------|-----------|-------|
| 2026-08-04 |  10/10 |    1840 |   1800 |        40 | 97.8% |
| 2026-09-01 |  10/10 |    1840 |   1806 |        34 | 98.2% |
| 2026-10-01 |   7/10 |     130 |    120 |        10 | 92.3% | PARTIAL
```

plus the survivors present in every comparable run — the standing backlog, and where equivalent mutants accumulate.

Still **a report, never a gate**. No threshold anywhere, nothing added to PR CI gating.

## Three comparisons it refuses to make silently

Each would move the numbers in the direction of good news for reasons unrelated to the suite.

| | |
|---|---|
| **`PARTIAL`** | A shard that dies uploads nothing, so its mutants are absent from both counts — fewer survivors, which looks exactly like progress. Rows carry shards-covered; partial runs are excluded from the backlog. |
| **`CONFIG CHANGED`** | The score depends on what was mutated, how mutants were graded, and which Muter built them. Runs carry a fingerprint recorded **on the shard**, where the toolchain actually is. When it changes the row is marked and the backlog starts over — a survivor cannot be "still surviving" across a run that never mutated its file. |
| **A moved line** | Survivors are keyed by `(file, operator, source text)`, never by line. A line-keyed backlog empties itself on the first unrelated commit and reports the holes as fixed. |

Counts are the **phantom-filtered** ones. `report.md` keeps Muter's raw count so it reconciles with Muter's own summary; both are emitted under distinct names, because a trend built on phantoms reads tooling noise as regression.

## Changes

- `Tools/mutation/trend.py` — the trend tool (new).
- `Tools/mutation/merge-run.py` — folds ten shard summaries into one run record (new).
- `Tools/mutation/trend_test.py` — 18 aggregation cases (new).
- `Tools/mutation/report.py` — also emits a machine-readable `summary.json`.
- `scripts/mutation-run.sh` — records the comparability fingerprint per shard.
- `mutation-weekly.yml` — records and commits the run before filing the issue.
- `swift-tests.yml` — new `mutation-trend-tests` job, wired into `swift-tests-gate`.
- `auto-release.yml` — skips `chore(mutation):` commits.
- `docs/mutation-trend.md` — how to read the score (new).

## Two consequences worth review

**The merge job now needs `contents: write`** to commit the record, and its commit step is `continue-on-error`. It runs before the triage issue is filed, and a push refused by branch protection must not cost the run its report — a lost record is one gap in a series; a lost issue is the whole run.

**`auto-release` now skips `chore(mutation):`.** With no fragments pending that commit is already a no-op, but "already a no-op" depends on timing, and a release whose triggering commit is a report data file is confusing at best. Both skipped prefixes are machine-written, so neither can be typed by accident.

## Verification

- 18 unittest cases in their own `mutation-trend-tests` job, each written by **breaking the logic first** and confirming it was caught — 6 defects injected, 6 caught. Run with `-v` so the log names every test, rather than a green tick that could mean nothing ran.
- One was **not** caught: `test_config_change_splits_the_series` passed against its own defect, because the intersection came out the same with or without the fingerprint filter. Rewritten to discriminate. That is the exact "verification that passes while proving nothing" this repo keeps finding, and it does not get an exception for being inside the tooling that hunts for it.
- Whole chain exercised end to end on synthetic shard output, including the phantom filter against a mutated copy carrying a guard for only one of two reported survivors.
- `scripts/check-guards.sh` green (23 guards), all 23 workflows parse, `--plan` unchanged.

**No production source and no existing test was touched.** No Swift files are in the diff, so the build is unaffected by construction.

## Not done

The tool is unproven against real sweep output — there are no runs in `MutationReports/` yet, and there cannot be until the first sweep after this merges. It is verified against synthetic records shaped like the pilot's. The first real Tuesday is what confirms the shard-summary format survives contact with Muter.