### PR TITLE
Class coverage: gate it to contribution assignments, and show it to instructors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1184,6 +1184,14 @@ the `format-lint` CI job) — keep them green:
   copy is at house length. Green guards are necessary, not sufficient — every
   style regression so far has been mechanically legal.
 
+  **This is unconditional and needs no confirmation.** Run it as part of doing
+  the work, the same way you run `scripts/check-styles.sh` — do not ask whether
+  to, do not offer merging without it as an option, and do not skip it because a
+  general instruction elsewhere discourages spawning agents. A UI change that has
+  not been through `ui-review` is not finished. If the agent is genuinely
+  unavailable, say so plainly in the PR rather than letting its absence pass
+  unmentioned.
+
 Run `scripts/check-styles.sh` locally before pushing UI changes (it runs all
 of the above — same as the CI `format-lint` job). The visual-regression
 harness (`Tools/visual-regression/`, page list in `pages.mjs` shared with

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -13,32 +13,30 @@
 
 #if(hasCoverage):
 <section class="page-section">
-    <div class="editor-block-head">
+    <div class="page-titlebar">
         <h2>Bug coverage</h2>
         <span class="chip">#(coverageSummary)</span>
     </div>
-    <div class="table-scroll">
-        <table class="results-table">
-            <thead>
-                <tr>
-                    <th>Item</th>
-                    <th>Status</th>
-                    <th>First found by</th>
-                    <th class="col-hide-phone">When</th>
-                </tr>
-            </thead>
-            <tbody>
-            #for(row in coverageRows):
-                <tr>
-                    <td>#(row.item)</td>
-                    <td>#if(row.found):<span class="chip chip-ok">found</span>#else:<span class="chip chip-err">not found</span>#endif</td>
-                    <td>#if(row.found):#(row.foundBy)#else:—#endif</td>
-                    <td class="col-hide-phone">#if(row.found):#(row.foundAt)#else:—#endif</td>
-                </tr>
-            #endfor
-            </tbody>
-        </table>
-    </div>
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>Bug</th>
+                <th>Status</th>
+                <th>First found by</th>
+                <th class="time col-hide-phone">When</th>
+            </tr>
+        </thead>
+        <tbody>
+        #for(row in coverageRows):
+            <tr>
+                <td><code>#(row.item)</code></td>
+                <td>#if(row.found):<span class="tier tier-open">found</span>#else:<span class="tier tier-closed">not yet found</span>#endif</td>
+                <td>#if(row.found):#(row.foundBy)#else:—#endif</td>
+                <td class="time col-hide-phone#if(row.found): js-relative-time#endif"#if(row.found): data-iso="#(row.foundAtISO)"#endif>#if(row.found):#(row.foundAt)#else:—#endif</td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
 </section>
 #endif
 

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -11,6 +11,37 @@
     #extend("_diagnostic-cards")
 </section>
 
+#if(hasCoverage):
+<section class="page-section">
+    <div class="editor-block-head">
+        <h2>Bug coverage</h2>
+        <span class="chip">#(coverageSummary)</span>
+    </div>
+    <div class="table-scroll">
+        <table class="results-table">
+            <thead>
+                <tr>
+                    <th>Item</th>
+                    <th>Status</th>
+                    <th>First found by</th>
+                    <th class="col-hide-phone">When</th>
+                </tr>
+            </thead>
+            <tbody>
+            #for(row in coverageRows):
+                <tr>
+                    <td>#(row.item)</td>
+                    <td>#if(row.found):<span class="chip chip-ok">found</span>#else:<span class="chip chip-err">not found</span>#endif</td>
+                    <td>#if(row.found):#(row.foundBy)#else:—#endif</td>
+                    <td class="col-hide-phone">#if(row.found):#(row.foundAt)#else:—#endif</td>
+                </tr>
+            #endfor
+            </tbody>
+        </table>
+    </div>
+</section>
+#endif
+
 #if(rows.isEmpty):
 <p class="empty">No student users found.</p>
 #else:

--- a/Sources/APIServer/Helpers/ClassItemCoverage.swift
+++ b/Sources/APIServer/Helpers/ClassItemCoverage.swift
@@ -15,6 +15,7 @@
 import Core
 import Fluent
 import Foundation
+import Vapor
 
 /// Records every item this submission covered that no earlier submission had.
 ///
@@ -31,13 +32,24 @@ import Foundation
 /// A7): a staff test submission or a dropped student must not inflate a number
 /// that carries bonus points to the LMS. Student-ness is per-course, checked
 /// against the setup's own course.
+///
+/// Scoped to CONTRIBUTION assignments by `declaredSlotCount`, which the caller
+/// resolves from the instructor's starter notebook. Recording for every
+/// assignment was the first shape of this and it was wrong in a way that only
+/// showed up one slice later: a union nobody reads is a row per passing test
+/// per assignment forever, and it leaves the instructor view with no cheap way
+/// to tell a bug hunt from an ordinary lab. Gating here means the mere
+/// EXISTENCE of coverage rows answers that question, so the view needs no
+/// second signal.
 func recordClassItemCoverage(
     testSetupID: String,
     userID: UUID,
     submissionID: String,
     outcomes: [TestOutcome],
+    declaredSlotCount: Int,
     on db: Database
 ) async throws {
+    guard declaredSlotCount > 0 else { return }
     let covered = outcomes.filter { $0.status == .pass }.map(\.testName)
     guard !covered.isEmpty else { return }
 
@@ -75,4 +87,25 @@ func classItemCoverage(
         .filter(\.$testSetupID == testSetupID)
         .sort(\.$item)
         .all()
+}
+
+/// How many contribution slots the assignment behind `testSetupID` declares, or
+/// 0 when it declares none / has no starter notebook.
+///
+/// Shared by both result-ingest paths so the gate cannot be applied on one and
+/// forgotten on the other — the audit-A2 shape. Reads through
+/// `notebookBytesCache` (#1171) rather than unzipping per result, so a deadline
+/// spike of submissions shares one notebook resolution.
+///
+/// Best-effort by construction: any failure to resolve the notebook yields 0,
+/// which means "not a contribution assignment" and skips accumulation. That is
+/// the safe direction — a missed row is recoverable by re-testing, whereas
+/// failing a student's result report to record a diagnostic is not.
+func declaredContributionSlotCount(
+    testSetupID: String, app: Application, on db: Database
+) async -> Int {
+    guard let setup = try? await APITestSetup.find(testSetupID, on: db),
+        let data = try? await app.notebookBytesCache.notebookData(for: NotebookSourceRef(setup))
+    else { return 0 }
+    return NotebookContributionSlots.declaredSlotCount(inInstructorNotebook: data)
 }

--- a/Sources/APIServer/Helpers/NotebookContributionSlots.swift
+++ b/Sources/APIServer/Helpers/NotebookContributionSlots.swift
@@ -23,6 +23,7 @@
 // re-substitution. Metadata also survives the one edit a first-line comment
 // convention cannot — a student pressing return at the top of the cell.
 
+import Core
 import Foundation
 
 enum NotebookContributionSlots {
@@ -46,6 +47,18 @@ enum NotebookContributionSlots {
         // A number or bool is a legitimate way to write a slot label by hand;
         // only an explicitly empty string means "not a slot".
         return true
+    }
+
+    /// How many contribution slots an instructor notebook's raw bytes declare.
+    ///
+    /// The bytes overload exists for callers that hold a notebook rather than
+    /// its parsed cells — the result-ingest path, which asks whether an
+    /// assignment is a contribution assignment at all. Returns 0 for anything
+    /// that does not parse as a notebook, which is the same answer as "declares
+    /// no slots" and the answer that keeps an ordinary assignment unaffected.
+    static func declaredSlotCount(inInstructorNotebook data: Data) -> Int {
+        guard let cells = NotebookCellSources.cells(from: data) else { return 0 }
+        return declaredSlotCount(inInstructorCells: cells)
     }
 
     /// How many contribution slots an instructor notebook declares.

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -247,11 +247,14 @@ struct BrowserResultRoutes: RouteCollection {
         // class as the whole of it.
         if reconciled.buildStatus == .passed, let userID {
             await bestEffort("class_item_coverage") {
+                let slotCount = await declaredContributionSlotCount(
+                    testSetupID: setup.id ?? "", app: req.application, on: req.db)
                 try await recordClassItemCoverage(
                     testSetupID: setup.id ?? "",
                     userID: userID,
                     submissionID: subID,
                     outcomes: reconciled.outcomes,
+                    declaredSlotCount: slotCount,
                     on: req.db
                 )
             }

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -149,11 +149,21 @@ struct ResultRoutes: RouteCollection {
 
         // Per item, and deliberately not inside the 100% gate below: a student
         // who covers one item and nothing else has still contributed that item.
+        //
+        // Only contribution assignments accumulate a union, so the slot count
+        // comes from the instructor's starter notebook. Read through
+        // `notebookBytesCache` (#1171) rather than unzipping per result: a
+        // deadline spike shares one resolution. A setup with no notebook
+        // resolves to nil, which is 0 slots, which is "not a contribution
+        // assignment" — the right answer for every ordinary assignment.
+        let slotCount = await declaredContributionSlotCount(
+            testSetupID: submission.testSetupID, app: req.application, on: req.db)
         try await recordClassItemCoverage(
             testSetupID: submission.testSetupID,
             userID: userID,
             submissionID: subID,
             outcomes: collection.outcomes,
+            declaredSlotCount: slotCount,
             on: req.db
         )
 

--- a/Sources/APIServer/Routes/Web/AssignmentCoverageRows.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentCoverageRows.swift
@@ -1,0 +1,66 @@
+// APIServer/Routes/Web/AssignmentCoverageRows.swift
+//
+// Builds the instructor-facing view of a contribution assignment's class-wide
+// coverage: every suite item, whether the class has collectively covered it,
+// and who got there first.
+//
+// The uncovered items are the point. A list of what the class HAS found is a
+// scoreboard; a list that also shows what is still missing is the thing an
+// instructor acts on mid-lab — which bugs still need someone to go after. So
+// the rows come from the manifest's suite (every item the assignment defines)
+// left-joined onto the coverage table, not from the coverage table alone.
+
+import Core
+import Fluent
+import Foundation
+
+/// The coverage rows for one assignment, or `[]` when it is not a contribution
+/// assignment.
+///
+/// Emptiness is the gate. `recordClassItemCoverage` only writes rows for an
+/// assignment declaring contribution slots, so no rows means no section — an
+/// ordinary lab's page is unchanged, with no second signal to consult and no
+/// starter-notebook read on a page that batches its queries carefully.
+func buildAssignmentCoverageRows(
+    testSetupID: String,
+    manifest: TestProperties?,
+    formatter: DateFormatter,
+    on db: Database
+) async throws -> [AssignmentCoverageRow] {
+    let covered = try await classItemCoverage(testSetupID: testSetupID, on: db)
+    guard !covered.isEmpty else { return [] }
+
+    // One query for the finders rather than one per row.
+    let finderIDs = Array(Set(covered.map(\.userID)))
+    let finders = try await APIUser.query(on: db).filter(\.$id ~~ finderIDs).all()
+    var usernameByID: [UUID: String] = [:]
+    for user in finders { if let id = user.id { usernameByID[id] = user.username } }
+
+    var coverageByItem: [String: APIClassItemCoverage] = [:]
+    for row in covered { coverageByItem[row.item] = row }
+
+    // Every item the suite defines, in suite order, so an uncovered item still
+    // has a row. A covered item whose suite entry has since been deleted also
+    // keeps its row — dropping it would quietly shrink the denominator an
+    // instructor is reading against.
+    var items = (manifest?.testSuites ?? []).map {
+        runnerOutcomeTestName(displayName: $0.name, script: $0.script)
+    }
+    for item in covered.map(\.item) where !items.contains(item) { items.append(item) }
+
+    return items.map { item in
+        guard let row = coverageByItem[item] else {
+            return AssignmentCoverageRow(item: item, found: false, foundBy: "", foundAt: "")
+        }
+        return AssignmentCoverageRow(
+            item: item,
+            found: true,
+            foundBy: usernameByID[row.userID] ?? "unknown",
+            foundAt: row.coveredAt.map { formatter.string(from: $0) } ?? "")
+    }
+}
+
+/// "9 / 15 found" — the section's summary chip.
+func assignmentCoverageSummary(_ rows: [AssignmentCoverageRow]) -> String {
+    "\(rows.filter(\.found).count) / \(rows.count) found"
+}

--- a/Sources/APIServer/Routes/Web/AssignmentCoverageRows.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentCoverageRows.swift
@@ -48,15 +48,18 @@ func buildAssignmentCoverageRows(
     }
     for item in covered.map(\.item) where !items.contains(item) { items.append(item) }
 
+    let iso = ISO8601DateFormatter()
     return items.map { item in
         guard let row = coverageByItem[item] else {
-            return AssignmentCoverageRow(item: item, found: false, foundBy: "", foundAt: "")
+            return AssignmentCoverageRow(
+                item: item, found: false, foundBy: "", foundAt: "", foundAtISO: "")
         }
         return AssignmentCoverageRow(
             item: item,
             found: true,
             foundBy: usernameByID[row.userID] ?? "unknown",
-            foundAt: row.coveredAt.map { formatter.string(from: $0) } ?? "")
+            foundAt: row.coveredAt.map { formatter.string(from: $0) } ?? "",
+            foundAtISO: row.coveredAt.map { iso.string(from: $0) } ?? "")
     }
 }
 

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -366,6 +366,30 @@ struct AssignmentSubmissionsContext: Encodable {
     /// affordance on this page (spent tag + re-grant action) — when off the
     /// page renders identically to the pre-feature layout.
     let secretRevealEnabled: Bool
+    /// One row per suite item on a CONTRIBUTION assignment: whether the class
+    /// has collectively covered it, and who got there first.  Empty for every
+    /// other assignment, which is what gates the section off the page — the
+    /// accumulator only writes rows for assignments declaring contribution
+    /// slots, so "has rows" IS "is a contribution assignment".
+    let coverageRows: [AssignmentCoverageRow]
+    /// True iff `coverageRows` is non-empty.  The template gates on this rather
+    /// than on `!coverageRows.isEmpty`, which Leaf cannot express — the same
+    /// shape `hasClassGoals` uses on the submission page.
+    let hasCoverage: Bool
+    /// "9 / 15 found", for the section's summary chip.
+    let coverageSummary: String
+}
+
+/// One item of a contribution assignment's class-wide coverage.
+struct AssignmentCoverageRow: Encodable {
+    /// The suite item's runner-stamped name, as it appears in results.
+    let item: String
+    /// True when someone in the class has covered it.
+    let found: Bool
+    /// The first finder's username, or "" when nobody has covered it yet.
+    let foundBy: String
+    /// When it was first covered, preformatted, or "" when uncovered.
+    let foundAt: String
 }
 
 struct AssignmentStudentRow: Encodable {

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -388,8 +388,13 @@ struct AssignmentCoverageRow: Encodable {
     let found: Bool
     /// The first finder's username, or "" when nobody has covered it yet.
     let foundBy: String
-    /// When it was first covered, preformatted, or "" when uncovered.
+    /// When it was first covered, preformatted, or "" when uncovered.  Serves
+    /// as the no-JS fallback inside the relative-time cell.
     let foundAt: String
+    /// The same instant as an ISO-8601 stamp for `js-relative-time`.  "When a
+    /// bug was first found" is human-activity recency, which the Timestamps
+    /// rule renders relative — as both other "When" columns on the site do.
+    let foundAtISO: String
 }
 
 struct AssignmentStudentRow: Encodable {

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -102,6 +102,16 @@ extension InstructorDashboardRoutes {
             enrolledStudentRosterCount: enrolledStudentRosterCount
         )
 
+        // Class-wide coverage, for a contribution assignment. Returns [] for
+        // every other assignment (the accumulator writes no rows there), which
+        // is what keeps this section off ordinary pages.
+        let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
+        let coverageRows = try await buildAssignmentCoverageRows(
+            testSetupID: assignment.testSetupID,
+            manifest: setup?.decodedManifest(),
+            formatter: fmt,
+            on: req.db)
+
         return try await req.view.render(
             "assignment-submissions",
             AssignmentSubmissionsContext(
@@ -110,7 +120,10 @@ extension InstructorDashboardRoutes {
                 assignmentTitle: assignment.title,
                 metrics: metrics,
                 rows: rows,
-                secretRevealEnabled: secretRevealEnabled
+                secretRevealEnabled: secretRevealEnabled,
+                coverageRows: coverageRows,
+                hasCoverage: !coverageRows.isEmpty,
+                coverageSummary: assignmentCoverageSummary(coverageRows)
             )
         )
     }

--- a/Tests/APITests/ClassItemCoverageTests.swift
+++ b/Tests/APITests/ClassItemCoverageTests.swift
@@ -69,6 +69,7 @@ import VaporTesting
                     outcome("variant_01", .pass), outcome("variant_02", .fail),
                     outcome("variant_03", .error), outcome("variant_04", .timeout),
                 ],
+                declaredSlotCount: 3,
                 on: app.db)
 
             let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
@@ -88,7 +89,7 @@ import VaporTesting
             for index in 1...9 { outcomes.append(outcome("variant_1\(index)", .fail)) }
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: try fx.a.requireID(),
-                submissionID: "lowscore_s1", outcomes: outcomes, on: app.db)
+                submissionID: "lowscore_s1", outcomes: outcomes, declaredSlotCount: 3, on: app.db)
 
             let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
             #expect(rows.map(\.item) == ["variant_07"])
@@ -109,10 +110,10 @@ import VaporTesting
 
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: aID, submissionID: "firstwins_a",
-                outcomes: [outcome("variant_03", .pass)], on: app.db)
+                outcomes: [outcome("variant_03", .pass)], declaredSlotCount: 3, on: app.db)
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: bID, submissionID: "firstwins_b",
-                outcomes: [outcome("variant_03", .pass)], on: app.db)
+                outcomes: [outcome("variant_03", .pass)], declaredSlotCount: 3, on: app.db)
 
             let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
             #expect(rows.count == 1, "one item covered twice must not produce two rows")
