### PR TITLE
Contribution slots: bound a student's notebook contribution server-side

### DIFF
--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -106,8 +106,19 @@ func mergeNotebook(student studentData: Data, instructor instructorData: Data) -
         let instructorCells = instructorNB["cells"] as? [[String: Any]]
     else { return studentData }
 
-    let solutionCells = studentCells.filter { !isTestCell($0) }
+    var solutionCells = studentCells.filter { !isTestCell($0) }
     let testCells = instructorCells.filter { isTestCell($0) }
+
+    // Contribution slots (see `NotebookContributionSlots`). When the
+    // instructor's notebook declares slots, the student's contribution is
+    // bounded to what they wrote IN them — extra cells are ignored rather than
+    // prevented, which is the only form of the rule that survives an
+    // offline-edited upload. An assignment declaring no slots is unaffected:
+    // `declaredSlotCount` is 0 and `retainedStudentCells` returns its input, so
+    // every existing assignment goes through this path byte-identical.
+    let slotCount = NotebookContributionSlots.declaredSlotCount(inInstructorCells: instructorCells)
+    solutionCells = NotebookContributionSlots.retainedStudentCells(
+        solutionCells, limit: slotCount)
 
     studentNB["cells"] = solutionCells + testCells
 

--- a/Sources/APIServer/Helpers/NotebookContributionSlots.swift
+++ b/Sources/APIServer/Helpers/NotebookContributionSlots.swift
@@ -1,0 +1,79 @@
+// APIServer/Helpers/NotebookContributionSlots.swift
+//
+// Contribution slots: the server-side bound on how much of a student's
+// notebook counts as their contribution.
+//
+// WHY THIS IS SERVER-SIDE AND NOT AN EDITOR RULE. A collaborative assignment
+// gives each student a fixed number of places to write (three cells, one test
+// each). The obvious implementation is to stop the editor creating more cells,
+// and that does not work: JupyterLite keeps the document in the student's own
+// browser, and notebook mode deliberately keeps the upload form open beside the
+// editor so an `.ipynb` edited offline can be handed in. Any rule that only
+// holds inside the editor does not hold.
+//
+// So the bound is applied where every submission already passes through:
+// `mergeNotebook` reassembles the submitted notebook server-side before it is
+// stored. Extra cells are not PREVENTED, they are IGNORED — which needs no UI
+// enforcement, and survives an offline-edited upload unchanged.
+//
+// The marker is Chickadee-owned CELL METADATA rather than a source comment.
+// `NotebookSubstitution.fencedCellMetadataKey` already proves the mechanism:
+// it stamps `chickadee_personalized` on cells it rewrites, explicitly preserves
+// foreign cell metadata, and uses the mark to avoid clobbering student edits on
+// re-substitution. Metadata also survives the one edit a first-line comment
+// convention cannot — a student pressing return at the top of the cell.
+
+import Foundation
+
+enum NotebookContributionSlots {
+
+    /// Metadata key marking a cell as one of an assignment's contribution
+    /// slots. Present on the instructor's starter notebook to DECLARE the
+    /// slots, and carried through the student's copy to identify what they
+    /// wrote in them.
+    ///
+    /// The value is the slot's label (e.g. "1"), which is not interpreted
+    /// here — ordering is document order, so the label is for the author and
+    /// for display, not for sorting. Any non-empty string marks a slot.
+    static let slotMetadataKey = "chickadee_slot"
+
+    /// True when this cell carries a slot marker.
+    static func isSlotCell(_ cell: [String: Any]) -> Bool {
+        guard let metadata = cell["metadata"] as? [String: Any],
+            let raw = metadata[slotMetadataKey]
+        else { return false }
+        if let text = raw as? String { return !text.isEmpty }
+        // A number or bool is a legitimate way to write a slot label by hand;
+        // only an explicitly empty string means "not a slot".
+        return true
+    }
+
+    /// How many contribution slots an instructor notebook declares.
+    ///
+    /// Zero means the assignment is an ordinary one, and every caller treats
+    /// that as "apply no bound" — which is what keeps every existing
+    /// assignment byte-identical through this path.
+    static func declaredSlotCount(inInstructorCells cells: [[String: Any]]) -> Int {
+        cells.filter(isSlotCell).count
+    }
+
+    /// The student's cells, reduced to what their contribution is allowed to
+    /// be: the slot-marked cells in document order, capped at `limit`.
+    ///
+    /// Everything else the student wrote is dropped. That is the whole point —
+    /// a bound that only counted slot cells while keeping the rest would let a
+    /// student put fifty tests in one unmarked cell and bypass it entirely.
+    ///
+    /// The sharp edge, stated rather than hidden: a helper the student wrote
+    /// OUTSIDE a slot goes too, and their test then fails at grading against a
+    /// name that is no longer defined. The scaffold is what mitigates it — the
+    /// slots are where the prompt says to write — and the alternative (keeping
+    /// unmarked cells) reopens the bypass. Worth revisiting if a real offering
+    /// shows students tripping over it.
+    static func retainedStudentCells(
+        _ cells: [[String: Any]], limit: Int
+    ) -> [[String: Any]] {
+        guard limit > 0 else { return cells }
+        return Array(cells.filter(isSlotCell).prefix(limit))
+    }
+}

