### PR TITLE
Mutation testing: tests for the real gaps, and stop the sweep headline counting phantoms

### DIFF
--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -58,8 +58,43 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  plan:
+    # The shard count is ONE number, and it lives in Tools/mutation/config.json.
+    # It used to live in three places -- that file, the `shard:` matrix literal
+    # below, and whatever `--of` this dispatch passed -- hand-synced, with the
+    # quiet failure mode being the one this whole exercise exists to catch:
+    # dispatching `shards: 5` left the matrix at three jobs, so shards 3 and 4
+    # were never run, while the aggregator (reading config.json) saw 3 of 3 and
+    # called it a complete sweep. 40% of the files silently unmutated, reported
+    # as covered. Deriving the matrix here means the number cannot disagree with
+    # itself.
+    name: Plan the shards
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+      count: ${{ steps.plan.outputs.count }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: plan
+        env:
+          OVERRIDE: ${{ inputs.shards }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          override = (os.environ.get("OVERRIDE") or "").strip()
+          count = int(override) if override else json.load(
+              open("Tools/mutation/config.json"))["shardCount"]
+          if count < 1:
+              raise SystemExit(f"shard count must be >= 1, got {count}")
+          print(f"count={count}")
+          print("shards=" + json.dumps(list(range(count))))
+          PY
+          cat "$GITHUB_OUTPUT"
+
   mutate:
     name: "Shard ${{ matrix.shard }}"
+    needs: plan
     runs-on: ubuntu-latest
     # Each shard measures ~70 minutes of mutant testing plus a cold build of the
     # project inside Muter's copy. Generous, so a slow shard reports rather than
@@ -69,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2]
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
     container:
       # swift-CI, not plain swift. The -ci image is the one carrying python3,
       # lua5.4, octave and r-base; the plain image is the toolchain alone. Run 1
@@ -98,9 +133,9 @@ jobs:
         run: |
           scripts/mutation-run.sh \
             --shard ${{ matrix.shard }} \
+            --of ${{ needs.plan.outputs.count }} \
             --muter-src /tmp/muter-src \
-            --out mutation-report \
-            ${{ inputs.shards && format('--of {0}', inputs.shards) || '' }}
+            --out mutation-report
 
       - name: Upload this shard's report
         if: always()
@@ -112,7 +147,7 @@ jobs:
 
   file-issue:
     name: File one triage issue
-    needs: mutate
+    needs: [plan, mutate]
     # `always()` so a single wedged shard still yields a report for the other
     # nine, rather than losing an hour of compute to one bad apple.
     if: always()
@@ -180,8 +215,16 @@ jobs:
             // failed, no artifact was uploaded, `dirs` came back empty, and this
             // job reported success and filed nothing. Absence of findings is only
             // meaningful against a known denominator.
-            const expected = JSON.parse(
-              fs.readFileSync('Tools/mutation/config.json', 'utf8')).shardCount;
+            //
+            // It comes from the PLAN job, not from re-reading config.json: a
+            // dispatch may override the count, and a denominator that disagrees
+            // with the matrix is exactly the arithmetic that made a partial sweep
+            // read as a whole one.
+            const expected = Number('${{ needs.plan.outputs.count }}');
+            if (!Number.isInteger(expected) || expected < 1) {
+              core.setFailed(`plan job produced no usable shard count (got '${{ needs.plan.outputs.count }}')`);
+              return;
+            }
 
             let survivors = 0, phantoms = 0, killed = 0, missing = [];
             const sections = [];

--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -169,32 +169,93 @@ jobs:
           path: shards
 
       - name: Record this run for the trend
+        id: record
         run: |
+          # Pull the existing series in first, so trend.py sees every prior run
+          # rather than just this one. The records live on their own branch --
+          # see the commit step for why they cannot live on main.
+          if git fetch --quiet origin mutation-reports 2>/dev/null; then
+            git checkout --quiet FETCH_HEAD -- MutationReports 2>/dev/null || true
+            echo "Restored $(ls MutationReports/*.json 2>/dev/null | wc -l) prior record(s)."
+          else
+            echo "No mutation-reports branch yet; this is the first run recorded."
+          fi
           date="$(date -u +%Y-%m-%d)"
-          python3 Tools/mutation/merge-run.py shards "MutationReports/$date.json" "$date" || {
+          if ! python3 Tools/mutation/merge-run.py shards "MutationReports/$date.json" "$date"; then
             echo "::warning::No shard produced outcomes; no run recorded."
-            exit 0
-          }
-          python3 Tools/mutation/trend.py
-
-      - name: Commit the run record
-        # NEVER fatal. This step runs before the triage issue is filed, and a
-        # push refused by branch protection must not cost the run its report --
-        # the issue is the existing behaviour and the record is the addition.
-        # A lost record is one gap in a series; a lost issue is the whole run.
-        continue-on-error: true
-        run: |
-          if [ -z "$(git status --porcelain MutationReports)" ]; then
-            echo "Nothing to record."
+            echo "recorded=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add MutationReports
-          git commit -m "chore(mutation): record sweep $(date -u +%Y-%m-%d)"
-          # Rebase rather than force: this job races nothing, but main moves.
-          git pull --rebase origin "${GITHUB_REF_NAME}"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          echo "recorded=true" >> "$GITHUB_OUTPUT"
+          python3 Tools/mutation/trend.py | tee /tmp/trend.txt
+
+      - name: Commit the run record
+        id: commit
+        # NEVER fatal: a lost record is one gap in a series, a lost issue is the
+        # whole run, and the issue is filed by a later step.
+        #
+        # It targets `mutation-reports`, NOT the default branch. Run 3 tried main
+        # and was refused -- "Changes must be made through a pull request", plus
+        # four required status checks -- which is not a misconfiguration to fix
+        # but the repository's rules working correctly. A bot committing a
+        # generated artifact to main cannot satisfy them and never will, so the
+        # series gets its own unprotected branch. `continue-on-error` then hid
+        # the refusal completely, which is how a trend that can never accumulate
+        # would have looked exactly like a trend with nothing in it yet.
+        #
+        # A SIDE CLONE rather than a branch switch in the workspace: the records
+        # branch holds only MutationReports/, so checking it out over a tree full
+        # of tracked sources means deleting them and putting them back, and every
+        # cheaper-looking variant of that (orphan branch, stash, sparse checkout)
+        # has an edge case that ends with a half-written working tree.
+        continue-on-error: true
+        if: steps.record.outputs.recorded == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          date="$(date -u +%Y-%m-%d)"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          work=/tmp/mutation-reports
+          rm -rf "$work"
+
+          if ! git clone --quiet --depth 1 --branch mutation-reports "$remote" "$work" 2>/dev/null; then
+            echo "Creating the mutation-reports branch."
+            mkdir -p "$work"
+            git -C "$work" init --quiet
+            git -C "$work" remote add origin "$remote"
+            git -C "$work" checkout --quiet -b mutation-reports
+          fi
+
+          mkdir -p "$work/MutationReports"
+          cp "MutationReports/$date.json" "$work/MutationReports/"
+          git -C "$work" config user.name "github-actions[bot]"
+          git -C "$work" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$work" add MutationReports
+          if git -C "$work" diff --cached --quiet; then
+            echo "This run is already recorded; nothing to push."
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git -C "$work" commit -qm "chore(mutation): record sweep $date"
+          git -C "$work" push --quiet origin HEAD:mutation-reports
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Say so if the series was not persisted
+        # The point of the record is a SERIES. If it did not land, the next run
+        # has nothing to compare against, and silence is what let that go unseen
+        # for a whole run. This never fails the job -- the report still stands --
+        # but it is impossible to miss in the run summary.
+        if: steps.record.outputs.recorded == 'true' && steps.commit.outputs.pushed != 'true'
+        run: |
+          echo "::warning::The run record was NOT pushed to the mutation-reports branch."
+          {
+            echo "### ⚠️ Trend record not persisted"
+            echo ""
+            echo "This run measured fine, but its record did not reach the"
+            echo '`mutation-reports` branch, so it will be missing from the trend and'
+            echo "the next run has one less point to compare against."
+            echo "The merged record is still in this run's artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Merge the shards and file the issue
         uses: actions/github-script@v7
@@ -232,7 +293,8 @@ jobs:
             for (const d of dirs) {
               const shard = d.split('-').pop();
               const file = path.join('shards', d, 'report.md');
-              if (!fs.existsSync(file)) { missing.push(shard); continue; }
+              const summaryFile = path.join('shards', d, 'summary.json');
+              if (!fs.existsSync(file) || !fs.existsSync(summaryFile)) { missing.push(shard); continue; }
               const body = fs.readFileSync(file, 'utf8');
               // A report can EXIST and still say nothing was mutated -- run 2
               // uploaded ten of them, each reading "Muter produced no mutant
@@ -240,11 +302,23 @@ jobs:
               // zero survivors is how a totally broken sweep reported success.
               // Absence of outcomes is a failed shard, not an empty one.
               if (body.includes('no mutant outcomes at all')) { missing.push(shard); continue; }
-              const m = body.match(/\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)%/);
-              if (!m) { missing.push(shard); continue; }
-              killed += Number(m[1]); survivors += Number(m[2]);
-              const p = body.match(/Muter reported (\d+) survivor/);
-              if (p) phantoms += Number(p[1]);
+
+              // COUNTS COME FROM summary.json, NOT from scraping the markdown.
+              // Run 3 shipped two readers of one shard's output that disagreed:
+              // merge-run.py read this file and recorded the right answer (122
+              // killed, 23 survived, 84.1%), while this job scraped the report's
+              // table -- which then carried Muter's raw survivor count -- and
+              // headlined "87 survived ... plus 64 phantoms filtered out". The 87
+              // already CONTAINED the 64. The machine record was honest and the
+              // sentence a human reads was not, which is the whole failure this
+              // job exists to prevent. One source of truth, shared with the trend.
+              let summary;
+              try { summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8')); }
+              catch { missing.push(shard); continue; }
+              if ((summary.killed || 0) + (summary.survived || 0) === 0) { missing.push(shard); continue; }
+              killed += summary.killed || 0;
+              survivors += summary.survived || 0;
+              phantoms += (summary.phantoms || []).length;
               sections.push(body);
             }
 
@@ -262,9 +336,13 @@ jobs:
             const header = [
               `## Mutation sweep — logic tier`,
               '',
-              `**${killed} killed, ${survivors} survived** across `
-                + `${sections.length} of ${expected} shard(s)`
-                + (phantoms ? `, plus ${phantoms} phantom mutant(s) filtered out.` : '.'),
+              `**${killed} killed, ${survivors} survived** — `
+                + `${killed + survivors ? Math.round(100 * killed / (killed + survivors)) : 0}% `
+                + `across ${sections.length} of ${expected} shard(s)`
+                // "excluded", never "plus": the phantoms are NOT additional
+                // survivors sitting beside these, they are already out of the
+                // count above. The earlier wording read as 87 + 64.
+                + (phantoms ? `, with ${phantoms} phantom mutant(s) excluded.` : '.'),
               '',
             ];
             if (missing.length) {

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -47,8 +47,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - name: Mutation trend aggregation self-test
-        run: python3 -m unittest discover -s Tools/mutation -p 'trend_test.py' -v
+      - name: Mutation tooling self-tests
+        # `*_test.py`, not one named file: report_test.py existed for a week
+        # before anything ran it, because the pattern named its neighbour.
+        run: python3 -m unittest discover -s Tools/mutation -p '*_test.py' -v
 
   format-lint:
     runs-on: ubuntu-latest

--- a/Tests/CoreTests/JSONFooterNumberParsingTests.swift
+++ b/Tests/CoreTests/JSONFooterNumberParsingTests.swift
@@ -10,6 +10,13 @@
 // field (e.g. the reserved `score`) failed to parse, the whole object would fail
 // to parse, the footer would be ignored, and `shortResult` would fall back to the
 // raw line. So "shortResult == the footer's value" proves the number parsed.
+//
+// It proves ONLY that. A footer whose number parsed to the wrong value is still a
+// footer, so every assertion below on `shortResult` alone holds just as well when
+// the arithmetic is wrong — which is how mutation testing found that flipping the
+// exponent's sign (`exponentSign = -1` → `1`) failed nothing here. The
+// value-asserting tests at the bottom are the half that was missing: they read
+// the parsed number back through `score`, where a wrong value cannot hide.
 
 import Core
 import Testing
@@ -49,5 +56,53 @@ import Testing
         // A bare number parses as JSON but isn't an object, so it's not a footer.
         let result = interpret(stdout: "42")
         #expect(result.shortResult == "42")
+    }
+
+    // MARK: - The parsed VALUE, not just "it parsed"
+    //
+    // `score` is the only route by which a footer's number reaches an
+    // observable output, and it is clamped to 0...1 — so these cases stay
+    // inside that range on purpose, except where the clamp itself is the point.
+
+    @Test(arguments: [
+        ("5e-1", 0.5),
+        ("2.5E-2", 0.025),
+        ("25e-2", 0.25),
+        ("1e-3", 0.001),
+        ("7.5e-1", 0.75),
+        ("1e0", 1.0),
+        ("0e5", 0.0),  // a zero mantissa with a positive exponent is still zero
+    ])
+    func exponentIsAppliedWithTheRightSignAndMagnitude(literal: String, expected: Double) {
+        let result = interpret(stdout: "{\"shortResult\":\"x\",\"score\":\(literal)}")
+        #expect(result.shortResult == "x")  // the footer was recognised…
+        #expect(abs(result.score - expected) < 1e-12)  // …and carries the right number
+    }
+
+    @Test func positiveExponentOvershootsAndIsClampedRatherThanNegated() {
+        // `1.0e+4` is 10000, clamped to 1. Under a flipped exponent sign it
+        // would be 0.0001 — in range, so the clamp cannot mask the difference.
+        #expect(interpret(stdout: "{\"score\":1.0e+4}").score == 1)
+        // …and the explicit `+` must be consumed rather than ending the number:
+        // if it were not, the literal would fail to parse and this would not be
+        // a footer at all.
+        #expect(interpret(stdout: "{\"shortResult\":\"y\",\"score\":1.0e+4}").shortResult == "y")
+    }
+
+    @Test func fractionalDigitsAndExponentCompose() {
+        // fractionDigits and exponent are folded into one power of ten, so a
+        // literal exercising both at once pins that arithmetic rather than
+        // either half alone.
+        #expect(abs(interpret(stdout: "{\"score\":1234.5e-4}").score - 0.12345) < 1e-12)
+        #expect(abs(interpret(stdout: "{\"score\":0.00075e3}").score - 0.75) < 1e-12)
+    }
+
+    @Test func whitespaceAroundAFooterIsToleratedWithTheValueIntact() {
+        // Instructors hand-write these footers, so a generously spaced one is a
+        // plausible input; the parser skips whitespace at each structural point.
+        #expect(interpret(stdout: "{ \"shortResult\" : \"spaced\" , \"score\" : 0.25 }").score == 0.25)
+        #expect(
+            interpret(stdout: "{ \"shortResult\" : \"spaced\" , \"score\" : 0.25 }").shortResult
+                == "spaced")
     }
 }

