### PR TITLE
Accumulate the class-wide union of covered items

### DIFF
--- a/Sources/APIServer/Helpers/ClassItemCoverage.swift
+++ b/Sources/APIServer/Helpers/ClassItemCoverage.swift
@@ -1,0 +1,78 @@
+// APIServer/Helpers/ClassItemCoverage.swift
+//
+// Accumulates the class-wide union of covered items, one row per item,
+// attributed to the submission that covered it first. Called from every result
+// ingest path — the worker report and the browser result routes — beside the
+// class-badge award.
+//
+// Wired at BOTH paths deliberately. The class-record badges were once awarded
+// only in the worker handler, so browser-graded assignments never awarded any
+// record until audit A2 caught it; the comment recording that sits at the
+// browser call site. A half-wired accumulator is worse than none, because its
+// number reads as the whole class when it is only the half that happened to be
+// graded on one substrate.
+
+import Core
+import Fluent
+import Foundation
+
+/// Records every item this submission covered that no earlier submission had.
+///
+/// Safe to call repeatedly for the same submission: the unique constraint on
+/// (test_setup_id, item) means a re-test or a replayed report re-inserts
+/// nothing, and the original finder keeps the attribution.
+///
+/// Deliberately NOT gated on the submission's overall grade. A class goal over
+/// the union asks which items the class covered, not which students cleared a
+/// threshold — a student who finds one rare bug and nothing else has still
+/// contributed that bug.
+///
+/// Roster-scoped for the same reason the class-goal sweep's numerator is (audit
+/// A7): a staff test submission or a dropped student must not inflate a number
+/// that carries bonus points to the LMS. Student-ness is per-course, checked
+/// against the setup's own course.
+func recordClassItemCoverage(
+    testSetupID: String,
+    userID: UUID,
+    submissionID: String,
+    outcomes: [TestOutcome],
+    on db: Database
+) async throws {
+    let covered = outcomes.filter { $0.status == .pass }.map(\.testName)
+    guard !covered.isEmpty else { return }
+
+    guard let setup = try await APITestSetup.find(testSetupID, on: db),
+        try await courseRole(of: userID, inCourse: setup.courseID, db: db) == .student
+    else { return }
+
+    // One query for the whole submission rather than one per item: a suite can
+    // carry dozens of variants and this runs on the result path.
+    let alreadyCovered = try await APIClassItemCoverage.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$item ~~ covered)
+        .all()
+    let seen = Set(alreadyCovered.map(\.item))
+
+    for item in covered where !seen.contains(item) {
+        let row = APIClassItemCoverage(
+            testSetupID: testSetupID, item: item,
+            userID: userID, submissionID: submissionID)
+        // Ignore the conflict: two submissions covering the same item at once,
+        // first insert wins. Same shape as `awardImmutableBadge`.
+        try? await row.save(on: db)
+    }
+}
+
+/// The class's coverage of one assignment: how many distinct items have been
+/// covered, and by whom.
+///
+/// Reads the materialised union rather than the stored collections, which is
+/// the whole point of materialising it.
+func classItemCoverage(
+    testSetupID: String, on db: Database
+) async throws -> [APIClassItemCoverage] {
+    try await APIClassItemCoverage.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .sort(\.$item)
+        .all()
+}