--- a/Tests/APITests/MergeNotebookSlotTests.swift
+++ b/Tests/APITests/MergeNotebookSlotTests.swift
@@ -1,0 +1,184 @@
+// Coverage for contribution slots — the server-side bound on how much of a
+// student's notebook counts as their contribution.
+//
+// The property under test is deliberately NOT "the editor stopped them". A
+// student can add cells, reorder them, edit an `.ipynb` offline and upload it,
+// or delete a slot marker; `mergeNotebook` is where every one of those paths
+// converges, so the bound is asserted there against notebooks shaped the way
+// each of those students would produce.
+//
+// The back-compat case matters as much as the feature: an assignment that
+// declares no slots must go through this path unchanged, or every existing
+// notebook assignment silently loses its solution cells.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct MergeNotebookSlotTests {
+
+    // MARK: - Fixtures
+
+    private func cell(_ source: String, slot: String? = nil) -> [String: Any] {
+        var metadata: [String: Any] = [:]
+        if let slot { metadata[NotebookContributionSlots.slotMetadataKey] = slot }
+        return [
+            "cell_type": "code", "metadata": metadata,
+            "execution_count": NSNull(), "outputs": [],
+            "source": [source],
+        ]
+    }
+
+    private func testCell(_ name: String) -> [String: Any] {
+        [
+            "cell_type": "code", "metadata": [:],
+            "execution_count": NSNull(), "outputs": [],
+            "source": ["# TEST: tier=secret\n", "assert \(name)\n"],
+        ]
+    }
+
+    private func notebook(_ cells: [[String: Any]]) -> Data {
+        let obj: [String: Any] = [
+            "nbformat": 4, "nbformat_minor": 5, "metadata": [:], "cells": cells,
+        ]
+        return (try? JSONSerialization.data(withJSONObject: obj)) ?? Data()
+    }
+
+    private func sources(of data: Data) -> [String] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data),
+            let dict = obj as? [String: Any],
+            let cells = dict["cells"] as? [[String: Any]]
+        else { return [] }
+        return cells.map { cell in
+            if let arr = cell["source"] as? [String] { return arr.joined() }
+            return (cell["source"] as? String) ?? ""
+        }
+    }
+
+    /// An instructor notebook declaring `count` slots plus one hidden test.
+    private func instructorWithSlots(_ count: Int) -> Data {
+        var cells: [[String: Any]] = []
+        for index in 1...max(count, 1) where count > 0 {
+            cells.append(cell("# write your test here\n", slot: "\(index)"))
+        }
+        cells.append(testCell("True"))
+        return notebook(cells)
+    }
+
+    // MARK: - The bound
+
+    @Test func keepsOnlyWhatTheStudentWroteInSlots() {
+        let student = notebook([
+            cell("test_one()\n", slot: "1"),
+            cell("scratch work\n"),
+            cell("test_two()\n", slot: "2"),
+        ])
+        let merged = mergeNotebook(student: student, instructor: instructorWithSlots(3))
+        let kept = sources(of: merged)
+        #expect(kept.contains("test_one()\n"))
+        #expect(kept.contains("test_two()\n"))
+        #expect(
+            !kept.contains("scratch work\n"),
+            "A cell outside a slot must not reach grading — otherwise the bound is bypassable.")
+    }
+
+    /// The bypass this bound exists to close: a student who puts twenty tests in
+    /// cells beyond their allotted slots contributes only the first three.
+    @Test func capsSlotCellsAtTheDeclaredCount() {
+        var cells: [[String: Any]] = []
+        for index in 1...20 { cells.append(cell("test_\(index)()\n", slot: "\(index)")) }
+        let merged = mergeNotebook(student: notebook(cells), instructor: instructorWithSlots(3))
+        let kept = sources(of: merged).filter { $0.hasPrefix("test_") }
+        #expect(kept.count == 3, "Expected 3 slot cells, got \(kept.count)")
+        #expect(kept == ["test_1()\n", "test_2()\n", "test_3()\n"], "Cap must take document order")
+    }
+
+    /// An offline-edited upload is the path no editor rule can reach, so it is
+    /// the one that proves the bound is real rather than cosmetic.
+    @Test func anOfflineEditedUploadIsBoundedTheSameWay() {
+        var cells = [cell("test_a()\n", slot: "1")]
+        for index in 1...50 { cells.append(cell("sneaky_\(index)()\n")) }
+        let merged = mergeNotebook(student: notebook(cells), instructor: instructorWithSlots(3))
+        let kept = sources(of: merged)
+        #expect(kept.contains("test_a()\n"))
+        #expect(!kept.contains { $0.hasPrefix("sneaky_") })
+    }
+
+    /// Deleting the marker loses the slot rather than smuggling the cell
+    /// through. Legible, self-inflicted, and recoverable by resetting the
+    /// starter — the alternative (treating unmarked cells as slots) is the
+    /// bypass again.
+    @Test func aCellWithItsMarkerRemovedIsNotASlot() {
+        let student = notebook([cell("test_one()\n"), cell("test_two()\n", slot: "2")])
+        let merged = mergeNotebook(student: student, instructor: instructorWithSlots(3))
+        let kept = sources(of: merged)
+        #expect(!kept.contains("test_one()\n"))
+        #expect(kept.contains("test_two()\n"))
+    }
+
+    @Test func slotOrderFollowsTheStudentsDocumentNotTheLabel() {
+        let student = notebook([
+            cell("second\n", slot: "2"),
+            cell("first\n", slot: "1"),
+        ])
+        let merged = mergeNotebook(student: student, instructor: instructorWithSlots(1))
+        #expect(sources(of: merged).first == "second\n")
+    }
+
+    // MARK: - The instructor's cells still win
+
+    @Test func instructorTestCellsAreStillReimposed() {
+        let student = notebook([
+            cell("test_one()\n", slot: "1"),
+            testCell("False"),  // a student-authored "test" cell
+        ])
+        let merged = mergeNotebook(student: student, instructor: instructorWithSlots(2))
+        let kept = sources(of: merged)
+        #expect(kept.contains { $0.contains("assert True") }, "instructor test must be present")
+        #expect(!kept.contains { $0.contains("assert False") }, "student test cell must be dropped")
+    }
+
+    // MARK: - Back-compat: an assignment with no slots is untouched
+
+    /// The case that would break every existing notebook assignment if the
+    /// bound applied unconditionally: with no slots declared, nothing is
+    /// dropped.
+    @Test func anAssignmentDeclaringNoSlotsKeepsEveryStudentCell() {
+        let student = notebook([
+            cell("import pandas as pd\n"),
+            cell("def solution():\n    return 42\n"),
+            cell("solution()\n"),
+        ])
+        let instructor = notebook([cell("# starter\n"), testCell("True")])
+        let merged = mergeNotebook(student: student, instructor: instructor)
+        let kept = sources(of: merged)
+        #expect(kept.contains("import pandas as pd\n"))
+        #expect(kept.contains("def solution():\n    return 42\n"))
+        #expect(kept.contains("solution()\n"))
+    }
+
+    @Test func aStudentWhoWroteNothingInAnySlotContributesNothing() {
+        let student = notebook([cell("nothing marked\n")])
+        let merged = mergeNotebook(student: student, instructor: instructorWithSlots(3))
+        let kept = sources(of: merged)
+        #expect(!kept.contains("nothing marked\n"))
+        #expect(kept.contains { $0.contains("assert True") }, "grading still runs")
+    }
+
+    // MARK: - Marker shapes
+
+    @Test func anEmptyStringMarkerDoesNotDeclareASlot() {
+        #expect(!NotebookContributionSlots.isSlotCell(cell("x\n", slot: "")))
+        #expect(NotebookContributionSlots.isSlotCell(cell("x\n", slot: "1")))
+    }
+
+    @Test func aNonStringMarkerStillCountsAsASlot() {
+        let numeric: [String: Any] = [
+            "cell_type": "code",
+            "metadata": [NotebookContributionSlots.slotMetadataKey: 2],
+            "source": ["x\n"],
+        ]
+        #expect(NotebookContributionSlots.isSlotCell(numeric))
+    }
+}

