### PR TITLE
fix(mutation): apply survivors by content; cover the Java and Racket literal renderers

### DIFF
--- a/Tests/CoreTests/JSONValueJavaLiteralTests.swift
+++ b/Tests/CoreTests/JSONValueJavaLiteralTests.swift
@@ -1,0 +1,221 @@
+// Tests/CoreTests/JSONValueJavaLiteralTests.swift
+//
+// The Java literal renderer and its companion type classifier, neither of
+// which had a test anywhere in the tree before this file: `javaLiteral` and
+// `javaDeclaredType` appeared under `Sources/` and nowhere under `Tests/`.
+// The 2026-08-19 mutation sweep reported all sixteen of their mutants as
+// survivors, which for code no test references is the only answer it could
+// have given.
+//
+// `JavaLiteralTypingTests` below is named by `JSONValueJavaLiteral.swift`'s own
+// doc comment as the thing that "pins that every `javaLiteral` output
+// classifies to a type that actually holds it". It did not exist. The round
+// trip it describes is worth pinning for the reason the doc gives — declaring
+// every field `Object` does not compile at the call site, so the classifier's
+// answers decide whether a generated test builds at all — so the suite is
+// written here under the name already documented rather than under a new one.
+//
+// Each test names the mutation it was written to kill.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct JSONValueJavaLiteralTests {
+
+    /// Kills the `SwapTernary` at the `.bool` case.
+    @Test func booleansRenderAsJavaKeywords() {
+        #expect(JSONValue.bool(true).javaLiteral == "true")
+        #expect(JSONValue.bool(false).javaLiteral == "false")
+    }
+
+    @Test func nullRendersAsJavasNull() {
+        #expect(JSONValue.null.javaLiteral == "null")
+    }
+
+    /// Kills the `ChangeLogicalConnector`, both `RelationalOperatorReplacement`
+    /// candidates and the `SwapTernary` on the int-width guard — the one place
+    /// in this renderer where a wrong answer fails to BUILD rather than
+    /// producing a wrong value. Java widens `int` to `long` but never narrows,
+    /// so an `L` suffix on a value that fits in `int` makes "possible lossy
+    /// conversion" of every call into a student's `f(int x)`.
+    ///
+    /// The boundaries are tested exactly, not approximately: a mutant that
+    /// shifts `>` to `>=` is invisible to any test that only checks a value
+    /// well inside the range.
+    @Test func intsTakeTheLongSuffixOnlyPastInt32() {
+        #expect(JSONValue.int(0).javaLiteral == "0")
+        #expect(JSONValue.int(1).javaLiteral == "1")
+        #expect(JSONValue.int(-1).javaLiteral == "-1")
+        // Exactly at the boundaries: still `int`.
+        #expect(JSONValue.int(2_147_483_647).javaLiteral == "2147483647")
+        #expect(JSONValue.int(-2_147_483_648).javaLiteral == "-2147483648")
+        // One step past, in both directions: now `long`.
+        #expect(JSONValue.int(2_147_483_648).javaLiteral == "2147483648L")
+        #expect(JSONValue.int(-2_147_483_649).javaLiteral == "-2147483649L")
+    }
+
+    /// Kills the `SwapTernary` and the FIRST `ChangeLogicalConnector` on the
+    /// double guard: an integral double must keep its point or the literal
+    /// changes type, and it must not gain a second one.
+    @Test func integralDoublesKeepTheirPoint() {
+        #expect(JSONValue.double(2).javaLiteral == "2.0")
+        #expect(JSONValue.double(-4).javaLiteral == "-4.0")
+        #expect(JSONValue.double(1.5).javaLiteral == "1.5")
+    }
+
+    /// Kills the SECOND `ChangeLogicalConnector` on that guard, which the
+    /// integral cases cannot reach because they satisfy the first term and
+    /// short-circuit.
+    @Test func exponentialDoublesAreNotGivenASpuriousPoint() {
+        #expect(JSONValue.double(1e-5).javaLiteral == "1e-05")
+        #expect(JSONValue.double(1e20).javaLiteral == "1e+20")
+    }
+
+    @Test func nonFiniteDoublesUseTheBoxedConstants() {
+        #expect(JSONValue.double(.nan).javaLiteral == "Double.NaN")
+        #expect(JSONValue.double(.infinity).javaLiteral == "Double.POSITIVE_INFINITY")
+        #expect(JSONValue.double(-.infinity).javaLiteral == "Double.NEGATIVE_INFINITY")
+    }
+
+    /// `Arrays.asList`, always — never `List.of`, which throws on a null
+    /// element and would turn an authored case carrying a JSON null into a
+    /// runtime error. The null case is the one worth pinning, since one form
+    /// for every array is what stops it reaching a branch nobody tested.
+    @Test func arraysAlwaysUseArraysAsList() {
+        #expect(JSONValue.array([]).javaLiteral == "java.util.Arrays.asList()")
+        #expect(JSONValue.array([.int(1), .int(2)]).javaLiteral == "java.util.Arrays.asList(1, 2)")
+        #expect(
+            JSONValue.array([.int(1), .null, .string("x")]).javaLiteral
+                == #"java.util.Arrays.asList(1, null, "x")"#)
+    }
+
+    /// Kills the `RelationalOperatorReplacement` on the key sort. Map equality
+    /// is order-independent, so the ordering is not what makes a test pass —
+    /// it is what makes the generated source stable across runs, and the
+    /// `spec_hash` header depends on that.
+    @Test func objectKeysAreSortedAscending() {
+        #expect(
+            JSONValue.object([:]).javaLiteral
+                == "new java.util.LinkedHashMap<String, Object>()")
+        #expect(
+            JSONValue.object(["b": .int(2), "a": .int(1), "c": .int(3)]).javaLiteral
+                == #"new java.util.LinkedHashMap<String, Object>() {{ put("a", 1); put("b", 2); put("c", 3); }}"#
+        )
+    }
+
+    @Test func stringsTakeCStyleEscapes() {
+        #expect(JSONValue.string("ok").javaLiteral == #""ok""#)
+        #expect(JSONValue.string("a\"b").javaLiteral == #""a\"b""#)
+        #expect(JSONValue.string(#"a\b"#).javaLiteral == #""a\\b""#)
+        #expect(JSONValue.string("a\nb\tc\rd").javaLiteral == #""a\nb\tc\rd""#)
+        // Non-ASCII passes through as UTF-8 source bytes.
+        #expect(JSONValue.string("é").javaLiteral == #""é""#)
+    }
+
+    /// Kills the `ChangeLogicalConnector` and both
+    /// `RelationalOperatorReplacement` candidates in the string encoder's
+    /// control-character guard.
+    ///
+    /// The escapes are three-digit OCTAL, and the renderer's doc explains the
+    /// rule that forces it: Java processes a backslash-u escape in the lexer,
+    /// before it knows what a string literal is, so the one for a newline
+    /// becomes a real line break mid-string and the file fails to compile.
+    /// This test is therefore also the guard against anyone "simplifying" the
+    /// encoder to match its five siblings.
+    @Test func controlCharactersUseThreeDigitOctalNeverUnicodeEscapes() {
+        #expect(JSONValue.string("a\u{01}b").javaLiteral == #""a\001b""#)
+        #expect(JSONValue.string("a\u{00}b").javaLiteral == #""a\000b""#)
+        #expect(JSONValue.string("a\u{1F}b").javaLiteral == #""a\037b""#)
+        // 0x7F is above the 0x20 floor, so it is the second term's own case.
+        #expect(JSONValue.string("a\u{7F}b").javaLiteral == #""a\177b""#)
+        // 0x20 itself is printable and must survive as a space.
+        #expect(JSONValue.string("a b").javaLiteral == #""a b""#)
+        // Whatever else changes, a backslash-u escape must never be emitted.
+        for scalar in UInt32(0)...UInt32(0x7F) {
+            guard let u = Unicode.Scalar(scalar) else { continue }
+            #expect(!JSONValue.string(String(Character(u))).javaLiteral.contains(#"\u"#))
+        }
+    }
+}
+
+/// The round trip `JSONValueJavaLiteral.swift` already documents: every
+/// `javaLiteral` output must classify to a Java type that actually holds it.
+///
+/// This matters at the point `_ck_inputs.java` is written, where the value is
+/// gone and only its rendered source remains — so the classifier reads text,
+/// and a wrong answer is a compile error in a generated file rather than a
+/// wrong mark. The sweep found four of its five branches unpinned.
+@Suite struct JavaLiteralTypingTests {
+
+    /// Kills the `RelationalOperatorReplacement` at the null branch and both
+    /// the `ChangeLogicalConnector` and the two `RelationalOperatorReplacement`
+    /// candidates at the boolean branch.
+    ///
+    /// Note the asymmetry: negating the null test does NOT change the answer
+    /// for `null` itself, which reaches the same `Object` through the trailing
+    /// fallback. It changes the answer for everything else, so `true` and
+    /// `false` are what detect it — and both are needed, since each mutant of
+    /// the boolean branch spares one of them.
+    @Test func scalarLiteralsClassifyToPrimitives() {
+        #expect(javaDeclaredType(forLiteral: "null") == "Object")
+        #expect(javaDeclaredType(forLiteral: "true") == "boolean")
+        #expect(javaDeclaredType(forLiteral: "false") == "boolean")
+        #expect(javaDeclaredType(forLiteral: #""hi""#) == "String")
+        #expect(javaDeclaredType(forLiteral: "Double.NaN") == "double")
+    }
+
+    /// Kills the `SwapTernary` on the sign strip. Swapped, a negative literal
+    /// keeps its sign and fails the `isNumber` test while a positive one loses
+    /// its first digit — so both signs are needed, and both fall through to
+    /// `Object`, which compiles but will not pass to a student's `f(int x)`.
+    @Test func signedNumbersClassifyByWidthNotBySign() {
+        #expect(javaDeclaredType(forLiteral: "5") == "int")
+        #expect(javaDeclaredType(forLiteral: "-5") == "int")
+        #expect(javaDeclaredType(forLiteral: "2147483648L") == "long")
+        #expect(javaDeclaredType(forLiteral: "-2147483649L") == "long")
+        #expect(javaDeclaredType(forLiteral: "2.0") == "double")
+        #expect(javaDeclaredType(forLiteral: "-2.0") == "double")
+        #expect(javaDeclaredType(forLiteral: "1e-05") == "double")
+    }
+
+    @Test func containersClassifyToTheirInterfaces() {
+        #expect(
+            javaDeclaredType(forLiteral: "java.util.Arrays.asList(1, 2)")
+                == "java.util.List<Object>")
+        #expect(
+            javaDeclaredType(forLiteral: "new java.util.LinkedHashMap<String, Object>()")
+                == "java.util.Map<String, Object>")
+    }
+
+    /// An unrecognised shape falls back to `Object` — the safe direction, per
+    /// the renderer's doc: it compiles for any use that does not need a
+    /// primitive.
+    @Test func unrecognisedShapesFallBackToObject() {
+        #expect(javaDeclaredType(forLiteral: "someIdentifier") == "Object")
+        #expect(javaDeclaredType(forLiteral: "") == "Object")
+    }
+
+    /// The round trip itself, over one value of every `JSONValue` case. This
+    /// is the assertion the renderer's doc claims exists; the per-branch tests
+    /// above are what make each mutation individually visible.
+    @Test(arguments: [
+        (JSONValue.null, "Object"),
+        (JSONValue.bool(true), "boolean"),
+        (JSONValue.int(5), "int"),
+        (JSONValue.int(-5), "int"),
+        (JSONValue.int(2_147_483_648), "long"),
+        (JSONValue.double(2), "double"),
+        (JSONValue.double(1e-5), "double"),
+        (JSONValue.double(.nan), "double"),
+        (JSONValue.string("hi"), "String"),
+        (JSONValue.array([.int(1)]), "java.util.List<Object>"),
+        (JSONValue.object(["a": .int(1)]), "java.util.Map<String, Object>"),
+    ])
+    func everyRenderedLiteralClassifiesToATypeThatHoldsIt(
+        value: JSONValue, expected: String
+    ) {
+        #expect(javaDeclaredType(forLiteral: value.javaLiteral) == expected)
+    }
+}