--- a/Tests/CoreTests/SuiteExecutionTests.swift
+++ b/Tests/CoreTests/SuiteExecutionTests.swift
@@ -39,6 +39,18 @@ private final class EventLog: Sendable {
     var events: [SuiteRunEvent] { storage.withLock { $0 } }
 }
 
+/// `SuiteRunEvent` is not `Equatable` (it carries a `TestOutcome`), so compare
+/// rendered strings — which also makes a failure legible as a sequence diff
+/// rather than a pattern-match that silently matched nothing.
+private func describe(_ event: SuiteRunEvent) -> String {
+    switch event {
+    case .missingScript(let s): return "missingScript(\(s))"
+    case .willRun(let s): return "willRun(\(s))"
+    case .didFinish(let s, let outcome, let timedOut):
+        return "didFinish(\(s), \(outcome.status.rawValue), timedOut: \(timedOut))"
+    }
+}
+
 @Suite struct SuiteExecutionTests {
 
     @Test func runsEachScriptAndShapesOutcomes() async {
@@ -143,5 +155,76 @@ private final class EventLog: Sendable {
         #expect(outcomes[0].status == .pass)
         #expect(outcomes[0].attemptNumber == 3)
         #expect(outcomes[0].isFirstPassSuccess == false)
+    }
+
+    // MARK: - The event stream
+    //
+    // These exist because a mutation run deleted `onEvent(.willRun(…))` and
+    // `onEvent(.didFinish(…))` from the loop and NOTHING failed: the suite
+    // asserted only the returned outcomes, and the events are a separate
+    // output. They are not decoration — `RunnerDaemon+JobProcessing` turns them
+    // into the `test_execution_start` / `test_execution_end` / `timeout`
+    // structured log events that `docs/operational-diagnostics.md` documents,
+    // so losing one blinds the runner's observability without touching a mark.
+    //
+    // `missingScript` was already covered; the other two were not.
+
+    @Test func emitsWillRunAndDidFinishAroundEveryScriptThatRuns() async {
+        let executor = FakeExecutor(outputs: ["a.py": pass(5), "b.py": fail()])
+        let log = EventLog()
+
+        _ = await executeSuites(
+            [SuiteItem(script: "a.py", tier: .pub), SuiteItem(script: "b.py", tier: .pub)],
+            timeLimitSeconds: 10, attemptNumber: 1, executor: executor,
+            onEvent: { log.record($0) })
+
+        // Order matters: `willRun` must precede its script's `didFinish`, which
+        // is what makes the two log events bracket one execution.
+        #expect(
+            log.events.map(describe) == [
+                "willRun(a.py)",
+                "didFinish(a.py, pass, timedOut: false)",
+                "willRun(b.py)",
+                "didFinish(b.py, fail, timedOut: false)",
+            ])
+    }
+
+    @Test func didFinishCarriesTheTimedOutFlagThatDrivesTheTimeoutLogEvent() async {
+        let killed = ScriptOutput(
+            exitCode: -1, stdout: "", stderr: "still running when killed",
+            executionTimeMs: 10_000, timedOut: true)
+        let log = EventLog()
+
+        _ = await executeSuites(
+            [SuiteItem(script: "slow.py", tier: .pub)],
+            timeLimitSeconds: 10, attemptNumber: 1, executor: FakeExecutor(outputs: ["slow.py": killed]),
+            onEvent: { log.record($0) })
+
+        #expect(
+            log.events.map(describe) == [
+                "willRun(slow.py)",
+                "didFinish(slow.py, timeout, timedOut: true)",
+            ])
+    }
+
+    @Test func aScriptSkippedByItsPrerequisiteFiresNoEvents() async {
+        // The dependency gate `continue`s before both emissions, so a skipped
+        // script must not look like an execution in the log.
+        let executor = FakeExecutor(outputs: ["a.py": fail(), "b.py": pass()])
+        let log = EventLog()
+
+        _ = await executeSuites(
+            [
+                SuiteItem(script: "a.py", tier: .pub),
+                SuiteItem(script: "b.py", tier: .pub, dependsOn: ["a.py"]),
+            ],
+            timeLimitSeconds: 10, attemptNumber: 1, executor: executor,
+            onEvent: { log.record($0) })
+
+        #expect(
+            log.events.map(describe) == [
+                "willRun(a.py)",
+                "didFinish(a.py, fail, timedOut: false)",
+            ])
     }
 }

