### PR TITLE
ci(mutation): widen the per-PR trigger to the real scope, and make triage a queue

### DIFF
--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -14,9 +14,26 @@ name: Mutation testing (changed files)
 # 6 lines means a 60-line diff is ~10 mutants and a couple of minutes, where the
 # whole tree is ~10,000 and never affordable.
 #
-# SCOPE is deliberately the same set the weekly sweep mutates
-# (Tools/mutation/config.json `include`). A PR touching nothing in that set is
-# skipped entirely rather than run empty, and the job says which files it took.
+# SCOPE is the same set the weekly sweep mutates, and there is exactly ONE list
+# of it: `include` in Tools/mutation/config.json, which the "Work out which
+# mutable files this PR touches" step reads at run time. A PR touching nothing in
+# that set exits there with count=0, so every later step is skipped and the job
+# is a no-op that says so.
+#
+# THE TRIGGER IS DELIBERATELY WIDER THAN THE SCOPE, and that is the fix for a
+# defect rather than sloppiness. `paths:` cannot be computed from a file, so a
+# narrow filter here is a SECOND copy of the include list — hand-maintained, and
+# required to agree with the first. It did not: this filter was written as
+# `Sources/RunnerCore/**` in #1456, when that was the whole sweep scope, and #1460
+# widened the sweep to Sources/Core hours later without touching it. For the next
+# eleven days a PR changing only Sources/Core — 8,639 lines, and 58 of the 75
+# survivors in run 32265903112 — was silently never mutation-tested, while this
+# comment claimed parity with config.json.
+#
+# So the filter now names the whole of Sources/ and lets the derived list do the
+# deciding. The cost is a container spin-up on a PR that turns out to touch
+# nothing mutable; the benefit is that widening the sweep can never again leave
+# the per-PR job behind, because there is nothing here to forget to update.
 #
 # It opts out of the drive-to-green reflex on purpose: `continue-on-error` means a
 # broken Muter, a red baseline or a slow shard cannot fail somebody's pull
@@ -26,7 +43,7 @@ name: Mutation testing (changed files)
 on:
   pull_request:
     paths:
-      - "Sources/RunnerCore/**"
+      - "Sources/**"
 
 permissions:
   contents: read
@@ -168,6 +185,24 @@ jobs:
       - name: Report
         if: always() && steps.files.outputs.count != '0'
         run: |
