### PR TITLE
test(mutation): answer the rest of run 32265903112's survivor queue

### DIFF
--- a/Sources/Core/Models/TestOutcomeCollectionTruncation.swift
+++ b/Sources/Core/Models/TestOutcomeCollectionTruncation.swift
@@ -39,12 +39,8 @@ extension TestOutcomeCollection {
             outcomes.reduce(0) { $0 + ($1.longResult?.utf8.count ?? 0) }
             + (compilerOutput?.utf8.count ?? 0)
         let overhead = max(0, serializedSize() - longBytes)
-        let carrierCount = max(
-            1,
-            outcomes.filter { ($0.longResult?.isEmpty == false) }.count
-                + ((compilerOutput?.isEmpty == false) ? 1 : 0))
 
-        var perCarrierCap = max(1024, (budgetBytes - overhead) / carrierCount)
+        var perCarrierCap = max(1024, (budgetBytes - overhead) / max(1, outputCarrierCount))
         var truncated = self
         for _ in 0..<8 {
             truncated = truncatedCopy(perCarrierCap: perCarrierCap)
@@ -52,6 +48,24 @@ extension TestOutcomeCollection {
             perCarrierCap = max(256, perCarrierCap / 2)
         }
         return (truncated, true)
+    }
+
+    /// Everything that shares the output budget: each outcome carrying a
+    /// non-empty `longResult`, plus `compilerOutput` when it is non-empty.
+    ///
+    /// `compilerOutput` counts because it is truncated by the same cap the
+    /// outcomes are, so leaving it out of the divisor hands every carrier a
+    /// share the collection cannot afford. The halving loop below absorbs that
+    /// — the result still fits — which is exactly why this is a named,
+    /// separately-asserted quantity rather than an expression inline in the
+    /// arithmetic: an off-by-one here is invisible from outside, and the
+    /// 2026-08-19 mutation sweep found two mutants of it surviving on that
+    /// basis. `TestOutcomeCollectionTruncationTests` pins the count itself.
+    ///
+    /// Internal, not private, so the tests can see it; it is not API.
+    var outputCarrierCount: Int {
+        outcomes.filter { ($0.longResult?.isEmpty == false) }.count
+            + ((compilerOutput?.isEmpty == false) ? 1 : 0)
     }
 
     private func serializedSize() -> Int {

--- a/Tests/CoreTests/CourseRoleOrderingTests.swift
+++ b/Tests/CoreTests/CourseRoleOrderingTests.swift
@@ -1,0 +1,64 @@
+// Tests/CoreTests/CourseRoleOrderingTests.swift
+//
+// `CourseRole: Comparable` is the whole basis of authority in this codebase.
+// Every `requireCourseRole(atLeast:)` gate and every `evaluateCourseWrite` call
+// resolves to one `<` against a rank, so flipping that comparison does not
+// weaken permissions in one place — it inverts them everywhere at once, letting
+// a student do what only an instructor may and locking instructors out of their
+// own courses.
+//
+// The 2026-08-19 sweep (run 32265903112) reported the flip as a survivor. The
+// full suite does kill it — dozens of APITests depend on the gates — but the
+// sweep skips APITests, and a Core type whose ordering is asserted only by an
+// APIServer route test is a Core invariant nothing local pins. The relation is
+// three lines of Core; its assertions belong beside it.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct CourseRoleOrderingTests {
+
+    /// The ordering, stated as the ladder it is meant to be.
+    @Test func rolesAscendFromStudentToInstructor() {
+        #expect(CourseRole.student < CourseRole.ta)
+        #expect(CourseRole.ta < CourseRole.instructor)
+        #expect(CourseRole.student < CourseRole.instructor)
+    }
+
+    /// The other direction, so a flip cannot pass by satisfying only the first
+    /// set. `<` and `>` disagreeing is the entire content of the mutation.
+    @Test func theRelationIsNotReversible() {
+        #expect(!(CourseRole.ta < CourseRole.student))
+        #expect(!(CourseRole.instructor < CourseRole.ta))
+        #expect(!(CourseRole.instructor < CourseRole.student))
+    }
+
+    /// A role is never strictly less than itself, and `>=` — the form every
+    /// gate is actually written in — admits it.
+    @Test func aRoleMeetsItsOwnBar() {
+        for role in CourseRole.allCases {
+            #expect(!(role < role))
+            #expect(role >= role, "\(role) must clear its own atLeast check")
+        }
+    }
+
+    /// The gate semantics the ranks exist for, spelled out: `atLeast: .ta`
+    /// admits TAs and instructors and nobody else; `atLeast: .instructor`
+    /// admits instructors only. Written as the comparison the gates perform, so
+    /// this fails if the relation is inverted rather than if a gate is
+    /// refactored.
+    @Test func atLeastAdmitsExactlyTheRolesItNames() {
+        #expect(CourseRole.allCases.filter { $0 >= .student } == CourseRole.allCases)
+        #expect(CourseRole.allCases.filter { $0 >= .ta } == [.ta, .instructor])
+        #expect(CourseRole.allCases.filter { $0 >= .instructor } == [.instructor])
+    }
+
+    /// `allCases` order is the privilege order, which is what lets the
+    /// assertions above be written as literals — and what a roster UI relies on
+    /// when it lists roles.
+    @Test func declarationOrderMatchesPrivilegeOrder() {
+        #expect(CourseRole.allCases == CourseRole.allCases.sorted())
+    }
+}

--- a/Tests/CoreTests/DatasetDiagnosticsTests.swift
+++ b/Tests/CoreTests/DatasetDiagnosticsTests.swift
@@ -331,4 +331,78 @@ import Testing
             DatasetDiagnostics.overlap(spec: spec, sourceCSV: pool)
                 == DatasetDiagnostics.overlap(spec: spec, sourceCSV: pool))
     }