--- a/Tests/CoreTests/JSONValueRacketLiteralTests.swift
+++ b/Tests/CoreTests/JSONValueRacketLiteralTests.swift
@@ -1,0 +1,125 @@
+// Tests/CoreTests/JSONValueRacketLiteralTests.swift
+//
+// The Racket literal renderer, which until this file had no test anywhere in
+// the tree — `racketLiteral` appeared under `Sources/` and nowhere under
+// `Tests/`. The 2026-08-19 mutation sweep reported all seven of its mutants as
+// survivors for exactly that reason, and unreachable code is not a borderline
+// call: no test referenced the property, so no test could tell the difference
+// when it changed.
+//
+// Racket is the opposite of C++ here (see the renderer's own doc): dynamically
+// typed, so nothing is unrenderable and there is no refusal table to pin. What
+// there is to pin is the spelling of each form, and every expectation below is
+// Racket reader syntax rather than a convention chosen here.
+//
+// Each test names the mutation it was written to kill, so a later reader can
+// tell which expectations are load-bearing and which are scaffolding.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct JSONValueRacketLiteralTests {
+
+    /// Kills the `SwapTernary` at the `.bool` case: `#t` and `#f` are not
+    /// interchangeable, and a swapped pair inverts every generated boolean
+    /// expectation while still producing a legal Racket program.
+    @Test func booleansUseRacketReaderSyntax() {
+        #expect(JSONValue.bool(true).racketLiteral == "#t")
+        #expect(JSONValue.bool(false).racketLiteral == "#f")
+    }
+
+    /// `'null`, not `'()` and not `#f` — the renderer's doc explains why each
+    /// of those would collide with a value an expectation could legitimately
+    /// want.
+    @Test func nullIsTheSymbolRacketsJSONReaderProduces() {
+        #expect(JSONValue.null.racketLiteral == "'null")
+    }
+
+    @Test func integersRenderBare() {
+        #expect(JSONValue.int(0).racketLiteral == "0")
+        #expect(JSONValue.int(42).racketLiteral == "42")
+        #expect(JSONValue.int(-7).racketLiteral == "-7")
+        // Racket integers are arbitrary precision, so the C++/Java suffix
+        // question has no analogue: past int32 is still a bare literal.
+        #expect(JSONValue.int(2_147_483_648).racketLiteral == "2147483648")
+    }
+
+    /// Kills the `SwapTernary` and the FIRST `ChangeLogicalConnector` on the
+    /// flonum guard. `2.0` must not read as the exact integer `2`, and it must
+    /// not gain a second point either — `equal?` distinguishes `2` from `2.0`,
+    /// so both directions are a wrong mark rather than a crash.
+    @Test func integralDoublesStayFlonums() {
+        #expect(JSONValue.double(2).racketLiteral == "2.0")
+        #expect(JSONValue.double(-4).racketLiteral == "-4.0")
+        #expect(JSONValue.double(1.5).racketLiteral == "1.5")
+    }
+
+    /// Kills the SECOND `ChangeLogicalConnector` on the same guard, which the
+    /// integral-double cases above cannot reach: they satisfy the first term
+    /// and short-circuit. A double whose Swift description is exponential
+    /// carries no `.`, so it exercises the `contains("e")` term alone.
+    @Test func exponentialDoublesAreNotGivenASpuriousPoint() {
+        #expect(JSONValue.double(1e-5).racketLiteral == "1e-05")
+        #expect(JSONValue.double(1e20).racketLiteral == "1e+20")
+    }
+
+    @Test func nonFiniteDoublesUseTheReaderSpellings() {
+        #expect(JSONValue.double(.nan).racketLiteral == "+nan.0")
+        #expect(JSONValue.double(.infinity).racketLiteral == "+inf.0")
+        #expect(JSONValue.double(-.infinity).racketLiteral == "-inf.0")
+    }
+
+    /// Kills the `SwapTernary` on the array case. An empty list is `(list)`,
+    /// and the swapped form renders it `(list )` while rendering every
+    /// non-empty array as the empty list — silently dropping every element.
+    @Test func arraysRenderAsListApplications() {
+        #expect(JSONValue.array([]).racketLiteral == "(list)")
+        #expect(JSONValue.array([.int(1)]).racketLiteral == "(list 1)")
+        #expect(
+            JSONValue.array([.int(1), .string("x"), .bool(false)]).racketLiteral
+                == #"(list 1 "x" #f)"#)
+        // `(list ...)` rather than a quoted `'(...)` so a nested form is
+        // evaluated rather than rendered as literal source text.
+        #expect(
+            JSONValue.array([.array([.int(1)])]).racketLiteral == "(list (list 1))")
+    }
+
+    /// Kills the `RelationalOperatorReplacement` on the key sort. Key order is
+    /// not cosmetic: `JSONValue.object` is a Dictionary, so without the sort
+    /// the generated source differs run to run and the `spec_hash` header that
+    /// makes manifest bytes change when a case changes stops meaning anything.
+    @Test func objectKeysAreSortedAscending() {
+        #expect(JSONValue.object([:]).racketLiteral == "(hash)")
+        #expect(
+            JSONValue.object(["b": .int(2), "a": .int(1), "c": .int(3)]).racketLiteral
+                == #"(hash "a" 1 "b" 2 "c" 3)"#)
+    }
+
+    @Test func stringsTakeRacketsEscapeSet() {
+        #expect(JSONValue.string("ok").racketLiteral == #""ok""#)
+        #expect(JSONValue.string("a\"b").racketLiteral == #""a\"b""#)
+        #expect(JSONValue.string(#"a\b"#).racketLiteral == #""a\\b""#)
+        #expect(JSONValue.string("a\nb\tc\rd").racketLiteral == #""a\nb\tc\rd""#)
+        // Racket has no `\/`, so a solidus passes through unescaped where the
+        // JSON escape set would allow escaping it.
+        #expect(JSONValue.string("a/b").racketLiteral == #""a/b""#)
+        // Racket source is UTF-8: printable non-ASCII needs no escape.
+        #expect(JSONValue.string("é").racketLiteral == #""é""#)
+    }
+
+    /// Kills the `ChangeLogicalConnector` in the string encoder's control
+    /// character guard. Under `&&` no scalar satisfies both terms, so every
+    /// control character is embedded raw — which for a stray NUL makes the
+    /// generated file unparseable rather than merely unreadable.
+    @Test func controlCharactersAreEscapedIncludingDEL() {
+        #expect(JSONValue.string("a\u{01}b").racketLiteral == #""a\u0001b""#)
+        #expect(JSONValue.string("a\u{00}b").racketLiteral == #""a\u0000b""#)
+        #expect(JSONValue.string("a\u{1F}b").racketLiteral == #""a\u001Fb""#)
+        // 0x7F is above the 0x20 floor, so it is the second term's own case.
+        #expect(JSONValue.string("a\u{7F}b").racketLiteral == #""a\u007Fb""#)
+        // 0x20 itself is printable and must survive as a space.
+        #expect(JSONValue.string("a b").racketLiteral == #""a b""#)
+    }
+}

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -91,6 +91,51 @@ def _skip_to_matching_brace(text: str, open_idx: int) -> int:
     return -1
 
 
