### PR TITLE
test(mutation): pin the notebook extractor's top-level predicates

### DIFF
--- a/Tests/WorkerTests/NotebookExtractionPredicateTests.swift
+++ b/Tests/WorkerTests/NotebookExtractionPredicateTests.swift
@@ -1,0 +1,124 @@
+// Tests/WorkerTests/NotebookExtractionPredicateTests.swift
+//
+// The three predicates inside RunnerCore's notebook extractor that decide what
+// a top-level line IS: whether it declares something (safe to keep at module
+// level) or executes something (quarantined), whether an assignment's
+// right-hand side calls a function, and where a line's significant text starts
+// and ends.
+//
+// The 2026-08-19 sweep (run 32265903112) reported seven surviving candidates
+// across them. They sit in RunnerCore, which carries no APITests-skip caveat —
+// its covering tests all run in the sweep — so these are the strongest kind of
+// evidence the sweep produces: the suite really does run this code and really
+// could not tell the difference.
+//
+// Each test names the mutation it kills. Every one was confirmed SURVIVED by
+// `Tools/mutation/verify-survivor.py` against that run's record before it was
+// written, and KILLED after.
+
+import Foundation
+import Testing
+
+@testable import RunnerCore
+
+@Suite struct NotebookExtractionPredicateTests {
+
+    // MARK: isSafeTopLevelStatement — the quarantine decision
+
+    /// Kills the SECOND `ChangeLogicalConnector` on the bare-string-literal
+    /// check and the one on its continuation line.
+    ///
+    /// The guard reads `hasPrefix(""" ) || hasPrefix(''') || hasPrefix(") ||
+    /// hasPrefix(')`, and the two mutants that survive turn it into `""" || '`
+    /// and `""" || '''` respectively — each dropping one of the SINGLE-delimiter
+    /// forms while keeping a triple. So the case that separates them is a plain
+    /// one-delimiter string: a module-level `"a docstring"` or `'a docstring'`,
+    /// which the mutants quarantine as if it executed something.
+    ///
+    /// Quarantining a docstring is not cosmetic — a quarantined top-level line
+    /// is not kept in the introspectable source, so `inspect.getsource` and any
+    /// `astStructure` check stop seeing it.
+    @Test func plainStringLiteralsAreRecognisedAsSafeNotJustTripleQuoted() {
+        // The triple-quoted forms (already covered, kept so the set is whole).
+        #expect(isSafeTopLevelStatement(#""""a docstring""""#))
+        #expect(isSafeTopLevelStatement("'''a docstring'''"))
+        // The single-delimiter forms — the ones the survivors drop.
+        #expect(isSafeTopLevelStatement(#""a docstring""#))
+        #expect(isSafeTopLevelStatement("'a docstring'"))
+    }
+
+    /// Kills the `ChangeLogicalConnector` in `trimSpacesAndTabs`
+    /// (`$0 == " " && $0 == "\t"`), which makes the predicate false for every
+    /// character so nothing is trimmed at all.
+    ///
+    /// `isSafeTopLevelStatement` trims before testing its prefixes, so with the
+    /// trim disabled an indented `def` no longer starts with `def ` and every
+    /// indented declaration is quarantined.
+    @Test func leadingIndentationIsTrimmedBeforeThePrefixTests() {
+        #expect(isSafeTopLevelStatement("def f():"))
+        #expect(isSafeTopLevelStatement("    def f():"))
+        #expect(isSafeTopLevelStatement("\tclass C:"))
+        #expect(isSafeTopLevelStatement("  import os"))
+        // Trailing horizontal space must not defeat a match either.
+        #expect(isSafeTopLevelStatement("import os  "))
+    }
+
+    /// A statement that executes is still quarantined — the predicate is only
+    /// useful if it says no to something.
+    @Test func executingStatementsAreNotSafe() {
+        #expect(!isSafeTopLevelStatement("print('hi')"))
+        #expect(!isSafeTopLevelStatement("x = compute()"))
+    }
+
+    // MARK: rhsContainsFunctionCall
+
+    /// Kills the third and fourth `ChangeLogicalConnector` candidates on the
+    /// identifier test — `prev.isNumber && prev == "_"` and
+    /// `prev == "_" && prev == ")"`. Both make the underscore case impossible
+    /// (nothing is both a digit and an underscore, or both an underscore and a
+    /// close paren), and between them they also drop the digit and the
+    /// close-paren cases.
+    ///
+    /// A false negative here means an assignment whose RHS calls a function is
+    /// treated as a constant and kept at module level, so the call runs at
+    /// import time — which is the thing the quarantine exists to prevent.
+    @Test func anIdentifierEndingInADigitUnderscoreOrParenStillCounts() {
+        // The plain letter case, already covered.
+        #expect(rhsContainsFunctionCall("f(x)"))
+        // A name ending in a digit — `prev.isNumber`.
+        #expect(rhsContainsFunctionCall("load_v2(path)"))
+        // A name ending in an underscore — the case both survivors make
+        // unreachable.
+        #expect(rhsContainsFunctionCall("private_(x)"))
+        // A call on the result of a call — `prev == ")"`.
+        #expect(rhsContainsFunctionCall("factory()(arg)"))
+    }
+
+    @Test func aParenNotPrecededByAnIdentifierIsNotACall() {
+        #expect(!rhsContainsFunctionCall("(1 + 2) * 3"))
+        #expect(!rhsContainsFunctionCall("[1, 2, 3]"))
+        #expect(!rhsContainsFunctionCall("x + 1"))
+    }
+
+    // MARK: trimWhitespaceAndNewlines, through the public extractor
+
+    /// Kills the first `ChangeLogicalConnector` in `trimWhitespaceAndNewlines`
+    /// (`$0 == " " && $0 == "\t" || …`), which leaves newlines and carriage
+    /// returns trimmed but spaces and tabs not.
+    ///
+    /// `extractPython` skips a cell whose trimmed source is empty. With the
+    /// mutant a cell holding only spaces trims to itself, reads as non-empty,
+    /// and is emitted — so the extracted module gains a cell boundary and a
+    /// blank body, and `codeCellCount` counts a cell the author did not write.
+    @Test func whitespaceOnlyCellsAreSkippedWhateverTheWhitespaceIs() {
+        let cells = [
+            NotebookCell(cellType: "code", source: "def f():\n    return 1"),
+            NotebookCell(cellType: "code", source: "   "),
+            NotebookCell(cellType: "code", source: "\t\t"),
+            NotebookCell(cellType: "code", source: "\n\n"),
+            NotebookCell(cellType: "code", source: " \t\n "),
+        ]
+        let extracted = extractPython(cells: cells, filename: "nb.ipynb")
+        #expect(extracted.codeCellCount == 1, "only the one real cell should count")
+    }
+}

