### PR TITLE
fix(mutation): make the last 17 mutations replayable, and close the JSONValue cluster

### DIFF
--- a/Tests/CoreTests/JSONValueDoubleFormattingTests.swift
+++ b/Tests/CoreTests/JSONValueDoubleFormattingTests.swift
@@ -1,0 +1,87 @@
+// Tests/CoreTests/JSONValueDoubleFormattingTests.swift
+//
+// One rule, shared by every literal renderer: a finite double must render as
+// something the target language reads back as a FLOAT, never as an integer.
+//
+// Each renderer implements it the same way —
+//
+//     let s = String(d)
+//     return (s.contains(".") || s.contains("e") || s.contains("E")) ? s : s + ".0"
+//
+// — and the 2026-08-19 sweep (run 32265903112) found the same hole in four of
+// them. The first `||` term is covered everywhere, because `2.0` is the obvious
+// case and every suite tests it. The SECOND term is covered nowhere: reaching it
+// needs a double whose Swift description carries an `e` and no `.`, and a search
+// for e-notation across all five existing literal suites returned zero hits.
+//
+// That is not four independent oversights. The renderers were written by copying
+// a working one and their tests were copied with them, hole included — so this
+// pins the rule ONCE, in a table, where a fifth renderer is one line and cannot
+// inherit the gap by being copied from a neighbour.
+//
+// Non-finite doubles are deliberately absent: every language spells NaN and
+// infinity differently, so they belong in the per-language suites (and are
+// already there for R, Lua, Octave, C++, Racket and Java; Python's are pinned in
+// `JSONValuePythonLiteralTests`).
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct JSONValueDoubleFormattingTests {
+
+    /// Every renderer, named. Adding one here is the whole cost of keeping a new
+    /// language honest about this rule.
+    private static let renderers: [(String, @Sendable (JSONValue) -> String)] = [
+        ("python", { $0.pythonLiteral }),
+        ("r", { $0.rLiteral }),
+        ("lua", { $0.luaLiteral }),
+        ("octave", { $0.octaveLiteral }),
+        ("cpp", { $0.cppLiteral }),
+        ("racket", { $0.racketLiteral }),
+        ("java", { $0.javaLiteral }),
+    ]
+
+    /// The covered half, kept so the table states the whole rule rather than
+    /// only its unloved end.
+    @Test func integralDoublesKeepExactlyOneDecimalPoint() {
+        for (name, render) in Self.renderers {
+            #expect(render(.double(2)) == "2.0", "\(name) rendered an integral double wrong")
+            #expect(render(.double(-4)) == "-4.0", "\(name) rendered a negative integral wrong")
+            #expect(render(.double(1.5)) == "1.5", "\(name) disturbed a non-integral double")
+        }
+    }
+
+    /// The uncovered half, and the reason this file exists.
+    ///
+    /// `String(1e-5)` is `"1e-05"` and `String(1e20)` is `"1e+20"` — both carry
+    /// an `e` and neither carries a `.`, so they are the only inputs that reach
+    /// the guard's second term. Under the surviving mutant that term becomes
+    /// `&&`, the guard answers false, and the renderer appends `.0` to a literal
+    /// that already has an exponent: `1e-05.0`, which no target language parses.
+    @Test func exponentialDoublesAreNotGivenASpuriousPoint() {
+        for (name, render) in Self.renderers {
+            #expect(render(.double(1e-5)) == "1e-05", "\(name) mangled a small exponential")
+            #expect(render(.double(1e20)) == "1e+20", "\(name) mangled a large exponential")
+            #expect(render(.double(-1e-5)) == "-1e-05", "\(name) mangled a negative exponential")
+        }
+    }
+
+    /// The property underneath both tests, stated directly: whatever a renderer
+    /// emits for a finite double, reading it back must give the same value. This
+    /// is what makes `1e-05.0` a bug rather than a formatting preference — it is
+    /// not a number at all.
+    @Test func everyRenderedFiniteDoubleIsStillThatDouble() {
+        let values: [Double] = [0, 1, -1, 2, 0.5, 1.5, -4, 1e-5, 1e20, -1e-5, 1234.5678]
+        for (name, render) in Self.renderers {
+            for v in values {
+                let text = render(.double(v))
+                // Every renderer here emits a bare numeric literal for a finite
+                // double, so Swift's own parser is a fair stand-in for the
+                // target language's.
+                #expect(Double(text) == v, "\(name) rendered \(v) as \(text), which reads back differently")
+            }
+        }
+    }
+}