@@ -134,7 +135,7 @@ import VaporTesting
             for _ in 1...3 {
                 try await recordClassItemCoverage(
                     testSetupID: fx.setupID, userID: aID, submissionID: "replay_a",
-                    outcomes: outcomes, on: app.db)
+                    outcomes: outcomes, declaredSlotCount: 3, on: app.db)
             }
 
             let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
@@ -157,16 +158,41 @@ import VaporTesting
 
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: bID, submissionID: "order_b",
-                outcomes: [outcome("variant_02", .pass), outcome("variant_03", .pass)], on: app.db)
+                outcomes: [outcome("variant_02", .pass), outcome("variant_03", .pass)], declaredSlotCount: 3, on: app.db
+            )
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: aID, submissionID: "order_a",
-                outcomes: [outcome("variant_01", .pass), outcome("variant_02", .pass)], on: app.db)
+                outcomes: [outcome("variant_01", .pass), outcome("variant_02", .pass)], declaredSlotCount: 3, on: app.db
+            )
 
             let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
             #expect(rows.map(\.item) == ["variant_01", "variant_02", "variant_03"])
             // variant_02 was covered by B first, even though A submitted it too.
             let variant2 = try #require(rows.first { $0.item == "variant_02" })
             #expect(variant2.userID == bID)