--- a/changelog.d/notebook-contribution-slots.md
+++ b/changelog.d/notebook-contribution-slots.md
@@ -1,0 +1,17 @@
+### Added
+
+- **Contribution slots bound a student's notebook contribution, server-side.**
+  A collaborative assignment gives each student a fixed number of places to write
+  (three cells, one test each). Enforcing that in the editor cannot work —
+  JupyterLite keeps the document in the student's own browser, and notebook mode
+  deliberately keeps the upload form open beside it — so the bound is applied
+  where every submission already converges: `mergeNotebook` reassembles the
+  submitted notebook before it is stored, and now keeps only the slot-marked
+  cells, in document order, capped at the count the instructor's starter notebook
+  declares. Extra cells are not prevented, they are ignored, which needs no UI
+  enforcement and survives an offline-edited upload unchanged. The marker is
+  Chickadee-owned cell metadata (`chickadee_slot`), following the
+  `chickadee_personalized` precedent, because a first-line comment convention
+  breaks the moment a student presses return at the top of a cell. An assignment
+  declaring no slots is unaffected — nothing is dropped — so every existing
+  notebook assignment goes through this path byte-identical.

--- a/docs/collaborative-class-assignments.md
+++ b/docs/collaborative-class-assignments.md
@@ -454,7 +454,10 @@ found it. Check for the general mechanism before adding the specific one.
 
 ### Phase 1 — bound the contribution (useful on its own)
 