--- a/Tests/WorkerTests/ScriptClassificationTests.swift
+++ b/Tests/WorkerTests/ScriptClassificationTests.swift
@@ -69,4 +69,105 @@ import Testing
         #expect(classifyScriptInterpreter(name: "weird", source: "just some text") == .unknown)
         #expect(classifyScriptInterpreter(name: "weird", source: "") == .unknown)
     }
+
+    /// A Python file behind a license header, which the five-line content
+    /// window only sees because comment and blank lines are filtered out first.
+    ///
+    /// Found by mutation testing: `!$0.isEmpty && !$0.hasPrefix("#")` survived
+    /// becoming `||`, which keeps every line (an empty line satisfies the
+    /// second test, a comment line the first) and so fills the whole window
+    /// with the header. Every existing content-sniff case put its Python
+    /// keyword within the first line or two, where the difference does not
+    /// show. A license header is the ordinary shape of the input that does.
+    @Test func pythonContentSniffLooksPastACommentHeader() {
+        let licensed = """
+            # Copyright (c) 2026 Example University
+            #
+            # Licensed under the Apache License, Version 2.0 (the "License");
+            # you may not use this file except in compliance with the License.
+            # You may obtain a copy of the License at
+            #
+            #     http://www.apache.org/licenses/LICENSE-2.0
+
+            import os
+
+            print(os.getcwd())
+            """
+        #expect(classifyScriptInterpreter(name: "grade", source: licensed) == .python)
+
+        // The same rule from the other side: blank lines are not content either.
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\n\n\n\n\n\ndef f():\n    pass")
+                == .python)
+    }
+
+    /// Every keyword in the content-sniff list must suffice ON ITS OWN.
+    ///
+    /// The check is a five-way `||`, and mutation testing killed exactly one
+    /// connector at a time: turning the last one into `&&` — dropping
+    /// `if __name__ == ` as an independent signal — failed nothing, because
+    /// every existing case happened to also contain `import` or `def`. A
+    /// per-keyword table is the shape that cannot rot that way: adding a
+    /// keyword to the classifier without adding it here leaves an obvious hole.
+    @Test(arguments: [
+        "import os",
+        "from math import sqrt",
+        "def main():",
+        "class Grader:",
+        "if __name__ == \"__main__\":",
+    ])
+    func eachPythonKeywordAloneIdentifiesPython(line: String) {
+        #expect(classifyScriptInterpreter(name: "grade", source: line) == .python)
+    }
+
+    /// The leading run trimmed before the shebang is read is exactly these five
+    /// characters, and each is load-bearing on its own.
+    ///
+    /// The BOM is the one that matters in practice: a file authored on Windows
+    /// or exported from a spreadsheet tool arrives with `U+FEFF` first, and an
+    /// untrimmed BOM makes `#!` stop being a prefix — so the script silently
+    /// falls through to the content sniff and classifies as `.unknown`. Nothing
+    /// fed this classifier a BOM before.
+    @Test(arguments: [" ", "\t", "\n", "\r", "\u{feff}"])
+    func leadingRunIsTrimmedBeforeTheShebangIsRead(lead: String) {
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\(lead)#!/usr/bin/env python3\nx = 1")
+                == .python)
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\(lead)#!/bin/sh\necho hi") == .sh)
+    }
+
+    /// A BOM in front of a shebang, spelled out as the whole realistic input
+    /// rather than one character: BOM, then CRLF line endings.
+    ///
+    /// Note what is NOT asserted here. A BOM followed by a BLANK CRLF line and
+    /// then the shebang classifies as `.unknown`, because Swift treats `"\r\n"`
+    /// as a single `Character` that equals neither `"\r"` nor `"\n"`, so the
+    /// leading-run trim stops at it. That is a real gap in CRLF handling rather
+    /// than a property worth pinning — tracked separately; pinning it here would
+    /// enshrine it.
+    @Test func bomBeforeAShebangDoesNotDefeatDetection() {
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\u{feff}#!/usr/bin/env python3\nx = 1")
+                == .python)
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\u{feff}#!/usr/bin/env lua\nprint(1)")
+                == .lua)
+        // CRLF *after* the shebang is fine: the trim never reaches it.
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\u{feff}#!/usr/bin/env python3\r\nx = 1")
+                == .python)
+    }
+
+    /// The content sniff compares each line with horizontal whitespace trimmed,
+    /// so indentation defeats neither the keyword match nor the comment filter.
+    @Test func contentSniffTrimsIndentationBeforeMatching() {
+        #expect(classifyScriptInterpreter(name: "grade", source: "    import os") == .python)
+        #expect(
+            classifyScriptInterpreter(name: "grade", source: "\tdef f():\n\t    pass") == .python)
+        // An indented comment is still a comment, so it does not consume a slot
+        // in the five-line window.
+        let indentedHeader = "    # one\n    # two\n    # three\n    # four\n    # five\nimport os"
+        #expect(classifyScriptInterpreter(name: "grade", source: indentedHeader) == .python)
+    }
 }

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -126,11 +126,11 @@ def main() -> int:
             "shard": shard_nums[0] if shard_nums else None,
             "shardCount": shard_nums[1] if len(shard_nums) > 1 else None,
             "killed": len(killed),