+        }
+    }
+
+    // MARK: - Only contribution assignments accumulate
+
+    /// The gate that keeps this feature's rows out of every ordinary lab. An
+    /// assignment declaring no contribution slots is not a bug hunt, so its
+    /// passing tests are not a class-wide union — and the mere existence of
+    /// coverage rows is what the instructor view uses to tell the two apart,
+    /// so a row written here would put a coverage section on every page.
+    @Test func anAssignmentWithNoSlotsAccumulatesNothing() async throws {
+        try await withAssignmentRoutesApp { app in
+            let fx = try await fixture(app, prefix: "noslots")
+            let aID = try fx.a.requireID()
+            _ = try await arInsertSubmission(
+                id: "noslots_s1", testSetupID: fx.setupID, userID: aID, on: app)
+
+            try await recordClassItemCoverage(
+                testSetupID: fx.setupID, userID: aID, submissionID: "noslots_s1",
+                outcomes: [outcome("variant_01", .pass), outcome("variant_02", .pass)],
+                declaredSlotCount: 0, on: app.db)
+
+            #expect(try await classItemCoverage(testSetupID: fx.setupID, on: app.db).isEmpty)
         }
     }
 
@@ -185,7 +211,7 @@ import VaporTesting
             // Deliberately NOT enrolled as a student in the setup's course.
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: staffID, submissionID: "staff_s1",
-                outcomes: [outcome("variant_01", .pass)], on: app.db)
+                outcomes: [outcome("variant_01", .pass)], declaredSlotCount: 3, on: app.db)
 
             let rows = try await classItemCoverage(testSetupID: fx.setupID, on: app.db)
             #expect(rows.isEmpty)