+          # The header goes in the SUMMARY, not just in this file's comments.
+          # `continue-on-error` already stops this job failing a PR, but the
+          # pressure that matters is social: a survivor listed on your own diff
+          # reads as a to-do, and the cheapest way to clear a to-do is an
+          # assertion that runs the line without checking the result. That is
+          # precisely the failure mutation testing exists to detect, so the one
+          # place guaranteed to be read has to say that closing an item with a
+          # reason is a real answer.
+          {
+            echo "> **This is a report, not a gate, and there is no score to chase.**"
+            echo "> A survivor is a question — *could the suite tell the difference?*"
+            echo "> Three answers are legitimate and the third is not failure: write the"
+            echo "> test; decide nothing reaching this code can tell the difference and"
+            echo "> **record why**; or find the mutant already dead. Some are unkillable by"
+            echo "> construction, so a run that 'fixed' every one would be worse than this"
+            echo "> one. See \`docs/mutation-triage.md\`."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
           if [ -f mutation-report/report.md ]; then
             cat mutation-report/report.md >> "$GITHUB_STEP_SUMMARY"
           else

--- a/Tools/mutation/equivalent-mutants.json
+++ b/Tools/mutation/equivalent-mutants.json
@@ -1,0 +1,41 @@
+{
+  "_comment": [
+    "SURVIVORS CLOSED WITH A REASON RATHER THAN A TEST.",
+    "",
+    "docs/mutation-triage.md gives three legitimate answers to a survivor, and",
+    "the second is 'nothing reaching this code can tell the difference — close",
+    "it, record why'. Until this file existed the recording had nowhere to live",
+    "that the sweep could read, so an equivalent mutant came back every week",
+    "looking exactly like an untriaged gap. Whoever picked it up either",
+    "re-derived the argument or, worse, wrote a test asserting something that",
+    "cannot vary.",
+    "",
+    "With it, the survivor list IS the open queue and can reach zero. That is",
+    "the metric worth having: not a percentage, which no honest suite can drive",
+    "to 100 because some mutants are unkillable by construction, but a count of",
+    "questions nobody has answered yet.",
+    "",
+    "AN ENTRY IS KEYED ON THE MUTATION TEXT, NOT A LINE NUMBER. Lines move, and",
+    "a stale line number would silently excuse whatever mutant drifted into it.",
+    "Matching on the normalised mutated statement also makes an entry",
+    "self-invalidating in the right way: edit the code and the text stops",
+    "matching, so the survivor reappears and the argument has to be made again",
+    "against the code as it now is.",
+    "",
+    "`reason` must be an argument, not a label. It has to say what makes the",
+    "mutant unobservable — which inputs can reach the site and why none of them",
+    "distinguishes the two versions. 'equivalent mutant' is not a reason.",
+    "",
+    "This is NOT a suppression list. Do not add an entry because a mutant is",
+    "hard to kill, or because the test would be awkward. Those are gaps, and a",
+    "gap parked here is indistinguishable from a lie."
+  ],
+  "entries": [
+    {
+      "file": "Sources/RunnerCore/JSONLite.swift",
+      "operator": "RelationalOperatorReplacement",
+      "mutated": "let start = pos if current != \"-\" { pos += 1 } while let c = current, (c >= \"0\" && c <= \"9\") || c == \".\" || c == \"e\" || c == \"E\" || c == \"+\" || c == \"-\" { pos += 1 } guard let value = JSONParser.parseDoubleLiteral(chars[start..<pos]) else { return nil } return .number(value)",
+      "reason": "parseValue routes here only when the current character is '-' or a digit, and the while loop that follows accepts BOTH. `start` is captured before the `if`, so the sign is consumed either by the `if` or by the loop's first iteration and `pos` lands in the same place either way. The slice handed to parseDoubleLiteral is therefore identical for every input that can reach this function, including a lone '-', a leading digit followed by a non-numeric character, and '--5'. Verified SURVIVED against run 32265903112 after JSONFooterGrammarTests killed the other fourteen candidates in this file."
+    }
+  ]
+}

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -210,6 +210,32 @@ def harvest_schemata(mutated_root: str) -> tuple[dict[tuple[str, str], list[int]
     )
 
 
+
+def load_equivalent_ledger() -> dict[tuple[str, str, str], str]:
+    """Survivors closed with a recorded reason, keyed (file, operator, mutation).
+
+    A malformed ledger is a hard error rather than an empty dict. Failing open
+    here would silently re-open every answered survivor, which looks like a
+    week's worth of regressions and trains the reader to ignore the list.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "equivalent-mutants.json")
+    if not os.path.isfile(path):
+        return {}
+    with open(path) as fh:
+        entries = json.load(fh).get("entries", [])
+    ledger: dict[tuple[str, str, str], str] = {}
+    for e in entries:
+        reason = (e.get("reason") or "").strip()
+        if len(reason) < 40:
+            raise SystemExit(
+                f"equivalent-mutants.json: {e.get('file')} {e.get('operator')} has no real "
+                "reason. An entry must argue why nothing reaching the site can observe the "
+                "change; a label is not an argument, and this file is not a suppression list."
+            )
+        ledger[(e["file"], e["operator"], " ".join(e["mutated"].split()))] = reason
+    return ledger
+
+
 def harvest_true_positions(mutated_root: str) -> dict[tuple[str, str], list[int]]:
     """Positions only -- kept as the narrow entry point for the phantom filter."""
     return harvest_schemata(mutated_root)[0]
@@ -293,6 +319,32 @@ def main() -> int:
         inert_set = set(inert)
         resolved = [r for r in resolved if r not in inert_set]
 
+    # SURVIVORS ALREADY ANSWERED, with a reason instead of a test. See
+    # equivalent-mutants.json: without this the survivor list can never reach
+    # zero, because a genuinely unkillable mutant comes back every week looking
+    # exactly like an untriaged gap. Filtering them is what turns the list into
+    # a QUEUE -- the metric worth having, since no honest suite drives the
+    # percentage to 100.
+    #
+    # Keyed on the mutation text rather than a line number, so an entry cannot
+    # drift onto a different mutant and stops matching the moment the code it
+    # excuses is edited.
+    ledger = load_equivalent_ledger()
+    equivalent = []
+    if ledger:
+        for key in list(mutation_of):
+            path, _line, operator = key
+            muts = mutation_of[key]
+            if not muts:
+                continue
+            if all((path, operator, " ".join(m["mutated"].split())) in ledger for m in muts):
+                equivalent.append(key)
+        if equivalent:
+            eq_set = set(equivalent)
+            resolved = [r for r in resolved if r not in eq_set]
+            for key in equivalent:
+                del mutation_of[key]
+
     os.makedirs(out_dir, exist_ok=True)
     with open(os.path.join(out_dir, "survivors.tsv"), "w") as fh:
         fh.write("file\treported_line\ttrue_line\toperator\tsource\n")
@@ -332,6 +384,13 @@ def main() -> int:
                     "mutations": mutation_of.get((path, line, operator), []),
                 }
                 for path, line, operator in sorted(resolved)
+            ],
+            # Survivors closed with a recorded reason (equivalent-mutants.json).
+            # Carried in the record so the trend can show the queue shrinking
+            # for the right reason rather than the list merely getting shorter.
+            "answeredWithReason": [
+                {"file": path, "line": line, "operator": operator}
+                for path, line, operator in sorted(equivalent)
             ],
             # Mutations Muter emitted UNCHANGED (see the quarantine above).
             # Recorded rather than dropped so the count reconciles and so a
@@ -422,6 +481,22 @@ def main() -> int:
                     out.append(f"    - becomes: `{one}`")
         else:
             out.append("No survivors. Every mutant in this shard was killed.")
+
+        if equivalent:
+            out += [
+                "",
+                "### Already answered — closed with a reason, not a test",
+                "",
+                f"{len(equivalent)} survivor(s) are recorded in",
+                "`Tools/mutation/equivalent-mutants.json` as unkillable by construction,",
+                "each with the argument for why. They are listed here rather than dropped so",
+                "the reasoning stays visible and so re-opening one is a deliberate act. Do",
+                "not write tests for these; if you think an argument is wrong, delete the",
+                "entry and the survivor comes back.",
+                "",
+            ]
+            for path, line, operator in sorted(equivalent):
+                out.append(f"- `{path}` L{line} `{operator}`")
 
         if inert:
             out += [

--- a/Tools/mutation/report_test.py
+++ b/Tools/mutation/report_test.py
@@ -261,5 +261,84 @@ if ProcessInfo.processInfo.environment["Probe_SwapTernary_10_5_120"] != nil {
         self.assertEqual(summary.get("inertMutants"), [])
 
 
+
+class EquivalentLedgerTests(unittest.TestCase):
+    """Survivors answered with a reason must leave the open queue.
+
+    The point of the ledger is that the survivor list becomes a QUEUE that can
+    reach zero. A percentage cannot: some mutants are unkillable by
+    construction, so chasing 100% means writing tests for inputs that cannot
+    occur. A count of unanswered questions is the honest target, and it only
+    works if answering one removes it.
+    """
+
+    RAW = """\
+Probe.swift:10  ChangeLogicalConnector  mutant survived
+
+Of the 1 mutants introduced into your code, your test suite killed 0.
+Mutation Score of Test Suite: 0%
+Muter took 00:00:01.000
+"""
+
+    MUTATED = '''\
+import class Foundation.ProcessInfo
+if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"] != nil {
+    return a && b
+} else {
+    return a || b
+}
+'''
+
+    def _with_ledger(self, entries):
+        """Point report.py at a temporary ledger and run it."""
+        real = os.path.join(HERE, "equivalent-mutants.json")
+        backup = open(real).read() if os.path.exists(real) else None
+        with open(real, "w") as fh:
+            json.dump({"entries": entries}, fh)
+        try:
+            return run(self.RAW, self.MUTATED)
+        finally:
+            if backup is None:
+                os.unlink(real)
+            else:
+                with open(real, "w") as fh:
+                    fh.write(backup)
+
+    def test_a_ledgered_survivor_leaves_the_open_list(self):
+        _code, report, summary = self._with_ledger([{
+            "file": "Probe.swift",
+            "operator": "ChangeLogicalConnector",
+            "mutated": "return a && b",
+            "reason": "Nothing reaching this site can observe the change, because "
+                      "both operands are always equal for every caller in the tree.",
+        }])
+        self.assertEqual(summary["survived"], 0)
+        self.assertEqual(len(summary["answeredWithReason"]), 1)
+        self.assertIn("Already answered", report)
+
+    def test_a_ledger_entry_for_a_different_mutation_does_not_excuse_this_one(self):
+        """Keyed on the mutation text, so an entry cannot drift onto its neighbour."""
+        _code, _report, summary = self._with_ledger([{
+            "file": "Probe.swift",
+            "operator": "ChangeLogicalConnector",
+            "mutated": "return a || c",
+            "reason": "A real argument about a different mutation entirely, long "
+                      "enough to pass the reason check but keyed elsewhere.",
+        }])
+        self.assertEqual(summary["survived"], 1)
+        self.assertEqual(summary["answeredWithReason"], [])
+
+    def test_an_entry_without_a_real_reason_is_refused(self):
+        """The ledger is not a suppression list, and says so by failing."""
+        code, _report, summary = self._with_ledger([{
+            "file": "Probe.swift",
+            "operator": "ChangeLogicalConnector",
+            "mutated": "return a && b",
+            "reason": "equivalent mutant",
+        }])
+        self.assertNotEqual(code, 0)
+        self.assertIsNone(summary)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/mutation/workflow_scope_test.py
+++ b/Tools/mutation/workflow_scope_test.py
@@ -1,0 +1,72 @@
+"""The per-PR job's trigger must not be narrower than the scope it mutates.
+
+WHY THIS EXISTS. `paths:` in a GitHub workflow cannot be computed from a file, so
+any filter listing source directories is a SECOND copy of
+`Tools/mutation/config.json`'s `include` — hand-maintained, and silently required
+to agree with the first.
+
+It did not agree. `mutation-pr.yml` was written with `Sources/RunnerCore/**` in
+#1456, when that was the entire sweep scope. #1460 widened the sweep to
+`Sources/Core` hours later and did not touch the filter. For eleven days a pull
+request changing only `Sources/Core` — 8,639 lines, and 58 of the 75 survivors in
+run 32265903112 — never triggered the job, while the workflow's own comment
+claimed parity with config.json. Nothing failed; the job simply did not run, which
+looks identical to a job that ran and found nothing.
+
+The fix was to widen the trigger to all of `Sources/**` and let the run-time step
+that already reads `include` do the deciding, so there is one list again. This
+test is what stops the filter being narrowed back "to save a container spin-up":
+narrowing it re-creates the second list, and the second list is what drifted.
+"""
+
+import json
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+CONFIG = os.path.join(HERE, "config.json")
+WORKFLOW = os.path.join(REPO, ".github/workflows/mutation-pr.yml")
+
+
+def trigger_paths() -> list[str]:
+    """The `paths:` entries of the pull_request trigger.
+
+    Read with a small parser rather than PyYAML: the mutation tooling's test job
+    runs on a bare python3 with no pip install step, and a dependency here would
+    make the guard skip itself on the one machine that runs it.
+    """
+    with open(WORKFLOW) as fh:
+        text = fh.read()
+    block = re.search(r"\non:\n(.*?)\n\w", text, re.S)
+    assert block, "no `on:` block in mutation-pr.yml"
+    return re.findall(r'^\s*-\s*"([^"]+)"', block.group(1), re.M)
+
+
+class WorkflowScopeTests(unittest.TestCase):
+
+    def test_every_configured_include_is_reachable_from_the_trigger(self):
+        includes = json.load(open(CONFIG))["include"]
+        paths = trigger_paths()
+        self.assertTrue(paths, "the pull_request trigger lists no paths")
+        for inc in includes:
+            # A filter entry covers an include when the directory it names is
+            # that include or an ancestor of it. `Sources/RunnerCore/**` covers
+            # `Sources/RunnerCore` itself, so the equality case is not optional:
+            # leaving it out makes this guard fail on a correct configuration,
+            # which is how a guard gets deleted rather than heeded.
+            reachable = any(
+                inc == (prefix := p.rstrip("*").rstrip("/")) or inc.startswith(prefix + "/")
+                for p in paths
+            )
+            self.assertTrue(
+                reachable,
+                f"config.json mutates {inc!r} but mutation-pr.yml's trigger "
+                f"{paths} would not fire for a PR that only touches it. Widen the "
+                f"trigger — do not add a second copy of the include list.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/changelog.d/mutation-pr-scope-and-triage-queue.md
+++ b/changelog.d/mutation-pr-scope-and-triage-queue.md
@@ -1,0 +1,33 @@
+### Fixed
+
+- **The per-PR mutation job was not watching most of the code it claimed to.**
+  Its `paths:` filter was written as `Sources/RunnerCore/**` when that was the
+  whole sweep scope, and widening the sweep to `Sources/Core` hours later did
+  not update it — so for eleven days a pull request touching only
+  `Sources/Core` (8,639 lines, and 58 of the 75 survivors in the latest run)
+  silently never triggered a mutation run, while the workflow's own comment
+  claimed parity with `config.json`. The trigger now names all of `Sources/**`
+  and lets the run-time step that already reads `include` do the deciding, so
+  there is one list rather than two that must agree. A guard
+  (`workflow_scope_test.py`) fails if the filter is ever narrowed below the
+  configured scope again.
+
+### Added
+
+- **Survivors closed with a reason are now recorded where the sweep can read
+  them.** `Tools/mutation/equivalent-mutants.json` holds mutants that are
+  unkillable by construction, each with the argument for why nothing reaching
+  the site can observe the change. Previously that reasoning lived only in a
+  commit message, so an equivalent mutant returned every week indistinguishable
+  from an untriaged gap. Entries are keyed on the mutation text rather than a
+  line number, so one cannot drift onto a neighbouring mutant and stops
+  matching the moment the code it excuses is edited; `report.py` refuses an
+  entry whose reason is a label rather than an argument. This is what makes the
+  survivor list a queue that can reach zero — the honest target, since no suite
+  can drive the percentage to 100.
+- **The per-PR report says it is a report.** The step summary now opens with
+  the three legitimate answers to a survivor, including that closing one with a
+  recorded reason is a real answer. `continue-on-error` already stops the job
+  failing a PR; the pressure worth heading off is social, since the cheapest
+  way to clear a survivor listed on your own diff is an assertion that runs the
+  line without checking the result.

--- a/docs/mutation-triage.md
+++ b/docs/mutation-triage.md
@@ -136,6 +136,40 @@ When a test lands, say in its comment what the mutation was and why the gap
 mattered — the tests added from the first pilot do this, and it is what stops a
 later reader deleting them as redundant.
 
+**When the answer is "no test", write it in `Tools/mutation/equivalent-mutants.json`.**
+A reason recorded only in a commit message is invisible to the next sweep, so the
+survivor comes back every week looking exactly like an untriaged gap — and
+whoever picks it up either re-derives the argument or writes a test asserting
+something that cannot vary. An entry there moves it out of the open list into
+report.md's "Already answered" section.
+
+Three things about that file, because it is one careless edit away from being a
+suppression list:
+
+- **It is keyed on the mutation text, not a line number.** Lines move, and a
+  stale line would silently excuse whatever mutant drifted into it. Matching the
+  normalised mutated statement also means an entry self-invalidates when the code
+  is edited: the survivor reappears and the argument gets made again against the
+  code as it now is. That is the desired behaviour, not a nuisance.
+- **`reason` must be an argument.** Say which inputs can reach the site and why
+  none of them distinguishes the two versions. `report.py` refuses an entry
+  shorter than a sentence, but it cannot tell a bad argument from a good one.
+- **Never park a hard-to-kill mutant there.** That is a gap, and a gap in this
+  file is indistinguishable from a lie.
+
+## The number to watch is the queue, not the score
+
+There is no coverage target here, and the mutation percentage is not one either:
+some mutants are unkillable by construction, so a suite that drove it to 100%
+would be asserting things that cannot vary. Muter also reports outcomes that are
+not mutants at all — 134 phantoms and 9 inert no-ops in run 32265903112, against
+383 real ones.
+
+What can honestly reach zero is the count of survivors nobody has answered yet.
+Killed mutants leave the list on their own; phantoms, inert mutations and
+recorded equivalents are filtered into their own sections. What remains is the
+queue, and emptying it is the goal.
+
 ## Where things are
 
 | | |


### PR DESCRIPTION
Three of the four follow-ups from the coverage/mutation review. The fourth (Worker scope) is filed as **#1472** rather than done here, because it depends on a test fix that deserves its own change.

Refs #1447, #1472.

## 1. The per-PR job was not watching most of what it claimed to

Its trigger read `paths: ["Sources/RunnerCore/**"]` — correct in #1456, when that was the entire sweep scope. #1460 widened the sweep to `Sources/Core` hours later and did not touch the filter.

For eleven days, **a PR touching only `Sources/Core` never triggered a mutation run** — 8,639 lines, and 58 of the 75 survivors in the latest sweep. Nothing failed. The job simply did not run, which is indistinguishable from a job that ran and found nothing. Meanwhile the workflow's own comment said "SCOPE is deliberately the same set the weekly sweep mutates".

`paths:` can't be computed from a file, so any directory list there is a **second copy** of `include` that has to agree with the first. Rather than correcting the copy, the trigger now names all of `Sources/**` and the run-time step — which *already* reads `include` from `config.json` and already exits `count=0` when nothing intersects — becomes the only place scope is defined. Cost: a container spin-up on a PR that turns out to touch nothing mutable. `workflow_scope_test.py` fails if the filter is narrowed below the configured scope again.

That guard was itself worth writing carefully: the first version failed on a *correct* configuration (it dropped the exact-match case, so `Sources/RunnerCore/**` didn't count as covering `Sources/RunnerCore`). A guard that fails for a bogus reason is how guards get deleted rather than heeded. It now passes on the current config and fails on the old one naming `Sources/Core` exactly.

## 2. Triage now has a queue that can reach zero

`Tools/mutation/equivalent-mutants.json` records survivors closed with a **reason** instead of a test. Until now that reasoning lived only in a commit message — invisible to the next sweep — so an equivalent mutant came back every week indistinguishable from an untriaged gap, and whoever picked it up either re-derived the argument or wrote a test asserting something that cannot vary.

`report.py` filters ledgered survivors into an "Already answered" section beside the phantoms and the inert mutations.

Two design points that matter more than the feature:

- **Keyed on the mutation text, not a line number.** A line moves and would then excuse whatever mutant drifted into it. Matching the normalised statement also makes an entry *self-invalidating*: edit the code and the survivor reappears, so the argument is remade against the code as it now is. That's the desired behaviour.
- **An entry whose `reason` is a label is refused outright.** The one thing this file must never become is a suppression list, and the failure mode is a one-line edit away.

First entry is `JSONLite`'s `parseNumber` sign check — the survivor #1470 deliberately left alive. I verified the key matches the real record, so it leaves the open list on the next sweep rather than being a no-op.

## 3. The per-PR report now says it is a report

The step summary opens with the three legitimate answers to a survivor, including that closing one with a recorded reason is a real answer. `continue-on-error` already stops the job failing a PR; the pressure worth heading off is **social** — the cheapest way to clear a survivor listed on your own diff is an assertion that runs the line without checking the result, which is the exact failure mutation testing exists to detect.

The triage doc also gains a section saying the number to watch is the unanswered queue, not the score. 134 phantoms and 9 inert no-ops against 383 real outcomes in the last run is why a percentage can't be the target.

## Not here: Worker (#1472)

Measured, so the decision is on numbers rather than instinct:

| target | LOC | ~mutants | graded by | added cost |
|---|---:|---:|---|---|
| `Sources/Worker` | 5,668 | ~944 | the fast suite | **~19 min per shard** |
| `Sources/APIServer` | 94,119 | ~15,686 | APITests, 6–9 min per run | ~1,700h serial |

Worker is affordable; APIServer is not, and should stay excluded absent per-mutant test narrowing. But Worker is blocked on a live problem: `config.json` skips the `WorkerTests` suite because it "spawns concurrent worker daemons", and `WorkerDaemonTests` is a **sibling that does the same and is kept** — it destroyed a shard today on a `maxConcurrent >= 2` race. Fixing that is worth doing on its own merits, before any scope change.

## Verification

- 46 Python tests (was 42); all four new ones seen to fail against the previous implementation.
- `scripts/check-guards.sh`: 23 guards, each seen to fail on its own defect.
- `format-lint` and SwiftLint clean. No Swift changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qPZYk8SHvaw3P9M4kAjw2)_