### PR TITLE
ci: retire every Node 20 action pin

### DIFF
--- a/.github/workflows/browser-grading-smoke.yml
+++ b/.github/workflows/browser-grading-smoke.yml
@@ -47,7 +47,7 @@ jobs:
     outputs:
       run_smoke: ${{ steps.decide.outputs.run_smoke }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -117,9 +117,9 @@ jobs:
           # silently be graded against Octave's plotting function.
           - { language: octave, mode: eval }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/mutation-pr.yml
+++ b/.github/workflows/mutation-pr.yml
@@ -97,7 +97,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Cache the patched Muter build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/muter-src
           key: muter-${{ runner.os }}-7f1f258-${{ hashFiles('Tools/mutation/0001-restore-parse-tree-cache.patch') }}
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload the report
         if: always() && steps.files.outputs.count != '0'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutation-report-pr
           path: mutation-report/

--- a/.github/workflows/mutation-probe.yml
+++ b/.github/workflows/mutation-probe.yml
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload the Muter report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: muter-probe-report
           path: ${{ runner.temp }}/muter-report.txt

--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Cache the patched Muter build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/muter-src
           # Keyed on the pin AND the patch, so editing either rebuilds rather
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload this shard's report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutation-report-${{ matrix.shard }}
           path: mutation-report/
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: mutation-report-*
           path: shards
@@ -279,7 +279,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Merge the shards and file the issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/revendor-kernels.yml
+++ b/.github/workflows/revendor-kernels.yml
@@ -72,13 +72,13 @@ jobs:
     # cache. chickadee-lua adds ~10 MB of packages and little time.
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Needed to push the rebuild back; harmless otherwise.
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           # Must match the kernel's own Python (currently 3.13). The derived
           # module index takes its C-extension stdlib names from the building
@@ -105,7 +105,7 @@ jobs:
       # Solving and downloading the environments is the slow half. Keyed on the
       # env files so a rebuild triggered by anything else reuses the packages.
       - name: Cache the empack package downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/empack
           key: empack-${{ hashFiles('Tools/jupyterlite/environment-*.yml') }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -94,14 +94,14 @@ jobs:
 
       - name: Upload visual diffs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-diffs
           path: visual-diffs/
           if-no-files-found: ignore
 
       - name: Upload bootstrap baselines
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-baselines-bootstrap
           path: visual-bootstrap/

--- a/changelog.d/node20-action-pins.md
+++ b/changelog.d/node20-action-pins.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **No workflow pins a Node 20 action any more.** GitHub's runners deprecated
+  Node 20 (2025-09-19) and force such actions onto Node 24 with a warning in
+  every affected job — the mutation sweep, probe, and per-PR workflows, the
+  kernel re-vendor, the browser-grading smoke, and visual regression all
+  carried one or more. The fifteen stale pins move to the majors that declare
+  Node 24, most already in use elsewhere in this repository: `checkout` v4→v6,
+  `cache` v4→v5, `upload-artifact` v4→v7, `download-artifact` v4→v8,
+  `setup-node` v4→v6, `setup-python` v5→v6, and `github-script` v7→v8. Every
+  target's `action.yml` was checked for `using: node24`, and every remaining
+  pin in the tree (docker, CodeQL, codecov, trivy, zap, the composite
+  actions) verified as Node 24, composite, or docker — so the deprecation
+  warning is gone repository-wide, not just moved.


### PR DESCRIPTION
## What

Bumps the fifteen remaining action pins that still declare a Node 20 runtime, across six workflows: `mutation-weekly`, `mutation-pr`, `mutation-probe`, `revendor-kernels`, `browser-grading-smoke`, and `visual-regression`. This removes the deprecation annotation these jobs print on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/upload-artifact@v4.

The warning is about the *actions'* bundled runtime declaration, not this repository's code — GitHub deprecated Node 20 on hosted runners (2025-09-19) and force-runs such actions on Node 24 while nagging. The fix is pinning the majors that declare `node24`.

## The bumps

| Action | From | To | In-repo precedent |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | 31 existing uses |
| `actions/cache` | v4 | v5 | 8 existing uses |
| `actions/upload-artifact` | v4 | v7 | 2 existing uses |
| `actions/download-artifact` | v4 | v8 | 1 existing use |
| `actions/setup-node` | v4 | v6 | 2 existing uses |
| `actions/setup-python` | v5 | v6 | 1 existing use |
| `actions/github-script` | v7 | v8 | none — verified directly |

## Verification

- **Every target tag's `action.yml` fetched and checked**: all fifteen old pins declare `using: node20`; all seven target majors declare `using: node24`.
- **`download-artifact@v8` keeps the aggregator's contract**: the `pattern` input survives, and `merge-multiple` still defaults to false (per-artifact subdirectories), which is the `shards/mutation-report-N/` layout `mutation-weekly`'s merge script reads.
- **`revendor-kernels`' push-back is safe across the checkout major**: it already pins `persist-credentials: true` explicitly, so no default change can bite.
- **`github-script@v8`** is a runtime bump; the one script using it (the weekly aggregator) calls only stable `github.rest.issues` / `core.*` / `require('fs'|'path')` APIs.
- **Every remaining pin in the tree audited**: `docker/*@current`, `softprops/action-gh-release@v3`, `zaproxy/action-baseline@v0.15.0`, and `github/codeql-action@v4` all declare `node24`; `codecov/codecov-action@v7` and `aquasecurity/trivy-action@v0.36.0` are composite; the local composite actions use `cache@v5` only. So the warning is gone repository-wide, not just moved.
- All six edited workflows re-parse as YAML; the diff is exactly the fifteen `uses:` lines plus a changelog fragment.

Cache note: entries written by `cache@v4` (the Muter build, the empack downloads) restore under v5 — same service and key namespace; worst case is one cold rebuild.

The in-flight mutation sweep re-run (32886018037) is unaffected — it runs on the workflow snapshot taken at dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgtL16bqbvwksSMzckiWZp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgtL16bqbvwksSMzckiWZp)_