### PR TITLE
test(mutation): cover the footer parser's grammar, and quarantine inert mutants

### DIFF
--- a/Tests/CoreTests/JSONFooterGrammarTests.swift
+++ b/Tests/CoreTests/JSONFooterGrammarTests.swift
@@ -1,0 +1,122 @@
+// Tests/CoreTests/JSONFooterGrammarTests.swift
+//
+// What RunnerCore's footer parser (JSONLite) ACCEPTS and REJECTS, as opposed to
+// what it computes — `JSONFooterNumberParsingTests` next door pins the numeric
+// values, and between them they cover the parser.
+//
+// The 2026-08-19 sweep (run 32265903112) reported ten surviving mutants in
+// JSONLite and the two it killed were both in number parsing. That is the shape
+// of the gap: the footer contract only names `shortResult` and `score`, so the
+// parser had been tested on the two field types those use, while remaining a
+// general JSON parser that a script may legitimately hand an array, a null, a
+// boolean or a `\u` escape. Every mutant below was confirmed SURVIVED by
+// `Tools/mutation/verify-survivor.py` against that run's record before the test
+// was written, and KILLED after.
+//
+// `parseJSON` is internal to RunnerCore, so — as in the sibling suite — it is
+// exercised through the public `interpretScriptOutput`. The lever is that a last
+// stdout line is only treated as a footer when it parses as a JSON *object*: if
+// any part of the line fails to parse, the footer is dropped and `shortResult`
+// falls back to the raw line. So "shortResult is the footer's value" proves the
+// line parsed, and "shortResult is the whole raw line" proves it did not.
+
+import Core
+import Testing
+
+@Suite struct JSONFooterGrammarTests {
+
+    private func interpret(stdout: String) -> InterpretedScriptResult {
+        interpretScriptOutput(
+            ScriptOutput(
+                exitCode: 0, stdout: stdout, stderr: "", executionTimeMs: 0, timedOut: false))
+    }
+
+    /// Kills the `RelationalOperatorReplacement` on `isAtEnd` (`pos >= count` →
+    /// `pos <= count`), which makes "at end" true almost everywhere and so lets
+    /// `parseJSON`'s trailing-content guard pass on anything.
+    ///
+    /// A footer is the whole line or it is not a footer. Accepting a prefix
+    /// would let a line that merely BEGINS with an object silently set a
+    /// student's score from whatever that prefix said.
+    @Test func aLineIsNotAFooterWhenAnythingFollowsTheObject() {
+        let line = #"{"shortResult":"ok","score":0.5} and then some prose"#
+        let result = interpret(stdout: line)
+        #expect(result.shortResult == line)
+        #expect(result.score == 1.0)  // no footer, so the exit code decides
+    }
+
+    /// Kills `ChangeLogicalConnector` candidate 2 on `skipWhitespace`
+    /// (`c == "\t" && c == "\n"`), which stops tabs being skipped.
+    ///
+    /// `trimHorizontal` strips tabs from the ENDS of the line before the parser
+    /// sees it, so only an interior tab reaches `skipWhitespace` — which is
+    /// exactly what a script that pretty-prints its footer with tabs emits.
+    @Test func interiorTabsBetweenTokensAreSkipped() {
+        let result = interpret(stdout: "{\"shortResult\":\t\"ok\",\t\"score\":\t0.25}")
+        #expect(result.shortResult == "ok")
+        #expect(result.score == 0.25)
+    }
+
+    /// Kills `ChangeLogicalConnector` candidate 3 on `skipWhitespace`
+    /// (`c == "\n" && c == "\r"`), which stops a carriage return being skipped.
+    ///
+    /// This is a LONE `\r`, deliberately, and it is the only way that arm is
+    /// reachable. A `\r\n` is a single `Character` in Swift, so it never reaches
+    /// the parser as a bare `\r` — that grapheme-cluster behaviour is #1457,
+    /// where CRLF output loses its footer entirely, and this test must not be
+    /// read as covering it. `\n` alone is unreachable here for the same reason
+    /// the line was split on it; Muter never mutates that arm in isolation, so
+    /// there is nothing separate to close.
+    @Test func aTrailingCarriageReturnDoesNotDefeatTheFooter() {
+        let result = interpret(stdout: "{\"shortResult\":\"ok\",\"score\":0.5}\r")
+        #expect(result.shortResult == "ok")
+        #expect(result.score == 0.5)
+    }
+
+    /// Kills `ChangeLogicalConnector` candidate 2 at the `parseValue` dispatch
+    /// (`c >= "0" || c <= "9"`), which is a tautology — every character then
+    /// routes to `parseNumber` instead of being rejected.
+    ///
+    /// A leading `+` is the case that makes it visible: JSON forbids it, but
+    /// `parseDoubleLiteral` accepts one (it has to read exponents like `1e+3`),
+    /// so under the mutant `+5` becomes a number and the malformed footer is
+    /// honoured.
+    @Test func aLeadingPlusIsNotAValidNumberAndVoidsTheFooter() {
+        let line = #"{"shortResult":"ok","score":+5}"#
+        #expect(interpret(stdout: line).shortResult == line)
+    }
+
+    /// Kills the `RelationalOperatorReplacement` on the empty-array check
+    /// (`current == "]"` → `!=`), which returns an empty array for a populated
+    /// one and mis-parses `[]`.
+    @Test func arrayValuesParseWhetherEmptyOrPopulated() {
+        #expect(interpret(stdout: #"{"shortResult":"ok","cases":[1,2,3]}"#).shortResult == "ok")
+        #expect(interpret(stdout: #"{"shortResult":"ok","cases":[]}"#).shortResult == "ok")
+    }
+
+    /// Kills the `RelationalOperatorReplacement` on `parseUnicodeEscape`'s bounds
+    /// guard (`pos + 4 <= count` → `>=`), which inverts it: the escape is
+    /// rejected whenever there is room for it and attempted when there is not.
+    @Test func unicodeEscapesInStringsParse() {
+        // `\u0042` is the letter B; the parser must decode it rather than
+        // pass it through, so the footer reads "ABC".
+        let result = interpret(stdout: #"{"shortResult":"A\u0042C"}"#)
+        #expect(result.shortResult == "ABC")
+    }
+
+    /// Kills the `SwapTernary` in `parseNull`, which returns nil for `null` and
+    /// `.null` for everything else — dropping any footer carrying a JSON null.
+    @Test func nullValuesParse() {
+        #expect(interpret(stdout: #"{"shortResult":"ok","detail":null}"#).shortResult == "ok")
+    }
+
+    /// Kills both `RelationalOperatorReplacement`s in `matchLiteral` — the
+    /// bounds guard (`pos + lit.count <= count` → `>=`) and the character
+    /// comparison (`!= ch` → `== ch`, which returns false on the first character
+    /// that MATCHES). Either one makes every literal fail, so `true`, `false`
+    /// and `null` all stop parsing.
+    @Test func booleanLiteralsParse() {
+        #expect(interpret(stdout: #"{"shortResult":"ok","passed":true}"#).shortResult == "ok")
+        #expect(interpret(stdout: #"{"shortResult":"ok","passed":false}"#).shortResult == "ok")
+    }
+}

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -268,6 +268,31 @@ def main() -> int:
         else:
             phantoms.append((path, reported, operator))
 
+    # A SECOND WAY A SURVIVOR CAN BE MEANINGLESS, and one only visible now that
+    # the original is recorded beside the mutation: Muter's `SwapTernary`
+    # sometimes emits the statement UNCHANGED apart from whitespace. Nine of the
+    # 75 survivors in run 32265903112 were this, every one of them a
+    # SwapTernary on a `cond ? a : b` whose branches came back unswapped.
+    #
+    # It is not a phantom -- the schema really was inserted, so the guard-based
+    # filter above passes it -- and it is not an equivalent mutant either, since
+    # the code is not merely behaviourally identical but textually identical.
+    # Nothing can kill it, and before the original was recorded there was no way
+    # to tell it from a real hole: it reads as "the suite could not see this
+    # change" when in truth there was no change to see. Two of them were left
+    # behind by a triage pass that had already covered the file properly.
+    inert = []
+    for key in list(mutation_of):
+        muts = mutation_of[key]
+        if not muts or any("original" not in m for m in muts):
+            continue
+        if all(" ".join(m["mutated"].split()) == " ".join(m["original"].split()) for m in muts):
+            inert.append(key)
+            del mutation_of[key]
+    if inert:
+        inert_set = set(inert)
+        resolved = [r for r in resolved if r not in inert_set]
+
     os.makedirs(out_dir, exist_ok=True)
     with open(os.path.join(out_dir, "survivors.tsv"), "w") as fh:
         fh.write("file\treported_line\ttrue_line\toperator\tsource\n")
@@ -307,6 +332,13 @@ def main() -> int:
                     "mutations": mutation_of.get((path, line, operator), []),
                 }
                 for path, line, operator in sorted(resolved)