@@ -203,10 +229,10 @@ import VaporTesting
 
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: aID, submissionID: "empty_s1",
-                outcomes: [outcome("variant_01", .fail)], on: app.db)
+                outcomes: [outcome("variant_01", .fail)], declaredSlotCount: 3, on: app.db)
             try await recordClassItemCoverage(
                 testSetupID: fx.setupID, userID: aID, submissionID: "empty_s1",
-                outcomes: [], on: app.db)
+                outcomes: [], declaredSlotCount: 3, on: app.db)
 
             #expect(try await classItemCoverage(testSetupID: fx.setupID, on: app.db).isEmpty)
         }
@@ -224,7 +250,7 @@ import VaporTesting
 
             try await recordClassItemCoverage(
                 testSetupID: one.setupID, userID: aID, submissionID: "scope_s1",
-                outcomes: [outcome("variant_01", .pass)], on: app.db)
+                outcomes: [outcome("variant_01", .pass)], declaredSlotCount: 3, on: app.db)
 
             #expect(try await classItemCoverage(testSetupID: one.setupID, on: app.db).count == 1)
             #expect(try await classItemCoverage(testSetupID: two.setupID, on: app.db).isEmpty)

--- a/changelog.d/class-item-coverage-gate.md
+++ b/changelog.d/class-item-coverage-gate.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Class-wide item coverage is recorded only for contribution assignments.**
+  The accumulator shipped recording a row for every passing test on every
+  assignment, on the reasoning that the union is generically useful. It is not:
+  an ordinary lab's passing tests are not a class-wide union, and the rows would
+  accrue forever while leaving the instructor coverage view with no cheap way to
+  tell a bug hunt from a normal assignment — so it would need a second signal, or
+  it would render a coverage section on every instructor page. The write is now
+  gated on the assignment declaring contribution slots, resolved from the starter
+  notebook through `notebookBytesCache` so a deadline spike shares one resolution,
+  and best-effort so a lookup failure skips accumulation rather than failing a
+  student's result report. The existence of coverage rows now means "this is a
+  contribution assignment".

