### PR TITLE
chore: collapse AuthProvider, drop dead code, and stop script edits un-declaring the language

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1498,16 +1498,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 
 .test-output-row td { padding-top: 0; }
 
-.test-output-panel { padding: .35rem 0 .2rem; }
-
-.test-output-heading {
-    font-size: var(--text-xs);
-    text-transform: uppercase;
-    letter-spacing: .05em;
-    color: var(--gray-500);
-    font-weight: 700;
-}
-
 .test-output-pre-wide { margin-top: .35rem; }
 
 .warning-box {

--- a/Sources/APIServer/Auth/LocalAuthProvider.swift
+++ b/Sources/APIServer/Auth/LocalAuthProvider.swift
@@ -1,30 +1,22 @@
-// APIServer/Auth/AuthProvider.swift
+// APIServer/Auth/LocalAuthProvider.swift
 //
-// Pluggable credential-verification strategy.
+// Username/password credential verification against the local user table —
+// the whole of AUTH_MODE=local, and the local half of AUTH_MODE=dual.  The
+// SSO path is not username/password-shaped and never comes through here; it
+// lives in SSOAuthRoutes.
 //
-// AUTH_MODE=local  → LocalAuthProvider (BCrypt, default)
-// AUTH_MODE=sso    → future OIDC provider
-// AUTH_MODE=dual   → both; local is tried first
-//
-// Callers use req.application.authProvider.authenticate(…) instead of
-// talking to the database directly. This keeps auth logic out of route
-// handlers and makes testing without a real SSO server straightforward.
+// A plain stateless struct, not a strategy protocol: there is exactly one
+// way to verify a local password, and the protocol seam that used to wrap
+// this went unused by the SSO flow and the tests alike (#449).
 
 import Fluent
 import Vapor
 
-// MARK: - Protocol
-
-/// Returns the matching `APIUser` on success, or `nil` for invalid credentials.
-/// Implementations must be safe to call from concurrent request handlers.
-protocol AuthProvider: Sendable {
-    func authenticate(username: String, password: String, on req: Request) async throws -> APIUser?
-}
-
-// MARK: - LocalAuthProvider
-
 /// BCrypt-backed credential verification against the local user table.
-struct LocalAuthProvider: AuthProvider {
+///
+/// Returns the matching `APIUser` on success, or `nil` for invalid
+/// credentials.  Safe to call from concurrent request handlers.
+struct LocalAuthProvider {
     func authenticate(username: String, password: String, on req: Request) async throws -> APIUser? {
         let user = try await APIUser.query(on: req.db)
             .filter(\.$username == username)
@@ -61,17 +53,3 @@ private actor TimingEqualizerHashCache {
 }
 
 private let timingEqualizerHashCache = TimingEqualizerHashCache()
-
-// MARK: - Application storage
-
-private struct AuthProviderKey: StorageKey {
-    typealias Value = any AuthProvider
-}
-
-extension Application {
-    /// The active auth provider. Defaults to `LocalAuthProvider` if not explicitly set.
-    var authProvider: any AuthProvider {
-        get { storage[AuthProviderKey.self] ?? LocalAuthProvider() }
-        set { storage[AuthProviderKey.self] = newValue }
-    }
-}

--- a/Sources/APIServer/Bootstrap/AppDirectories.swift
+++ b/Sources/APIServer/Bootstrap/AppDirectories.swift
@@ -61,5 +61,4 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     )
     app.storage[LocalRunnerManagerKey.self] = LocalRunnerManager()
     app.storage[DataExportManagerKey.self] = DataExportManager()
-    app.authProvider = LocalAuthProvider()
 }

--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -244,29 +244,6 @@ func declareManifestLanguage(
     }
 }
 
-/// Removes the recorded `language`, returning the assignment to derived
-/// resolution. Returns true when a value was actually removed.
-///
-/// The escape hatch from the one-way door `AssignmentLanguage.rederive`
-/// documents: a recorded language outranks every content signal, so without a
-/// way back an assignment declared wrong once would keep rendering in that
-/// language forever, however its notebook and scripts changed underneath.
-///
-/// Guarded exactly like `setManifestLanguage`, and for the same reason: clearing
-/// changes which language generated tests render in just as setting does, and
-/// only the pattern-family application path knows how to re-render and clean up
-/// the old side.
-func clearManifestLanguage(setup: APITestSetup, on db: any Database) async throws -> Bool {
-    guard currentManifestLanguage(setup.manifest) != nil else { return false }
-    if manifestHasGeneratedScripts(setup.manifest) {
-        throw AppError.badRequest(reason: languageChangeAfterGenerationMessage)
-    }
-    try await mutateManifest(setup: setup, on: db) { dict in
-        dict.removeValue(forKey: "language")
-    }
-    return true
-}
-
 /// True when the manifest carries any generated test — a pattern-family case or
 /// a notebook check. Read off `generatedBy` rather than the family/check lists
 /// so a family that has produced no enabled case doesn't block a change that

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -117,7 +117,7 @@ struct AuthRoutes: RouteCollection {
         }
 
         guard
-            let user = try await req.application.authProvider.authenticate(
+            let user = try await LocalAuthProvider().authenticate(
                 username: body.username,
                 password: body.password,
                 on: req

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -107,9 +107,13 @@ func updateManifestAddingScript(
         disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
         builtInAchievementsSeeded: props.builtInAchievementsSeeded,
         datasets: props.datasets,
-        // Preserve the recorded language: rebuilding the manifest to add or
-        // remove one script must never silently drop it back to "unrecorded".
+        // Preserve the recorded language AND the declared flag: rebuilding the
+        // manifest to add or remove one script must never silently drop the
+        // language back to "unrecorded", nor un-declare an assignment — least
+        // of all one whose declaration is "none", where `language` alone
+        // carries no evidence.
         language: props.language,
+        languageDeclared: props.languageDeclared == true,
         // Likewise preserve the minimum-runner-version gate across the rebuild.
         minimumRunnerVersion: props.minimumRunnerVersion
     )
@@ -163,52 +167,14 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
         disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
         builtInAchievementsSeeded: props.builtInAchievementsSeeded,
         datasets: props.datasets,
-        // Preserve the recorded language: rebuilding the manifest to add or
-        // remove one script must never silently drop it back to "unrecorded".
+        // Preserve the recorded language AND the declared flag: rebuilding the
+        // manifest to add or remove one script must never silently drop the
+        // language back to "unrecorded", nor un-declare an assignment — least
+        // of all one whose declaration is "none", where `language` alone
+        // carries no evidence.
         language: props.language,
+        languageDeclared: props.languageDeclared == true,
         // Likewise preserve the minimum-runner-version gate across the rebuild.
-        minimumRunnerVersion: props.minimumRunnerVersion
-    )
-}
-
-/// Returns manifest JSON identical to `manifestJSON` except for its recorded
-/// `language`, rebuilt through the canonical `makeWorkerManifestJSON` writer so
-/// every other field is preserved. Returns nil if the manifest can't be decoded.
-func updateManifestLanguage(manifestJSON: String, language: AssignmentLanguage?) -> String? {
-    guard let props = decodeManifest(fromJSON: manifestJSON) else { return nil }
-    let entries = props.testSuites.enumerated().map { idx, e in
-        ConfiguredSuiteEntry(
-            script: e.script,
-            tier: e.tier.rawValue,
-            order: idx + 1,
-            dependsOn: e.dependsOn,
-            points: e.points,
-            displayName: e.name,
-            generatedBy: e.generatedBy,
-            generatedByCheck: e.generatedByCheck,
-            sectionID: e.sectionID,
-            hint: e.hint,
-            timeLimitSeconds: e.timeLimitSeconds
-        )
-    }
-    return try? makeWorkerManifestJSON(
-        testSuites: entries,
-        includeMakefile: props.makefile != nil,
-        gradingMode: props.gradingMode.rawValue,
-        submissionMode: props.submissionMode.rawValue,
-        requiredFiles: props.requiredFiles,
-        timeLimitSeconds: props.timeLimitSeconds,
-        starterNotebook: props.starterNotebook,
-        patternFamilies: props.patternFamilies,
-        notebookChecks: props.notebookChecks,
-        sections: props.sections,
-        globalVariables: props.globalVariables,
-        globalExpressions: props.globalExpressions,
-        achievements: props.achievements,
-        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
-        builtInAchievementsSeeded: props.builtInAchievementsSeeded,
-        datasets: props.datasets,
-        language: language,
         minimumRunnerVersion: props.minimumRunnerVersion
     )
 }

--- a/Sources/APIServer/Utilities/CppScriptHelpers.swift
+++ b/Sources/APIServer/Utilities/CppScriptHelpers.swift
@@ -42,12 +42,6 @@ func isValidCppIdentifier(_ name: String) -> Bool {
     return !cppReservedWords.contains(name)
 }
 
-/// `name` if it is usable as a C++ identifier; nil otherwise. Callers refuse
-/// at save time with a message naming the field — never silently rewrite.
-func cppIdentifier(_ name: String) -> String? {
-    isValidCppIdentifier(name) ? name : nil
-}
-
 /// A `//` comment line with newlines stripped, so authored text (labels,
 /// hints) cannot break out of comment position in generated source.
 func cppComment(_ text: String) -> String {

--- a/Sources/APIServer/Utilities/RacketScriptHelpers.swift
+++ b/Sources/APIServer/Utilities/RacketScriptHelpers.swift
@@ -1,9 +1,9 @@
 // APIServer/Utilities/RacketScriptHelpers.swift
 //
-// Racket-side helpers for generated scripts: the identifier grammar, and the
-// module-path form a generated test uses to reach the submission.
+// Racket-side helpers for generated scripts: the identifier grammar.
+// (Submission module loading lives in the runtime itself —
+// Tools/runner-support/test_runtime.rkt builds the `(file …)` path.)
 
-import Core
 import Foundation
 
 /// Characters that end an identifier in Racket's reader. Everything else is
@@ -40,14 +40,4 @@ func isValidRacketIdentifier(_ name: String) -> Bool {
         return false
     }
     return true
-}
-
-/// The `(file "…")` module path a generated test hands to `dynamic-require`.
-///
-/// A quoted relative path rather than a bare identifier: `(require student)`
-/// would look up a COLLECTION named `student` on the collection path, not the
-/// file beside the test, and would fail with a confusing "collection not found"
-/// rather than a missing-submission message.
-func racketSubmissionModulePath(_ filename: String) -> String {
-    "(file \(JSONValue.string(filename).racketLiteral))"
 }

--- a/Tests/APITests/AssignmentHelpersManifestTests.swift
+++ b/Tests/APITests/AssignmentHelpersManifestTests.swift
@@ -271,6 +271,66 @@ final class AssignmentHelpersManifestTests {
                 .minimumRunnerVersion == "0.5.0")
     }
 