+
+    // MARK: - 10. The worst-pair estimate
+
+    /// The worst-pair number is the only one on `DatasetOverlap` an instructor
+    /// acts on — "the unluckiest pair in your class is expected to share this
+    /// many rows" — and until the 2026-08-19 sweep (run 32265903112) nothing
+    /// asserted it was any different from the mean. The existing assertion is
+    /// `worstPairSharedRows >= expectedSharedRows`, which equality satisfies,
+    /// so five separate mutants collapsed the estimate onto the mean and
+    /// survived: the variance guard's `poolRows > 1`, the pair count's
+    /// `classSize > 1` (both as a relational flip and as a swapped ternary),
+    /// and each half of `pairs >= 2, variance > 0`.
+    ///
+    /// Every one of them reports "the worst pair shares the average amount",
+    /// which is the answer that makes a spec look safe.
+    @Test func theWorstPairIsStrictlyWorseThanAverageForARealSample() throws {
+        let overlap = try #require(DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool))
+        #expect(
+            overlap.worstPairSharedRows > overlap.expectedSharedRows,
+            "an extreme-value estimate that equals the mean is not an estimate")
+        #expect(overlap.worstPairSharedRows <= Double(overlap.rowsPerStudent))
+    }
+
+    /// The estimate's value, re-derived from the documented formula rather
+    /// than copied from the implementation: `mean + sigma * sqrt(2 * ln pairs)`
+    /// over a class's `C(C-1)/2` pairs, with the hypergeometric variance
+    /// `k * (k/n) * (1 - k/n) * (n - k)/(n - 1)`.
+    ///
+    /// Pinning the number and not just the inequality is what separates "the
+    /// spread is used at all" from "the spread is used correctly" — a mutant
+    /// that drops the pair count to a constant, or halves the variance, still
+    /// clears the inequality above.
+    @Test func theWorstPairMatchesTheDocumentedClosedForm() throws {
+        let n = 200.0
+        let k = 40.0
+        let mean = k * k / n
+        let variance = k * (k / n) * (1 - k / n) * ((n - k) / (n - 1))
+        let pairs =
+            Double(DatasetDiagnostics.defaultClassSize)
+            * Double(DatasetDiagnostics.defaultClassSize - 1) / 2
+        let derived = mean + variance.squareRoot() * (2 * Foundation.log(pairs)).squareRoot()
+
+        let overlap = try #require(DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool))
+        #expect(abs(overlap.expectedSharedRows - mean) < 1e-9)
+        #expect(abs(overlap.worstPairSharedRows - derived) < 1e-9)
+    }
+
+    /// The two degenerate inputs the guards exist for, stated as behaviour so
+    /// they cannot be mistaken for the collapse above.
+    ///
+    /// A class of one has no pairs, and a whole-file sample has no variance —
+    /// in both the honest answer IS the mean, and the estimate must not invent
+    /// a spread. That is why the strict inequality above is asserted on a
+    /// reducing sample at the default class size and nowhere else.
+    @Test func theEstimateFallsBackToTheMeanWhenThereIsNothingToEstimate() throws {
+        let soloClass = try #require(
+            DatasetDiagnostics.overlap(spec: plainSpec(40), sourceCSV: pool, classSize: 1))
+        #expect(soloClass.worstPairSharedRows == soloClass.expectedSharedRows)
+
+        let wholeFile = try #require(DatasetDiagnostics.overlap(spec: plainSpec(nil), sourceCSV: pool))
+        #expect(wholeFile.worstPairSharedRows == wholeFile.expectedSharedRows)
+    }
+
+    /// Stratification sums a variance per stratum, so the same collapse is
+    /// reachable by a second route — and the rare-stratum floor means a
+    /// stratified spec is exactly where an instructor most needs the worst
+    /// pair to be honest.
+    @Test func theStratifiedEstimateAlsoCarriesASpread() throws {
+        let overlap = try #require(
+            DatasetDiagnostics.overlap(spec: stratifiedSpec(40), sourceCSV: pool))
+        #expect(overlap.worstPairSharedRows > overlap.expectedSharedRows)
+        #expect(overlap.worstPairSharedRows <= Double(overlap.rowsPerStudent))
+    }
+
 }

--- a/Tests/CoreTests/InputsFileRenderingTests.swift
+++ b/Tests/CoreTests/InputsFileRenderingTests.swift
@@ -1,0 +1,99 @@
+// Tests/CoreTests/InputsFileRenderingTests.swift
+//
+// `renderInputsFile` writes the per-student `_ck_inputs.*` preamble every
+// generated test loads. Its assertions live in `Tests/APITests`, which the
+// mutation sweep does not run, and the Racket form had none at all — which is
+// how the 2026-08-19 sweep (run 32265903112) found a `SwapTernary` on Racket's
+// empty-versus-populated split surviving.
+//
+// That mutant is worth naming, because it is not a subtle one: it exchanges the
+// two branches AND leaves the entries concatenated onto the wrong side, so an
+// assignment with no personalization inputs emits `(define ck-inputs\n  (hash\n`
+// — an unterminated form. The file is `dynamic-require`d by every generated
+// test, so the failure is a read error on every test in the assignment, for
+// every student, with nothing in the test scripts to point at.
+//
+// The empty case is the one that goes unwritten, in every language, because an
+// author testing by hand always has an input. So the shape is pinned twice:
+// exact bytes for Racket, and an `allCases` property that a seventh language
+// inherits without editing this file.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct InputsFileRenderingTests {
+
+    // MARK: - Racket, by byte
+
+    @Test func racketWithNoInputsRendersAClosedEmptyHash() {
+        #expect(
+            AssignmentLanguage.racket.renderInputsFile([:]) == """
+                #lang racket/base
+                ; Auto-generated per-student grading inputs (issue #461). Do not edit.
+                (provide ck-inputs)
+                (define ck-inputs (hash))
+
+                """)
+    }
+
+    @Test func racketWithInputsRendersAPopulatedHashInKeyOrder() {
+        #expect(
+            AssignmentLanguage.racket.renderInputsFile([
+                "threshold": "42",
+                "alpha": "0.5",
+            ]) == """
+                #lang racket/base
+                ; Auto-generated per-student grading inputs (issue #461). Do not edit.
+                (provide ck-inputs)
+                (define ck-inputs
+                  (hash
+                   "alpha" 0.5
+                   "threshold" 42))
+
+                """)
+    }
+
+    // MARK: - Every language
+
+    /// The empty map is the case a language forgets, so ask it of all of them.
+    ///
+    /// Balanced delimiters is the weakest useful statement of "this file
+    /// parses" that holds across seven syntaxes, and it is exactly what the
+    /// Racket survivor breaks.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func anEmptyInputMapRendersACompleteFile(language: AssignmentLanguage) {
+        let rendered = language.renderInputsFile([:])
+        #expect(!rendered.isEmpty)
+        #expect(rendered.hasSuffix("\n"), "\(language) left the file without a final newline")
+        #expect(
+            rendered.contains(language.lineCommentPrefix),
+            "\(language) dropped the do-not-edit header")
+        for (open, close) in [("(", ")"), ("{", "}"), ("[", "]")] {
+            #expect(
+                rendered.filter { String($0) == open }.count
+                    == rendered.filter { String($0) == close }.count,
+                "\(language) rendered unbalanced \(open)\(close) for an empty input map")
+        }
+    }
+
+    /// And the populated case, so the empty-case assertion above cannot be
+    /// satisfied by a renderer that always emits the empty form.
+    @Test(arguments: AssignmentLanguage.allCases)
+    func apopulatedInputMapMentionsEveryKey(language: AssignmentLanguage) {
+        let rendered = language.renderInputsFile([
+            "threshold": language.literal(.int(42)),
+            "label": language.literal(.string("ok")),
+        ])
+        #expect(rendered.contains("threshold"), "\(language) dropped an input name")
+        #expect(rendered.contains("label"), "\(language) dropped an input name")
+        #expect(rendered != language.renderInputsFile([:]))
+        for (open, close) in [("(", ")"), ("{", "}"), ("[", "]")] {
+            #expect(
+                rendered.filter { String($0) == open }.count
+                    == rendered.filter { String($0) == close }.count,
+                "\(language) rendered unbalanced \(open)\(close) for a populated input map")
+        }
+    }
+}