+def _trailing_else_body(text: str, after_branch: int) -> str | None:
+    """The `<original>` in the final `else` of a schema chain, or None.
+
+    WHY THE ORIGINAL IS WORTH AS MUCH AS THE MUTATION. A mutation on its own can
+    only be applied by POSITION, and Muter's positions are known-wrong -- this
+    file's own report says so. Measured against run 32255707345: the reported
+    line holds the whole mutated statement for 15 of 84 candidates and something
+    else entirely for the other 69, because Muter records the ENCLOSING
+    statement (often a whole computed-property body) while the line points at
+    one operator inside it. Splicing that onto the reported line deletes a `case`
+    label or comments out the rest of the line, and the compile error that
+    follows reads as a failing suite -- which is to say, as "already covered".
+
+    With the original in hand the replacement is exact and needs no position at
+    all: find this text, put that text there. The chain is walked rather than
+    regex-matched because `else if` branches nest arbitrarily and each carries a
+    mutation of its own.
+    """
+    i, n = after_branch, len(text)
+    while i < n:
+        while i < n and text[i].isspace():
+            i += 1
+        if not text.startswith("else", i):
+            return None
+        i += 4
+        while i < n and text[i].isspace():
+            i += 1
+        if text.startswith("if", i):
+            brace = text.find("{", i)
+            if brace < 0:
+                return None
+            end = _skip_to_matching_brace(text, brace)
+            if end < 0:
+                return None
+            i = end
+            continue
+        if i < n and text[i] == "{":
+            end = _skip_to_matching_brace(text, i)
+            if end < 0:
+                return None
+            return text[i + 1 : end - 1].strip()
+        return None
+    return None
+
+
 def harvest_schemata(mutated_root: str) -> tuple[dict[tuple[str, str], list[int]], dict]:
     """Read the mutated copy: true mutant positions AND the mutation itself.
 
@@ -148,9 +193,17 @@ def harvest_schemata(mutated_root: str) -> tuple[dict[tuple[str, str], list[int]
                 # whose mutation is "nothing" permanently unverifiable, and the
                 # events it deletes are exactly the kind nothing asserts on.
                 body = text[brace + 1 : end - 1].strip()
-                mutations.setdefault((stem, operator, line), []).append(
-                    {"column": int(col), "offset": int(off), "mutated": body}
-                )
+                # The ORIGINAL, from the chain's trailing `else`. This is what
+                # lets a verifier replace by CONTENT rather than by Muter's
+                # known-wrong line number -- see `_trailing_else_body`. It may
+                # legitimately be absent (a malformed or unterminated chain), in
+                # which case the mutation is recorded without one and the
+                # verifier refuses it rather than applying it blind.
+                original = _trailing_else_body(text, end)
+                record = {"column": int(col), "offset": int(off), "mutated": body}
+                if original is not None:
+                    record["original"] = original
+                mutations.setdefault((stem, operator, line), []).append(record)
     return (
         {k: sorted(v) for k, v in positions.items()},
         {k: sorted(v, key=lambda d: d["offset"]) for k, v in mutations.items()},

--- a/Tools/mutation/report_test.py
+++ b/Tools/mutation/report_test.py
@@ -177,5 +177,44 @@ class RecordedMutationTests(unittest.TestCase):
         self.assertTrue(all(s["mutations"] == [] for s in summary["survivors"]))
 
 
+
+class OriginalCaptureTests(unittest.TestCase):
+    """The schema's trailing `else` must reach the run record.
+
+    Without it a verifier can only apply a mutation by POSITION, and Muter's
+    positions are the ones this file's own report calls known-wrong. The
+    consequence is not a missing verdict but a WRONG one: the mis-applied edit
+    fails to compile, the suite goes red, and red reads as "already covered".
+    """
+
+    def test_the_record_carries_the_original_for_each_mutation(self):
+        code, _report, summary = run(RAW, MUTATED)
+        self.assertEqual(code, 0)
+        muts = summary["survivors"][0]["mutations"]
+        self.assertTrue(muts, "no mutation recorded")
+        self.assertEqual(muts[0]["mutated"], 'return a || b ? "}" : "end"')
+        self.assertEqual(muts[0]["original"], 'return a && b ? "}" : "end"')
+
+    def test_the_original_survives_an_else_if_chain(self):
+        """Two mutants of one statement share one chain; the original is last."""
+        chained = (
+            'import class Foundation.ProcessInfo\n'
+            'if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"]'
+            ' != nil {\n'
+            '    return a || b ? "}" : "end"\n'
+            '} else if ProcessInfo.processInfo.environment'
+            '["Probe_ChangeLogicalConnector_10_9_124"] != nil {\n'
+            '    return a && b ? "}" : "other"\n'
+            '} else {\n'
+            '    return a && b ? "}" : "end"\n'
+            '}\n'
+        )
+        _code, _report, summary = run(RAW, chained)
+        muts = summary["survivors"][0]["mutations"]
+        self.assertEqual(len(muts), 2)
+        for m in muts:
+            self.assertEqual(m["original"], 'return a && b ? "}" : "end"')
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/mutation/verify-survivor.py
+++ b/Tools/mutation/verify-survivor.py
@@ -48,6 +48,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 
@@ -82,35 +83,107 @@ def pick(survivors: list[dict], path: str, line: int, operator: str | None) -> l
     ]
 
 
-def apply_mutation(source_path: str, line: int, mutated: str) -> str | None:
-    """Replace the statement at `line` with the mutation. Returns the original.
+def whole_line_is_the_statement(current: str, mutated: str) -> bool:
+    """Whether replacing the whole of `current` with `mutated` is faithful.
 
-    Muter records the mutated STATEMENT, so the replacement is line-oriented and
-    only safe when the target line still looks like what was mutated. Returning
-    None rather than editing on a mismatch is deliberate: a verifier that
-    silently mutates the wrong line reports a verdict about code nobody asked
-    about.
+    Only true when the line holds exactly the statement that was mutated. The
+    counter-examples are the common ones, not exotica: `case .equals: return lhs
+    == value` loses its `case` label, a continuation line like `|| $0.signal ==
+    .gradeJumpPercent` gets the whole expression pasted beside the half already
+    above it, and a mutation whose recorded text opens with `//` comments out
+    whatever followed on the line.
+    """
+    if not mutated.strip() or len(mutated.splitlines()) != 1:
+        return False
+    cur, mut = " ".join(current.split()), " ".join(mutated.split())
+    if mut.startswith("//"):
+        return False
+    # One token differs (the mutated operator) and nothing else moves, so the
+    # token count and the punctuation that frames a statement must both match.
+    return len(cur.split()) == len(mut.split()) and cur.count(":") == mut.count(":")
+
+
+def apply_mutation(source_path: str, line: int, mutated: str, original: str | None) -> str | None:
+    """Apply the mutation to the file, returning the file's previous contents.
+
+    PREFER CONTENT OVER POSITION. When the run record carries the schema's
+    `original` -- the trailing `else` of Muter's chain -- the edit is an exact
+    textual swap and Muter's line number is not consulted at all. That matters
+    because those line numbers are known-wrong: `report.py` says so in the issue
+    body it writes, and measured against run 32255707345 only 15 of 84
+    candidates had the mutated statement actually occupying the reported line.
+
+    Returning None rather than editing is the whole safety property here. A
+    mis-applied mutation does not fail honestly -- it fails to COMPILE, the
+    suite goes red, and the caller reads that as `KILLED`, which the protocol
+    spells "already covered, do not write a test". Silently discarding a real
+    gap is the one outcome mutation testing exists to prevent.
     """
     with open(source_path) as fh:
