### PR TITLE
feat(mutation): make survivors reproducible, and give triage a protocol

### DIFF
--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -392,10 +392,16 @@ jobs:
             const today = new Date().toISOString().slice(0, 10);
             const body = header.concat(sections).join('\n') + [
               '',
-              '<sub>Filed automatically by `.github/workflows/mutation-weekly.yml`.',
-              'Triage by deciding, per survivor, whether a test should exist — after',
-              'confirming the mutant by hand. Closing one with a reason is a legitimate',
-              'outcome, not a backlog item.</sub>',
+              '---',
+              '',
+              '**Triage protocol: [`docs/mutation-triage.md`](../blob/main/docs/mutation-triage.md).**',
+              'A survivor is a question, not a defect. Verify before writing anything —',
+              '`Tools/mutation/verify-survivor.py` replays the exact mutation Muter',
+              'inserted and reports whether it still survives — and again afterwards, so',
+              'the new test is seen to fail. Closing one as "correctly, no test" with the',
+              'reason recorded is a complete outcome, not a backlog item.',
+              '',
+              '<sub>Filed automatically by `.github/workflows/mutation-weekly.yml`.</sub>',
             ].join('\n');
 
             const issue = await github.rest.issues.create({

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -41,11 +41,87 @@ SCORE = re.compile(r"Mutation Score of Test Suite:\s*(\d+)%")
 TOOK = re.compile(r"Muter took\s+(\S+)")
 
 
-def harvest_true_positions(mutated_root: str) -> dict[tuple[str, str], list[int]]:
-    """Map (file stem, operator) -> sorted true line numbers, from the copy."""
-    found: dict[tuple[str, str], set[int]] = {}
+def _skip_to_matching_brace(text: str, open_idx: int) -> int:
+    """Index just past the `}` matching the `{` at `open_idx`, or -1.
+
+    Brace counting has to ignore braces inside string literals, interpolations
+    and comments, or a mutation containing `"{"` truncates the extraction. When
+    anything looks wrong the answer is -1 and the caller records NOTHING: a
+    guessed mutation is worse than an absent one, for the same reason a phantom
+    is worse than a missing survivor -- somebody acts on it.
+    """
+    depth, i, n = 0, open_idx, len(text)
+    while i < n:
+        c = text[i]
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            i = n if j < 0 else j + 2
+            continue
+        if c == '"':
+            # Raw strings (#"..."#) and multiline ("""...""") both start with a
+            # quote; walk the literal with escape handling and bail out if it is
+            # unterminated rather than guessing where it ends.
+            if text.startswith('"""', i):
+                j = text.find('"""', i + 3)
+                if j < 0:
+                    return -1
+                i = j + 3
+                continue
+            i += 1
+            while i < n and text[i] != '"':
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                i += 1
+            if i >= n:
+                return -1
+            i += 1
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return -1
+
+
+def harvest_schemata(mutated_root: str) -> tuple[dict[tuple[str, str], list[int]], dict]:
+    """Read the mutated copy: true mutant positions AND the mutation itself.
+
+    Muter rewrites each mutable statement into a switch whose branches carry the
+    mutations and whose final `else` carries the original:
+
+        if ProcessInfo.processInfo.environment["<id>"] != nil {
+            <mutated>
+        } else if ProcessInfo.processInfo.environment["<id2>"] != nil {
+            <mutated 2>
+        } else {
+            <original>
+        }
+
+    Capturing `<mutated>` is what makes a survivor ACTIONABLE. Muter's own plain
+    output gives a file, a line and an operator name -- and that is not enough to
+    reproduce the mutant. `return (i > Int(Int32.max) || i < Int(Int32.min)) ? …`
+    carries two comparisons, so "RelationalOperatorReplacement at line 57" names
+    two possible mutations and says nothing about what either was replaced with.
+    Anyone triaging it has to guess, and guessing wrong is not hypothetical: a
+    triage pass that mutated whole `||` chains where Muter mutates one connector
+    called three real gaps covered.
+
+    A reported row cannot always be tied to ONE schema -- two mutants of the same
+    operator can share a line -- so every candidate for a (stem, operator, line)
+    is returned. Being handed two exact mutations beats being handed none.
+    """
+    positions: dict[tuple[str, str], set[int]] = {}
+    mutations: dict[tuple[str, str, int], list[dict]] = {}
     if not mutated_root or not os.path.isdir(mutated_root):
-        return {}
+        return {}, {}
     for root, _dirs, files in os.walk(mutated_root):
         if "/.build" in root:
             continue
@@ -56,9 +132,34 @@ def harvest_true_positions(mutated_root: str) -> dict[tuple[str, str], list[int]
                 text = open(os.path.join(root, name), errors="ignore").read()
             except OSError:
                 continue
-            for stem, operator, line, _col, _off in SCHEMA_ID.findall(text):
-                found.setdefault((stem, operator), set()).add(int(line))
-    return {k: sorted(v) for k, v in found.items()}
+            for m in SCHEMA_ID.finditer(text):
+                stem, operator, line, col, off = m.groups()
+                line = int(line)
+                positions.setdefault((stem, operator), set()).add(line)
+                brace = text.find("{", m.end())
+                if brace < 0:
+                    continue
+                end = _skip_to_matching_brace(text, brace)
+                if end < 0:
+                    continue
+                # An EMPTY body is not a failed extraction -- it is what
+                # RemoveSideEffects looks like, since that operator deletes the
+                # statement outright. Skipping it would leave the one operator
+                # whose mutation is "nothing" permanently unverifiable, and the
+                # events it deletes are exactly the kind nothing asserts on.
+                body = text[brace + 1 : end - 1].strip()
+                mutations.setdefault((stem, operator, line), []).append(
+                    {"column": int(col), "offset": int(off), "mutated": body}
+                )
+    return (
+        {k: sorted(v) for k, v in positions.items()},
+        {k: sorted(v, key=lambda d: d["offset"]) for k, v in mutations.items()},
+    )
+
+
+def harvest_true_positions(mutated_root: str) -> dict[tuple[str, str], list[int]]:
+    """Positions only -- kept as the narrow entry point for the phantom filter."""
+    return harvest_schemata(mutated_root)[0]
 
 
 def repo_path(base: str, cache: dict[str, str]) -> str:
@@ -91,13 +192,14 @@ def main() -> int:
     survived = [r for r in rows if r[3] == "survived"]
     killed = [r for r in rows if r[3] == "killed"]
 
-    truth = harvest_true_positions(mutated_root)
+    truth, schemata = harvest_schemata(mutated_root)
     cache: dict[str, str] = {}
 
     # A reported survivor is only real if a schema was actually inserted for it.
     # Compare against the guards harvested from the mutated copy; anything with
     # no guard was never mutated, so its "survival" means nothing.
     resolved, phantoms = [], []
+    mutation_of: dict[tuple[str, int, str], list[dict]] = {}
     for base, reported, operator, _ in survived:
         stem = base[:-6] if base.endswith(".swift") else base
         candidates = truth.get((stem, operator), [])
@@ -107,6 +209,9 @@ def main() -> int:
             resolved.append((path, reported, operator))
         elif reported in candidates:
             resolved.append((path, reported, operator))
+            mutation_of[(path, reported, operator)] = schemata.get(
+                (stem, operator, reported), []
+            )
         else:
             phantoms.append((path, reported, operator))
 
@@ -139,6 +244,14 @@ def main() -> int:
                     "line": line,
                     "operator": operator,
                     "source": source_line(path, line),
+                    # The mutation itself, lifted from the schemata in the
+                    # mutated copy. Without it a survivor is not reproducible:
+                    # an operator name plus a line number does not say WHICH
+                    # sub-expression changed or what it became. A list because
+                    # two mutants of one operator can share a line; empty when
+                    # the copy was unavailable or the extraction was unsure,
+                    # never a guess.
+                    "mutations": mutation_of.get((path, line, operator), []),
                 }
                 for path, line, operator in sorted(resolved)
             ],
@@ -215,6 +328,13 @@ def main() -> int:
                     current = path
                 src = source_line(path, line)
                 out.append(f"- L{line} `{operator}`" + (f" — `{src}`" if src else ""))
+                # The mutation, so the reader can reproduce it without guessing
+                # which sub-expression Muter touched.
+                for mut in mutation_of.get((path, line, operator), []):
+                    one = " ".join(mut["mutated"].split())
+                    if len(one) > 160:
+                        one = one[:157] + "..."
+                    out.append(f"    - becomes: `{one}`")
         else:
             out.append("No survivors. Every mutant in this shard was killed.")
 

--- a/Tools/mutation/report_test.py
+++ b/Tools/mutation/report_test.py
@@ -35,13 +35,22 @@ Muter took 00:01:02.000
 """
 
 # The mutated copy carries a guard for line 10 only. Line 20 is a phantom.
+#
+# The shape is Muter's real one: the mutation in the `if` body, the ORIGINAL in
+# the trailing `else`. The line-10 mutation deliberately contains a brace inside
+# a string literal, because a naive brace count truncates there and would record
+# a mangled mutation -- worse than recording none.
 MUTATED = '''\
 import class Foundation.ProcessInfo
 if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"] != nil {
-    return a || b
+    return a || b ? "}" : "end"
+} else {
+    return a && b ? "}" : "end"
 }
 if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_30_5_300"] != nil {
     return c && d
+} else {
+    return c || d
 }
 '''
 
@@ -125,6 +134,47 @@ class PublishedNumbersTests(unittest.TestCase):
         code, report, _summary = run("Muter took 00:00:01.000\n", MUTATED)
         self.assertEqual(code, 1, "a run that measured nothing must not exit 0")
         self.assertIn("no mutant outcomes at all", report)
+
+
+class RecordedMutationTests(unittest.TestCase):
+    """The mutation itself must reach the record, or a survivor is not actionable.
+
+    An operator name and a line number do not say WHICH sub-expression changed
+    or what it became, and a triage pass that guessed got three of them wrong.
+    """
+
+    def test_the_survivor_carries_the_mutation_muter_actually_inserted(self):
+        _code, _report, summary = run(RAW, MUTATED)
+        surv = [s for s in summary["survivors"] if s["line"] == 10]
+        self.assertEqual(len(surv), 1)
+        muts = surv[0]["mutations"]
+        self.assertEqual(len(muts), 1, "the line-10 schema should be recorded")
+        self.assertEqual(muts[0]["mutated"], 'return a || b ? "}" : "end"')
+
+    def test_a_brace_inside_a_string_does_not_truncate_the_mutation(self):
+        # The regression this guards: counting braces without skipping string
+        # literals sees the `}` inside the quotes as the end of the body and
+        # records `return a || b ? "` -- not Swift, and not the mutation.
+        _code, _report, summary = run(RAW, MUTATED)
+        muts = [s for s in summary["survivors"] if s["line"] == 10][0]["mutations"]
+        self.assertTrue(muts[0]["mutated"].endswith('"end"'))
+
+    def test_the_markdown_shows_the_mutation_next_to_the_survivor(self):
+        _code, report, _summary = run(RAW, MUTATED)
+        self.assertIn("becomes:", report)
+        self.assertIn('return a || b ? "}" : "end"', report)
+
+    def test_a_phantom_gets_no_mutation_because_none_was_inserted(self):
+        _code, _report, summary = run(RAW, MUTATED)
+        self.assertTrue(all(p["line"] != 10 for p in summary["phantoms"]))
+        self.assertEqual([p["line"] for p in summary["phantoms"]], [20])
+
+    def test_without_a_mutated_copy_the_mutation_list_is_empty_not_guessed(self):
+        # No ground truth means no mutation may be invented. An empty list is
+        # what verify-survivor.py reports as UNVERIFIABLE, which is the honest
+        # answer; a plausible-looking guess would be acted on.
+        _code, _report, summary = run(RAW, None)
+        self.assertTrue(all(s["mutations"] == [] for s in summary["survivors"]))
 
 
 if __name__ == "__main__":

--- a/Tools/mutation/verify-survivor.py
+++ b/Tools/mutation/verify-survivor.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Apply one recorded mutation, run the suite, and say whether it dies.
+
+WHY THIS EXISTS. A mutation report is a list of QUESTIONS, and the only honest
+way to answer one is to make the change and watch what happens. Reasoning about
+it from the source does not work -- measured, twice, in opposite directions:
+
+  * A triage pass that read Muter's list and reasoned about the code called four
+    already-covered sites "holes" and one unkillable mutant "the highest-value
+    finding here". Roughly half the list was wrong.
+  * The same pass then mutated whole `||` chains where Muter mutates ONE
+    connector, which is a stronger change, and so called three REAL gaps
+    covered. Being careful in the wrong direction is just as wrong.
+
+So this runs the experiment instead, and it is meant to be run TWICE per
+survivor:
+
+    before writing anything   -> expect SURVIVED. Anything else means the
+                                 finding is stale (the code moved) or was never
+                                 real, and no test should be written for it.
+    after writing the test    -> expect KILLED, and by the test you just added.
+
+That second run is this repository's existing rule -- a check never seen to fail
+is not a check (scripts/check-guards.sh) -- applied to a unit test.
+
+USAGE
+
+    Tools/mutation/verify-survivor.py --run-record MutationReports/<file>.json \\
+        --file Sources/Core/JSONValue.swift --line 57 --operator ChangeLogicalConnector
+
+    Tools/mutation/verify-survivor.py --all --run-record <file>.json   # every survivor
+
+The mutation comes from the run record's `mutations` field, so what runs here is
+what Muter actually inserted -- not a reconstruction. A survivor whose record
+carries no mutation cannot be verified mechanically and is reported as such
+rather than approximated.
+
+EXIT CODES
+    0  the mutant SURVIVED  (a real gap, or an equivalent mutant)
+    1  the mutant was KILLED
+    2  could not verify (no recorded mutation, source drifted, build failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+# Tools/mutation/verify-survivor.py -> three levels up is the repo root.
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CONFIG = os.path.join(REPO, "Tools/mutation/config.json")
+
+
+def load_test_command() -> list[str]:
+    """The sweep's own test command, so a verdict here means the same thing.
+
+    Read from config rather than restated: a verifier running a different suite
+    than the sweep would answer a different question and look like it answered
+    this one.
+    """
+    with open(CONFIG) as fh:
+        return ["swift"] + json.load(fh)["testArgs"]
+
+
+def survivors_from(record_path: str) -> list[dict]:
+    with open(record_path) as fh:
+        return json.load(fh).get("survivors", [])
+
+
+def pick(survivors: list[dict], path: str, line: int, operator: str | None) -> list[dict]:
+    return [
+        s
+        for s in survivors
+        if s["file"] == path
+        and s["line"] == line
+        and (operator is None or s["operator"] == operator)
+    ]
+
+
+def apply_mutation(source_path: str, line: int, mutated: str) -> str | None:
+    """Replace the statement at `line` with the mutation. Returns the original.
+
+    Muter records the mutated STATEMENT, so the replacement is line-oriented and
+    only safe when the target line still looks like what was mutated. Returning
+    None rather than editing on a mismatch is deliberate: a verifier that
+    silently mutates the wrong line reports a verdict about code nobody asked
+    about.
+    """
+    with open(source_path) as fh:
+        lines = fh.readlines()
+    if not 1 <= line <= len(lines):
+        return None
+    original = "".join(lines)
+    if not mutated.strip():
+        # RemoveSideEffects: the mutation IS the absence of the statement.
+        del lines[line - 1]
+    else:
+        indent = re.match(r"\s*", lines[line - 1]).group(0)
+        body = "\n".join(indent + ln.lstrip() if ln.strip() else ln for ln in mutated.splitlines())
+        lines[line - 1] = body + "\n"
+    with open(source_path, "w") as fh:
+        fh.writelines(lines)
+    return original
+
+
+def run_suite(cmd: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True, timeout=7200)
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def failing_suites(output: str) -> list[str]:
+    return sorted(
+        {
+            ln.split("Suite ")[1].split(" failed")[0]
+            for ln in output.splitlines()
+            if "Suite " in ln and " failed" in ln
+        }
+    )
+
+
+def verify_one(survivor: dict, cmd: list[str], quiet: bool) -> int:
+    path = survivor["file"]
+    line = survivor["line"]
+    label = f"{path}:{line} {survivor['operator']}"
+    muts = survivor.get("mutations") or []
+    if not muts:
+        print(f"UNVERIFIABLE  {label}")
+        print("    No mutation was recorded for this survivor, so it cannot be")
+        print("    reproduced mechanically. Confirm it by hand before acting on it.")
+        return 2
+
+    source_path = os.path.join(REPO, path)
+    if not os.path.isfile(source_path):
+        print(f"UNVERIFIABLE  {label}\n    {path} no longer exists; the finding is stale.")
+        return 2
+
+    worst = 1
+    for i, mut in enumerate(muts, 1):
+        tag = f"{label}" + (f"  [candidate {i} of {len(muts)}]" if len(muts) > 1 else "")
+        shown = " ".join(mut["mutated"].split())[:150] or "<statement deleted>"
+        backup = apply_mutation(source_path, line, mut["mutated"])
+        if backup is None:
+            print(f"UNVERIFIABLE  {tag}\n    Line {line} is out of range; the source has moved.")
+            worst = max(worst, 2)
+            continue
+        try:
+            code, output = run_suite(cmd)
+        finally:
+            with open(source_path, "w") as fh:
+                fh.write(backup)
+        if code == 0:
+            print(f"SURVIVED      {tag}")
+            print(f"    applied: {shown}")
+            print("    Nothing in the suite could tell the difference. Either a real")
+            print("    gap, or an equivalent mutant -- decide which, and record why.")
+            worst = 0
+        else:
+            suites = failing_suites(output)
+            print(f"KILLED        {tag}")
+            print(f"    failed: {', '.join(suites) if suites else 'suite failed'}")
+            if not quiet:
+                print("    Already covered. Do not write a test for this one.")
+            worst = min(worst, 1) if worst != 0 else 0
+    return worst
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--run-record", required=True, help="A MutationReports/<date>-run<id>.json")
+    ap.add_argument("--file", help="Survivor's file, repo-relative")
+    ap.add_argument("--line", type=int, help="Survivor's line")
+    ap.add_argument("--operator", help="Muter operator name; omit to take every operator on that line")
+    ap.add_argument("--all", action="store_true", help="Verify every survivor in the record")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    survivors = survivors_from(args.run_record)
+    if args.all:
+        targets = survivors
+    else:
+        if not args.file or args.line is None:
+            ap.error("--file and --line are required unless --all is given")
+        targets = pick(survivors, args.file, args.line, args.operator)
+        if not targets:
+            print(f"No survivor at {args.file}:{args.line} in {args.run_record}.")
+            print("Check the file path is repo-relative and the line matches the record.")
+            return 2
+
+    if not shutil.which("swift"):
+        print("swift is not on PATH.")
+        return 2
+
+    cmd = load_test_command()
+    print(f"Suite: {' '.join(cmd)}\n")
+    verdicts = [verify_one(t, cmd, args.quiet) for t in targets]
+    if len(verdicts) > 1:
+        n = {0: 0, 1: 0, 2: 0}
+        for v in verdicts:
+            n[v] += 1
+        print(f"\n{n[0]} survived, {n[1]} killed, {n[2]} unverifiable, of {len(verdicts)}.")
+    return 0 if 0 in verdicts else (2 if all(v == 2 for v in verdicts) else 1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/changelog.d/mutation-survivor-handoff.md
+++ b/changelog.d/mutation-survivor-handoff.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Mutation survivors are now reproducible, and there is a protocol for acting
+  on them.** A survivor used to be recorded as a file, a line and an operator
+  name — not enough to reproduce it, since one line can carry several mutable
+  sub-expressions and the operator says nothing about what replaced which. The
+  run record now carries the mutation Muter actually inserted, lifted from the
+  schemata in the mutated copy, and `Tools/mutation/verify-survivor.py` replays
+  it against the sweep's own suite. Run it before writing a test (expect the
+  mutant to survive; anything else means the finding is stale) and after
+  (expect it killed, by the test just added). `docs/mutation-triage.md` is the
+  protocol, including the three legitimate outcomes — one of which is "no test,
+  here is why".

--- a/docs/mutation-triage.md
+++ b/docs/mutation-triage.md
@@ -1,0 +1,118 @@
+# Triaging mutation survivors
+
+This is the working protocol for turning a mutation sweep's survivor list into
+tests. It is written to be handed to someone — or something — starting cold.
+
+**Read this first: a survivor is not a bug.** It is one question, always the
+same one: *the suite could not tell the difference when this expression changed
+— should it have?* Three answers are legitimate, and the third is not failure:
+
+| answer | what you do |
+|---|---|
+| yes, that behaviour should be pinned | write the test |
+| no — nothing reaching this code can tell the difference | close it, **record why** |
+| the mutant is already dead / never existed | close it, no test |
+
+Anyone treating the list as a defect backlog will produce tests that pass while
+proving nothing, which is the exact failure mutation testing exists to detect.
+**There is no score to chase.** Some survivors are unkillable by construction,
+and a run that "fixed" them would be worse than one that left them alone.
+
+---
+
+## The loop
+
+Per survivor, twice through the verifier — before and after. Both runs matter,
+and skipping the first is how you write a test for a hole that is not there.
+
+```
+Tools/mutation/verify-survivor.py --run-record MutationReports/<date>-run<id>.json \
+    --file Sources/Core/JSONValue.swift --line 57 --operator ChangeLogicalConnector
+```
+
+**Before writing anything — expect `SURVIVED`.**
+`KILLED` means the finding is stale (the code moved, or somebody already covered
+it); close it and move on. `UNVERIFIABLE` means no mutation was recorded, so
+confirm by hand or skip — never approximate one.
+
+**After writing the test — expect `KILLED`, naming your new suite.**
+If your test passes but the mutant still survives, the test is not exercising
+the behaviour it claims to. That is the whole point of the second run.
+
+The verifier applies the mutation Muter actually inserted, taken from the run
+record, and runs the sweep's own test command from `Tools/mutation/config.json`
+so a verdict here means what a verdict there means.
+
+## Work by file, not by survivor
+
+Survivors cluster. In the 2026-08-19 sweep, 36 of 95 were in the four
+`JSONValue*Literal` renderers and 16 more in `AchievementEvaluation`. One
+table-driven test usually kills several, and a per-survivor task list produces
+redundant work plus one chance to guess wrong per item.
+
+Take a file, read its survivors together, and ask what single test would pin the
+behaviour they all poke at.
+
+## Traps, all of them measured
+
+**Mutate exactly what the tool mutated.** Muter's `ChangeLogicalConnector`
+changes ONE connector; flipping a whole `a || b || c` chain to `&&` is a
+stronger change that fails tests the real mutant survives. A triage pass that
+did this called three genuine gaps "already covered". The verifier avoids the
+trap entirely by replaying the recorded mutation — this is why you use it rather
+than editing by hand.
+
+**One line can carry several mutants.** `return (i > Int(Int32.max) || i <
+Int(Int32.min)) ? …` has two comparisons, so `RelationalOperatorReplacement` at
+that line names two possible mutations. The record lists every candidate and the
+verifier tries each, reporting them separately. Do not assume the first is the
+one that survived.
+
+**Phantoms are already filtered — do not re-add them.** Muter reports mutants it
+never inserted, and they always read as survived: 131 of 226 in the 2026-08-19
+run, 43 of 50 in one shard. `Tools/mutation/report.py` quarantines them against
+the guards actually present in the mutated copy. Read survivors from the run
+record or the issue's Survivors section, never from Muter's raw output.
+
+**A `Sources/Core` survivor is weaker evidence than a `Sources/RunnerCore` one.**
+The sweep skips `APITests` because it dominates the runtime, and ~5% of Core is
+reachable only from there. If a Core survivor sits in such a file, confirm it
+against the full suite before writing anything — otherwise you are looking at
+the same artefact a missing interpreter produces, where a test that never ran
+makes its mutants read as gaps.
+
+**Equivalent mutants are common in parsers and defensive code.** `JSONLite`'s
+`skipWhitespace` treats `\n` as skippable, but the footer is by definition the
+last non-empty *line*, so no input reaching that parser contains one. No test can
+kill it. `containsSubstring`'s empty-needle guard has no caller that passes an
+empty needle. Close these with the reason written down; the reason is the
+deliverable.
+
+## What a finished survivor looks like
+
+Either a test that has been seen to fail under its mutation, or a sentence
+saying why no test should exist. Both are complete. A survivor left open with
+neither is the only bad outcome.
+
+When a test lands, say in its comment what the mutation was and why the gap
+mattered — the tests added from the first pilot do this, and it is what stops a
+later reader deleting them as redundant.
+
+## Where things are
+
+| | |
+|---|---|
+| run records (the series) | `mutation-reports` branch, `MutationReports/*.json` |
+| the sweep | `.github/workflows/mutation-weekly.yml`, Tuesdays 06:00 UTC |
+| scope and its reasoning | `Tools/mutation/config.json` |
+| the trend | `Tools/mutation/trend.py` |
+| why the tooling distrusts its own tool | `docs/mutation-testing-pilot.md` |
+| tracking issue | #1447 |
+
+Pull the current series with:
+
+```
+git fetch origin mutation-reports
+git checkout FETCH_HEAD -- MutationReports
+python3 Tools/mutation/trend.py
+```


### PR DESCRIPTION
Turns the sweep's survivor list into something a person — or an agent — can act on without guessing.

## The blocker

A survivor was recorded as a file, a line and an operator name. That is not enough to reproduce it:

```json
{"file": "Sources/Core/JSONValueJavaLiteral.swift", "line": 57,
 "operator": "RelationalOperatorReplacement",
 "source": "return (i > Int(Int32.max) || i < Int(Int32.min)) ? \"\\(i)L\" : String(i)"}
```

Two comparisons on that line, and the record says neither which one changed nor what it became. Guessing wrong is measured, not hypothetical: the pilot's triage pass mutated whole `||` chains where Muter mutates **one** connector, and called three real gaps covered.

## What changed

**`report.py` lifts the mutation out of the mutated copy.** Muter's schemata put each mutation in an `if` body and the original in the trailing `else`, so both are already on disk:

```swift
if ProcessInfo.processInfo.environment["<id>"] != nil {
    <mutated>
} else {
    <original>
}
```

Every candidate for a `(file, operator, line)` is recorded — two mutants of one operator can share a line, and two exact mutations beat none. An **empty** body is kept rather than skipped: that is what `RemoveSideEffects` looks like, and dropping it would leave the one operator whose mutation is "nothing" permanently unverifiable.

**`verify-survivor.py` replays it** against the sweep's own test command (read from `config.json`, so a verdict here means what a verdict there means) and reports `SURVIVED` / `KILLED` / `UNVERIFIABLE`. Run twice:

| when | expect | otherwise |
|---|---|---|
| before writing anything | `SURVIVED` | `KILLED` → the finding is stale; close it |
| after writing the test | `KILLED`, by your new suite | your test isn't exercising what it claims |

That second run is `scripts/check-guards.sh`'s rule — a check never seen to fail is not a check — applied to a unit test.

**`docs/mutation-triage.md`** is the protocol: the three legitimate outcomes (one being "no test, here is why"), the loop, why to batch by file, and the traps.

## Verification

**The verifier, end to end against known ground truth** — two mutations whose verdicts I established by hand earlier:

```
SURVIVED      Sources/RunnerCore/ScriptClassification.swift:167 KnownEquivalent
    applied: if needle.isEmpty { return false }
KILLED        Sources/RunnerCore/SuiteExecution.swift:86 KnownCovered
    failed: SuiteExecutionTests
```

The unreachable empty-needle guard survives; the `willRun` deletion dies in the suite that covers it — which also exercises the empty-mutation deletion path. Source restored cleanly.

**The extraction tests were vacuous until they weren't.** The brace scanner skips string literals and comments, because a mutation containing an unmatched brace in a string would otherwise be truncated and recorded mangled — worse than absent, since somebody acts on it. My first fixture used a *balanced* `"{"`/`"}"` pair, so a naive brace counter passed it by accident. Changed to an unmatched brace, the naive implementation now fails with exactly the corruption in view:

```
AssertionError: 'return a || b ? "' != 'return a || b ? "}" : "end"'
```

- `python3 -m unittest discover -s Tools/mutation -p '*_test.py'` — 28 passing (was 23)
- Each new test seen to fail against the naive scanner before being kept

## Not addressed here

Run 4's record predates this, so its 95 survivors carry no `mutations` and the verifier reports them `UNVERIFIABLE` rather than approximating. Next Tuesday's run is the first with reproducible survivors. That is the honest behaviour — an invented mutation would be acted on.

Refs #1447. Survivor list: #1461.

---
_Generated by [Claude Code](https://claude.ai/code/session_0136amKs8tbCmVhi4cMSY1en)_