--- a/Tests/CoreTests/NotebookFunctionScannerTests.swift
+++ b/Tests/CoreTests/NotebookFunctionScannerTests.swift
@@ -561,4 +561,97 @@ struct NotebookFunctionScannerTests {
         let r = scanNotebookForSectionsAndFunctions(nb, language: .r)
         #expect(r.functions.map(\.info.name) == ["shown"])
     }
+
+    // MARK: - Parameter names the scanner must and must not accept
+
+    /// Kills the `RelationalOperatorReplacement` on the identifier-start rule
+    /// (`first.isLetter || first == "_"` becomes `|| first != "_"`).
+    ///
+    /// The flip is silent in both directions and both directions matter. A
+    /// parameter actually named with a leading underscore stops being reported,
+    /// so the family editor shows a signature one column short and every case
+    /// row silently shifts its arguments left. A parameter starting with a
+    /// digit — which no Python signature can contain, so its presence means the
+    /// line was misparsed — starts being reported instead of rejected.
+    @Test func parameterNamesMayStartWithAnUnderscoreButNotADigit() {
+        let underscored = scanFunctions(notebook(code: "def f(_unused, x):\n    pass\n"))
+        #expect(underscored.count == 1)
+        #expect(underscored[0].paramNames == ["_unused", "x"])
+
+        // A bare `_` is the conventional throwaway and is still a parameter.
+        let bare = scanFunctions(notebook(code: "def g(_, y):\n    pass\n"))
+        #expect(bare.count == 1)
+        #expect(bare[0].paramNames == ["_", "y"])
+
+        // Not an identifier: dropped, not reported.
+        let digitLed = scanFunctions(notebook(code: "def h(1bad, ok):\n    pass\n"))
+        #expect(digitLed.count == 1)
+        #expect(digitLed[0].paramNames == ["ok"])
+    }
+
+    // MARK: - The decode path's length realignment
+
+    /// `init(from:)` keeps a tolerance the memberwise init dropped in 0.5: a
+    /// stored `paramTypes` / `paramHasDefault` whose length disagrees with
+    /// `paramNames` is replaced by a correctly-sized neutral array rather than
+    /// carried through. Every consumer indexes these arrays by parameter
+    /// position, so a short one is an out-of-range crash and a long one silently
+    /// mislabels columns.
+    ///
+    /// The 2026-08-19 sweep reported four survivors here — a relational flip and
+    /// a swapped ternary on each of the two arrays — because nothing asserted the
+    /// rule from either side. Under every one of them a *correct* wire payload is
+    /// the one that gets discarded.
+    @Test func alignedWireArraysSurviveDecoding() throws {
+        let json = Data(
+            """
+            {
+              "name": "bmi",
+              "paramNames": ["mass", "height"],
+              "paramTypes": ["float", null],
+              "paramHasDefault": [false, true],
+              "hasTypeHints": true,
+              "hasDocstring": false,
+              "isShadowed": false
+            }
+            """.utf8)
+        let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
+        #expect(decoded.paramTypes == ["float", nil])
+        #expect(decoded.paramHasDefault == [false, true])
+    }
+
+    @Test func misalignedWireArraysAreReplacedNotCarried() throws {
+        let json = Data(
+            """
+            {
+              "name": "bmi",
+              "paramNames": ["mass", "height"],
+              "paramTypes": ["float"],
+              "paramHasDefault": [true, false, true],
+              "hasTypeHints": true,
+              "hasDocstring": false,
+              "isShadowed": false
+            }
+            """.utf8)
+        let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
+        #expect(decoded.paramTypes == [nil, nil])
+        #expect(decoded.paramHasDefault == [false, false])
+    }
+
+    @Test func absentWireArraysAreSizedFromParamNames() throws {
+        let json = Data(
+            """
+            {
+              "name": "bmi",
+              "paramNames": ["mass", "height"],
+              "hasTypeHints": false,
+              "hasDocstring": false,
+              "isShadowed": false
+            }
+            """.utf8)
+        let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
+        #expect(decoded.paramTypes == [nil, nil])
+        #expect(decoded.paramHasDefault == [false, false])
+    }
+
 }