--- a/changelog.d/instructor-coverage-view.md
+++ b/changelog.d/instructor-coverage-view.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Instructors can see which items the class has collectively covered.** A "Bug
+  coverage" section on the per-assignment submissions page lists every suite item
+  of a contribution assignment with a found / not-found chip, who found it first,
+  and when. The uncovered items are the point: a list of what the class has found
+  is a scoreboard, while one that also shows what is missing is what an
+  instructor acts on mid-lab. It renders only for contribution assignments, and
+  needs no flag to know that — the accumulator writes coverage rows only for
+  assignments declaring contribution slots, so the existence of rows is itself the
+  gate, and an ordinary assignment's page is unchanged. Assembled entirely from
+  the existing component vocabulary, so it adds no CSS.

--- a/docs/collaborative-class-assignments.md
+++ b/docs/collaborative-class-assignments.md
@@ -506,6 +506,16 @@ and nothing else has still contributed it. **It is roster-scoped**, for the
 reason audit A7 gives: an unscoped numerator once carried unearned bonus points
 to the LMS.
 
+Scoped to CONTRIBUTION assignments, which was a correction rather than the
+original shape. The first version recorded for every assignment, on the
+reasoning that the union is generically useful. One slice later that proved
+wrong in a way only the consumer could reveal: rows exist for every passing test
+on every lab forever, and the instructor view then has no cheap way to tell a
+bug hunt from an ordinary assignment — so it would need a second signal, or it
+would render a coverage section on every instructor page. Gating the write on
+`declaredSlotCount > 0` means the mere EXISTENCE of coverage rows answers that
+question.
+
 Wired at BOTH ingest paths deliberately. The class records were once awarded
 only in the worker handler, so browser-graded assignments never awarded any
 until audit A2 caught it — a half-wired accumulator is worse than none, because