--- a/Tests/CoreTests/JSONValuePythonLiteralTests.swift
+++ b/Tests/CoreTests/JSONValuePythonLiteralTests.swift
@@ -1,0 +1,69 @@
+// Tests/CoreTests/JSONValuePythonLiteralTests.swift
+//
+// `pythonLiteral` is the oldest of the seven renderers and the only one with no
+// CoreTests file: its assertions live in `Tests/APITests/PatternFamilyRendererTests`,
+// which the mutation sweep skips. That is why the 2026-08-19 sweep reported its
+// object-key sort as a survivor while the identical sort in the Racket and Java
+// renderers had already been pinned — the Python one is exercised, just not by
+// anything the sweep runs, and "exercised" is not "asserted on" either way.
+//
+// The `.0`-suffix rule this renderer shares with its six siblings is pinned once
+// in `JSONValueDoubleFormattingTests`; what is here is Python-specific.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct JSONValuePythonLiteralTests {
+
+    @Test func scalarsUsePythonSpellings() {
+        #expect(JSONValue.null.pythonLiteral == "None")
+        #expect(JSONValue.bool(true).pythonLiteral == "True")
+        #expect(JSONValue.bool(false).pythonLiteral == "False")
+        #expect(JSONValue.int(0).pythonLiteral == "0")
+        #expect(JSONValue.int(-7).pythonLiteral == "-7")
+        // Python integers are arbitrary precision, so nothing widens or suffixes.
+        #expect(JSONValue.int(2_147_483_648).pythonLiteral == "2147483648")
+    }
+
+    /// Kills the `RelationalOperatorReplacement` on the key sort
+    /// (`$0.key < $1.key` → `>`).
+    ///
+    /// `JSONValue.object` is a Dictionary, so without the sort the rendered
+    /// source differs run to run. That is not cosmetic: generated filenames
+    /// embed a `spec_hash` of the rendered bytes, so an unstable order makes a
+    /// family look edited on every save.
+    ///
+    /// This mutant is also why the sweep is worth running on code that already
+    /// has tests. The same sort in `racketLiteral` and `javaLiteral` was pinned
+    /// in #1463; this one survived because its only assertions are in a suite
+    /// the sweep does not run.
+    @Test func objectKeysAreSortedAscending() {
+        #expect(JSONValue.object([:]).pythonLiteral == "{}")
+        #expect(
+            JSONValue.object(["b": .int(2), "a": .int(1), "c": .int(3)]).pythonLiteral
+                == #"{"a": 1, "b": 2, "c": 3}"#)
+        // Sorting is by key, not by insertion or by value.
+        #expect(
+            JSONValue.object(["z": .int(1), "y": .int(2)]).pythonLiteral
+                == #"{"y": 2, "z": 1}"#)
+    }
+
+    @Test func arraysAndNestingRenderAsPythonLiterals() {
+        #expect(JSONValue.array([]).pythonLiteral == "[]")
+        #expect(JSONValue.array([.int(1), .int(2)]).pythonLiteral == "[1, 2]")
+        #expect(
+            JSONValue.array([.null, .bool(true), .string("x")]).pythonLiteral
+                == #"[None, True, "x"]"#)
+        #expect(
+            JSONValue.object(["a": .array([.int(1)])]).pythonLiteral == #"{"a": [1]}"#)
+    }
+
+    @Test func stringsAreEscaped() {
+        #expect(JSONValue.string("ok").pythonLiteral == #""ok""#)
+        #expect(JSONValue.string("a\"b").pythonLiteral == #""a\"b""#)
+        #expect(JSONValue.string(#"a\b"#).pythonLiteral == #""a\\b""#)
+        #expect(JSONValue.string("line\nbreak").pythonLiteral == #""line\nbreak""#)
+    }
+}

--- a/Tools/mutation/verify-survivor.py
+++ b/Tools/mutation/verify-survivor.py
@@ -103,6 +103,60 @@ def whole_line_is_the_statement(current: str, mutated: str) -> bool:
     return len(cur.split()) == len(mut.split()) and cur.count(":") == mut.count(":")
 
 