-**2. Slot markers and slot extraction.** *Medium.* The core of the feature.
+**2. Slot markers and slot extraction.** *Medium.* **Done.** The core of the
+feature, and it turned out to fit entirely inside `mergeNotebook`'s existing
+signature — the instructor notebook is already in hand at that call site, so the
+slot count derives there with no call-site changes and no new plumbing.
 - A Chickadee-owned cell metadata key (`metadata.chickadee_slot`) following the
   `chickadee_personalized` precedent in `NotebookSubstitution`, which already
   proves the round-trip and already preserves foreign cell metadata.
@@ -471,7 +474,17 @@ The one open authoring question: how an instructor *marks* a slot. Typing a
 marker comment that the server converts to metadata on notebook save keeps the
 gesture inside ordinary notebook editing and needs no editor surface; a
 JupyterLite toolbar action would be nicer and costs a runtime patch. Recommend
-the marker comment for v1 and revisit only if instructors ask.
+the marker comment for v1 and revisit only if instructors ask. **Still open** —
+the extraction half is built and the authoring gesture is not, so slots are
+currently declared by hand-editing cell metadata.
+
+**One sharp edge, recorded rather than hidden.** A helper the student writes
+OUTSIDE a slot is dropped with everything else, and their test then fails at
+grading against a name that is no longer defined. Keeping unmarked cells would
+reopen the bypass this bound exists to close (fifty tests in one unmarked cell),
+so the documented behaviour is what shipped — but it is the thing most likely to
+confuse a real student, and worth revisiting if an offering shows them tripping
+over it.
 *Proven by:* extraction tests over a student notebook with cells added, removed,
 reordered and unmarked; plus a test that an offline-edited upload with twenty
 cells still grades exactly the slot contents.