--- a/Sources/APIServer/Migrations/CreateClassItemCoverage.swift
+++ b/Sources/APIServer/Migrations/CreateClassItemCoverage.swift
@@ -1,0 +1,24 @@
+// APIServer/Migrations/CreateClassItemCoverage.swift
+
+import Fluent
+
+struct CreateClassItemCoverage: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("class_item_coverage")
+            .id()
+            .field("test_setup_id", .string, .required)
+            .field("item", .string, .required)
+            .field("user_id", .uuid, .required)
+            .field("submission_id", .string, .required)
+            .field("covered_at", .datetime)
+            // First finder wins. The constraint is not decoration: it is what
+            // makes the union monotone and idempotent under retests, replayed
+            // reports and concurrent submissions.
+            .unique(on: "test_setup_id", "item")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("class_item_coverage").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIClassItemCoverage.swift
+++ b/Sources/APIServer/Models/APIClassItemCoverage.swift
@@ -1,0 +1,67 @@
+// APIServer/Models/APIClassItemCoverage.swift
+//
+// One row per (assignment, item) the class has collectively covered, attributed
+// to the submission that covered it FIRST.
+//
+// This is the durable union behind a collaborative assignment's class-wide goal
+// — "the class has found 9 of the 15 seeded bugs". The per-test outcomes it is
+// derived from already exist in `result_collections`, so nothing here is new
+// information; what is new is that the union is materialised, attributed and
+// cheap to read.
+//
+// WHY IT IS WRITTEN AT INGEST RATHER THAN FOLDED IN THE SWEEP. The class-goal
+// sweep is deliberately blob-free (#1160): it reads grade summaries and never
+// the stored collection JSON, because it runs on a timer over every
+// goal-bearing assignment forever. Unioning per-outcome data there would mean
+// decoding every submission's collection every five minutes for the whole term.
+// Accumulating one row at result time costs a single insert on a path that has
+// already decoded the collection anyway.
+//
+// FIRST-FINDER WINS, ENFORCED BY THE SCHEMA. The unique constraint on
+// (test_setup_id, item) is what makes this monotone and idempotent rather than
+// merely intended: a re-test, a replayed report, or two students covering the
+// same item concurrently all collapse to the row that landed first. The class
+// number can therefore never go down — which matters because it drives a
+// visible progress bar that freezes into a grade push.
+
+import Fluent
+import Vapor
+
+final class APIClassItemCoverage: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
+    static let schema = "class_item_coverage"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    /// The assignment this coverage belongs to.
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    /// The covered item — the runner-stamped test name of the suite entry that
+    /// passed. For a seeded-bug assignment that is one buggy variant; the
+    /// instructor's driver decides what passing means.
+    @Field(key: "item")
+    var item: String
+
+    /// The student whose submission covered it first.
+    @Field(key: "user_id")
+    var userID: UUID
+
+    /// The specific submission that covered it first. Attribution is what makes
+    /// the aggregate auditable — an instructor can see who found each item.
+    @Field(key: "submission_id")
+    var submissionID: String
+
+    @Timestamp(key: "covered_at", on: .create)
+    var coveredAt: Date?
+
+    init() {}
+
+    init(testSetupID: String, item: String, userID: UUID, submissionID: String) {
+        self.testSetupID = testSetupID
+        self.item = item
+        self.userID = userID
+        self.submissionID = submissionID
+    }
+}

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -240,6 +240,23 @@ struct BrowserResultRoutes: RouteCollection {
         // (audit A2).  Same rounded-percent gate and student-role guard as
         // `ResultRoutes`; the reconciled collection carries the
         // server-authoritative attempt number.
+        // The class-wide union of covered items. Outside the 100% gate below,
+        // because coverage is per item rather than per student — and wired here
+        // as well as in `ResultRoutes` for the reason the comment above records:
+        // a side effect wired at only one ingest path silently reports half the
+        // class as the whole of it.
+        if reconciled.buildStatus == .passed, let userID {
+            await bestEffort("class_item_coverage") {
+                try await recordClassItemCoverage(
+                    testSetupID: setup.id ?? "",
+                    userID: userID,
+                    submissionID: subID,
+                    outcomes: reconciled.outcomes,
+                    on: req.db
+                )
+            }
+        }
+
         if reconciled.buildStatus == .passed,
             let userID,
             gradePercent(from: reconciled) == 100

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -121,31 +121,55 @@ struct ResultRoutes: RouteCollection {
                 }
             }
 
-            // Award class-wide badges when a student submission earns 100%.
-            if submission.kind == APISubmission.Kind.student,
-                collection.buildStatus == .passed,
-                let userID = submission.userID,
-                let subID = submission.id
-            {
-                let grade = gradePercent(from: collection) ?? 0
-                if grade == 100 {
-                    let disabled =
-                        (try? await APITestSetup.find(submission.testSetupID, on: req.db))
-                        .map { BuiltInAchievements.disabled(in: $0) } ?? []
-                    try await awardClassBadgesFor100Percent(
-                        testSetupID: submission.testSetupID,
-                        userID: userID,
-                        submissionID: subID,
-                        executionTimeMs: collection.executionTimeMs,
-                        attemptNumber: submission.attemptNumber ?? 1,
-                        disabled: disabled,
-                        on: req.db
-                    )
-                }
-            }
+            try await applyClassWideEffects(
+                submission: submission, collection: collection, on: req)
         }
 
         return ReportResponse(received: true)
