### PR TITLE
test: make the wedge-watchdog arming guard race-free

### DIFF
--- a/Tests/APITests/WedgeWatchdogArmingTests.swift
+++ b/Tests/APITests/WedgeWatchdogArmingTests.swift
@@ -22,14 +22,29 @@ import VaporTesting
     /// arming seam. If the `WedgeWatchdog.track` wrapper is ever removed from
     /// it, the target silently loses the only stall guard that survives
     /// cooperative-pool saturation.
+    ///
+    /// Asserted via the task-local, not a counter delta: the global
+    /// `activeTrackedScopes` moves with every parallel test's scope, so
+    /// "before < inside" flaked whenever another test's scope drained between
+    /// the two reads (2026-08-22, run 32542491009 — the reads sat 66 s apart
+    /// on a loaded postgres lane, the sole failure in 3,045 tests). The
+    /// task-local is ours alone: another suite's scope can neither satisfy it
+    /// nor disturb it. The counter check inside the body is a same-instant
+    /// floor — our own scope guarantees it, concurrent scopes only add.
     @Test func withAppArmsTheWatchdog() async throws {
-        let scopesBefore = WedgeWatchdog.activeTrackedScopes
+        var trackedInside = false
         var scopesInside = 0
         let app = try await Application.make(.testing)
         try await withApp(app) { _ in
+            trackedInside = WedgeWatchdog.isInsideTrackedScope
             scopesInside = WedgeWatchdog.activeTrackedScopes
         }
-        #expect(scopesInside > scopesBefore)
+        #expect(trackedInside)
+        #expect(scopesInside >= 1)
+        // And the scope really closed: leaving `withApp` must leave the
+        // task-local behind, or a helper that hoisted the wrapper too high
+        // would keep "tracking" long after the app is gone.
+        #expect(WedgeWatchdog.isInsideTrackedScope == false)
     }
 
     /// Entering and leaving a tracked scope both count as activity, which is

--- a/Tests/TestSupport/WedgeWatchdog.swift
+++ b/Tests/TestSupport/WedgeWatchdog.swift
@@ -83,13 +83,23 @@ public enum WedgeWatchdog {
     }()
 
     /// How many `track` scopes are currently in flight. The watchdog is armed
-    /// exactly when this is non-zero. Exposed so a target can assert its own
-    /// arming seam is still wired — the guard is worth having because losing
-    /// the arming is silent: everything keeps passing, and the next wedge is
-    /// again a 20-minute job kill with no evidence.
+    /// exactly when this is non-zero. Process-global by design (the monitor
+    /// compares it against zero), which means a two-point delta of it is racy
+    /// under parallel tests — an arming assertion should read
+    /// `isInsideTrackedScope` instead, and use this only as a same-instant
+    /// floor (`>= 1` from inside a scope).
     public static var activeTrackedScopes: Int {
         state.withLock { $0.activeHelpers }
     }
+
+    /// True while the current task is inside a `track` scope. Task-local, so
+    /// unlike `activeTrackedScopes` it is untouched by other tests' scopes
+    /// starting or finishing concurrently — the race that made a
+    /// before/inside counter delta flake on a loaded postgres lane
+    /// (2026-08-22, run 32542491009: the two reads sat 66 s apart, plenty for
+    /// every other in-flight scope to drain). This is the arming-seam
+    /// assertion surface; the counter above is the monitor's.
+    @TaskLocal public static var isInsideTrackedScope = false
 
     /// Seconds since the last reported activity. This is what the monitor
     /// thread compares against `stallLimitSeconds`.
@@ -127,7 +137,9 @@ public enum WedgeWatchdog {
                 current.lastActivity = Date()
             }
         }