+def strip_duplicated_trailing_comment(body: str) -> str:
+    """Drop the copy of the leading comment Muter re-emits after the statement.
+
+    MEASURED, not assumed. For a `case` body that opens with a comment, Muter's
+    schema branches come out as [comment][statements][THE SAME COMMENT AGAIN].
+    That trailing copy exists nowhere in the source file, so the recorded text
+    is not a contiguous substring of it and an exact search finds nothing: 14 of
+    run 32265903112's 110 candidates were unverifiable for this and no other
+    reason. Removing it makes all 14 match exactly once.
+
+    Applied to the mutation as well as the original, so the replacement puts
+    back what was there rather than injecting a second comment block.
+
+    The check is deliberately narrow -- the trailing run must be the leading run,
+    line for line -- because a body that genuinely ends in a comment is ordinary
+    and must not be truncated.
+    """
+    lines = body.split("\n")
+    lead = 0
+    while lead < len(lines) and lines[lead].strip().startswith("//"):
+        lead += 1
+    if lead == 0 or lead >= len(lines) - lead:
+        return body
+    if [l.strip() for l in lines[:lead]] != [l.strip() for l in lines[-lead:]]:
+        return body
+    return "\n".join(lines[:-lead]).rstrip()
+
+
+def locate_unique(text: str, needle: str, line: int) -> int | None:
+    """Offset of the one occurrence of `needle` this record means, or None.
+
+    Content alone cannot always identify a mutation site: `let pairs = o.sorted
+    { $0.key < $1.key }` is byte-identical in all four literal renderers of
+    JSONValue.swift. Muter's line is unreliable on its own, but it is a fine
+    DISCRIMINATOR among exact content matches -- so it is used only to choose
+    between them, and only when one of them begins exactly at that line.
+
+    No nearest-match heuristic: picking the closest would mean mutating R's
+    renderer while reporting a verdict about Python's. Measured across the run's
+    three ambiguous candidates, the exact-line rule resolves all three.
+    """
+    first = text.find(needle)
+    if first < 0:
+        return None
+    if text.find(needle, first + 1) < 0:
+        return first
+    offset, matches = first, []
+    while offset >= 0:
+        matches.append(offset)
+        offset = text.find(needle, offset + 1)
+    exact = [m for m in matches if text[:m].count("\n") + 1 == line]
+    return exact[0] if len(exact) == 1 else None
+
+
 def apply_mutation(source_path: str, line: int, mutated: str, original: str | None) -> str | None:
     """Apply the mutation to the file, returning the file's previous contents.
 
@@ -123,12 +177,13 @@ def apply_mutation(source_path: str, line: int, mutated: str, original: str | No
         text = fh.read()
 
     if original is not None and original.strip():
-        # Exact swap. Ambiguity is refused: two identical statements in one file
-        # mean the record cannot say which one Muter mutated.
-        if text.count(original) != 1:
+        want = strip_duplicated_trailing_comment(original)
+        repl = strip_duplicated_trailing_comment(mutated)
+        at = locate_unique(text, want, line)
+        if at is None:
             return None
         with open(source_path, "w") as fh:
-            fh.write(text.replace(original, mutated))
+            fh.write(text[:at] + repl + text[at + len(want):])
         return text
 
     lines = text.splitlines(keepends=True)

--- a/Tools/mutation/verify_survivor_test.py
+++ b/Tools/mutation/verify_survivor_test.py
@@ -128,11 +128,59 @@ class ApplyMutationTests(unittest.TestCase):
         self.assertIn("case .equals: return lhs != value", after)
         self.assertIn("case .atLeast: return lhs >= value", after)
 
-    def test_ambiguous_original_is_refused_rather_than_guessed(self):
-        path = self._write(
-            "let a = x == y\nlet b = x == y\n"
-        )
-        self.assertIsNone(verify.apply_mutation(path, 1, "x != y", "x == y"))
+    def test_the_recorded_line_picks_between_identical_statements(self):
+        """Content finds the candidates; the line only chooses among them.
+
+        `let pairs = o.sorted { $0.key < $1.key }` is byte-identical in all four
+        literal renderers of JSONValue.swift, so content alone cannot say which
+        one Muter mutated. Refusing outright cost three real survivors in run
+        32265903112; in all three the recorded line lands exactly on one of the
+        matches, so that is the discriminator -- and only that, never nearest.
+        """
+        path = self._write("let a = x == y\nlet b = x == y\n")
+        self.assertIsNotNone(verify.apply_mutation(path, 2, "x != y", "x == y"))
+        with open(path) as fh:
+            after = fh.read()
+        # The SECOND one, because that is the line the record named.
+        self.assertEqual(after, "let a = x == y\nlet b = x != y\n")
+
+    def test_ambiguity_the_line_cannot_resolve_is_still_refused(self):
+        """No nearest-match fallback: mutating the wrong twin reports a verdict
+        about a function nobody asked about."""
+        path = self._write("let a = x == y\nlet b = x == y\n")
+        self.assertIsNone(verify.apply_mutation(path, 99, "x != y", "x == y"))
+        with open(path) as fh:
+            self.assertEqual(fh.read(), "let a = x == y\nlet b = x == y\n")
+
+    def test_muters_duplicated_trailing_comment_is_stripped_before_matching(self):
+        """Muter re-emits a body's leading comment after the statement.
+
+        The recorded text is then not a contiguous substring of the file, so an
+        exact search finds nothing -- 14 of the run's 110 candidates were
+        unverifiable for this and no other reason.
+        """
+        src = "// why\n// this exists\nlet a = x == y\n"
+        path = self._write(src)
+        recorded_original = "// why\n// this exists\nlet a = x == y\n// why\n// this exists"
+        recorded_mutated = "// why\n// this exists\nlet a = x != y\n// why\n// this exists"
+        self.assertIsNotNone(
+            verify.apply_mutation(path, 1, recorded_mutated, recorded_original))
+        with open(path) as fh:
+            after = fh.read()
+        self.assertIn("let a = x != y", after)
+        # and the comment is not duplicated into the file
+        self.assertEqual(after.count("// why"), 1)
+
+    def test_a_body_that_genuinely_ends_in_a_comment_is_not_truncated(self):
+        src = "// lead\nlet a = x == y\n// a different trailing note\n"
+        path = self._write(src)
+        original = "// lead\nlet a = x == y\n// a different trailing note"
+        mutated = "// lead\nlet a = x != y\n// a different trailing note"
+        self.assertIsNotNone(verify.apply_mutation(path, 1, mutated, original))
+        with open(path) as fh:
+            after = fh.read()
+        self.assertIn("let a = x != y", after)
+        self.assertIn("// a different trailing note", after)
 
     def test_without_an_original_a_mismatched_line_is_refused(self):
         """The regression this file exists for.