### PR DESCRIPTION
Slice 2 of the collaborative-class-assignment plan (design note and Phase 0 landed in #1464).

## What this does

A collaborative assignment gives each student a fixed number of places to write — three cells, one test each. The obvious implementation is to stop the editor creating more cells, and it cannot work: JupyterLite keeps the document in the student's own browser, and notebook mode deliberately keeps the upload form open beside the editor so an `.ipynb` edited offline can be handed in. **Any rule that only holds inside the editor does not hold.**

So the bound is applied where every submission already converges. `mergeNotebook` reassembles the submitted notebook server-side before it is stored — it already drops the student's test cells, re-imposes the instructor's, and adopts the instructor's kernelspec because an in-browser editor cannot be trusted with it. Slot extraction is the same operation with a different filter: keep the student's slot-marked cells in document order, capped at the count the instructor's notebook declares, drop the rest.

Extra cells are not *prevented*, they are *ignored*.

## Why it is small

It fits inside `mergeNotebook`'s existing signature. The instructor notebook is already in hand at that call site, so the slot count derives there with no new plumbing and **no changes to any of the four submission paths** that call it (the upload form plus all three `BrowserResultRoutes` paths).

The marker is Chickadee-owned cell metadata (`chickadee_slot`), following the `chickadee_personalized` precedent in `NotebookSubstitution` — which already proves the round-trip and already preserves foreign cell metadata. Metadata survives the one edit a first-line comment convention cannot: a student pressing return at the top of the cell.

## Back-compat is the load-bearing case

An assignment declaring no slots yields a count of 0, `retainedStudentCells` returns its input, and nothing is dropped. Without that, every existing notebook assignment would silently lose its solution cells. It has its own test.

## Tests

Ten, shaped around the students who would break it rather than the happy path: extra cells alongside slots, twenty slot cells against three declared, an offline upload carrying fifty unmarked cells, a deleted marker, slots out of document order, and a student-authored cell wearing a `# TEST:` header. The offline-upload case is the one that proves the bound is real rather than cosmetic.

## One sharp edge, recorded rather than hidden

A helper the student writes **outside** a slot is dropped too, and their test then fails at grading against a name that is no longer defined. Keeping unmarked cells would reopen the bypass this exists to close (fifty tests in one unmarked cell), so the documented behaviour is what shipped — but it is the most likely thing to confuse a real student, and it is flagged in both the code and the doc as worth revisiting if an offering shows them tripping over it.

## Still open

How an instructor *marks* a slot. The extraction half is built; the authoring gesture is not, so slots are declared by hand-editing cell metadata for now. The plan recommends a marker comment the server converts on notebook save, over a JupyterLite toolbar action that would cost a runtime patch.

## Verification

- 13 tests pass in `MergeNotebookSlotTests` + the 3 pre-existing `MergeNotebookKernelspecTests` (no regression).
- 598 tests across the Notebook/Submission suites pass on this base.
- `scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GuGKuZkbjcYBzW73fZ3SU

---
_Generated by [Claude Code](https://claude.ai/code/session_015GuGKuZkbjcYBzW73fZ3SU)_