--- a/Tests/CoreTests/PatternFamilyCaseAlignmentTests.swift
+++ b/Tests/CoreTests/PatternFamilyCaseAlignmentTests.swift
@@ -1,0 +1,131 @@
+// Tests/CoreTests/PatternFamilyCaseAlignmentTests.swift
+//
+// `PatternCase` carries two arrays parallel to `args`: `argsProvided` (false
+// means "leave this argument off the call and let the function's own default
+// apply") and `argVarRefs` (non-nil means "pass this family variable instead of
+// the literal"). Both are optional on the wire — an empty array means "the
+// pre-v0.4.94 default for every position" — so the model can only index them
+// safely if a NON-empty one is exactly as long as `args`.
+//
+// Both the memberwise init and `init(from:)` enforce that by discarding a
+// mismatched array. The 2026-08-19 sweep (run 32265903112) reported four
+// survivors across the two sites — a relational flip and a swapped ternary on
+// each — and every one of them inverts the rule: the CORRECTLY sized array is
+// the one thrown away, and a wrong-length one is kept for the renderer to index.
+//
+// The rule is exercised today only through `Tests/APITests`, which the sweep
+// does not run. That is why it survived, and it is also why these assertions
+// belong here: `PatternCase` is a Core model with a Core invariant, and pinning
+// it in an APIServer renderer suite leaves it unpinned for every other consumer.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct PatternFamilyCaseAlignmentTests {
+
+    private static let twoArgs: [JSONValue] = [.int(1), .string("x")]
+
+    // MARK: - The memberwise init
+
+    @Test func anAlignedArgsProvidedIsKept() {
+        let one = PatternCase(
+            key: "01", label: "aligned", args: Self.twoArgs, expected: .bool(true),
+            argsProvided: [true, false])
+        #expect(one.argsProvided == [true, false])
+    }
+
+    @Test func aMisalignedArgsProvidedIsDiscarded() {
+        // Short, long, and the empty "all provided" default all land on `[]`,
+        // which every consumer reads as "no position is omitted".
+        for provided in [[true], [true, false, true], []] {
+            let one = PatternCase(
+                key: "01", label: "misaligned", args: Self.twoArgs, expected: .bool(true),
+                argsProvided: provided)
+            #expect(one.argsProvided.isEmpty)
+        }
+    }
+
+    @Test func anAlignedArgVarRefsIsKept() {
+        let one = PatternCase(
+            key: "01", label: "aligned", args: Self.twoArgs, expected: .bool(true),
+            argVarRefs: ["patients", nil])
+        #expect(one.argVarRefs == ["patients", nil])
+    }
+
+    @Test func aMisalignedArgVarRefsIsDiscarded() {
+        let one = PatternCase(
+            key: "01", label: "misaligned", args: Self.twoArgs, expected: .bool(true),
+            argVarRefs: ["patients"])
+        #expect(one.argVarRefs.isEmpty)
+    }
+
+    @Test func aCaseWithNoArgsAcceptsOnlyEmptyParallelArrays() {
+        let one = PatternCase(
+            key: "01", label: "no args", args: [], expected: .int(0),
+            argsProvided: [true], argVarRefs: ["v"])
+        #expect(one.argsProvided.isEmpty)
+        #expect(one.argVarRefs.isEmpty)
+    }
+
+    // MARK: - The decode path
+
+    private func decode(_ json: String) throws -> PatternCase {
+        try JSONDecoder().decode(PatternCase.self, from: Data(json.utf8))
+    }
+
+    @Test func alignedWireArraysSurviveDecoding() throws {
+        let one = try decode(
+            """
+            {
+              "key": "01",
+              "label": "aligned",
+              "args": [1, "x"],
+              "argsProvided": [true, false],
+              "argVarRefs": ["patients", null],
+              "expected": true
+            }
+            """)
+        #expect(one.argsProvided == [true, false])
+        #expect(one.argVarRefs == ["patients", nil])
+    }
+
+    @Test func misalignedWireArraysAreDiscardedOnDecoding() throws {
+        let one = try decode(
+            """
+            {
+              "key": "01",
+              "label": "misaligned",
+              "args": [1, "x"],
+              "argsProvided": [true],
+              "argVarRefs": ["patients", null, "extra"],
+              "expected": true
+            }
+            """)
+        #expect(one.argsProvided.isEmpty)
+        #expect(one.argVarRefs.isEmpty)
+    }
+
+    @Test func absentWireArraysDecodeToTheAllProvidedDefault() throws {
+        let one = try decode(
+            """
+            {"key": "01", "label": "plain", "args": [1, "x"], "expected": true}
+            """)
+        #expect(one.argsProvided.isEmpty)
+        #expect(one.argVarRefs.isEmpty)
+    }
+
+    /// The round trip, which is what the suite editor actually performs on
+    /// every save: an aligned case must come back aligned, or the renderer
+    /// starts passing an argument the instructor asked it to omit.
+    @Test func anAlignedCaseRoundTripsThroughJSON() throws {
+        let original = PatternCase(
+            key: "01", label: "round trip", args: Self.twoArgs, expected: .bool(true),
+            argsProvided: [true, false], argVarRefs: [nil, "label"])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(PatternCase.self, from: data)
+        #expect(decoded.argsProvided == [true, false])
+        #expect(decoded.argVarRefs == [nil, "label"])
+    }
+}

--- a/Tests/CoreTests/TestOutcomeCollectionTruncationTests.swift
+++ b/Tests/CoreTests/TestOutcomeCollectionTruncationTests.swift
@@ -112,4 +112,60 @@ import Testing
         #expect(decoded.outcomes.count == 20)
         #expect(decoded.passCount == result.passCount)
     }
+
+    // MARK: - Who shares the budget
+
+    /// `outputCarrierCount` is the divisor the per-carrier cap is computed
+    /// from. It is asserted directly because it cannot be seen from outside:
+    /// the halving loop retries until the encoded form fits, so a wrong
+    /// divisor still produces a collection within budget — it just splits the
+    /// budget unfairly, keeping roughly twice or half as much output as it
+    /// should.
+    ///
+    /// The 2026-08-19 sweep (run 32265903112) found both mutants of the
+    /// `compilerOutput` term surviving on exactly that basis. Neither can
+    /// break the budget guarantee, which is what every existing test here
+    /// checks, and both silently change how much of a student's output
+    /// survives.
+    @Test func nonEmptyCompilerOutputIsOneOfTheCarriers() {
+        let withOutput = makeCollection(
+            outcomeCount: 3, longResultBytes: 100, compilerOutput: "boom")
+        #expect(withOutput.outputCarrierCount == 4)
+
+        let withoutOutput = makeCollection(outcomeCount: 3, longResultBytes: 100)
+        #expect(withoutOutput.outputCarrierCount == 3)
+    }
+
+    /// An empty string is not output. Counting it would reserve a share of the
+    /// budget for a carrier that has nothing to truncate, shrinking everyone
+    /// else's for no gain — and it is the case both mutants get backwards.
+    @Test func emptyCompilerOutputIsNotACarrier() {
+        let empty = makeCollection(outcomeCount: 2, longResultBytes: 100, compilerOutput: "")
+        #expect(empty.outputCarrierCount == 2)
+
+        let nilOutput = makeCollection(outcomeCount: 2, longResultBytes: 100)
+        #expect(nilOutput.outputCarrierCount == 2)
+    }
+
+    /// The same rule on the outcome side, so the count is pinned whole rather
+    /// than only at the term the sweep happened to mutate.
+    @Test func onlyOutcomesWithOutputAreCarriers() {
+        let quiet = makeCollection(outcomeCount: 4, longResultBytes: 0)
+        #expect(quiet.outputCarrierCount == 0, "an empty longResult carries nothing")
+
+        let mixed = makeCollection(outcomeCount: 4, longResultBytes: 0, compilerOutput: "boom")
+        #expect(mixed.outputCarrierCount == 1)
+    }
+
+    /// A collection with nothing to truncate must still divide by something.
+    /// The `max(1, …)` at the call site is what stops that; asserting the raw
+    /// count is zero is what makes the guard's existence visible here.
+    @Test func aCollectionWithNoOutputHasNoCarriersAndStillTruncatesSafely() {
+        let quiet = makeCollection(outcomeCount: 3, longResultBytes: 0)
+        #expect(quiet.outputCarrierCount == 0)
+        let (result, didTruncate) = quiet.truncatingOversizedOutput(budgetBytes: 100)
+        #expect(didTruncate)
+        #expect(result.outcomes.count == 3)
+    }
+
 }