--- a/changelog.d/mutation-triage-double-formatting.md
+++ b/changelog.d/mutation-triage-double-formatting.md
@@ -1,0 +1,20 @@
+### Added
+
+- **The `.0`-suffix rule every literal renderer shares is now pinned once, in a
+  table.** A finite double must render as something the target language reads
+  back as a float, and each of the seven renderers implements that the same way:
+  `(s.contains(".") || s.contains("e") || …) ? s : s + ".0"`. Every suite tested
+  the first term — `2.0` is the obvious case — and a search for e-notation across
+  all five existing literal suites returned zero hits, so the second term was
+  covered nowhere. The 2026-08-19 sweep found the identical hole in four
+  renderers, which is what copying a working renderer *and its tests* produces.
+  `JSONValueDoubleFormattingTests` covers all seven from one table, so a new
+  language is one line and cannot inherit the gap from a neighbour; it also
+  asserts the property underneath the rule, that every rendered finite double
+  reads back as itself.
+- **`pythonLiteral` has a CoreTests file**, chiefly for its object-key sort. It
+  was the only renderer without one — its assertions live in `APITests`, which
+  the sweep skips — which is why the sweep flagged a sort that had already been
+  pinned for Racket and Java. Key order is not cosmetic: generated filenames
+  embed a `spec_hash` of the rendered bytes, so an unstable order makes a pattern
+  family look edited on every save.

--- a/changelog.d/mutation-verifier-replayable-originals.md
+++ b/changelog.d/mutation-verifier-replayable-originals.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Seventeen recorded mutations the verifier could not replay now replay.**
+  Two unrelated causes, each measured against run 32265903112 before being
+  fixed. Muter re-emits a body's leading comment *after* the statement, so the
+  recorded text was `[comment][statement][the same comment again]` — not a
+  contiguous region of any file, which made an exact search fail for 14 of 110
+  candidates; stripping that duplicate makes all 14 match exactly once. And
+  three candidates were refused as ambiguous because their statement is
+  byte-identical across sibling functions (`let pairs = o.sorted { $0.key <
+  $1.key }` appears in all four literal renderers) — Muter's line is unreliable
+  on its own but is a sound *discriminator* among exact content matches, so it
+  now chooses between them, and only when one begins exactly at that line.
+  There is deliberately no nearest-match fallback: picking the closest would
+  mean mutating one renderer while reporting a verdict about another.