-        lines = fh.readlines()
+        text = fh.read()
+
+    if original is not None and original.strip():
+        # Exact swap. Ambiguity is refused: two identical statements in one file
+        # mean the record cannot say which one Muter mutated.
+        if text.count(original) != 1:
+            return None
+        with open(source_path, "w") as fh:
+            fh.write(text.replace(original, mutated))
+        return text
+
+    lines = text.splitlines(keepends=True)
     if not 1 <= line <= len(lines):
         return None
-    original = "".join(lines)
     if not mutated.strip():
-        # RemoveSideEffects: the mutation IS the absence of the statement.
+        # RemoveSideEffects: the mutation IS the absence of the statement. Only
+        # safe positionally when the record names the deleted statement's own
+        # line, which without an `original` cannot be confirmed -- so this is
+        # allowed only when the line is a single self-contained statement.
+        if lines[line - 1].strip().endswith(("{", "}")):
+            return None
         del lines[line - 1]
-    else:
+    elif whole_line_is_the_statement(lines[line - 1], mutated):
         indent = re.match(r"\s*", lines[line - 1]).group(0)
-        body = "\n".join(indent + ln.lstrip() if ln.strip() else ln for ln in mutated.splitlines())
-        lines[line - 1] = body + "\n"
+        lines[line - 1] = indent + mutated.strip() + "\n"
+    else:
+        return None
     with open(source_path, "w") as fh:
         fh.writelines(lines)