+    }
+
+    // MARK: - Class-wide effects
+
+    /// The class-level side effects of one student result: the union of covered
+    /// items, and the class badges a 100% earns.
+    ///
+    /// Extracted from `report` because it is the part that GROWS — every
+    /// class-level signal added to the platform lands here, and inlining them
+    /// pushed the route past the body-length limit. Keeping it separate also
+    /// keeps the two gates visible: coverage is per item and ungated by grade,
+    /// badges are per student and gated at 100%.
+    private func applyClassWideEffects(
+        submission: APISubmission, collection: TestOutcomeCollection, on req: Request
+    ) async throws {
+        guard submission.kind == APISubmission.Kind.student,
+            collection.buildStatus == .passed,
+            let userID = submission.userID,
+            let subID = submission.id
+        else { return }
+
+        // Per item, and deliberately not inside the 100% gate below: a student
+        // who covers one item and nothing else has still contributed that item.
+        try await recordClassItemCoverage(
+            testSetupID: submission.testSetupID,
+            userID: userID,
+            submissionID: subID,
+            outcomes: collection.outcomes,
+            on: req.db
+        )
+
+        guard gradePercent(from: collection) == 100 else { return }
+        let disabled =
+            (try? await APITestSetup.find(submission.testSetupID, on: req.db))
+            .map { BuiltInAchievements.disabled(in: $0) } ?? []
+        try await awardClassBadgesFor100Percent(
+            testSetupID: submission.testSetupID,
+            userID: userID,
+            submissionID: subID,
+            executionTimeMs: collection.executionTimeMs,
+            attemptNumber: submission.attemptNumber ?? 1,
+            disabled: disabled,
+            on: req.db
+        )
     }
 
     // MARK: - DB persistence

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -355,6 +355,7 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateAssignmentRequirements())
     app.migrations.add(CreateClassAchievements())
     app.migrations.add(CreateAchievementResults())
+    app.migrations.add(CreateClassItemCoverage())
     app.migrations.add(CreatePreEnrollments())
     app.migrations.add(SessionRecord.migration)
     app.migrations.add(CreateClientDiagnostics())