### PR DESCRIPTION
Two commits: a verifier fix that made the last unverifiable mutations replayable, and the cluster it unblocked. Refs #1447, #1466.

---

# 1. `ffa3029` — the last 17 recorded mutations now replay

Two unrelated causes, both measured against run 32265903112 **before** anything was written.

**Muter re-emits a body's leading comment after the statement.** For a `case` body opening with a comment, the recorded text comes out as `[comment][statement][the same comment again]` — a shape existing in no source file, so an exact search finds nothing. **14** candidates were absent for this and no other reason; stripping the duplicate makes all 14 match exactly once. The check is narrow on purpose (the trailing run must be the leading run, line for line), because a body that genuinely ends in a comment is ordinary and must not be truncated — there's a test for that.

**Three were refused as ambiguous.** `let pairs = o.sorted { $0.key < $1.key }` is byte-identical in all four literal renderers, so content alone cannot say which one Muter mutated. Muter's line is unreliable *alone* — that's why #1470 stopped using it to locate the edit — but it's a sound **discriminator** among exact content matches. It now chooses between them, and only when one begins exactly at that line.

**No nearest-match fallback, deliberately.** Picking the closest would mutate R's renderer while reporting a verdict about Python's. Unresolvable ambiguity is still refused.

This **loosens** a rule shipped in #1470. Refusing ambiguity outright was right with no discriminator available; it was costing three real survivors. The test encoding the strict rule failed, correctly, and is replaced by two — one for the resolvable case, one proving the unresolvable case still refuses.

### A wrong diagnosis, recorded because it nearly shipped

I first blamed `_skip_to_matching_brace` for mis-parsing string interpolation containing a nested literal (`"\(values[$0] ?? "'null")"`), and wrote a rewrite of that scanner. **The tests I wrote for it passed against the unmodified scanner** — so they exercised no defect. Inspecting the recorded text then showed it contained the statement all along; the comment was simply repeated. The rewrite was reverted. It would have been a subtle parser change justified by a story I never verified, and only the seen-to-fail rule caught it.

---

# 2. `6ba5f6a` — one hole, copied four times

Every literal renderer enforces the same rule with the same expression:

```swift
(s.contains(".") || s.contains("e") || s.contains("E")) ? s : s + ".0"
```

Every suite tests the first term, because `2.0` is the obvious case. Reaching the **second** needs a double whose Swift description carries an `e` and no `.` — and a search for e-notation across all five existing literal suites returned **zero hits**. Under the mutant that term becomes `&&`, the guard answers false, and the renderer appends `.0` to a literal that already has an exponent: `1e-05.0`, which no target language parses.

That is not four independent oversights: the renderers were copied from a working one and the tests came with them, hole included. So `JSONValueDoubleFormattingTests` pins the rule **once**, in a table over all seven renderers — a fifth language is one line and cannot inherit the gap from a neighbour. It also asserts the property underneath the rule (every rendered finite double reads back as itself), which is what makes `1e-05.0` a bug rather than a formatting preference.

**Python had no CoreTests file at all**, which is why the sweep flagged its object-key sort while the identical sort in Racket and Java was pinned back in #1463. Its assertions live in `APITests`, which the sweep skips — the code is exercised, just not by anything doing the measuring. Key order matters because generated filenames embed a `spec_hash` of the rendered bytes, so an unstable order makes a family look edited on every save.

| | |
|---|---|
| before | Python L65 ×2 and L71, Lua L222 c2, R L101 c2, Octave L192 c2 — all **SURVIVED** |
| after | **11 of 11 KILLED** |
| green | full sweep command → **766 tests in 91 suites**, was 759 |

Candidate 1 at L101/L192/L222 was already killed by the per-language suites (the integral half). The four `SwapTernary` entries at those lines are inert no-ops, quarantined by #1470 and skipped.

### Not encoded, deliberately

`pythonLiteral` renders NaN as `nan` and infinity as `inf` — the reason its guard tests `contains("n")` where its siblings test `contains("E")`. **Neither is a valid Python literal**, so a generated test carrying one raises `NameError`; every other renderer spells these explicitly. Asserting the current output would lock in behaviour that looks wrong, and establishing reachability is a separate question from this cluster, so no test claims it either way.

---

`format-lint` and SwiftLint clean. Working tree clean after every verifier run.