### PR TITLE
fix(tests): make the daemon-fanout overlap a rendezvous, not a 100ms race

### DIFF
--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -1089,9 +1089,11 @@ import Testing
             if rendezvousClosed {
                 return
             }
+            // `Task {}` inherits this actor's isolation, so after the sleep
+            // the close runs as a synchronous same-actor call.
             let watchdog = Task { [holdTimeout] in
                 try? await Task.sleep(for: holdTimeout)
-                await self.closeRendezvous()
+                self.closeRendezvous()
             }
             await withCheckedContinuation { held.append($0) }
             watchdog.cancel()

--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -1038,18 +1038,30 @@ import Testing
 
     /// Records the peak number of simultaneous `run(...)` invocations so a
     /// concurrency test can prove the daemon's worker-loop fanout actually
-    /// processes jobs in parallel.  Holds each invocation open for `delay`
-    /// so the time window for overlap is reliable.
+    /// processes jobs in parallel.
+    ///
+    /// Overlap is a RENDEZVOUS, not a race: each invocation is held open
+    /// until a second one is simultaneously active (or `holdTimeout`
+    /// expires).  An earlier version held each invocation open for a fixed
+    /// 100 ms and hoped two would coincide, but the per-job pipeline stages
+    /// ahead of the runner (submission download, workspace prep) jitter by
+    /// more than that on a loaded runner, so the executions can serialize
+    /// with no regression present — which failed the weekly mutation
+    /// sweep's baseline (2026-08-25, shard 1) and cost the shard.  Holding
+    /// until the second arrival makes overlap an event the daemon must
+    /// produce rather than a scheduling coincidence.
     private actor ConcurrencyRecordingRunner: ScriptRunner {
         private var activeCount = 0
         private var maxObserved = 0
         private var totalCompletions = 0
+        private var held: [CheckedContinuation<Void, Never>] = []
+        private var rendezvousClosed = false
         private let output: ScriptOutput
-        private let delay: Duration
+        private let holdTimeout: Duration
 
-        init(output: ScriptOutput, delay: Duration) {
+        init(output: ScriptOutput, holdTimeout: Duration) {
             self.output = output
-            self.delay = delay
+            self.holdTimeout = holdTimeout
         }
 
         func run(
@@ -1057,10 +1069,41 @@ import Testing
         ) async -> ScriptOutput {
             activeCount += 1
             maxObserved = Swift.max(maxObserved, activeCount)
-            try? await Task.sleep(for: delay)
+            await holdForOverlap()
             activeCount -= 1
             totalCompletions += 1
             return output
+        }
+
+        /// Suspends until a second invocation is active.  The moment two
+        /// are, the rendezvous closes and every held (and future)
+        /// invocation returns immediately.  A genuinely serialized daemon
+        /// never produces the second arrival; the watchdog then closes the
+        /// rendezvous at `holdTimeout` so the jobs drain and the test fails
+        /// on the `maxConcurrent` assertion instead of hanging.
+        private func holdForOverlap() async {
+            if activeCount >= 2 {
+                closeRendezvous()
+                return
+            }
+            if rendezvousClosed {
+                return
+            }
+            let watchdog = Task { [holdTimeout] in
+                try? await Task.sleep(for: holdTimeout)
+                await self.closeRendezvous()
+            }
+            await withCheckedContinuation { held.append($0) }
+            watchdog.cancel()
+        }
+
+        private func closeRendezvous() {
+            rendezvousClosed = true
+            let released = held
+            held = []
+            for continuation in released {
+                continuation.resume()
+            }
         }
 
         func snapshot() -> (maxConcurrent: Int, total: Int) {
@@ -1075,10 +1118,12 @@ import Testing
 
     /// With `maxConcurrentJobs > 1`, the daemon should actually run more
     /// than one job at a time — not serialize them through a single
-    /// worker loop.  This test feeds 5 jobs and a 100 ms per-job delay,
-    /// then asserts the recording runner observed at least 2 concurrent
-    /// invocations (more is fine; less means the worker-loop fanout
-    /// regressed).
+    /// worker loop.  This test feeds 5 jobs; the recording runner holds
+    /// each invocation open until a second one is simultaneously active,
+    /// then asserts at least 2 concurrent invocations were observed (more
+    /// is fine; less means the worker-loop fanout regressed).  The hold is
+    /// safe because each slot runs its own worker loop, so one held slot
+    /// cannot stop another slot's job from reaching the runner.
     @Test func workerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("worker-daemon-concurrent-\(UUID().uuidString)", isDirectory: true)
@@ -1097,9 +1142,13 @@ import Testing
         }
         let poller = MockPoller(jobs: jobs.map(Optional.some) + [nil])
         let reporter = MockReporter()
+        // Generous for the same reason as `waitUntil`'s default: the hold
+        // releases the instant the second job arrives, so a large ceiling
+        // adds nothing to passing runs — it only decides how long a real
+        // fanout regression takes to drain and fail.
         let runner = ConcurrencyRecordingRunner(
             output: ScriptOutput(exitCode: 0, stdout: "passed", stderr: "", executionTimeMs: 1, timedOut: false),
-            delay: .milliseconds(100)
+            holdTimeout: .seconds(15)
         )
         let daemon = WorkerDaemon(
             poller: poller,
@@ -1115,7 +1164,11 @@ import Testing
         )
 
         let task = Task { try await daemon.run() }
-        _ = await waitUntil(timeoutSeconds: 10) { await reporter.snapshot().count == 5 }
+        // 30s, not the usual 10: on a real fanout regression the first job
+        // is held for the full 15s hold timeout before the rest drain, and
+        // this gate must outlast that so the failure reads "1 concurrent
+        // invocation", not "jobs never completed".
+        _ = await waitUntil(timeoutSeconds: 30) { await reporter.snapshot().count == 5 }
         let shutDown = await awaitCancelledDaemon(task)
         #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 

--- a/changelog.d/mutation-shard-concurrency-flake.md
+++ b/changelog.d/mutation-shard-concurrency-flake.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The daemon-fanout concurrency test no longer races a 100 ms overlap
+  window, which cost the weekly mutation sweep a shard.** Shard 1 of the
+  2026-08-25 sweep produced no mutants because Muter's unmutated baseline
+  failed on `workerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows`:
+  the test held each mock script execution open for a fixed 100 ms and
+  asserted two would coincide, but the pipeline stages ahead of the runner
+  (submission download, workspace prep) jitter by more than that with the
+  whole test tree in one process on a 2-core runner, so all five executions
+  serialized with no regression present — the shard's own logs show the five
+  job pipelines overlapping and only the execution windows missing each
+  other. The recording runner now holds each invocation open until a second
+  one is simultaneously active, making overlap an event the daemon must
+  produce rather than a scheduling coincidence; a genuinely serialized
+  daemon trips a 15 s watchdog instead, drains its jobs, and still fails the
+  `maxConcurrent` assertion.


### PR DESCRIPTION
## What failed

Shard 1 of the 2026-08-25 weekly mutation sweep ([run 32816997116](https://github.com/JimWallace/Chickadee/actions/runs/32816997116)) produced no mutants. Muter's **unmutated baseline** failed with exactly one issue:

```
✘ workerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows()
  WorkerDaemonTests.swift:1124: Expectation failed: (maxConcurrent → 1) >= 2
  "expected >= 2 concurrent script invocations, got 1; fanout may have regressed"
```

A red baseline means Muter mutates nothing, so the shard uploaded a "no mutant outcomes at all" report and its eighth of the tree went unmeasured this week (the aggregator correctly named the missing shard rather than reading it as clean — #1493 is that sweep's triage issue).

## Why it is a flake, not a fanout regression

The test fed 5 jobs through the daemon and asserted that at least two of the mock 100 ms script executions overlapped. That races per-job pipeline jitter against a fixed 100 ms window. In the failing shard's own logs:

- all five jobs were accepted before any finished (`runner_active_jobs` reached 5), and all five job wall-clocks were ~1.7 s ending within the same second — the **pipelines** overlapped fine;
- but the stages ahead of the runner staggered the executions apart: submission downloads measured 87–319 ms and workspace prep 9–374 ms, so the five 100 ms **execution windows** serialized perfectly (each `test_execution_end` precedes the next `test_execution_start`).

The mutation baseline is the worst case for this: the whole 834-test tree in one process on a 2-core runner. The three prior sweeps ran the same test in the same baseline and passed, and per-PR `worker-tests` runs it green — scheduling noise, not the daemon serializing.

## The fix

`ConcurrencyRecordingRunner` now makes overlap a **rendezvous instead of a race**: each `run(...)` invocation is held open until a second invocation is simultaneously active, so overlap is an event the daemon must produce rather than a scheduling coincidence.

- **Passing path gains zero latency** — the hold releases the instant the second job arrives.
- **Deadlock-free** — each slot runs its own worker loop (`RunnerDaemon.run` spawns one per slot), so a held slot cannot stop another slot's job from reaching the runner.
- **The guarded regression still fails cleanly** — a genuinely serialized daemon never produces the second arrival; a 15 s watchdog then closes the rendezvous so the jobs drain and the test fails on the `maxConcurrent` assertion instead of hanging. The outer completion gate widens 10 s → 30 s so that path reads "got 1", not "jobs never completed".

This keeps `WorkerDaemonTests` in the mutation baseline (it is one of the sibling suites `--skip WorkerTests/` deliberately keeps, since they grade Core mutants) rather than widening the skip list — the same direction as #1472, which is about making the skipped `WorkerTests` suite itself survivable.

## Validation

- `swift-format lint --strict` clean on the changed file.
- Fixed test run green locally, including repeated runs (local matrix posted as a PR comment once complete).
- Regression path exercised locally by forcing serialization in the daemon: the test still fails on the `maxConcurrent` assertion, draining via the watchdog rather than hanging.

Refs #1493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgtL16bqbvwksSMzckiWZp