-        return try await body()
+        return try await $isInsideTrackedScope.withValue(true) {
+            try await body()
+        }
     }
 
     private static func startMonitorIfNeeded(_ current: inout State) {

--- a/changelog.d/watchdog-arming-race.md
+++ b/changelog.d/watchdog-arming-race.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **The wedge-watchdog arming guard no longer races parallel tests.**
+  `WedgeWatchdogArmingTests.withAppArmsTheWatchdog` asserted a before/inside
+  delta of the process-global tracked-scope counter, which any concurrent
+  test's scope could zero out by draining between the two reads — it was the
+  sole failure in a 3,045-test `api-tests-postgres` run on a loaded lane
+  (2026-08-22). `WedgeWatchdog.track` now also sets a task-local,
+  `isInsideTrackedScope`, and the guard asserts that from inside `withApp`:
+  another suite's scope can neither satisfy it nor disturb it, so the
+  assertion is race-free and strictly stronger. Verified in both directions —
+  it fails when the `track` wrapper is stripped from `withApp`.
+  `docs/ci-flakiness.md` records the sighting, and marks Family 5's
+  ceiling-equalization attack note done (the workflow has carried matching
+  25-minute ceilings on both api-tests lanes for some time).

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -485,6 +485,11 @@ regression in the change under test and is not one.
    noisy-neighbour-vs-saturation question the *next* time this happens rather
    than requiring another lucky log tail.
 2. **Re-tune the ceiling — but do not expect it to have saved this run.**
+   **DONE** — `api-tests` carries `timeout-minutes: 25` in
+   `swift-tests.yml`, equal to the postgres lane (verified 2026-08-22; the
+   change itself predates the current history graft and was never marked
+   here). The caveats below stand as written: headroom for the ordinary
+   tail, not a rescue for a 5× starvation event.
    The sqlite lane is capped at 20 min against postgres' 25 despite carrying
    the wider spread, and equalising them is defensible on the baseline alone:
    the ordinary tail is 441 s, and 20 min leaves ~1107 s of test budget after
@@ -498,6 +503,30 @@ regression in the change under test and is not one.
    than instead of it.
 3. **Finish the CLOEXEC sweep** on the three helpers above, closing the
    mechanism that turns a transient overload into a permanent one.
+
+**The arming guard's own first flake (2026-08-22) — FIXED.** The watchdog's
+drift guard `WedgeWatchdogArmingTests.withAppArmsTheWatchdog` was itself the
+sole failure in a 3,045-test `api-tests-postgres` run (run 32542491009,
+branch `claude/student-avatar-generation-t2suku`; the sqlite lane passed the
+same commit, and the diff — avatar art — cannot reach it). The assertion
+compared two reads of the process-global `activeTrackedScopes` counter,
+before `withApp` and inside it: under parallel tests that delta is racy,
+because every concurrent test's scope moves the same counter. On this run
+the lane was heavily contended (postgres checkpoints of 60+ s in the service
+log; the test body took 66.5 s), so the window between the reads was wide
+enough for every other in-flight scope to drain — one net −1 by others plus
+our own +1 reads as "no increase", and `(scopesInside → 1) > (scopesBefore
+→ 1)` failed.
+
+The fix replaces the delta with a `@TaskLocal` — `WedgeWatchdog.track` now
+sets `isInsideTrackedScope` for its body, and the test asserts it from
+inside `withApp`. Task-locals follow the task tree, so another suite's scope
+can neither satisfy the assertion (no false pass through, say,
+`withPatternFamilyFixture`'s self-arming) nor disturb it (no false fail from
+scopes draining concurrently) — strictly stronger than the counter delta and
+race-free. The global counter keeps its job as the monitor's arming signal;
+the test still pins a same-instant floor (`activeTrackedScopes >= 1` from
+inside the scope, which concurrent activity can only raise).
 
 ---
 


### PR DESCRIPTION
Fixes the one live flake in the Swift test lanes' recent history.

## The flake

`WedgeWatchdogArmingTests.withAppArmsTheWatchdog` was the **sole failure in a 3,045-test `api-tests-postgres` run** last night (run 32542491009, 2026-08-22 01:22, branch `claude/student-avatar-generation-t2suku`): `Expectation failed: (scopesInside → 1) > (scopesBefore → 1)` after 66.5 s. The sqlite lane passed the same commit, and the diff (avatar art) cannot reach the watchdog.

The assertion compared two reads of the **process-global** `activeTrackedScopes` counter — one before `withApp`, one inside it. Under parallel tests every concurrent `withApp` scope moves that same counter, so the delta is racy: one other test's scope draining between the reads cancels our own +1 and the "increase" never shows. On this run the lane was heavily contended (60-second postgres checkpoints in the service-container log), stretching the window between the reads to over a minute — plenty for every other in-flight scope to drain.

## The fix

`WedgeWatchdog.track` now also sets a `@TaskLocal`, `isInsideTrackedScope`, and the guard asserts it from inside `withApp`'s body. Task-locals follow the task tree, so another suite's scope can neither **satisfy** the assertion (no false pass through `withPatternFamilyFixture`'s self-arming) nor **disturb** it (no false fail from concurrent scopes draining) — race-free and strictly stronger than the counter delta. The global counter keeps its job as the monitor's arming signal, and the test still pins a same-instant floor (`activeTrackedScopes >= 1` from inside the scope, which concurrent activity can only raise).

Verified in both directions:
- Green as-is (and the whole `WorkerTests` target, 354 tests, green — the other `track` consumer).
- **Seen to fail first**: with the `WedgeWatchdog.track` wrapper deliberately stripped from `withApp`, the rewritten guard fails with 2 issues — the seam it exists to protect is still protected.

## Ledger

`docs/ci-flakiness.md` gets the sighting recorded under Family 5 (whose contention conditions produced it, though the shape is a racy assertion rather than starvation), and its attack note 2 (equalize the api-tests ceiling) marked **DONE** — `swift-tests.yml` has carried matching 25-minute ceilings on both api-tests lanes since before the current history graft, but the note still read as open.

Surveyed and deliberately not touched: the webkit editor/grading probe families (the exec-hang investigation — a research project with its own doc trail, not a test-level fix), and the `#1178` telemetry, which shows no other Swift-lane flake in the Aug 19–22 window.

## Validation

`swift build --build-tests` green; `WedgeWatchdogArmingTests` (3) and `WorkerTests` (354) green; `scripts/lint.sh` exit 0; `scripts/swiftlint.sh` 0 violations in 1076 files; changelog fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkeyq2x3B6fYN8o7NSSf9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkeyq2x3B6fYN8o7NSSf9o)_