+            ],
+            # Mutations Muter emitted UNCHANGED (see the quarantine above).
+            # Recorded rather than dropped so the count reconciles and so a
+            # regression in the operator is visible rather than silent.
+            "inertMutants": [
+                {"file": path, "line": line, "operator": operator}
+                for path, line, operator in sorted(inert)
             ],
             "phantoms": [
                 {"file": path, "line": line, "operator": operator}
@@ -390,6 +422,23 @@ def main() -> int:
                     out.append(f"    - becomes: `{one}`")
         else:
             out.append("No survivors. Every mutant in this shard was killed.")
+
+        if inert:
+            out += [
+                "",
+                "### Inert mutants — no change was made, so nothing could see one",
+                "",
+                f"Muter emitted {len(inert)} mutation(s) **identical to the original**",
+                "apart from whitespace — every one a `SwapTernary` whose branches came",
+                "back unswapped. The schema was inserted, so these are not phantoms; but",
+                "there is no change for a test to detect, so they are not holes either.",
+                "They are listed here rather than dropped so the count reconciles, and so",
+                "the day the operator starts working the list shrinks visibly.",
+                "",
+            ]
+            for path, line, operator in sorted(inert):
+                src = source_line(path, line)
+                out.append(f"- `{path}` L{line} `{operator}`" + (f" — `{src}`" if src else ""))
 
         if phantoms:
             out += [

--- a/Tools/mutation/report_test.py
+++ b/Tools/mutation/report_test.py
@@ -216,5 +216,50 @@ class OriginalCaptureTests(unittest.TestCase):
             self.assertEqual(m["original"], 'return a && b ? "}" : "end"')
 
 
+
+class InertMutantTests(unittest.TestCase):
+    """Muter sometimes emits a mutation identical to the original.
+
+    Nine of run 32265903112's 75 survivors were this, every one a SwapTernary
+    whose branches came back unswapped. The schema WAS inserted, so the
+    phantom filter passes it; but there is no change for a test to detect, so
+    it is not a hole. Before the original was recorded alongside the mutation
+    there was no way to tell the two apart, and two of these were left looking
+    like gaps in a file that had just been covered properly.
+    """
+
+    RAW_ONE = """\
+Probe.swift:10  SwapTernary  mutant survived
+
+Of the 1 mutants introduced into your code, your test suite killed 0.
+Mutation Score of Test Suite: 0%
+Muter took 00:00:01.000
+"""
+
+    # The `if` body and the `else` body differ only in spacing.
+    INERT = '''\
+import class Foundation.ProcessInfo
+if ProcessInfo.processInfo.environment["Probe_SwapTernary_10_5_120"] != nil {
+    return flag  ? a :  b
+} else {
+    return flag ? a : b
+}
+'''
+
+    def test_an_unchanged_mutation_is_quarantined_not_reported_as_a_hole(self):
+        _code, report, summary = run(self.RAW_ONE, self.INERT)
+        self.assertEqual(summary["survived"], 0)
+        self.assertEqual(len(summary["survivors"]), 0)
+        self.assertEqual(len(summary["inertMutants"]), 1)
+        self.assertEqual(summary["inertMutants"][0]["operator"], "SwapTernary")
+        self.assertIn("Inert mutants", report)
+
+    def test_a_genuinely_changed_mutation_is_still_a_survivor(self):
+        real = self.INERT.replace("return flag  ? a :  b", "return flag ? b : a")
+        _code, _report, summary = run(self.RAW_ONE, real)
+        self.assertEqual(summary["survived"], 1)
+        self.assertEqual(summary.get("inertMutants"), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/changelog.d/mutation-triage-jsonlite-footer-grammar.md
+++ b/changelog.d/mutation-triage-jsonlite-footer-grammar.md
@@ -1,0 +1,27 @@
+### Added
+
+- **The result-footer parser is now tested for the grammar it accepts, not just
+  the numbers it computes.** RunnerCore's `JSONLite` is a general JSON parser,
+  but the footer contract only names `shortResult` and `score`, so it had been
+  exercised on those two field types alone — leaving arrays, `null`, booleans,
+  `\u` escapes, interior tabs and trailing-content rejection unpinned. The
+  2026-08-19 sweep reported ten surviving mutants there and killed only the two
+  in number parsing. `JSONFooterGrammarTests` covers the rest, each test naming
+  the mutation it kills. One mutant is deliberately left alive with its reason
+  recorded: flipping `parseNumber`'s `if current == "-"` to `!=` is an
+  equivalent mutant, because the loop that follows accepts `-` as well, so the
+  slice handed to `parseDoubleLiteral` is unchanged for every input that can
+  reach it.
+
+### Fixed
+
+- **The sweep no longer reports mutations Muter never actually made.** Nine of
+  run 32265903112's 75 survivors were `SwapTernary` mutations emitted
+  *identical to the original* apart from whitespace — the branches came back
+  unswapped. These are not phantoms (the schema really was inserted, so the
+  existing guard-based filter passes them) and not equivalent mutants (the code
+  is textually unchanged, not merely behaviourally so); nothing can kill them,
+  and they read exactly like real holes. Recording each mutation's `original`
+  made them detectable for the first time, and `report.py` now quarantines them
+  into their own section beside the phantoms. Two had already been mistaken for
+  leftover gaps in a file that had just been covered properly.

--- a/docs/mutation-triage.md
+++ b/docs/mutation-triage.md
@@ -106,12 +106,25 @@ against the full suite before writing anything — otherwise you are looking at
 the same artefact a missing interpreter produces, where a test that never ran
 makes its mutants read as gaps.
 
-**Equivalent mutants are common in parsers and defensive code.** `JSONLite`'s
-`skipWhitespace` treats `\n` as skippable, but the footer is by definition the
-last non-empty *line*, so no input reaching that parser contains one. No test can
-kill it. `containsSubstring`'s empty-needle guard has no caller that passes an
-empty needle. Close these with the reason written down; the reason is the
-deliverable.
+**Equivalent mutants are common in parsers and defensive code.**
+`containsSubstring`'s empty-needle guard has no caller that passes an empty
+needle. `JSONLite`'s `parseNumber` is a subtler one: mutating `if current == "-"`
+to `!=` changes nothing, because the `while` loop that follows accepts `-` too
+and `start` is captured before either — so the sign is consumed either by the
+`if` or by the loop, and the slice handed to `parseDoubleLiteral` is identical
+for every input `parseValue` can route there. Close these with the reason
+written down; the reason is the deliverable.
+
+**But make the argument about the mutation Muter actually generates, not the one
+you can imagine.** This section used to claim `skipWhitespace`'s `\n` arm was
+unkillable, because the footer is by definition the last non-empty *line*. The
+reachability half is right and the conclusion was wrong: `ChangeLogicalConnector`
+mutates ONE connector in `" " || "\t" || "\n" || "\r"`, so no candidate isolates
+`\n`. Each disables a *pair* — and the pairs reach tabs (interior ones survive
+`trimHorizontal`) and a lone `\r`, both of which a script can emit. Measured
+against run 32265903112, two of those three candidates survived the suite and
+both are now killed by `JSONFooterGrammarTests`. An equivalence argument has to
+name the recorded mutation and show THAT one cannot be observed.
 
 ## What a finished survivor looks like
 


### PR DESCRIPTION
Second triage cluster from the 2026-08-19 sweep — and the first done with a verifier that can be trusted. Run **32265903112** is also the first record to carry `original` for all **110 of 110** candidate mutations, so every verdict below is a replay of what Muter actually inserted.

Refs #1447, #1466.

## 1. The footer parser was tested for its numbers, not its grammar

`JSONLite` is a general JSON parser, but the footer contract names only `shortResult` and `score` — so it had been exercised on those two field types and nothing else. The sweep reported ten survivors there, and the only two it killed were both in number parsing. Unpinned: trailing-content rejection, interior tabs, a lone carriage return, arrays, `null`, booleans, `\u` escapes, and the `parseValue` dispatch guard.

`JSONFooterGrammarTests` covers them through the public `interpretScriptOutput`, since `parseJSON` is internal to RunnerCore. The lever is that a line is a footer only if it parses as a JSON *object*: "shortResult is the footer's value" proves it parsed, "shortResult is the raw line" proves it did not.

| | |
|---|---|
| **before** | 14 of 15 candidates **SURVIVED** (the two already-covered ones are in number parsing) |
| **after** | 14 of 15 **KILLED**, every one attributed to `JSONFooterGrammarTests` |
| **green** | full sweep command → 752 tests in 88 suites, was 744 |

**The fifteenth is left alive on purpose.** Flipping `parseNumber`'s `if current == "-"` to `!=` is an equivalent mutant: the `while` loop that follows accepts `-` as well, and `start` is captured before either, so the sign is consumed by the `if` or by the loop and the slice handed to `parseDoubleLiteral` is identical for every input `parseValue` can route there. The reason is recorded in the triage doc rather than papered over with a test that would assert nothing.

## 2. Muter sometimes emits no mutation at all

Nine of the run's 75 survivors carry a `mutated` body **identical to `original` apart from whitespace** — every one a `SwapTernary` whose branches came back unswapped.

They are not phantoms: the schema really was inserted, so the existing guard-based filter passes them. They are not equivalent mutants either: the code is *textually* unchanged, not merely behaviourally so. Nothing can kill them, and they read exactly like real holes — two were sitting in `JSONValueJavaLiteral` and `JSONValueRacketLiteral` looking like leftover gaps in files #1463 had just covered properly.

Recording the original is what made this visible at all. `report.py` now quarantines them into their own section beside the phantoms — listed rather than dropped, so the count reconciles and so the list shrinks visibly if the operator is ever fixed.

Falsification, since "the tests are inadequate" is the competing explanation: in the #1463 pass I swapped that same ternary **by hand** to `? s + ".0" : s` and the existing tests **killed** it. A real swap dies; Muter's recorded one survives because it is not a swap.

## 3. A correction to the triage doc

`docs/mutation-triage.md` used `skipWhitespace`'s `\n` arm as its worked example of an unkillable mutant. The reachability half is right — the footer is one line — but the conclusion is wrong, because `ChangeLogicalConnector` mutates **one** connector and no candidate isolates `\n`. Each disables a *pair*, and the pairs reach interior tabs (which survive `trimHorizontal`) and a lone `\r`, both of which a script can emit. Two of those three candidates survived the suite and both are killed here.

The rule that replaces it: an equivalence argument has to name the recorded mutation and show *that one* cannot be observed.

The CR test uses a **lone** `\r` deliberately and says so in its comment — `\r\n` is a single `Character` in Swift and never reaches the parser as a bare `\r`. That is #1457, which is still open, and this test must not be read as covering it.

## Verification

- 42 Python tests (was 40); both new ones seen to fail against the pre-quarantine `report.py` (`1 != 0` — the inert mutant counted as a survivor).
- `swift-format`, `scripts/lint.sh` and SwiftLint `--strict` clean.
- Working tree clean after every verifier run.

Happy to split the `report.py` quarantine out if you'd rather review it separately; it is here because the same recorded `original` is what produced both halves.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qPZYk8SHvaw3P9M4kAjw2)_