--- a/Tests/APITests/ClassItemCoverageTests.swift
+++ b/Tests/APITests/ClassItemCoverageTests.swift
@@ -1,0 +1,233 @@
+// The class-wide union of covered items: one row per (assignment, item),
+// attributed to the submission that covered it first.
+//
+// The properties asserted here are the ones the class goal will grade on, so
+// they are the ones that must not be merely intended:
+//
+//   * FIRST-FINDER WINS and attribution never moves, so the number is monotone
+//     and a re-test cannot rewrite history;
+//   * ORDER INDEPENDENCE, so the same submissions in any order reach the same
+//     final state — a ranking rule would break this, which is why the design
+//     rejected one;
+//   * ROSTER SCOPING, because an unscoped numerator is how the class-goal sweep
+//     once granted unearned bonus points all the way to the LMS (audit A7).
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct ClassItemCoverageTests {
+
+    private func outcome(_ name: String, _ status: TestStatus) -> TestOutcome {
+        TestOutcome(
+            testName: name, testClass: nil, tier: .pub, status: status,
+            shortResult: status.defaultShortResult, longResult: nil,
+            executionTimeMs: 1, memoryUsageBytes: nil,
+            attemptNumber: 1, isFirstPassSuccess: false)
+    }
+
+    /// A setup + assignment + two enrolled students, the shape every test needs.
+    private func fixture(
+        _ app: Application, prefix: String
+    ) async throws -> (setupID: String, a: APIUser, b: APIUser) {
+        let courseID = try await app.testCourseID(enrollmentMode: .auto)
+        let setupID = "\(prefix)_setup"
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#,
+            zipPath: app.testSetupsDirectory + "\(setupID).zip",
+            courseID: courseID)
+        try await setup.save(on: app.db)
+        // Title varies by prefix: the assignment slug is unique per course, and
+        // one test builds two fixtures in the same course.
+        _ = try await arInsertAssignment(
+            testSetupID: setupID, title: "Bug Hunt \(prefix)", isOpen: true, on: app)
+
+        let a = try await arInsertStudent(username: "\(prefix)_a", on: app)
+        try await arEnrollStudentInTestCourse(a, on: app)
+        let b = try await arInsertStudent(username: "\(prefix)_b", on: app)
+        try await arEnrollStudentInTestCourse(b, on: app)
+        return (setupID, a, b)
+    }
+
+    // MARK: - What counts as covered
+
+    @Test func onlyPassingOutcomesAreCovered() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "onlypass")
+            _ = try await arInsertSubmission(
+                id: "onlypass_s1", testSetupID: fx.setupID, userID: try fx.a.requireID(), on: app)
+
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: try fx.a.requireID(),
+                submissionID: "onlypass_s1",
+                outcomes: [
+                    outcome("variant_01", .pass), outcome("variant_02", .fail),
+                    outcome("variant_03", .error), outcome("variant_04", .timeout),
+                ],
+                on: app.db)
+
+            let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
+            #expect(rows.map(\.item) == ["variant_01"])
+        }
+    }
+
+    /// Coverage is per item, not per student, so a submission that scores badly
+    /// overall still contributes whatever it did cover.
+    @Test func aLowScoringSubmissionStillContributesWhatItCovered() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "lowscore")
+            _ = try await arInsertSubmission(
+                id: "lowscore_s1", testSetupID: fx.setupID, userID: try fx.a.requireID(), on: app)
+
+            var outcomes = [outcome("variant_07", .pass)]
+            for index in 1...9 { outcomes.append(outcome("variant_1\(index)", .fail)) }
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: try fx.a.requireID(),
+                submissionID: "lowscore_s1", outcomes: outcomes, on: app.db)
+
+            let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
+            #expect(rows.map(\.item) == ["variant_07"])
+        }
+    }
+
+    // MARK: - First finder wins, and keeps it
+
+    @Test func theFirstSubmissionToCoverAnItemKeepsTheAttribution() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "firstwins")
+            let aID = try fx.a.requireID()
+            let bID = try fx.b.requireID()
+            _ = try await arInsertSubmission(
+                id: "firstwins_a", testSetupID: fx.setupID, userID: aID, on: app)
+            _ = try await arInsertSubmission(
+                id: "firstwins_b", testSetupID: fx.setupID, userID: bID, on: app)
+
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: aID, submissionID: "firstwins_a",
+                outcomes: [outcome("variant_03", .pass)], on: app.db)
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: bID, submissionID: "firstwins_b",
+                outcomes: [outcome("variant_03", .pass)], on: app.db)
+
+            let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
+            #expect(rows.count == 1, "one item covered twice must not produce two rows")
+            #expect(rows.first?.userID == aID, "attribution must stay with the first finder")
+            #expect(rows.first?.submissionID == "firstwins_a")
+        }
+    }
+
+    /// A re-test replays the same outcomes. Nothing may duplicate, and the
+    /// original finder must keep the credit — the number can only go up.
+    @Test func replayingASubmissionChangesNothing() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "replay")
+            let aID = try fx.a.requireID()
+            _ = try await arInsertSubmission(
+                id: "replay_a", testSetupID: fx.setupID, userID: aID, on: app)
+
+            let outcomes = [outcome("variant_01", .pass), outcome("variant_02", .pass)]
+            for _ in 1...3 {
+                try await recordClassItemCoverage(
+                    testSetupID: fx.setupID, userID: aID, submissionID: "replay_a",
+                    outcomes: outcomes, on: app.db)
+            }
+
+            let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
+            #expect(rows.map(\.item) == ["variant_01", "variant_02"])
+        }
+    }
+
+    /// Order independence: the same two submissions, interleaved either way,
+    /// reach the same final set. Only attribution differs, and only by who
+    /// genuinely got there first.
+    @Test func theFinalUnionDoesNotDependOnArrivalOrder() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "order")
+            let aID = try fx.a.requireID()
+            let bID = try fx.b.requireID()
+            _ = try await arInsertSubmission(
+                id: "order_a", testSetupID: fx.setupID, userID: aID, on: app)
+            _ = try await arInsertSubmission(
+                id: "order_b", testSetupID: fx.setupID, userID: bID, on: app)
+
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: bID, submissionID: "order_b",
+                outcomes: [outcome("variant_02", .pass), outcome("variant_03", .pass)], on: app.db)
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: aID, submissionID: "order_a",
+                outcomes: [outcome("variant_01", .pass), outcome("variant_02", .pass)], on: app.db)
+
+            let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
+            #expect(rows.map(\.item) == ["variant_01", "variant_02", "variant_03"])
+            // variant_02 was covered by B first, even though A submitted it too.
+            let variant2 = try #require(rows.first { $0.item == "variant_02" })
+            #expect(variant2.userID == bID)
+        }
+    }
+
+    // MARK: - Roster scoping (audit A7)
+
+    /// A staff member testing their own assignment must not appear in a number
+    /// that carries bonus points to the LMS.
+    @Test func aNonStudentContributesNoCoverage() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "staff")
+            let staff = try await arInsertStudent(username: "staff_instructor", on: app)
+            let staffID = try staff.requireID()
+            _ = try await arInsertSubmission(
+                id: "staff_s1", testSetupID: fx.setupID, userID: staffID, on: app)
+
+            // Deliberately NOT enrolled as a student in the setup's course.
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: staffID, submissionID: "staff_s1",
+                outcomes: [outcome("variant_01", .pass)], on: app.db)
+
+            let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
+            #expect(rows.isEmpty)
+        }
+    }
+
+    // MARK: - Degenerate inputs
+
+    @Test func aSubmissionCoveringNothingWritesNothing() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "empty")
+            let aID = try fx.a.requireID()
+            _ = try await arInsertSubmission(
+                id: "empty_s1", testSetupID: fx.setupID, userID: aID, on: app)
+
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: aID, submissionID: "empty_s1",
+                outcomes: [outcome("variant_01", .fail)], on: app.db)
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: aID, submissionID: "empty_s1",
+                outcomes: [], on: app.db)
+
+            #expect(try await classItemCoverage(testSetupID: fx.setupID, on: app.db).isEmpty)
+        }
+    }
+
+    /// Coverage is scoped per assignment: the same item name in another
+    /// assignment is a different item.
+    @Test func coverageIsScopedToItsAssignment() async throws {
+        try await withAssignmentRoutesApp { app in
+            let one = try await fixture(app, prefix: "scopeone")
+            let two = try await fixture(app, prefix: "scopetwo")
+            let aID = try one.a.requireID()
+            _ = try await arInsertSubmission(
+                id: "scope_s1", testSetupID: one.setupID, userID: aID, on: app)
+
+            try await recordClassItemCoverage(
+                testSetupID: one.setupID, userID: aID, submissionID: "scope_s1",
+                outcomes: [outcome("variant_01", .pass)], on: app.db)
+
+            #expect(try await classItemCoverage(testSetupID: one.setupID, on: app.db).count == 1)
+            #expect(try await classItemCoverage(testSetupID: two.setupID, on: app.db).isEmpty)
+        }
+    }
+}