-    return original
+    return text
 
 
 def run_suite(cmd: list[str]) -> tuple[int, str]:
     proc = subprocess.run(cmd, cwd=REPO, capture_output=True, text=True, timeout=7200)
     return proc.returncode, proc.stdout + proc.stderr
+
+
+def _restore_on_signal(source_path: str, backup: str) -> None:
+    """Put the file back if this process is killed while a mutation is applied.
+
+    A suite run here is minutes long, so Ctrl-C during one is ordinary. Without
+    this the interrupt leaves a mutated source in the working tree, which then
+    looks like an edit the author made -- and the mutations are by construction
+    the kind that still compile and still pass.
+    """
+
+    def handler(signum, _frame):
+        with open(source_path, "w") as fh:
+            fh.write(backup)
+        sys.exit(128 + signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, handler)
+
+
+def tests_actually_ran(output: str) -> bool:
+    """Whether the suite ran at all, as opposed to failing to build.
+
+    `swift test` exits non-zero for both, and the difference is the difference
+    between "a test caught this" and "this is not valid Swift". Reading the
+    second as the first is how a mis-applied mutation reports `KILLED` and a
+    real gap gets closed as already-covered.
+    """
+    return "Test run with" in output or "Executed" in output
 
 
 def failing_suites(output: str) -> list[str]:
@@ -143,9 +216,18 @@ def verify_one(survivor: dict, cmd: list[str], quiet: bool) -> int:
     for i, mut in enumerate(muts, 1):
         tag = f"{label}" + (f"  [candidate {i} of {len(muts)}]" if len(muts) > 1 else "")
         shown = " ".join(mut["mutated"].split())[:150] or "<statement deleted>"
-        backup = apply_mutation(source_path, line, mut["mutated"])
+        backup = apply_mutation(source_path, line, mut["mutated"], mut.get("original"))
+        if backup is not None:
+            _restore_on_signal(source_path, backup)
         if backup is None:
-            print(f"UNVERIFIABLE  {tag}\n    Line {line} is out of range; the source has moved.")
+            print(f"UNVERIFIABLE  {tag}")
+            if mut.get("original"):
+                print("    The recorded original does not appear exactly once in the file;")
+                print("    the source has moved since the sweep. Re-run the sweep.")
+            else:
+                print("    This record carries no `original`, and the mutated statement is")
+                print(f"    not what line {line} holds, so it cannot be applied faithfully.")
+                print("    Re-run the sweep to record originals; do NOT edit by hand.")
             worst = max(worst, 2)
             continue
         try:
@@ -153,6 +235,13 @@ def verify_one(survivor: dict, cmd: list[str], quiet: bool) -> int:
         finally:
             with open(source_path, "w") as fh:
                 fh.write(backup)
+        if code != 0 and not tests_actually_ran(output):
+            print(f"UNVERIFIABLE  {tag}")
+            print(f"    applied: {shown}")
+            print("    The mutated source did not build, so no test graded it. This is")
+            print("    a bad mutation record or a moved source -- NOT a kill.")
+            worst = max(worst, 2)
+            continue
         if code == 0:
             print(f"SURVIVED      {tag}")
             print(f"    applied: {shown}")

--- a/Tools/mutation/verify_survivor_test.py
+++ b/Tools/mutation/verify_survivor_test.py
@@ -1,0 +1,171 @@
+"""Self-test for verify-survivor.py's application and verdict rules.
+
+WHY THIS FILE EXISTS. The verifier's whole job is to answer one question
+honestly, and as first written it could answer it backwards. It applied a
+mutation by REPLACING THE REPORTED LINE, but Muter records the enclosing
+statement while its line number points at one operator inside it -- so for
+`case .equals: return lhs == value` the edit dropped the `case` label, the file
+stopped compiling, `swift test` went red, and the verifier read red as `KILLED`.
+Under docs/mutation-triage.md, `KILLED` means "the finding is stale, close it".
+A real gap therefore closed itself.
+
+Measured against run 32255707345: 15 of 84 candidates had the mutated statement
+actually occupying the reported line. The other 69 would have been mis-applied,
+and the two that were run by hand before the fix confirmed both failure
+directions -- L80 and L118 reported `KILLED` on a compile error, while L117
+reported `SURVIVED` for source that was the mutant PLUS a leftover continuation
+line.
+
+So the rules under test are the two that make a wrong answer impossible:
+replace by content when the record carries the original, and never call a
+build failure a kill.
+"""
+
+import importlib.util
+import os
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# The module has a hyphen in its name, so it cannot be imported by name.
+_spec = importlib.util.spec_from_file_location(
+    "verify_survivor", os.path.join(HERE, "verify-survivor.py")
+)
+verify = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(verify)
+
+
+class WholeLineGuardTests(unittest.TestCase):
+    """The gate that decides whether a positional edit is even allowed.
+
+    Every case here is taken from a real survivor in run 32255707345, not
+    invented: each one was mis-applied by the unguarded implementation.
+    """
+
+    def test_rejects_a_line_whose_statement_is_behind_a_case_label(self):
+        # AchievementEvaluation.swift:80. Replacing the line deletes `case
+        # .equals:` and the switch stops compiling.
+        self.assertFalse(
+            verify.whole_line_is_the_statement(
+                "        case .equals: return lhs == value", "return lhs != value"
+            )
+        )
+
+    def test_rejects_a_continuation_line(self):
+        # AchievementEvaluation.swift:118. The mutation is the whole three-term
+        # expression; the line is its trailing `||` clause.
+        self.assertFalse(
+            verify.whole_line_is_the_statement(
+                "                || $0.signal == .gradeJumpPercent",
+                "$0.signal == .attempts || $0.signal == .executionTimeMs "
+                "&& $0.signal == .gradeJumpPercent",
+            )
+        )
+
+    def test_rejects_a_mutation_that_opens_with_a_comment(self):
+        # JSONValue.swift:65 and friends: Muter records the statement together
+        # with its leading comment. Spliced onto one line, `//` comments out
+        # everything after it and the edit silently deletes code.
+        self.assertFalse(
+            verify.whole_line_is_the_statement(
+                '        return (s.contains(".")) ? s : s + ".0"',
+                '// Ensure the literal parses as a Python float\nreturn s',
+            )
+        )
+
+    def test_rejects_a_multi_line_mutation(self):
+        self.assertFalse(
+            verify.whole_line_is_the_statement(
+                "        let pairs = o.sorted { $0.key < $1.key }",
+                "guard !o.isEmpty else { return nil }\nlet pairs = o.sorted { $0.key > $1.key }",
+            )
+        )
+
+    def test_allows_a_line_that_is_exactly_the_mutated_statement(self):
+        # AchievementEvaluation.swift:130, the one shape that applied correctly.
+        self.assertTrue(
+            verify.whole_line_is_the_statement(
+                "        scope == .individual && reward.type == .badge && !usesDynamicSignal",
+                "scope == .individual || reward.type == .badge && !usesDynamicSignal",
+            )
+        )
+
+
+class ApplyMutationTests(unittest.TestCase):
+
+    SOURCE = (
+        "struct S {\n"
+        "    private func compare(_ lhs: Double) -> Bool {\n"
+        "        switch comparator {\n"
+        "        case .atLeast: return lhs >= value\n"
+        "        case .equals: return lhs == value\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+
+    def _write(self, text=None):
+        fh = tempfile.NamedTemporaryFile("w", suffix=".swift", delete=False)
+        fh.write(self.SOURCE if text is None else text)
+        fh.close()
+        self.addCleanup(os.unlink, fh.name)
+        return fh.name
+
+    def test_original_drives_an_exact_swap_ignoring_the_line_number(self):
+        """The point of recording the original: position stops mattering.
+
+        The line number passed here is deliberately wrong -- Muter's often is --
+        and the edit must still land on the right statement.
+        """
+        path = self._write()
+        backup = verify.apply_mutation(
+            path, 999, "return lhs != value", "return lhs == value"
+        )
+        self.assertIsNotNone(backup)
+        with open(path) as fh:
+            after = fh.read()
+        self.assertIn("case .equals: return lhs != value", after)
+        self.assertIn("case .atLeast: return lhs >= value", after)
+
+    def test_ambiguous_original_is_refused_rather_than_guessed(self):
+        path = self._write(
+            "let a = x == y\nlet b = x == y\n"
+        )
+        self.assertIsNone(verify.apply_mutation(path, 1, "x != y", "x == y"))
+
+    def test_without_an_original_a_mismatched_line_is_refused(self):
+        """The regression this file exists for.
+
+        Before the fix this produced a file with the `case` label deleted, which
+        does not compile, which was then reported as a kill.
+        """
+        path = self._write()
+        self.assertIsNone(verify.apply_mutation(path, 5, "return lhs != value", None))
+        with open(path) as fh:
+            self.assertEqual(fh.read(), self.SOURCE)
+
+
+class VerdictTests(unittest.TestCase):
+
+    def test_a_build_failure_is_not_a_test_run(self):
+        output = (
+            "Building for debugging...\n"
+            "Sources/Core/AchievementEvaluation.swift:80:9: error: "
+            "'return' is not allowed outside of a case\n"
+            "error: fatalError\n"
+        )
+        self.assertFalse(verify.tests_actually_ran(output))
+
+    def test_a_real_failing_run_is_a_test_run(self):
+        output = (
+            "✘ Test foo() recorded an issue\n"
+            "✘ Suite AchievementTests failed after 0.1 seconds.\n"
+            "✘ Test run with 719 tests in 84 suites failed after 9.6 seconds.\n"
+        )
+        self.assertTrue(verify.tests_actually_ran(output))
+        self.assertEqual(verify.failing_suites(output), ["AchievementTests"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/changelog.d/mutation-triage-java-racket-literals.md
+++ b/changelog.d/mutation-triage-java-racket-literals.md
@@ -1,0 +1,16 @@
+### Added
+
+- **The Java and Racket literal renderers now have tests.** `javaLiteral`,
+  `javaDeclaredType` and `racketLiteral` appeared under `Sources/` and nowhere
+  under `Tests/`, so the 2026-08-19 mutation sweep reported all 23 of their
+  mutants as survivors — the answer it must give for code no test references.
+  `JSONValueJavaLiteralTests` and `JSONValueRacketLiteralTests` pin the
+  behaviours those mutants poke at: the `int`/`long` boundary exactly at
+  `Int32.max` and `Int32.min` (where a wrong answer is a compile error in the
+  generated test, not a wrong mark), integral and exponential doubles keeping
+  exactly one decimal point, sorted object keys, `Arrays.asList` admitting
+  nulls, `(list)` versus `(list …)`, and control-character escaping — Java's in
+  three-digit octal, never a backslash-u escape the lexer would eat.
+  `JavaLiteralTypingTests`, which `JSONValueJavaLiteral.swift`'s own doc comment
+  already cited as pinning the literal-to-declared-type round trip, did not
+  exist; it does now, under the name the doc already used.

--- a/changelog.d/mutation-verifier-applies-by-content.md
+++ b/changelog.d/mutation-verifier-applies-by-content.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **The mutation verifier could report a real gap as already covered.**
+  `verify-survivor.py` applied a recorded mutation by replacing Muter's reported
+  line, but Muter records the *enclosing statement* while its line and column
+  point at one operator inside it — positions `report.py` already calls
+  known-wrong. Measured across run 32255707345, the reported line held the whole
+  mutated statement for 15 of 84 candidates; for the other 69 the edit deleted a
+  `case` label, pasted an expression beside the half already above it, or
+  spliced in text opening with `//`. Those edits do not fail honestly, they fail
+  to compile — and `swift test` going red was read as `KILLED`, which the triage
+  protocol spells "already covered, do not write a test". `report.py` now
+  records each mutation's `original` (the trailing `else` of Muter's schema
+  chain) so the edit is an exact textual swap needing no position at all; the
+  verifier refuses to apply anything it cannot place faithfully, never calls a
+  build failure a kill, and restores the file if it is interrupted mid-run.
+  Records written before this carry no `original` and are now honestly reported
+  `UNVERIFIABLE` rather than silently mis-applied.

--- a/docs/mutation-triage.md
+++ b/docs/mutation-triage.md
@@ -32,8 +32,15 @@ Tools/mutation/verify-survivor.py --run-record MutationReports/<date>-run<id>.js
 
 **Before writing anything — expect `SURVIVED`.**
 `KILLED` means the finding is stale (the code moved, or somebody already covered
-it); close it and move on. `UNVERIFIABLE` means no mutation was recorded, so
-confirm by hand or skip — never approximate one.
+it); close it and move on. `UNVERIFIABLE` means the mutation could not be
+applied faithfully — no mutation was recorded, the recorded original no longer
+appears in the file, or the mutated source did not build. Confirm by hand or
+skip; never approximate one.
+
+**A `KILLED` always names the suite that caught it.** If it says only
+`suite failed`, read that as a bug report against the verifier rather than a
+verdict — it is what a mis-applied mutation used to look like, and the reason
+the applier now refuses rather than guesses (below).
 
 **After writing the test — expect `KILLED`, naming your new suite.**
 If your test passes but the mutant still survives, the test is not exercising
@@ -42,6 +49,24 @@ the behaviour it claims to. That is the whole point of the second run.
 The verifier applies the mutation Muter actually inserted, taken from the run
 record, and runs the sweep's own test command from `Tools/mutation/config.json`
 so a verdict here means what a verdict there means.
+
+**It applies the mutation by CONTENT, not by position, and this is load-bearing.**
+Muter reports a file, a line and a column, and those positions are known-wrong —
+`report.py` says so in the issue body it writes. Muter records the *enclosing
+statement* while the line points at one operator inside it, so replacing the
+reported line is only faithful when that line happens to hold the whole
+statement: measured across run 32255707345, 15 of 84 candidates. For the other
+69 the edit deletes a `case` label, pastes a whole expression beside the half
+already above it, or splices in text that opens with `//` and comments out the
+rest of the line. None of that fails honestly — it fails to COMPILE, the suite
+goes red, and red used to read as `KILLED`, which this protocol spells "already
+covered, do not write a test". A real gap closed itself.
+
+So each mutation is recorded together with its `original` (the trailing `else`
+of Muter's schema chain) and the edit is an exact textual swap. Records written
+before that existed carry no `original`; the verifier refuses them rather than
+falling back to position. **If a whole cluster comes back `UNVERIFIABLE` citing
+a missing `original`, the answer is a fresh sweep, never a hand-edit.**
 
 ## Work by file, not by survivor
 


### PR DESCRIPTION
Two commits from the first triage pass on #1461. The second was found by doing the first, and it is the more urgent of the two. **Happy to split them if you'd rather review separately** — I kept them together only because the branch is the one assigned to this work.

Refs #1447, #1462.

---

## 1. `f8cf08f` — the verifier could close a real gap by itself

`verify-survivor.py` shipped an hour before this and does not do what it says. It applies a recorded mutation by **replacing Muter's reported line** — but Muter records the *enclosing statement* while its line and column point at one operator inside it, and those positions are known-wrong: `report.py` prints exactly that in the issue body it writes.

Measured across run 32255707345: the reported line held the whole mutated statement for **15 of 84 candidates**. For the other 69 the edit deletes a `case` label, pastes a whole expression beside the half already above it, or splices in text opening with `//` that comments out the rest of the line.

None of that fails honestly. It fails to **compile** — `swift test` exits non-zero with no test having run — and the verifier read that as `KILLED`. Under `docs/mutation-triage.md`, `KILLED` means *"the finding is stale; close it and do not write a test."*

Confirmed on three real survivors before the fix:

| survivor | reported | actually |
|---|---|---|
| `AchievementEvaluation:80` | `KILLED` — "already covered" | `case .equals:` label deleted; build failed |
| `AchievementEvaluation:118` | `KILLED` ×2 | expression spliced onto a continuation line; build failed |
| `AchievementEvaluation:117` | `SURVIVED` | compiled, but the source was the mutant **plus** a leftover `\|\| gradeJumpPercent` — a verdict about code nobody asked about |

The applier's own docstring already promised it returned `None` "on a mismatch". No such check existed — it only range-checked the line number.

**Three changes, one per way of being wrong:**

- `report.py` records each mutation's `original` — the trailing `else` of Muter's schema chain, which it already parses and was discarding. The edit becomes an exact textual swap consulting no position at all. Ambiguity (original appearing more than once) is refused.
- `verify-survivor.py` refuses anything it cannot place faithfully, and never calls a build failure a kill — a run in which no test executed is `UNVERIFIABLE`.
- The verifier restores the source on `SIGINT`/`SIGTERM`. A suite run is minutes long, so interrupting one is ordinary; it used to leave a mutated file in the tree — one that by construction still compiles and still passes. (I hit this.)

**Verification.** 12 new tests, every one seen to fail against the previous implementation (10 error on the absent guard, 2 on the absent `original`); 40 passing overall, was 28. End to end on the real record: L80 and L118 now report `UNVERIFIABLE` naming the missing `original`, while L103 and L130 — the shapes that were always faithful — still build, run, and report `SURVIVED` with the applied text shown. Working tree clean after every run.

**Consequence you should know about:** records written before this carry no `original`, so the remaining #1461 clusters are now honestly `UNVERIFIABLE` and need a fresh sweep. The fix cannot recover positions that were never right. That is why the triage below stops at one cluster.

## 2. `abd56c3` — the Java and Racket literal renderers had no tests

`javaLiteral`, `javaDeclaredType` and `racketLiteral` appeared under `Sources/` and nowhere under `Tests/`. The sweep reported all 23 of their mutants as survivors — the only answer it could give for code no test references.

`JavaLiteralTypingTests` is not a new name: `JSONValueJavaLiteral.swift`'s doc comment already cites it as pinning the literal-to-declared-type round trip. It did not exist. It does now, under the name already used.

What is pinned, chosen from what the survivors poke at:

- **The int/long boundary exactly at `Int32.max` and `Int32.min`** — the one site here where a wrong answer fails to *build*: Java widens `int` to `long` but never narrows, so a stray `L` makes every call into a student's `f(int x)` a lossy conversion. A mutant shifting `>` to `>=` is invisible to any test checking only a value well inside the range.
- **Integral and exponential doubles keeping exactly one decimal point** — not redundant with each other: `2.0` satisfies the guard's first term and short-circuits, so only a value whose description carries an `e` and no `.` reaches the second.
- **Sorted object keys** — map and hash equality are order-independent, so no end-to-end test can see this; what depends on it is the generated source being stable, and the `spec_hash` header with it.
- **Control characters** — Java's escapes are three-digit octal, never a backslash-u escape, which `javac` processes in the lexer and which would break the source file.

This cluster was verified **by hand**, before the fix above existed and for the same reason it was needed: the sweep behind #1461 predates mutation recording, so the verifier correctly reports it `UNVERIFIABLE`. Every candidate replacement per operator was enumerated rather than guessing which one Muter inserted — a superset of the real mutant, so it cannot repeat the earlier pass's error of flipping a whole `||` chain where Muter flips one connector.

| | |
|---|---|
| before | 13 sites mutated simultaneously, new tests removed → **719 tests pass, SURVIVED** |
| after | 28 candidates one at a time → **all 28 KILLED**, each attributed |
| green | full sweep command with the tests in place → 744 tests in 87 suites |

---

## Also worth knowing (no change here)

**A flaky test can destroy a whole shard.** Shard 3 of run 32255707345 failed on its *unmutated baseline* — `workerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows` asserting `maxConcurrent >= 2` and seeing 1 — so Muter produced no outcomes and ~a third of the run's survivors were lost. `config.json` skips `WorkerTests/` reasoning it drops "the suite that... spawns concurrent worker daemons", but `WorkerDaemonTests` is a *sibling* that also spawns them and is in the kept set. Not in `docs/ci-flakiness.md`. I have not touched `config.json`: skipping that suite would remove the flake but might turn currently-killed RunnerCore mutants into survivors, and that trade is yours.