+    // Regression: rebuilding the manifest to add or remove a script must
+    // preserve `languageDeclared` alongside `language`.  makeWorkerManifestJSON
+    // builds a fresh dict, so an un-threaded flag was dropped on every script
+    // edit — turning a deliberate "None" declaration (languageDeclared with no
+    // language key, the case where `language` alone carries no evidence) back
+    // into "nobody has been asked".
+    @Test func updateManifestScriptEditsPreserveLanguageDeclaration() throws {
+        let declaredNone = try makeWorkerManifestJSON(
+            testSuites: [
+                ConfiguredSuiteEntry(
+                    script: "01_public.sh", tier: "public", order: 1,
+                    dependsOn: [], points: 1, displayName: nil)
+            ],
+            includeMakefile: false,
+            language: nil,
+            languageDeclared: true
+        )
+        // Sanity: the builder recorded the declaration.
+        #expect(
+            try JSONDecoder().decode(TestProperties.self, from: Data(declaredNone.utf8))
+                .languageDeclared == true)
+
+        let added = try #require(
+            updateManifestAddingScript(
+                manifestJSON: declaredNone,
+                entry: ConfiguredSuiteEntry(
+                    script: "02_public.sh", tier: "public", order: 99,
+                    dependsOn: [], points: 1, displayName: nil)))
+        let addedProps = try JSONDecoder().decode(TestProperties.self, from: Data(added.utf8))
+        #expect(addedProps.language == nil)
+        #expect(addedProps.languageDeclared == true)
+
+        let removed = try #require(
+            updateManifestRemovingScript(manifestJSON: added, filename: "02_public.sh"))
+        let removedProps = try JSONDecoder().decode(TestProperties.self, from: Data(removed.utf8))
+        #expect(removedProps.languageDeclared == true)
+
+        // A declared language survives the same round-trip: the two fields
+        // travel together.
+        let declaredR = try makeWorkerManifestJSON(
+            testSuites: [
+                ConfiguredSuiteEntry(
+                    script: "01_public.R", tier: "public", order: 1,
+                    dependsOn: [], points: 1, displayName: nil)
+            ],
+            includeMakefile: false,
+            language: .r,
+            languageDeclared: true
+        )
+        let addedR = try #require(
+            updateManifestAddingScript(
+                manifestJSON: declaredR,
+                entry: ConfiguredSuiteEntry(
+                    script: "02_public.R", tier: "public", order: 99,
+                    dependsOn: [], points: 1, displayName: nil)))
+        let addedRProps = try JSONDecoder().decode(TestProperties.self, from: Data(addedR.utf8))
+        #expect(addedRProps.language == .r)
+        #expect(addedRProps.languageDeclared == true)
+    }
+
     @Test func detectRequirementSuggestionsIgnoresSolutionNotebookImports() throws {
         let zipPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("detect-requirements-\(UUID().uuidString).zip")

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -687,7 +687,7 @@ private extension Data {
 /// from the stored hash, so logins against these fixtures are fast too.
 ///
 /// This only changes *test fixture* hashes. It does NOT touch the app's
-/// configured password hasher, so `AuthProvider`'s timing-equalizer (the
+/// configured password hasher, so `LocalAuthProvider`'s timing-equalizer (the
 /// account-enumeration defense exercised by
 /// `loginWithUnknownUserStillRunsBcryptVerify`) still runs at the production
 /// cost.

--- a/changelog.d/code-cleanup-kvhl1x.md
+++ b/changelog.d/code-cleanup-kvhl1x.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **Adding or removing a raw script no longer un-declares the assignment's
+  language.** The add-script and remove-script manifest rebuilds preserved
+  `language` but dropped `languageDeclared`, so one script edit through the
+  suite editor turned a deliberate "None" declaration back into "nobody has
+  been asked" — the exact conflation the declaration rule exists to remove.
+  Both rebuilds now thread the flag, like the pattern-family rebuild always
+  did, with a regression test covering the declared-None round-trip.
+
+### Removed
+
+- **The single-implementation `AuthProvider` protocol (#449).** `LocalAuthProvider`
+  is now a plain struct called directly from the login route; the protocol,
+  the `Application.authProvider` storage seam, and its eager bootstrap wiring
+  carried abstraction for a polymorphism that never existed (SSO login is not
+  username/password-shaped and never went through it, and no test mocked it).
+- **Four dead functions.** `updateManifestLanguage` (superseded by
+  `mutateManifest`-based edits, and it dropped `languageDeclared` on rebuild —
+  the same defect fixed above, waiting in a function nothing called),
+  `clearManifestLanguage` (superseded by `declareManifestLanguage(nil)`; its
+  doc comment cited the deleted `rederive` mechanism), `cppIdentifier` (unused
+  wrapper over `isValidCppIdentifier`, which every caller uses directly), and
+  `racketSubmissionModulePath` (submission module loading lives in
+  `test_runtime.rkt`, which builds its own `(file …)` path).
+- **Two dead stylesheet rules.** `.test-output-panel` and `.test-output-heading`
+  were referenced by no template, page script, or JS-built markup; the live
+  `test-output-*` family (`-row`, `-details`, `-pre`, `-pre-wide`) is untouched.

--- a/scripts/check-ui-vocabulary.sh
+++ b/scripts/check-ui-vocabulary.sh
@@ -57,7 +57,7 @@ status=0
 #
 # Shrink-only.  Lower it in the PR that earns it; headroom left behind gets
 # spent by the next person adding a copy.
-CATALOG_BASELINE=262
+CATALOG_BASELINE=260
 
 # Comment stripper.  A scanner cannot tell a selector from prose about a
 # selector, and this codebase has been bitten by that three times (the


### PR DESCRIPTION
Code-cleanup pass. Three removals, and one live defect the cleanup surfaced and fixes.

## The defect (found while deleting its dead twin)

`updateManifestAddingScript` and `updateManifestRemovingScript` preserved `language` across the rebuild but dropped **`languageDeclared`** — `makeWorkerManifestJSON` writes a fresh dict, so one raw-script add or delete through the suite editor turned a deliberate "None" declaration back into "nobody has been asked" (the exact conflation the CLAUDE.md corollary on `makeWorkerManifestJSON` warns about, and the rule the pattern-family rebuild already follows with its "a rebuild must not un-declare an assignment" comment). Both rebuilds now thread the flag. The regression test was **seen to fail first** — 3 issues against the un-threaded helpers — and covers the declared-None round-trip (the case where `language` alone carries no evidence) plus a declared-R add.

## Removals

- **`AuthProvider` protocol — the remaining scope of #449.** Single implementation, one call site, no test ever mocked the seam, and SSO login is not username/password-shaped so it never went through it. `LocalAuthProvider` is now a plain struct called directly from the login route; the `Application.authProvider` storage seam and its eager bootstrap wiring (which existed only to dodge the lazy-create race in the accessor) go with it. File renamed to `LocalAuthProvider.swift` per the file-naming convention.
- **Four dead functions**, none referenced anywhere in Sources/Tests/scripts:
  - `updateManifestLanguage` — superseded by the `mutateManifest`-based edits; it also dropped `languageDeclared` (the defect above, waiting in a function nothing called).
  - `clearManifestLanguage` — superseded by `declareManifestLanguage(nil)`; its doc comment cited the deleted `rederive` mechanism.
  - `cppIdentifier` — unused wrapper; every caller uses `isValidCppIdentifier` directly.
  - `racketSubmissionModulePath` — submission module loading lives in `test_runtime.rkt`, which builds its own `(file …)` path; no Swift-rendered code ever needed this.
- **Two dead stylesheet rules** (`.test-output-panel`, `.test-output-heading`) — referenced by no template, page script, or JS-built markup; the live `test-output-*` family (`-row`, `-details`, `-pre`, `-pre-wide`) is untouched, and `StatusClassStylesheetTests` already records precedent for removing a dead family here. The ui-vocabulary catalog ratchet is lowered 262 → 260 as its error message instructs.

## Issue state this touches

- **#449** — this completes the remaining scope (the 2026-07-16 comment narrowed it to the `AuthProvider` decision; `AlertNotifier` stays as resolved there).
- **#1253** — checked while scoping this task: all four deferred items are now done or deliberately settled on `main` (`assignments.leaf` is 312 lines, the claim types live in `WorkerClaimEvaluation.swift`, the double lint-disable is gone, and the two surviving `function_parameter_count` disables carry written justifications). Nothing of it remains in this PR; it can likely be closed.

## Validation

- `swift build` green; **`scripts/swiftlint.sh`** 0 violations in 1076 files; **`scripts/lint.sh`** exit 0; **`scripts/check-styles.sh`** OK (catalog 260/260); **`scripts/check-guards.sh`** OK (24/24 fixtures); **`scripts/eslint.sh`** OK.
- Targeted suites, all green: `AssignmentHelpersManifestTests` (23), `AuthRoutesTests` (21, including `loginWithUnknownUserStillRunsBcryptVerify` — the timing-equalizer defense is unchanged), `SetSubmissionModeAndLanguageToolTests` + `AssignmentLanguageResolutionTests` + `AchievementFixRegressionTests` (22), `PatternFamilyApplyTests` + `NewAssignmentDraftServiceTests` + `SubmissionModeRoutesTests` + `MCPContentEditCoverageTests` (53).
- The `styles.css` change is a pure deletion; the `ui-review` agent is not installed in this environment, so per CLAUDE.md I'm saying so plainly rather than letting it pass unmentioned — the change was self-checked against its criteria (no new construct, no idiom choice, no copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkeyq2x3B6fYN8o7NSSf9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkeyq2x3B6fYN8o7NSSf9o)_