--- a/Tools/mutation/equivalent-mutants.json
+++ b/Tools/mutation/equivalent-mutants.json
@@ -3,7 +3,7 @@
     "SURVIVORS CLOSED WITH A REASON RATHER THAN A TEST.",
     "",
     "docs/mutation-triage.md gives three legitimate answers to a survivor, and",
-    "the second is 'nothing reaching this code can tell the difference — close",
+    "the second is 'nothing reaching this code can tell the difference \u2014 close",
     "it, record why'. Until this file existed the recording had nowhere to live",
     "that the sweep could read, so an equivalent mutant came back every week",
     "looking exactly like an untriaged gap. Whoever picked it up either",
@@ -23,7 +23,7 @@
     "against the code as it now is.",
     "",
     "`reason` must be an argument, not a label. It has to say what makes the",
-    "mutant unobservable — which inputs can reach the site and why none of them",
+    "mutant unobservable \u2014 which inputs can reach the site and why none of them",
     "distinguishes the two versions. 'equivalent mutant' is not a reason.",
     "",
     "This is NOT a suppression list. Do not add an entry because a mutant is",
@@ -36,6 +36,12 @@
       "operator": "RelationalOperatorReplacement",
       "mutated": "let start = pos if current != \"-\" { pos += 1 } while let c = current, (c >= \"0\" && c <= \"9\") || c == \".\" || c == \"e\" || c == \"E\" || c == \"+\" || c == \"-\" { pos += 1 } guard let value = JSONParser.parseDoubleLiteral(chars[start..<pos]) else { return nil } return .number(value)",
       "reason": "parseValue routes here only when the current character is '-' or a digit, and the while loop that follows accepts BOTH. `start` is captured before the `if`, so the sign is consumed either by the `if` or by the loop's first iteration and `pos` lands in the same place either way. The slice handed to parseDoubleLiteral is therefore identical for every input that can reach this function, including a lone '-', a leading digit followed by a non-numeric character, and '--5'. Verified SURVIVED against run 32265903112 after JSONFooterGrammarTests killed the other fourteen candidates in this file."