--- a/Tests/CoreTests/WorkerHMACSigningTests.swift
+++ b/Tests/CoreTests/WorkerHMACSigningTests.swift
@@ -1,0 +1,78 @@
+// Tests/CoreTests/WorkerHMACSigningTests.swift
+//
+// `constantTimeEquals` is the comparison every runner request is admitted or
+// refused by: `WorkerHMACAuthMiddleware` computes the expected signature and
+// hands both strings here. Its two mutants from the 2026-08-19 sweep (run
+// 32265903112) are the two ways a comparison can be wrong, and they fail in
+// opposite, equally serious directions —
+//
+//   * `left.count != right.count` refuses every well-formed request: two
+//     signatures of the same length return false before the loop runs, so the
+//     runner fleet cannot authenticate at all.
+//   * `result != 0` accepts every request whose signature is the wrong length
+//     *and* rejects every correct one — an inverted verdict on a security
+//     boundary.
+//
+// Both are killed by the full suite, via APITests' middleware tests, which the
+// sweep does not run. A security primitive in Core whose only assertions are in
+// an APIServer route suite is one refactor away from having none, so the
+// primitive is pinned here directly.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct WorkerHMACSigningTests {
+
+    // MARK: - constantTimeEquals
+
+    @Test func identicalStringsCompareEqual() {
+        #expect(WorkerHMACSigning.constantTimeEquals("", ""))
+        #expect(WorkerHMACSigning.constantTimeEquals("a", "a"))
+        let signature = WorkerHMACSigning.hmacSHA256Hex(message: "m", secret: "s")
+        #expect(WorkerHMACSigning.constantTimeEquals(signature, signature))
+    }
+
+    @Test func sameLengthDifferentContentComparesUnequal() {
+        #expect(!WorkerHMACSigning.constantTimeEquals("abc", "abd"))
+        // A single flipped bit in the first byte, and in the last: the XOR
+        // accumulator must carry a difference wherever it occurs.
+        #expect(!WorkerHMACSigning.constantTimeEquals("abc", "bbc"))
+        #expect(!WorkerHMACSigning.constantTimeEquals("0000", "0001"))
+    }
+
+    @Test func differentLengthsCompareUnequal() {
+        #expect(!WorkerHMACSigning.constantTimeEquals("abc", "abcd"))
+        #expect(!WorkerHMACSigning.constantTimeEquals("abcd", "abc"))
+        #expect(!WorkerHMACSigning.constantTimeEquals("", "a"))
+        // A prefix is not a match, which is the case a length-blind loop over
+        // the shorter side would accept.
+        #expect(!WorkerHMACSigning.constantTimeEquals("a", "ab"))
+    }
+
+    /// The comparison is over UTF-8 bytes, not characters, so a multi-byte
+    /// scalar cannot collapse two different strings onto one length.
+    @Test func comparisonIsOverBytes() {
+        #expect(WorkerHMACSigning.constantTimeEquals("é", "é"))
+        #expect(!WorkerHMACSigning.constantTimeEquals("é", "e"))
+    }
+
+    // MARK: - hmacSHA256Hex
+
+    /// RFC 4231 test case 1, so the digest is pinned against the standard
+    /// rather than against itself. BrightSpace Valence signing shares this
+    /// function, so a change here moves two callers at once.
+    @Test func hmacMatchesTheRFC4231Vector() {
+        let key = String(repeating: "\u{0b}", count: 20)
+        #expect(
+            WorkerHMACSigning.hmacSHA256Hex(message: "Hi There", secret: key)
+                == "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")
+    }
+
+    @Test func theDigestIsLowercaseHexOfFixedWidth() {
+        let digest = WorkerHMACSigning.hmacSHA256Hex(message: "payload", secret: "secret")
+        #expect(digest.count == 64)
+        #expect(digest.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+}

--- a/Tests/CoreTests/ZipProcessSerializationTests.swift
+++ b/Tests/CoreTests/ZipProcessSerializationTests.swift
@@ -118,4 +118,115 @@ final class ZipProcessSerializationTests {
             #expect(seen == entryCount)
         }
     }
+
+    // MARK: - The process-wide lock
+
+    /// Kills the two `RemoveSideEffects` survivors from the 2026-08-19 sweep
+    /// (run 32265903112): the `zipProcessLock.lock()` inside
+    /// `withZipProcessLock`, and the one that IS `acquireZipProcessLock()`.
+    ///
+    /// Deleting either leaves the API shape intact and every other test in this
+    /// suite green — the concurrency test above passes precisely because the
+    /// children are meant to overlap — while removing the mutual exclusion the
+    /// file exists for. What comes back is the Foundation `Process` spawn race:
+    /// an intermittent `NSPOSIXErrorDomain Code=14` on an unrelated pull
+    /// request, or the SIGSEGV variant that no retry can catch.
+    ///
+    /// The assertion runs in the safe direction. Under the real lock the second
+    /// caller can NEVER enter while the first holds it, whatever the machine is
+    /// doing; a slow scheduler can only make this test pass spuriously, never
+    /// fail spuriously.
+    @Test func aHeldLockKeepsEveryOtherZipSpawnOut() {
+        let entered = DispatchSemaphore(value: 0)
+        let finished = DispatchSemaphore(value: 0)
+
+        // NSLock is thread-bound, so both halves use real threads: a Swift
+        // concurrency task may resume on a different thread than it suspended
+        // on, which would unlock from a thread that never locked.
+        acquireZipProcessLock()
+        Thread.detachNewThread {
+            withZipProcessLock { entered.signal() }
+            finished.signal()
+        }
+        let enteredWhileHeld = entered.wait(timeout: .now() + 1.0) == .success
+        releaseZipProcessLock()
+
+        #expect(
+            !enteredWhileHeld,
+            "a second zip spawn entered the serialized window while the lock was held")
+        #expect(
+            finished.wait(timeout: .now() + 10) == .success,
+            "the waiting spawn never ran after the lock was released")
+    }
+
+    // MARK: - The EFAULT retry
+
+    /// A `Process` that never spawns: it throws a chosen error for its first
+    /// `failures` attempts and counts every call.
+    ///
+    /// A real EFAULT cannot be provoked on demand — it is the residue of a race
+    /// — so the retry's *condition* can only be pinned by supplying the error.
+    /// Overriding `run()` also makes the attempt count observable, which is the
+    /// only difference between retrying and not when both paths end up throwing
+    /// the same error.
+    private final class ThrowingProcess: Process {
+        private let error: NSError
+        private let failures: Int
+        private(set) var attempts = 0
+
+        init(throwing error: NSError, times failures: Int) {
+            self.error = error
+            self.failures = failures
+            super.init()
+        }
+
+        override func run() throws {
+            attempts += 1
+            if attempts <= failures { throw error }
+        }
+    }
+
+    private func posixEFAULT() -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(EFAULT))
+    }
+
+    @Test func aTransientEFAULTIsRetriedAndSucceeds() throws {
+        let proc = ThrowingProcess(throwing: posixEFAULT(), times: 1)
+        try runProcessWithEFAULTRetry(proc)
+        #expect(proc.attempts == 2)
+    }
+
+    @Test func aPersistentEFAULTIsRetriedExactlyOnceThenPropagates() {
+        let proc = ThrowingProcess(throwing: posixEFAULT(), times: .max)
+        #expect(throws: (any Error).self) { try runProcessWithEFAULTRetry(proc) }
+        #expect(proc.attempts == 2, "the retry is once, not a loop")
+    }
+
+    /// Kills the `code !=` half of the `RelationalOperatorReplacement` pair and
+    /// the `ChangeLogicalConnector`: both make a non-EFAULT POSIX failure
+    /// retryable.
+    ///
+    /// Retrying the wrong error is not free. `runProcessWithEFAULTRetry` is
+    /// called with a `Process` whose pipes are already wired, so a second
+    /// `run()` after a genuine failure re-spawns against them — and the caller
+    /// waits out a 10 ms sleep per attempt on a path that services notebook
+    /// opens and dashboard page views.
+    @Test func anotherPOSIXFailureIsNotRetried() {
+        let proc = ThrowingProcess(
+            throwing: NSError(domain: NSPOSIXErrorDomain, code: Int(EPERM)), times: .max)
+        #expect(throws: (any Error).self) { try runProcessWithEFAULTRetry(proc) }
+        #expect(proc.attempts == 1)
+    }
+
+    /// Kills the `domain !=` half and, again, the `ChangeLogicalConnector`.
+    /// Error code 14 means something different in every domain — it is
+    /// `NSFileWriteUnknownError` in `NSCocoaErrorDomain` — so the domain is
+    /// what makes the number mean EFAULT at all.
+    @Test func theSameCodeInAnotherDomainIsNotRetried() {
+        let proc = ThrowingProcess(
+            throwing: NSError(domain: NSCocoaErrorDomain, code: Int(EFAULT)), times: .max)
+        #expect(throws: (any Error).self) { try runProcessWithEFAULTRetry(proc) }
+        #expect(proc.attempts == 1)
+    }
+
 }