-            # `survived` is the PHANTOM-FILTERED count -- the real holes. It is
-            # deliberately NOT the number in report.md's table, which carries
-            # Muter's raw count so it reconciles with Muter's own summary. Both
-            # are emitted under distinct names because a trend built on the raw
-            # count would read phantoms as regressions.
+            # `survived` is the PHANTOM-FILTERED count -- the real holes, and
+            # the same number report.md's table shows. `reportedSurvived` keeps
+            # Muter's raw count so the two can be reconciled, but nothing should
+            # SUM it: a trend built on the raw count reads phantoms as
+            # regressions, and a headline built on it reads them as holes.
             "survived": len(resolved),
             "reportedSurvived": len(survived),
             "survivors": [
@@ -161,14 +161,33 @@ def main() -> int:
             "Do not read a score from this run.",
         ]
     else:
+        # The table carries the PHANTOM-FILTERED numbers, and the score is
+        # recomputed from them rather than taken from Muter's summary.
+        #
+        # It used to print Muter's raw count "so it reconciles with Muter's own
+        # summary", and the 2026-08-19 sweep showed what that costs: shard 0
+        # read "50 survived, 37%" when 43 of those mutants were never inserted
+        # and its real score was 81%. A human triaging that shard would have
+        # concluded NotebookExtraction was barely tested. Reconciliation is
+        # worth one line of prose; it is not worth the headline number.
+        denominator = len(killed) + len(resolved)
+        net_score = f"{round(100 * len(killed) / denominator)}%" if denominator else "n/a"
+        muter_score = SCORE.search(text).group(1) + "%" if SCORE.search(text) else "n/a"
         out += [
             "| killed | survived | score | runtime |",
             "|---:|---:|---:|---|",
-            f"| {len(killed)} | {len(survived)} | "
-            f"{SCORE.search(text).group(1) + '%' if SCORE.search(text) else 'n/a'} | "
+            f"| {len(killed)} | {len(resolved)} | {net_score} | "
             f"{TOOK.search(text).group(1) if TOOK.search(text) else 'n/a'} |",
             "",
         ]