+    },
+    {
+      "file": "Sources/RunnerCore/NotebookExtraction.swift",
+      "operator": "ChangeLogicalConnector",
+      "mutated": "// Strip any trailing `#` comment first, so comment text (which may contain // `=` or `(`) can't be mistaken for assignment or call syntax below // (e.g. `print(x) # a = b` must not look like an assignment). let trimmed = trimSpacesAndTabs(strippingTrailingComment(from: rawTrimmed)) // A line that was nothing but a comment is harmless at module level. if trimmed.isEmpty { return true } for prefix in [\"def \", \"async def \", \"class \", \"import \", \"from \", \"@\"] where trimmed.hasPrefix(prefix) { return true } // Bare string literals are module-level docstrings \u2014 safe. if trimmed.hasPrefix(\"\\\"\\\"\\\"\") && trimmed.hasPrefix(\"'''\") || trimmed.hasPrefix(\"\\\"\") || trimmed.hasPrefix(\"'\") { return true } // Control-flow / side-effecting statements are quarantined. The `token + \"(\"` // branch catches bare calls whose name matches a keyword while avoiding false // matches on names that merely share a prefix (e.g. `format` vs `for`). for token in [ \"assert\", \"raise\", \"return\", \"del\", \"pass\", \"for\", \"while\", \"if\", \"with\", \"try\", \"except\", \"match\", \"finally\", \"else\", \"elif\", \"break\", \"continue\", \"yield\", \"global\", \"nonlocal\", \"async for\", \"async with\", ] { if trimmed == token || trimmed.hasPrefix(token + \" \") || trimmed.hasPrefix(token + \":\") || trimmed.hasPrefix(token + \"(\") { return false } } // Assignments: module level only when the RHS has no function calls. Keeps // module-level constants while quarantining `p = Patient(...)`-style code. if let rhsStart = findAssignmentRHS(in: trimmed) { let rhs = trimSpacesAndTabs(String(trimmed[rhsStart...])) return !rhsContainsFunctionCall(rhs) } return false // Strip any trailing `#` comment first, so comment text (which may contain // `=` or `(`) can't be mistaken for assignment or call syntax below // (e.g. `print(x) # a = b` must not look like an assignment).",
+      "reason": "The guard is `hasPrefix(\\\"\\\"\\\") || hasPrefix(''') || hasPrefix(\\\") || hasPrefix(')`, and its first two terms are REDUNDANT: a line starting with triple-double-quote necessarily starts with a double quote, and one starting with triple-single-quote necessarily starts with a single quote. The whole chain is therefore equivalent to just the two single-delimiter tests. This mutant replaces the first `||` with `&&`, and no string can start with both triple-double-quote and triple-single-quote, so that conjunct is false for every input -- leaving exactly the same two single-delimiter tests the original reduces to. Identical for all inputs, so no test can distinguish them. The two candidates that ARE observable at this site (the second connector and the one on the continuation line) each drop a single-delimiter term and are killed by NotebookExtractionPredicateTests."
     }
   ]
 }