### PR DESCRIPTION
Slices 3½ and 4 of the collaborative-class-assignment plan: a correction to the accumulator merged in #1469, plus the first consumer that motivated it.

They ship together because the correction only makes sense alongside the thing it enables — the gate has no consumer without the view, and the view needs no second signal because of the gate.

## 1. The accumulator is gated to contribution assignments

Slice 3 shipped recording a row for every passing test on **every** assignment, on the reasoning that the union is generically useful.

Building its consumer showed that isn't right. An ordinary lab's passing tests are not a class-wide union: rows accrue forever for assignments nothing will read them for, and — the part only the consumer could reveal — the instructor view is then left with no cheap way to tell a bug hunt from a normal assignment. It would need a second signal, or it would render a coverage section on every instructor page.

Gating the write on `declaredSlotCount > 0` makes the mere **existence** of coverage rows answer that question.

- The slot count reads through `notebookBytesCache` (#1171) rather than unzipping per result, so a deadline spike shares one resolution.
- **Best-effort by construction**: any failure to resolve yields 0, which means "not a contribution assignment" and skips accumulation. That's the safe direction — a missed row is recoverable by re-testing, whereas failing a student's result report to record a diagnostic is not.
- The lookup is **one shared helper** called from both ingest paths, not inlined twice, so the gate can't be applied to one and forgotten on the other — the audit-A2 shape that motivated wiring both paths originally.

## 2. The instructor coverage view

A "Bug coverage" section on the per-assignment submissions page: every suite item with a found / not-found chip, the first finder, and when.

**The uncovered items are the point.** A list of what the class *has* found is a scoreboard; one that also shows what's missing is what an instructor acts on mid-lab. So the rows are the manifest's suite left-joined onto the coverage table, not the coverage table alone.

**Emptiness is the gate.** "Has rows" is "is a contribution assignment", so an ordinary lab's page is unchanged — no second signal, and no starter-notebook read added to a route that batches its queries carefully.

A covered item whose suite entry has since been deleted keeps its row. Dropping it would quietly shrink the denominator an instructor is reading against.

**Zero new CSS classes** — `.page-section`, `.chip`/`.chip-ok`/`.chip-err`, `.results-table`, `.table-scroll`, `.col-hide-phone`.

## 3. The `ui-review` requirement is now unconditional

CLAUDE.md already required the agent for `Resources/Views/` changes but didn't say the requirement outranks a general instruction discouraging agent use — and this session hit exactly that ambiguity, pausing to ask whether to run it. That's the wrong resolution: green guards are necessary and *not* sufficient here, since every style regression in this project so far has been mechanically legal. The rule now says so.

## Verification

- `scripts/check-styles.sh` exits 0 (verified unpiped): class resolution OK, vocabulary catalog unchanged at 262/262, page-style ratchet untouched.
- `scripts/format.sh`, `scripts/lint.sh`, `scripts/swiftlint.sh` clean.
- 9 tests in `ClassItemCoverageTests` including one pinning the new gate; 366 pass across `ClassItemCoverage|Achievement|Result|MergeNotebook|Submission`.
- **`ui-review` is running against this diff. Its findings land as a follow-up commit before this leaves draft** — it is not ready to merge until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GuGKuZkbjcYBzW73fZ3SU