+        if phantoms:
+            out += [
+                f"> Muter's own summary claims {len(survived)} survivors and {muter_score}. "
+                f"{len(phantoms)} of them were never inserted into the mutated copy "
+                "(listed below), so the table above is the measurement and that one "
+                "is not.",
+                "",
+            ]
         if not truth:
             out += [
                 "> **Positions are Muter's own and are known to be wrong.** The mutated",

--- a/Tools/mutation/report_test.py
+++ b/Tools/mutation/report_test.py
@@ -1,0 +1,131 @@
+"""Self-test for report.py's phantom filtering and the numbers it publishes.
+
+The table in report.md is the number a human reads, and it was wrong once. The
+2026-08-19 sweep printed "50 survived, 37%" for a shard whose real figures were
+7 and 81%, because the table carried Muter's raw count while the JSON beside it
+carried the filtered one. Two readers of one shard, disagreeing, with the wrong
+one facing the human.
+
+So these assert the published numbers, not just the filtering: a fixture with a
+known phantom must produce a table showing the FILTERED survivor count and a
+score recomputed from it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPORT = os.path.join(HERE, "report.py")
+
+# Two survivors and one killed mutant, in Muter's plain output format. Muter's
+# own summary claims 2 survived and 33% -- and one of the two was never
+# inserted, which only the mutated copy can reveal.
+RAW = """\
+Probe.swift:10  ChangeLogicalConnector  mutant survived
+Probe.swift:20  RelationalOperatorReplacement    mutant survived
+Probe.swift:30  ChangeLogicalConnector  mutant killed
+
+Of the 3 mutants introduced into your code, your test suite killed 1.
+Mutation Score of Test Suite: 33%
+Muter took 00:01:02.000
+"""
+
+# The mutated copy carries a guard for line 10 only. Line 20 is a phantom.
+MUTATED = '''\
+import class Foundation.ProcessInfo
+if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"] != nil {
+    return a || b
+}
+if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_30_5_300"] != nil {
+    return c && d
+}
+'''
+
+
+def run(raw: str, mutated: str | None):
+    """Run report.py over a fixture and return (exit code, report.md, summary)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        raw_path = os.path.join(tmp, "muter-raw.txt")
+        with open(raw_path, "w") as fh:
+            fh.write(raw)
+        out_dir = os.path.join(tmp, "out")
+        mutated_root = os.path.join(tmp, "copy")
+        if mutated is not None:
+            os.makedirs(mutated_root)
+            with open(os.path.join(mutated_root, "Probe.swift"), "w") as fh:
+                fh.write(mutated)
+        proc = subprocess.run(
+            [sys.executable, REPORT, raw_path, out_dir, "shard 0 of 3", mutated_root],
+            capture_output=True, text=True)
+        report = ""
+        report_path = os.path.join(out_dir, "report.md")
+        if os.path.exists(report_path):
+            with open(report_path) as fh:
+                report = fh.read()
+        summary_path = os.path.join(out_dir, "summary.json")
+        summary = None
+        if os.path.exists(summary_path):
+            with open(summary_path) as fh:
+                summary = json.load(fh)
+        return proc.returncode, report, summary
+
+
+def table_row(report: str) -> list[str]:
+    for line in report.splitlines():
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) == 4 and cells[0].isdigit():
+            return cells
+    raise AssertionError(f"no table row found in:\n{report}")
+
+
+class PublishedNumbersTests(unittest.TestCase):
+
+    def test_table_reports_filtered_survivors_and_a_recomputed_score(self):
+        code, report, summary = run(RAW, MUTATED)
+        killed, survived, score, _runtime = table_row(report)
+        self.assertEqual(code, 0)
+        # 1 killed, 1 real survivor (line 20 was never inserted) -> 50%.
+        self.assertEqual(killed, "1")
+        self.assertEqual(survived, "1", "the table must exclude phantoms")
+        self.assertEqual(score, "50%", "the score must be recomputed, not Muter's 33%")
+        # And the JSON twin must agree with it, since the two disagreeing is the
+        # defect this file exists to prevent.
+        self.assertEqual(summary["killed"], 1)
+        self.assertEqual(summary["survived"], 1)
+        self.assertEqual(summary["reportedSurvived"], 2)
+        self.assertEqual(len(summary["phantoms"]), 1)
+
+    def test_muters_own_claim_is_still_shown_for_reconciliation(self):
+        _code, report, _summary = run(RAW, MUTATED)
+        self.assertIn("33%", report, "Muter's raw score should remain visible in prose")
+        self.assertIn("never inserted", report)
+
+    def test_the_phantom_is_listed_separately_and_not_as_a_survivor(self):
+        _code, report, _summary = run(RAW, MUTATED)
+        survivors, phantoms = report.split("### Phantom")
+        self.assertIn("L10", survivors)
+        self.assertNotIn("L20", survivors, "a phantom must not appear as a survivor")
+        self.assertIn("L20", phantoms)
+
+    def test_without_a_mutated_copy_nothing_is_filtered_and_it_says_so(self):
+        # Filtering needs ground truth. With none, over-reporting is the safe
+        # direction, but it must be announced rather than passed off as clean.
+        _code, report, summary = run(RAW, None)
+        _killed, survived, score, _ = table_row(report)
+        self.assertEqual(survived, "2")
+        self.assertEqual(score, "33%")
+        self.assertEqual(summary["phantoms"], [])
+        self.assertIn("known to be wrong", report)
+
+    def test_no_outcomes_at_all_is_a_failure_not_an_empty_result(self):
+        code, report, _summary = run("Muter took 00:00:01.000\n", MUTATED)
+        self.assertEqual(code, 1, "a run that measured nothing must not exit 0")
+        self.assertIn("no mutant outcomes at all", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/changelog.d/mutation-headline-phantom-arithmetic.md
+++ b/changelog.d/mutation-headline-phantom-arithmetic.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The mutation sweep's headline counted phantom mutants as survivors.** The
+  first successful sweep reported "122 killed, 87 survived ... plus 64 phantom
+  mutant(s) filtered out" — but the 87 already contained the 64, so the real
+  figures were 23 survivors and 84%, not 58%. One shard read 37% when its true
+  score was 81%. The per-shard table carried Muter's raw count while the JSON
+  beside it carried the filtered one, and the aggregator scraped the table; it
+  now reads the same `summary.json` the trend does, so the two cannot disagree.
+  `Tools/mutation/report_test.py` pins the published numbers.
+
+- **The sweep's trend record could never be saved.** It pushed to the default
+  branch, which requires a pull request and four status checks — rules a bot
+  committing a generated file cannot satisfy. `continue-on-error` then hid the
+  refusal, so a series that could never accumulate looked exactly like a series
+  with nothing in it yet. Records go to a `mutation-reports` branch, and a
+  failure to persist is announced in the run summary.

--- a/changelog.d/mutation-pilot-attribution.md
+++ b/changelog.d/mutation-pilot-attribution.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Two corrections to the mutation pilot's write-up.** The exponent finding was
+  attributed to a mutant Muter does not generate — its operators never rewrite a
+  numeric literal — so that gap was found *near* the report rather than in it;
+  the one exponent mutant testable faithfully was already covered. And the
+  pilot's 69% predates phantom filtering, so it is not comparable to the first
+  full sweep's 84%; the page now says so rather than inviting the comparison.

--- a/changelog.d/mutation-pilot-findings-tests.md
+++ b/changelog.d/mutation-pilot-findings-tests.md
@@ -1,0 +1,16 @@
+### Added
+
+- **Tests for the six real gaps the mutation pilot found**, each seen to fail
+  under the mutation it exists to catch: the suite runner's `willRun` /
+  `didFinish` event stream (which drives the runner's `test_execution_start` /
+  `test_execution_end` / `timeout` log events), the classifier's comment-and-blank
+  line filter and its five Python keywords taken one at a time, the leading
+  BOM/whitespace trim, and the JSON footer's exponent — where the existing tests
+  proved the number *parsed* without ever reading its value.
+
+### Fixed
+
+- **The mutation pilot's write-up, which overstated its own findings.** Of the
+  eleven survivors examined, four were already covered by the suite and one is
+  unkillable by construction; only six were real. `Tools/mutation/report.py`
+  exists to catch that class automatically and did not exist when the pilot ran.

--- a/changelog.d/mutation-shard-count-single-source.md
+++ b/changelog.d/mutation-shard-count-single-source.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **The mutation sweep derives its shard count from one place.** The number
+  lived in three — `Tools/mutation/config.json`, the workflow's hardcoded
+  `shard: [0, 1, 2]` matrix, and whatever `--of` a dispatch passed — hand-synced,
+  with a silent failure mode: dispatching `shards: 5` left the matrix at three
+  jobs, so two shards' files were never mutated while the aggregator, reading
+  the config, saw 3 of 3 and called it a complete sweep. A `plan` job now emits
+  the matrix and the denominator from a single read.

--- a/docs/mutation-testing-pilot.md
+++ b/docs/mutation-testing-pilot.md
@@ -6,11 +6,16 @@ scope.** A patched Muter was pointed at four files of `RunnerCore` and scored
 This is the first mutation score ever produced against Chickadee source that is
 a measurement rather than an artifact.
 
-**Read "What it found" with the correction in it.** The survivors were later
-verified one at a time by hand, and roughly half of the ones written up here as
-holes were already covered — Muter reports mutants it never inserted, and those
-always read as survived. Six were real and now have tests; following one of them
-turned up an unrelated product defect (#1457).
+**Read "What it found" with the correction in it, and do not quote the 69%.**
+The survivors were verified one at a time by hand afterwards, and roughly half of
+the ones written up here as holes were already covered — Muter reports mutants it
+never inserted, and those always read as survived. Six were real and now have
+tests; following one of them turned up an unrelated product defect (#1457).
+
+The pilot predates `Tools/mutation/report.py`, so **every number on this page is
+un-filtered**. The first full sweep of the same target, with filtering, scored
+**84%** — 122 killed, 23 survivors, 64 phantoms removed. That is the figure to
+compare against.
 
 Read [handoff-mutation-testing.md](handoff-mutation-testing.md) first for why
 stock Muter cannot do this, and
@@ -125,7 +130,7 @@ means a genuine gap.
 | `ScriptClassification` `if __name__ == ` keyword | hole | **real** |
 | `ScriptClassification` leading-trim set (space, BOM) | hole | **real** |
 | `ScriptClassification` horizontal-whitespace trim | hole | **real** |
-| `JSONLite` exponent sign | hole | **real** |
+| `JSONLite` exponent parsing | hole | **real, but not the mutant claimed** — see below |
 | `OutputInterpretation:106` `longResult` ternary | hole | already killed — 7 of the 14 `output-contract.json` cases assert a non-null `longResult` |
 | `JSONLite` `skipWhitespace()` deletions | hole | already killed |
 | `JSONLite` exponent `+` branch | hole | already killed |
@@ -171,9 +176,17 @@ how a Windows-authored or spreadsheet-exported file arrives, and an untrimmed
 BOM makes `#!` stop being a prefix — so the script falls through to the content
 sniff and classifies `.unknown`.
 
-**The exponent's sign.** `exponentSign = -1` → `1` failed nothing, and the reason
-is worth more than the finding. `JSONFooterNumberParsingTests` already parsed
-`1e3`, `2.5E-2` and `1.0e+4` — but it asserted only that the footer was
+**The exponent's value — and an attribution worth getting right.** The pilot
+listed three survivors in the exponent parser. The one testable faithfully (the
+`+` branch) turned out to be **already killed**. But probing the area with a
+sign flip — `exponentSign = -1` → `1` — failed nothing, and that mutation is
+**not one Muter generates**: its operators are relational, logical-connector,
+side-effect removal and ternary swap, and none of them rewrites a numeric
+literal. So this gap is real and was found *near* the report rather than *in*
+it.
+
+The reason is worth more than the finding. `JSONFooterNumberParsingTests`
+already parsed `1e3`, `2.5E-2` and `1.0e+4` — but it asserted only that the footer was
 *recognised*, which stays true when the arithmetic is wrong. The file's own
 header comment said as much ("proves the number parsed") without anyone reading
 it as a gap. This is the codebase's signature defect — a check that passes while
@@ -181,6 +194,31 @@ proving nothing — inside a test written to pin a parser.
 
 Tests for all six now exist, and each was **seen to fail** under its mutation
 before being committed.
+
+### The first full sweep corroborated the hand verification
+
+The weekly sweep ran end to end for the first time on 2026-08-19, over the same
+`RunnerCore` at commit `321220b` — before these tests landed. It scored **84%**:
+122 killed, 23 real survivors, with **64 phantoms filtered out**, meaning
+`report.py` removed nearly three quarters of Muter's reported survivors.
+
+Its real survivors in the two files examined here are, exactly:
+
+| file | survivors |
+|---|---|
+| `ScriptClassification.swift` | L97, L105, L138, L145 |
+| `SuiteExecution.swift` | L86, L90 |
+
+Those are the six sites verified real by hand, with nothing extra and nothing
+missing. **Two independent methods — Muter's schemata cross-checked against the
+mutated copy, and hand-applying each mutation to the real source — agree
+completely.** That is the best evidence available that the phantom filter is
+sound rather than merely plausible, and it is why the pilot's own numbers (taken
+before the filter existed) should not be quoted.
+
+The sweep's remaining 17 survivors are in `JSONLite` (10) and
+`NotebookExtraction` (7) — the latter deliberately excluded from the pilot for
+size — and are the standing triage list, in issue **#1459**.
 
 ### What following a thread turned up
 

--- a/docs/mutation-testing-pilot.md
+++ b/docs/mutation-testing-pilot.md
@@ -6,6 +6,12 @@ scope.** A patched Muter was pointed at four files of `RunnerCore` and scored
 This is the first mutation score ever produced against Chickadee source that is
 a measurement rather than an artifact.
 
+**Read "What it found" with the correction in it.** The survivors were later
+verified one at a time by hand, and roughly half of the ones written up here as
+holes were already covered — Muter reports mutants it never inserted, and those
+always read as survived. Six were real and now have tests; following one of them
+turned up an unrelated product defect (#1457).
+
 Read [handoff-mutation-testing.md](handoff-mutation-testing.md) first for why
 stock Muter cannot do this, and
 [mutation-testing-spike.md](mutation-testing-spike.md) for the root cause.
@@ -99,62 +105,104 @@ friendlier target than the Vapor layer, and none of these files contain the
 do/catch shape #308 names. It does mean the risk is smaller than it read on
 paper, and that a scoped run against similar code can be trusted today.
 
-## What it found
+## What it found — verified, and half of it was not there
 
-39 survivors. They are not uniform — separating them is the whole skill of
-reading a mutation report, and the split here is roughly two-thirds signal.
+39 survivors. Separating them is the whole skill of reading a mutation report,
+and the first pass at it (below, in the original wording) got it substantially
+wrong: it read Muter's list and reasoned about the code, without checking
+whether each mutant was real.
 
-### Real holes, worth tests
+**It was checked afterwards, mechanically.** Every claimed survivor was applied
+to the real source by hand and the suite the sweep runs (`swift test --skip
+APITests`, 760 tests, 14 seconds) was run against it. A suite that fails means
+the mutant is killable and Muter's "survived" was wrong. A suite that passes
+means a genuine gap.
 
-**The suite runner's event stream is untested** (`SuiteExecution.swift:82,86,90`).
-All three `RemoveSideEffects` survivors are `onEvent(...)` calls — `.missingScript`,
-`.willRun`, `.didFinish`. Deleting them fails nothing. The sharpest of the three
-is `.missingScript`: the code comments it as *"skip with no outcome (caller logs
-via the event)"*, so if that emission ever regressed, a missing test script would
-produce **no outcome and no log** — invisible in both directions.
+| site | claimed | verified |
+|---|---|---|
+| `SuiteExecution` `onEvent(.willRun)` / `.didFinish` | hole | **real** |
+| `ScriptClassification` comment/blank filter (`&&`→`\|\|`) | hole | **real** |
+| `ScriptClassification` `if __name__ == ` keyword | hole | **real** |
+| `ScriptClassification` leading-trim set (space, BOM) | hole | **real** |
+| `ScriptClassification` horizontal-whitespace trim | hole | **real** |
+| `JSONLite` exponent sign | hole | **real** |
+| `OutputInterpretation:106` `longResult` ternary | hole | already killed — 7 of the 14 `output-contract.json` cases assert a non-null `longResult` |
+| `JSONLite` `skipWhitespace()` deletions | hole | already killed |
+| `JSONLite` exponent `+` branch | hole | already killed |
+| `ScriptClassification` `containsSubstring` loop bounds | "highest-value finding" | already killed |
+| `ScriptClassification` empty-needle guard | — | **equivalent mutant**: every caller passes a non-empty string literal, so no test can reach it |
 
-**Content-based Python classification** (`ScriptClassification.swift:97,105`).
-Line 97's `!$0.isEmpty && !$0.hasPrefix("#")` survives becoming `||`, which
-would keep blank and comment lines inside the five-line window the sniffer
-looks at — so a Python file behind a license header would classify differently.
-Line 105 survives the `||` chain becoming `&&`, which would break content
-detection almost entirely. Nothing in the suite exercises this path.
+So of the eleven sites examined, **six were real, four were already covered, and
+one is unkillable by construction.** That ratio is the argument for
+`Tools/mutation/report.py`, which did not exist when this pilot ran: it audits
+Muter's output against the guards actually present in the mutated copy and
+quarantines the mutants that were never inserted.
 
-**Leading BOM and whitespace trimming** (`ScriptClassification.swift:138,145`).
-Both predicates survive `||` → `&&`, which makes them never true and disables
-trimming outright. No test feeds a source with a leading BOM — precisely the
-shape a Windows-authored submission arrives in.
+**One methodological trap, which flipped four verdicts.** The first verification
+pass mutated whole `||` chains at once — `a || b || c` → `a && b && c` — which is
+a *stronger* mutation than Muter's `ChangeLogicalConnector`, which changes one
+connector per mutant. Under the strong version the suite failed, and those sites
+were wrongly written off as covered. Re-run with faithful single-connector
+mutations, three of them survived. If you re-verify a report, **mutate exactly
+what the tool mutated**, one operator at a time.
 
-**The hand-rolled substring search** (`ScriptClassification.swift:174,175`).
-Three survivors in a hand-written `contains` loop that exists to stay
-Embedded-Swift-safe. Some of these mutants would index out of bounds if
-executed, so their survival means the loop's boundaries are never reached in
-tests. A hand-rolled algorithm with untested boundaries is the highest-value
-finding per line here.
+### The real ones, and what they cost
 
-**Numeric exponent parsing** (`JSONLite.swift:210,213,217`). The exponent sign
-branches survive, meaning **no test parses a footer with an exponent**. A script
-emitting `{"score": 5e-1}` is legal JSON under the documented contract, and
-nothing pins it.
+**The suite runner's event stream.** Deleting `onEvent(.willRun(...))` or
+`onEvent(.didFinish(...))` failed nothing: the suite asserted the returned
+outcomes, and the events are a separate output. They are not decoration —
+`RunnerDaemon+JobProcessing` turns them into the `test_execution_start` /
+`test_execution_end` / `timeout` structured log events that
+`docs/operational-diagnostics.md` documents. Losing one blinds the runner's
+observability without moving a single mark, which is the hardest kind of
+regression to notice. (`.missingScript`, the third event, was already covered.)
 
-**Whitespace-tolerant JSON** (`JSONLite.swift:35,57,59,64`). Several
-`skipWhitespace()` calls can be deleted without failing anything, because every
-fixture footer is tightly formatted. Instructors hand-write these footers, so
-`{ "score": 1 }` is an entirely plausible input. One generously-spaced fixture
-would kill several of these at once.
+**Content-based Python classification.** `!$0.isEmpty && !$0.hasPrefix("#")`
+survived becoming `||`, which keeps every line and so fills the five-line
+sniffing window with a licence header. Every existing case put its Python
+keyword on the first or second line, where the difference does not show. So did
+the five-way keyword `||`: turning the last connector into `&&` — dropping
+`if __name__ == ` as an independent signal — failed nothing, because every case
+also contained `import` or `def`.
 
-**`longResult` assembly** (`OutputInterpretation.swift:106`). The
-`sections.isEmpty ? nil : sections.joined(...)` ternary survives being swapped,
-so nothing asserts that stdout/stderr actually reach `longResult` — the field
-students read for detail when a test fails.
+**Leading BOM and whitespace trimming.** Both predicates survived a
+single-connector `||` → `&&`. Nothing fed the classifier a BOM, which is exactly
+how a Windows-authored or spreadsheet-exported file arrives, and an untrimmed
+BOM makes `#!` stop being a prefix — so the script falls through to the content
+sniff and classifies `.unknown`.
+
+**The exponent's sign.** `exponentSign = -1` → `1` failed nothing, and the reason
+is worth more than the finding. `JSONFooterNumberParsingTests` already parsed
+`1e3`, `2.5E-2` and `1.0e+4` — but it asserted only that the footer was
+*recognised*, which stays true when the arithmetic is wrong. The file's own
+header comment said as much ("proves the number parsed") without anyone reading
+it as a gap. This is the codebase's signature defect — a check that passes while
+proving nothing — inside a test written to pin a parser.
+
+Tests for all six now exist, and each was **seen to fail** under its mutation
+before being committed.
+
+### What following a thread turned up
+
+Writing the leading-trim tests surfaced a real product defect, unrelated to any
+mutant: in Swift `"\r\n"` is a **single** `Character` equal to neither `"\r"` nor
+`"\n"`, so `split(separator: "\n" as Character)` returns one element for a
+CRLF string. `OutputInterpretation` splits stdout that way, so a test script
+emitting CRLF has its JSON footer ignored entirely — the student sees the raw
+stdout as the summary and the footer's `score` is discarded, silently replacing
+partial credit with full marks on a pass. Filed as **#1457**.
+
+That is the honest case for the technique: the mutation report's own hit rate was
+about half, but the sites it pointed at were worth reading carefully, and reading
+them carefully found something the report never mentioned.
 
 ### Not worth chasing
 
 Some `JSONLite` survivors are unkillable by construction. Line 35's
 `skipWhitespace` treats `\n` and `\r` as skippable, but the footer is *by
 definition* the last non-empty **line** of stdout, so no input reaching this
-parser can contain one. Those mutants cannot be killed by any test worth
-writing, and a report that counts them as holes is over-reporting.
+parser can contain one. `containsSubstring`'s empty-needle guard is the same
+shape: no caller passes an empty needle, so no test can reach the branch.
 
 This is the irreducible cost of the technique: **a mutation score is not a
 target, and chasing 100% would mean writing tests for inputs that cannot


### PR DESCRIPTION
Acts on the mutation pilot's findings — auditing them first, which turned out to matter — and fixes two defects the first successful weekly sweep exposed in the tooling itself.

## 1. Every survivor was verified by hand before a test was written for it

Each claimed survivor was applied to the real source and the sweep's own suite (`swift test --skip APITests`, 760 tests, 14s) run against it, with a known-covered mutant as a control to prove the harness measured anything.

| site | pilot claimed | verified |
|---|---|---|
| `SuiteExecution` `onEvent(.willRun)` / `.didFinish` | hole | **real** |
| `ScriptClassification` comment/blank filter | hole | **real** |
| `ScriptClassification` `if __name__ == ` keyword | hole | **real** |
| `ScriptClassification` leading-trim set (space, BOM) | hole | **real** |
| `ScriptClassification` horizontal-whitespace trim | hole | **real** |
| `JSONLite` exponent | hole | **real, but not the mutant claimed** (below) |
| `OutputInterpretation:106` `longResult` ternary | hole | already killed — 7 of 14 `output-contract.json` cases pin it |
| `JSONLite` `skipWhitespace()` deletions | hole | already killed |
| `JSONLite` exponent `+` branch | hole | already killed |
| `containsSubstring` loop bounds | "highest-value finding" | already killed |
| `containsSubstring` empty-needle guard | — | **equivalent mutant** — no caller passes an empty needle |

Six real, four already covered, one unkillable.

**One trap, which flipped four verdicts.** The first pass mutated whole `||` chains at once — stronger than Muter's one-connector-per-mutant operator. Three sites written off as covered survived a faithful single-connector mutation. If you re-verify a report, mutate exactly what the tool mutated.

**One mis-attribution, corrected.** The exponent gap is real, but the mutation that finds it is a *sign flip*, and Muter does not generate those — its operators are relational, logical-connector, side-effect removal and ternary swap, none of which rewrites a numeric literal. It was found *near* the report, not in it. The one exponent mutant testable faithfully was already covered.

## 2. The tests

Twelve cases, **each seen to fail** under its mutation before being committed:

- **The event stream.** Deleting `onEvent(.willRun(…))` or `.didFinish(…)` failed nothing — the suite asserted the returned outcomes, and the events are a separate output. They are what `RunnerDaemon+JobProcessing` turns into the `test_execution_start` / `test_execution_end` / `timeout` structured log events, so losing one blinds the runner's observability without moving a mark.
- **The Python content sniff**, as two contracts rather than two mutants: each of the five keywords suffices alone, and comment/blank lines don't consume a slot in the five-line window.
- **The leading-trim set**, per character. Nothing had ever fed the classifier a BOM — which is how a Windows-authored file arrives, and an untrimmed BOM makes `#!` stop being a prefix.
- **The footer exponent's value.** The existing tests parsed `2.5E-2` but asserted only that the footer was *recognised*, which stays true when the arithmetic is wrong. That file's own header comment said so.

## 3. The sweep's headline counted phantoms as survivors

The first sweep that ran end to end reported *"122 killed, 87 survived … plus 64 phantom mutant(s) filtered out"*. **The 87 already contained the 64.**

| | reported | actual |
|---|---:|---:|
| survivors | 87 | **23** |
| score | 58% | **84%** |
| shard 0 | 50 survived, 37% | **7 survived, 81%** |

Shard 0 at 37% would have sent someone to write tests for `NotebookExtraction.swift` believing it was barely covered.

The cause was two readers of one output: `merge-run.py` read `summary.json` and logged the right answer; the issue-filing job scraped the markdown table, which deliberately carried Muter's raw count. The machine record was honest and the sentence a human reads was not — the exact failure this job exists to prevent.

Now the table publishes the filtered count with the score recomputed from it, Muter's raw claim survives as one line of prose for reconciliation, and the aggregator reads the same `summary.json` the trend does. **Verified against run 3's real artifacts:** the new aggregator emits `122 killed, 23 survived — 84%`, matching `merge-run.py` exactly.

`Tools/mutation/report_test.py` pins the published numbers and was seen to fail against the shipped version (`'2' != '1'`). The CI job's discovery pattern named a single file; it now matches `*_test.py`.

## 4. The trend record could never have been saved

It pushed to `main`, which requires a pull request and four status checks — rules a bot committing a generated file cannot satisfy. `continue-on-error` hid the refusal, so a series that could never accumulate looked identical to one with nothing in it yet. Records now go to a `mutation-reports` branch via a side clone, and failing to persist one is announced in the run summary.

## 5. The shard count now has one owner

It lived in three hand-synced places — `Tools/mutation/config.json`, the workflow's `shard: [0, 1, 2]` literal, and `--of`. Dispatching a larger count left the matrix at three jobs while the aggregator, reading the config, called it complete. A `plan` job now emits both the matrix and the denominator from a single read.

## A product defect found by following one thread

Filed as #1457, **not fixed here**. In Swift `"\r\n"` is a single `Character` equal to neither `"\r"` nor `"\n"`, so `split(separator: "\n" as Character)` returns one element for a CRLF string. `OutputInterpretation` splits stdout that way, so a CRLF-emitting script loses its footer — measured through the real API:

| stdout | `shortResult` | `score` |
|---|---|---|
| `checking...\n{"shortResult":"3/4 cases passed","score":0.75}\n` | `3/4 cases passed` | `0.75` |
| same with `\r\n` | *the entire raw stdout* | **`1.0`** |

Partial credit is silently replaced by full marks on a pass, zero on a fail. It's in `RunnerCore`, so both graders share it.

## Corroboration

Run 3 measured the same target at `321220b`, before these tests landed. Its phantom-filtered survivors in the two files examined are exactly `ScriptClassification` L97/L105/L138/L145 and `SuiteExecution` L86/L90 — the six verified real by hand, nothing extra, nothing missing. Two independent methods agreeing completely is the best evidence available that the phantom filter is sound.

## Verification

- `swift test --skip APITests` — 772 passing (was 760)
- `scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh` (0 violations / 1043 files), `scripts/no-new-xctest.sh` — all clean
- `python3 -m unittest discover -s Tools/mutation -p '*_test.py'` — 23 passing
- The seen-to-fail harness re-run after the tests: all 8 target mutations killed, the equivalent mutant still correctly surviving

Refs #1447. Triage list for the sweep's remaining 17 survivors: #1459.