--- a/changelog.d/mutation-triage-notebook-extraction.md
+++ b/changelog.d/mutation-triage-notebook-extraction.md
@@ -1,0 +1,22 @@
+### Added
+
+- **The notebook extractor's three top-level predicates are now tested.**
+  `isSafeTopLevelStatement`, `rhsContainsFunctionCall` and the whitespace trims
+  decide whether a notebook line is kept at module level or quarantined, and
+  the 2026-08-19 sweep reported seven surviving candidates across them — in
+  RunnerCore, whose covering tests all run in the sweep, so the suite really
+  did exercise this code and really could not tell the difference.
+  `NotebookExtractionPredicateTests` pins the cases that separate them: a plain
+  one-delimiter string literal (a module-level docstring the survivors
+  quarantine, which drops it from the introspectable source and so from
+  `inspect.getsource` and any `astStructure` check), an indented declaration
+  that only matches once leading whitespace is trimmed, an identifier ending in
+  a digit, underscore or close paren before a call (a false negative there
+  leaves a function call running at import time, which is what the quarantine
+  exists to prevent), and whitespace-only cells of every whitespace kind.
+- **A second entry in the equivalent-mutant ledger.** The bare-string-literal
+  guard tests four prefixes, and its first two are redundant: a line starting
+  with a triple quote necessarily starts with a single one, so the chain
+  reduces to the two single-delimiter tests. The mutant that ANDs the two
+  triple-quote tests together is therefore unkillable — nothing starts with
+  both — and is recorded with that argument rather than chased.


### PR DESCRIPTION
Fifth triage cluster from the 2026-08-19 sweep (run 32265903112). Refs #1447, #1466.

These sit in **RunnerCore**, whose covering tests all run in the sweep — so unlike a Core survivor there's no APITests-skip caveat. The suite genuinely exercises this code and genuinely could not tell the difference.

## What the predicates decide

Three of them, all answering "what is this top-level notebook line?":

- **`isSafeTopLevelStatement`** — declares something (keep at module level) or executes something (quarantine).
- **`rhsContainsFunctionCall`** — does an assignment's right-hand side call a function?
- **the whitespace trims** — where does a line's significant text start and end?

## The cases that separate them from their mutants

- **A plain one-delimiter string literal.** The guard tests four prefixes; the survivors drop the single-delimiter ones, so a module-level `"a docstring"` gets quarantined — which removes it from the introspectable source, and with it from `inspect.getsource` and any `astStructure` check.
- **An indented declaration.** `trimSpacesAndTabs` mutated to `&&` trims nothing, so `    def f():` stops matching `def ` and every indented declaration is quarantined.
- **An identifier ending in a digit, underscore or close paren before `(`.** A false negative treats a call as a constant and leaves it running at import time — exactly what the quarantine exists to prevent. Both surviving candidates make the underscore case unreachable.
- **Whitespace-only cells of every whitespace kind**, through the public `extractPython`, since the trim it depends on is private.

| | |
|---|---|
| before | 7 distinct candidates SURVIVED (L552 c1/c2 and L575 c2/c3 were already covered) |
| after | **15 of 17 KILLED**, all attributed to `NotebookExtractionPredicateTests` |
| green | new suite passes; `format-lint` and SwiftLint clean |

## The two that survive are the same one, and it cannot be killed

The guard reads:

```swift
hasPrefix("\"\"\"") || hasPrefix("'''") || hasPrefix("\"") || hasPrefix("'")
```

Its **first two terms are redundant** — anything starting with a triple quote starts with a single one — so the whole chain reduces to the two single-delimiter tests. The surviving mutant ANDs the two triple-quote tests together, and nothing starts with both, so it reduces to *exactly the same two tests*. Identical for every input.

Recorded in `Tools/mutation/equivalent-mutants.json` with that argument, which is the protocol's third legitimate outcome. It's the ledger's second entry, and I verified the key matches the real record so it actually leaves the open queue on the next sweep rather than being a no-op.

## A flake almost cost a real gap

The first before-pass reported this same candidate **`KILLED`** — naming no suite, which #1470 established is a bug report rather than a verdict. Re-running gave `SURVIVED` four times out of four.

Without that rule, an unkillable mutant would have been closed as "already covered" for entirely the wrong reason, and the equivalence argument above would never have been made. The outcome happens to be the same — no test either way — but the record would have said something false.

That's the **second time today** a flaky test has corrupted a mutation verdict; the first destroyed a whole shard and is filed as #1472.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qPZYk8SHvaw3P9M4kAjw2)_