--- a/Tests/CoreTests/ZipProcessSerializationTests.swift
+++ b/Tests/CoreTests/ZipProcessSerializationTests.swift
@@ -145,7 +145,7 @@ final class ZipProcessSerializationTests {
         // on, which would unlock from a thread that never locked.
         acquireZipProcessLock()
         Thread.detachNewThread {
-            withZipProcessLock { entered.signal() }
+            withZipProcessLock { _ = entered.signal() }
             finished.signal()
         }
         let enteredWhileHeld = entered.wait(timeout: .now() + 1.0) == .success
@@ -169,7 +169,10 @@ final class ZipProcessSerializationTests {
     /// Overriding `run()` also makes the attempt count observable, which is the
     /// only difference between retrying and not when both paths end up throwing
     /// the same error.
-    private final class ThrowingProcess: Process {
+    /// `@unchecked Sendable` because `Process` already claims it and Swift
+    /// requires a subclass to restate the claim. Nothing here is shared across
+    /// threads: each instance is created, run, and read inside one test body.
+    private final class ThrowingProcess: Process, @unchecked Sendable {
         private let error: NSError
         private let failures: Int
         private(set) var attempts = 0

--- a/Tools/mutation/verify-survivor.py
+++ b/Tools/mutation/verify-survivor.py
@@ -35,10 +35,17 @@ what Muter actually inserted -- not a reconstruction. A survivor whose record
 carries no mutation cannot be verified mechanically and is reported as such
 rather than approximated.
 
+VERDICTS
+    SURVIVED      nothing detects the change -- a real gap, or an equivalent mutant
+    KILLED        the suite detects it, and the line names which suite
+    INERT         Muter re-emitted the original; there is no change to detect
+    UNVERIFIABLE  the experiment could not be run (see the message)
+
 EXIT CODES
     0  the mutant SURVIVED  (a real gap, or an equivalent mutant)
     1  the mutant was KILLED
-    2  could not verify (no recorded mutation, source drifted, build failure)
+    2  could not verify (no recorded mutation, source drifted, build failure,
+       or the recorded mutation is INERT)
 """
 
 from __future__ import annotations
@@ -251,6 +258,23 @@ def failing_suites(output: str) -> list[str]:
     )
 
 
+def is_inert(mut: dict) -> bool:
+    """True when Muter's "mutation" is the original statement re-emitted.
+
+    `Tools/mutation/report.py` quarantines these out of a run's survivor list
+    (nine of the 75 in run 32265903112 were this), but a record produced before
+    that filter existed still carries them, and `--file/--line` reads the record
+    directly. Without this check the verifier applies an unchanged file, runs the
+    whole suite for two minutes, and reports SURVIVED -- which reads as "nothing
+    detects this change" when there was no change to detect. That is precisely
+    the answer that gets a test written for nothing.
+    """
+    original = mut.get("original")
+    if original is None:
+        return False
+    return " ".join(mut["mutated"].split()) == " ".join(original.split())
+
+
 def verify_one(survivor: dict, cmd: list[str], quiet: bool) -> int:
     path = survivor["file"]
     line = survivor["line"]
@@ -271,6 +295,16 @@ def verify_one(survivor: dict, cmd: list[str], quiet: bool) -> int:
     for i, mut in enumerate(muts, 1):
         tag = f"{label}" + (f"  [candidate {i} of {len(muts)}]" if len(muts) > 1 else "")
         shown = " ".join(mut["mutated"].split())[:150] or "<statement deleted>"
+        if is_inert(mut):
+            print(f"INERT         {tag}")
+            print("    Muter's mutated text is the original, modulo whitespace, so there")
+            print("    is no change for a test to detect. `SwapTernary` does this: it")
+            print("    re-emits `cond ? a : b` with the branches unswapped. Not a gap and")
+            print("    not an equivalent mutant either -- there is nothing here at all.")
+            print("    report.py quarantines these; a record written before it did still")
+            print("    carries them, which is why this check is here too.")
+            worst = max(worst, 2)
+            continue
         backup = apply_mutation(source_path, line, mut["mutated"], mut.get("original"))
         if backup is not None:
             _restore_on_signal(source_path, backup)

--- a/Tools/mutation/verify_survivor_test.py
+++ b/Tools/mutation/verify_survivor_test.py
@@ -215,5 +215,60 @@ class VerdictTests(unittest.TestCase):
         self.assertEqual(verify.failing_suites(output), ["AchievementTests"])
 
 
+class InertMutationTests(unittest.TestCase):
+    """Muter's `SwapTernary` sometimes re-emits the original statement.
+
+    Nine of the 75 survivors in run 32265903112 were this, and two of them
+    reached a triage pass that had already covered the file properly.
+    `report.py` quarantines them out of a run's survivor list, but the verifier
+    reads the record directly (`--file/--line`), so a record produced before that
+    filter -- or a hand-picked candidate out of one -- still reaches it. Without
+    this check the verifier applies an unchanged file, runs the suite for two
+    minutes, and reports SURVIVED: "nothing detects this change", about a change
+    that was never made.
+    """
+
+    def test_a_reemitted_original_is_inert(self):
+        # DatasetResolver.swift:30, verbatim from run 32265903112: the only
+        # difference is one extra space around the `:`.
+        self.assertTrue(
+            verify.is_inert(
+                {
+                    "original": '        let directory = sourceDirectory.hasSuffix("/") ? sourceDirectory : sourceDirectory + "/"',
+                    "mutated": '        let directory = sourceDirectory.hasSuffix("/")  ? sourceDirectory :  sourceDirectory + "/"',
+                }
+            )
+        )
+
+    def test_a_reflowed_multiline_original_is_inert(self):
+        # ZipArchiver.swift:80, same run: the branches are unswapped and the
+        # statement is merely folded onto one line.
+        self.assertTrue(
+            verify.is_inert(
+                {
+                    "original": '        destStandardized.path.hasSuffix("/")\n        ? destStandardized.path\n        : destStandardized.path + "/"',
+                    "mutated": '        destStandardized.path.hasSuffix("/") ? destStandardized.path :  destStandardized.path + "/"',
+                }
+            )
+        )
+
+    def test_a_genuinely_swapped_ternary_is_not_inert(self):
+        # PatternFamily.swift:209, same run and same operator -- the branches
+        # really are exchanged, and this one is killable.
+        self.assertFalse(
+            verify.is_inert(
+                {
+                    "original": "        self.argsProvided = argsProvided.count == args.count ? argsProvided : []",
+                    "mutated": "        self.argsProvided = argsProvided.count == args.count  ? [] :  argsProvided ",
+                }
+            )
+        )
+
+    def test_a_record_with_no_original_is_not_called_inert(self):
+        # Pre-#1462 records carry no `original`. "Cannot tell" must not become
+        # "nothing to see": those are UNVERIFIABLE, decided elsewhere.
+        self.assertFalse(verify.is_inert({"mutated": "return true"}))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/changelog.d/mutation-triage-core-invariants.md
+++ b/changelog.d/mutation-triage-core-invariants.md
@@ -1,0 +1,27 @@
+### Added
+
+- **Tests for four Core invariants the mutation sweep found unpinned.** The
+  2026-08-19 sweep reported 23 surviving candidates across four sites; each was
+  confirmed SURVIVED against the run record before a test was written and KILLED
+  after.
+  - `DatasetOverlap.worstPairSharedRows` was asserted only as
+    `>= expectedSharedRows`, which equality satisfies — five separate mutants
+    collapsed the extreme-value estimate onto the mean and survived, every one
+    of them reporting "the unluckiest pair shares the average amount". The
+    estimate is now pinned to its documented closed form, with the two
+    degenerate inputs (a class of one, a whole-file sample) stated as the cases
+    where the mean *is* the honest answer.
+  - `NotebookFunctionInfo`'s decoder realigns a `paramTypes` / `paramHasDefault`
+    array whose length disagrees with `paramNames`; nothing asserted it from
+    either side, so the mutants that discard a correct array and keep a
+    wrong-length one went unnoticed. The scanner's identifier-start rule is
+    pinned too: a parameter may begin with `_` and may not begin with a digit.
+  - `PatternCase` applies the same alignment rule to `argsProvided` /
+    `argVarRefs`. It was exercised only from `Tests/APITests`, which the sweep
+    does not run — and a Core model invariant pinned solely by an APIServer
+    renderer suite is unpinned for every other consumer.
+  - `ZipProcessSerialization`'s process-wide lock had no mutual-exclusion test:
+    deleting either `lock()` call left the whole suite green while restoring the
+    Foundation `Process` spawn race. The EFAULT retry's condition is now pinned
+    by domain and by code separately, so retrying the wrong failure is a test
+    failure rather than a silent 10 ms tax on the notebook-open path.

--- a/changelog.d/mutation-triage-core-invariants.md
+++ b/changelog.d/mutation-triage-core-invariants.md
@@ -1,9 +1,11 @@
 ### Added
 
-- **Tests for four Core invariants the mutation sweep found unpinned.** The
-  2026-08-19 sweep reported 23 surviving candidates across four sites; each was
-  confirmed SURVIVED against the run record before a test was written and KILLED
-  after.
+- **Tests for eight Core invariants the mutation sweep found unpinned.** The
+  2026-08-19 sweep (run 32265903112) reported 31 surviving candidates across
+  them; each was confirmed SURVIVED against the run record before a test was
+  written and KILLED after, and every kill names the suite that added the
+  assertion. Two further survivors turned out to be Muter re-emitting the
+  original statement — see the verifier change below.
   - `DatasetOverlap.worstPairSharedRows` was asserted only as
     `>= expectedSharedRows`, which equality satisfies — five separate mutants
     collapsed the extreme-value estimate onto the mean and survived, every one
@@ -25,3 +27,29 @@
     Foundation `Process` spawn race. The EFAULT retry's condition is now pinned
     by domain and by code separately, so retrying the wrong failure is a test
     failure rather than a silent 10 ms tax on the notebook-open path.
+  - `CourseRole`'s `<` — the relation every `requireCourseRole(atLeast:)` gate
+    resolves to — and `WorkerHMACSigning.constantTimeEquals`, the comparison
+    every runner request is admitted by, were both in that same
+    APITests-only class. Each now has assertions beside the type, including an
+    RFC 4231 vector for the HMAC itself.
+  - `renderInputsFile`'s Racket form had no assertion anywhere, and a surviving
+    mutant emitted an unterminated `(define ck-inputs (hash` for an assignment
+    with no personalization inputs — a read error on every generated test, for
+    every student. Pinned by byte, plus an `allCases` property (balanced
+    delimiters, header present, final newline) that a seventh language inherits
+    without editing the file.
+  - `TestOutcomeCollection`'s output budget is now split by a named
+    `outputCarrierCount`. The count was an inline expression inside the
+    per-carrier arithmetic, and the halving loop that follows absorbs an
+    off-by-one — the result still fits the budget, it just keeps roughly twice
+    or half as much of a student's output as it should — so no assertion made
+    from outside could see it.
+
+### Changed
+
+- **`Tools/mutation/verify-survivor.py` reports `INERT`.** Muter's `SwapTernary`
+  sometimes re-emits the original statement unchanged; `report.py` already
+  quarantines those out of a run's survivor list, but the verifier reads a
+  record directly, so it would apply an unchanged file, run the suite for two
+  minutes, and report `SURVIVED` — "nothing detects this change", about a change
+  that was never made. Two survivors in run 32265903112 were exactly this.

--- a/docs/mutation-triage.md
+++ b/docs/mutation-triage.md
@@ -106,6 +106,18 @@ against the full suite before writing anything — otherwise you are looking at
 the same artefact a missing interpreter produces, where a test that never ran
 makes its mutants read as gaps.
 
+**A full-suite kill on a Core survivor is not automatically a close.** The
+question the confirmation answers is "does any test detect this", and a second
+question follows it: is the test that detects it in the right layer.
+`PatternCase`'s length-alignment rule and `NotebookFunctionInfo`'s decoder
+realignment are Core model invariants whose only assertions lived in an
+APIServer renderer suite. The full suite kills their mutants, so they are not
+undetected — but every non-APIServer consumer of those models was relying on a
+test that does not exercise it, and the sweep could not see the rule at all.
+Both got a `Tests/CoreTests` assertion rather than a ledger entry. Reserve the
+ledger for mutants nothing *can* observe; "observed from somewhere else"
+belongs in a test where the invariant lives.
+
 **Equivalent mutants are common in parsers and defensive code.**
 `containsSubstring`'s empty-needle guard has no caller that passes an empty
 needle. `JSONLite`'s `parseNumber` is a subtler one: mutating `if current == "-"`


### PR DESCRIPTION
Empties the remaining triage queue from mutation run `32265903112`: **31 candidates across eight sites**, plus two that turned out not to be mutations at all. Each was confirmed `SURVIVED` against the run record before a test was written and `KILLED` after, and every kill names the suite that added the assertion.

```
31 KILLED  ·  2 INERT  ·  0 still open
```

## `DatasetDiagnostics` — the worst-pair estimate

`worstPairSharedRows` is the only number on `DatasetOverlap` an instructor acts on ("the unluckiest pair in your class is expected to share this many rows"), and the only assertion on it was `>= expectedSharedRows` — which equality satisfies. Five separate mutants collapsed the extreme-value estimate onto the mean and survived: the variance guard's `poolRows > 1`, the pair count's `classSize > 1` (as both a relational flip and a swapped ternary), and each half of `pairs >= 2, variance > 0`.

Every one of them reports "the worst pair shares the average amount", which is the answer that makes a spec look safe.

Now pinned to the documented closed form (`mean + σ·√(2·ln pairs)` over `C(C−1)/2` pairs), re-derived in the test rather than copied from the implementation. The two degenerate inputs — a class of one, a whole-file sample — are stated as the cases where the mean *is* the honest answer, so the strict inequality is asserted only where a spread must exist.

## `NotebookFunctionScanner`

The decoder realigns a `paramTypes` / `paramHasDefault` array whose length disagrees with `paramNames`; nothing asserted the rule from either side, so the four mutants that **discard a correctly-sized array and keep a wrong-length one** were invisible. Every consumer indexes these by parameter position, so a short one is out-of-range and a long one mislabels columns.

Also pins the identifier-start rule, whose flip is silent in both directions: a parameter genuinely named `_unused` stops being reported (the family editor shows a signature one column short and every case row shifts its arguments left), while a digit-led token — which no Python signature can contain, so its presence means the line was misparsed — starts being reported.

## `PatternFamily`, `CourseRole`, `WorkerHMACSigning` — the weak-evidence class

All three are killed by the full suite, via `Tests/APITests`, which the sweep does not run. That is not a close: none is an equivalent mutant, so none belongs in `equivalent-mutants.json`, and a Core invariant pinned solely by an APIServer suite is unpinned for every other consumer *and* invisible to the sweep. Each got an assertion where the invariant lives.

- `PatternCase`'s length-alignment rule for `argsProvided` / `argVarRefs`, on both the memberwise init and the decoder.
- `CourseRole`'s `<` — the single relation every `requireCourseRole(atLeast:)` gate resolves to. Flipping it does not weaken one permission; it inverts authority everywhere at once.
- `WorkerHMACSigning.constantTimeEquals`, with its two mutants failing in opposite directions: one refuses every well-formed runner request, the other inverts the verdict on a security boundary. The digest itself is pinned against RFC 4231 test case 1 rather than against itself, since BrightSpace Valence signing shares the function.

`docs/mutation-triage.md` records the distinction: reserve the ledger for mutants nothing *can* observe; "observed from somewhere else" is a layering answer, not a closure.

## `ZipProcessSerialization`

No mutual-exclusion test existed. Deleting either `zipProcessLock.lock()` left the entire suite green — including the concurrency test above it, which passes precisely because the children are *meant* to overlap — while removing the serialization that keeps the Foundation `Process` spawn race away. What comes back is an intermittent `NSPOSIXErrorDomain Code=14` on an unrelated PR, or the SIGSEGV variant no retry can catch.

The new test asserts in the safe direction: under a real lock the second caller can never enter while the first holds it, whatever the machine is doing, so a slow scheduler can only make it pass spuriously. It uses real threads because `NSLock` is thread-bound and a Swift concurrency task may resume where it did not suspend.

The EFAULT retry's condition is now pinned by domain and by code **separately** — a POSIX failure that isn't EFAULT, and code 14 in another domain, must each not retry. A real EFAULT is the residue of a race and cannot be provoked on demand, so a `Process` subclass supplies the error and counts attempts.

## `renderInputsFile` — the Racket form

No assertion anywhere. Its surviving `SwapTernary` exchanges the branches *and* leaves the entries concatenated onto the wrong side, so an assignment with no personalization inputs emits an unterminated `(define ck-inputs (hash`. The file is `dynamic-require`d by every generated test, so that is a read error on every test in the assignment, for every student, with nothing in the test scripts to point at.

Pinned by byte for Racket, plus an `allCases` property — balanced delimiters, header present, final newline, and a populated render that differs from the empty one — so a seventh language inherits the check without editing the file. The empty case is the one that goes unwritten in every language, because an author testing by hand always has an input.

## `TestOutcomeCollection` — one production change, and why

This is the only site that needed the source to move. Its two mutants change how the output budget is divided among carriers, and the halving loop that follows absorbs the difference: the result still fits the budget, it just keeps roughly twice or half as much of a student's output as it should. Simulating the arithmetic across ~130 collection shapes confirmed there is no external observation that separates them robustly — the amount actually retained is an artefact of where the halving lands, not a rule anyone chose, and pinning it would fail on any legitimate improvement to the search.

So the divisor became a named `outputCarrierCount` with the rule in its doc comment, and the count is asserted directly. Both mutants were then re-applied **by hand** to the extracted property and both die — the verifier correctly refuses a record whose original no longer exists, so this one is a manual after-pass rather than a tool one.

## `verify-survivor.py` reports `INERT`

Two of the queue's survivors were never mutations. Muter's `SwapTernary` sometimes re-emits the original statement with only whitespace moved; `report.py` already quarantines those out of a run's survivor list, but the verifier reads a record directly, so it applied an unchanged file, ran the suite for two minutes, and reported `SURVIVED` — "nothing detects this change", about a change that was never made. That is precisely the answer that gets a test written for nothing, and two of them had already reached a triage pass that had covered the file properly.

The verdict is now reported before anything runs. Its self-tests take both records verbatim, keep a genuinely-swapped ternary from the same run and operator as a negative case, and were seen to fail against a deliberately broken predicate.

## Verification

```
scripts/format.sh          clean
scripts/lint.sh            clean
scripts/swiftlint.sh       0 violations in 1067 files
swift build --build-tests  clean under CI flags (warnings-as-errors)
swift test (sweep scope)   813 tests in 96 suites passed
python guards              verify_survivor_test / report_test / workflow_scope_test — all pass
after-pass                 31/31 KILLED, 2 INERT
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qPZYk8SHvaw3P9M4kAjw2