--- a/changelog.d/class-item-coverage.md
+++ b/changelog.d/class-item-coverage.md
@@ -1,0 +1,15 @@
+### Added
+
+- **The class-wide union of covered items is now accumulated at result time.**
+  A collaborative assignment's class goal asks which items the class collectively
+  covered — "9 of the 15 seeded bugs" — and the per-test outcomes that answer it
+  already existed in `result_collections`. `APIClassItemCoverage` materialises the
+  union: one row per (assignment, item), attributed to the submission that covered
+  it first, written on both the worker and browser result paths. Accumulating at
+  ingest rather than in the class-goal sweep keeps that sweep blob-free (#1160) —
+  unioning per-outcome data on a five-minute timer would mean decoding every
+  submission's collection for the whole term. First-finder-wins is enforced by a
+  unique index rather than by convention, so the union is monotone and idempotent
+  under re-tests, replayed reports and concurrent submissions; coverage is
+  deliberately not gated on the submission's overall grade; and it is roster-scoped
+  so a staff test submission cannot inflate a number that carries bonus points.

--- a/docs/collaborative-class-assignments.md
+++ b/docs/collaborative-class-assignments.md
@@ -491,11 +491,26 @@ cells still grades exactly the slot contents.
 
 ### Phase 2 — accumulate (useful on its own)
 
-**3. Per-item coverage accumulation at result-ingest.** *Medium.* A table keyed
-by (test setup, item, first-covering submission, user, timestamp), written where
-`awardClassBadgesFor100Percent` is already called on the result path, with the
-existing sweep as reconciliation. No goal semantics yet — just the durable,
-attributed union.
+**3. Per-item coverage accumulation at result-ingest.** *Medium.* **Done.**
+`APIClassItemCoverage`, one row per (assignment, item) attributed to the
+submission that covered it first, written at both result-ingest paths. No goal
+semantics yet — just the durable, attributed union.
+
+Three properties are enforced rather than intended. **First-finder wins is a
+schema constraint**, not a code convention: the unique index on
+(test_setup_id, item) is what makes the union monotone and idempotent under
+re-tests, replayed reports and concurrent submissions, so the class number can
+never go down. **Coverage is ungated by grade** — it sits outside the
+`grade == 100` gate the class badges use, because a student who covers one item
+and nothing else has still contributed it. **It is roster-scoped**, for the
+reason audit A7 gives: an unscoped numerator once carried unearned bonus points
+to the LMS.
+
+Wired at BOTH ingest paths deliberately. The class records were once awarded
+only in the worker handler, so browser-graded assignments never awarded any
+until audit A2 caught it — a half-wired accumulator is worse than none, because
+its number reads as the whole class when it is only the half graded on one
+substrate.
 Incremental at ingest rather than folded in the sweep, because the sweep is
 deliberately blob-free (the `#1160` note) and unioning per-outcome data across a
 term every five minutes would undo that.


### PR DESCRIPTION
Slice 3 of the collaborative-class-assignment plan (design + Phase 0 in #1464, contribution slots in #1467).

## What this does

A collaborative assignment's class goal asks which items the class collectively covered — "9 of the 15 seeded bugs" — and the per-test outcomes that answer it already exist in `result_collections`. Nothing here is new information; what's new is that the union is **materialised, attributed, and cheap to read**.

`APIClassItemCoverage` holds one row per (assignment, item), attributed to the submission that covered it first, written at result time on both the worker and browser paths.

No goal semantics yet — that's slice 5. This is the durable union underneath it, and it's independently useful: it's what makes the aggregate auditable before anything grades on it.

## Why at ingest rather than in the sweep

The class-goal sweep is deliberately blob-free (#1160): it reads grade summaries and never the stored collection JSON, because it runs on a timer over every goal-bearing assignment forever. Unioning per-outcome data there would mean decoding every submission's collection every five minutes for the whole term. One insert on a path that has already decoded the collection costs nothing by comparison.

## Three properties are enforced, not intended

- **First-finder wins is a unique index** on `(test_setup_id, item)`, not a code convention. That's what makes the union monotone and idempotent under re-tests, replayed reports, and two students covering the same item concurrently — so the class number can never go down, which matters because it drives a progress bar that freezes into a grade push.
- **Coverage is ungated by grade.** It sits outside the `grade == 100` gate the class badges use, because a student who covers one item and nothing else has still contributed that item.
- **It is roster-scoped**, for the reason audit A7 gives: an unscoped numerator is how the class-goal sweep once granted unearned bonus points all the way to the LMS.

## Wired at both ingest paths deliberately

The class records were once awarded only in the worker handler, so browser-graded assignments never awarded any until audit A2 caught it — the comment recording that sits at the browser call site. A half-wired accumulator is worse than none, because its number reads as the whole class when it's only the half graded on one substrate.

## One refactor, and why it isn't a threshold bump

`ResultRoutes.report` gained one line too many for the 100-line body limit. CLAUDE.md permits raising the threshold; extracting `applyClassWideEffects` is better here, because that block is the part that *grows* — every class-level signal added to the platform lands in it — and separating it also keeps the two gates visible (coverage per item and ungated; badges per student at 100%). 161 tests across the Achievement/Result/MergeNotebook suites confirm the extraction changed no behaviour.

## Tests

Eight: what counts as covered (only passing outcomes), a low-scoring submission still contributing, first-finder attribution surviving both a second finder and a replay, order independence, roster scoping, per-assignment scoping, and the degenerate empty cases.

## Verification

- 161 tests pass across `ClassItemCoverage|Achievement|Result|MergeNotebook`.
- `scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GuGKuZkbjcYBzW73fZ3SU

---
_Generated by [Claude Code](https://claude.ai/code/session_015GuGKuZkbjcYBzW73fZ3SU)_