### PR TITLE
test: answer all six survivors of the 2026-08-25 mutation sweep

### DIFF
--- a/Tests/CoreTests/AchievementClassificationTests.swift
+++ b/Tests/CoreTests/AchievementClassificationTests.swift
@@ -193,4 +193,76 @@ import Testing
             !achievement(scope: .individual, reward: .badge, conditions: [])
                 .isSweepEvaluableClassGoal)
     }
+
+    // MARK: the union-goal family (2026-08-25 sweep, run 32886018037)
+    //
+    // Four survivors, one cause: these predicates' only assertions lived in
+    // `Tests/APITests/ClassUnionGoalTests`, which the sweep skips — the
+    // "detected from the wrong layer" shape docs/mutation-triage.md names.
+    // They are Core model invariants, so they get Core-layer assertions here.
+
+    /// Kills the `ChangeLogicalConnector` on `isUnionClassGoal`
+    /// (`isClassGoal && conditions.contains { $0.signal == .itemsCovered }`).
+    /// Under `||` every grade-counted class goal reads as union-counted, and
+    /// the sweep would grade it on item coverage it never accumulates.
+    @Test func unionClassGoalNeedsAClassGoalAndAnItemsCoveredCondition() {
+        let union = achievement(
+            scope: .classWide, reward: .points, conditions: [condition(.itemsCovered, .atLeast, 12)])
+        #expect(union.isUnionClassGoal)
+
+        // Each of these satisfies exactly one operand.
+        let gradeCounted = achievement(
+            scope: .classWide, reward: .points, conditions: [condition(.grade, .atLeast, 80)])
+        #expect(!gradeCounted.isUnionClassGoal)
+        let individualItems = achievement(
+            scope: .individual, reward: .badge, conditions: [condition(.itemsCovered, .atLeast, 12)])
+        #expect(!individualItems.isUnionClassGoal)
+    }
+
+    /// Kills the `RelationalOperatorReplacement` inside
+    /// `coveredItemsRequirement` (`$0.signal == .itemsCovered` → `!=`). The
+    /// sweep admits exactly one condition, so under the mutant the lookup
+    /// finds nothing on precisely the valid shape and every union goal reads
+    /// as having no requirement at all.
+    @Test func coveredItemsRequirementReadsTheItemsCoveredCondition() {
+        let target = AchievementTarget(kind: .section, ref: "bughunt")
+        let union = achievement(
+            scope: .classWide, reward: .points,
+            conditions: [
+                AchievementCondition(
+                    signal: .itemsCovered, comparator: .atLeast, value: 12, target: target)
+            ])
+        let requirement = union.coveredItemsRequirement
+        #expect(requirement?.count == 12)
+        #expect(requirement?.scope == target)
+    }
+
+    /// Kills the `RelationalOperatorReplacement` in `coveredItemNames`
+    /// (`$0.sectionID == ref` → `!=`), which counts every OTHER section's
+    /// items — the well-formedness gate beside a bug hunt instead of the
+    /// hunt's variants, so coverage would fill from tests the goal is
+    /// deliberately scoped away from.
+    @Test func sectionScopedItemNamesComeFromThatSectionOnly() {
+        let props = TestProperties(testSuites: [
+            TestSuiteEntry(tier: .pub, script: "publictest_variant_a.py", sectionID: "bughunt"),
+            TestSuiteEntry(tier: .pub, script: "publictest_variant_b.py", sectionID: "bughunt"),
+            TestSuiteEntry(tier: .pub, script: "publictest_wellformed.py", sectionID: "gate"),
+        ])
+        let scoped = props.coveredItemNames(
+            inScopeOf: AchievementTarget(kind: .section, ref: "bughunt"))
+        #expect(scoped == ["publictest_variant_a", "publictest_variant_b"])
+        #expect(props.coveredItemNames(inScopeOf: nil).count == 3)
+    }
+
+    /// Kills the `SwapTernary` on `AchievementSignal.allowedScopes`
+    /// (`readsTheWholeClass ? [.classWide] : allCases` swapped). Swapped, a
+    /// per-student scope is offered for `itemsCovered` — the badge that saves
+    /// cleanly and then never fires, the exact shape the property exists to
+    /// refuse — while every other signal is locked to class goals only.
+    @Test func itemsCoveredIsScopedToClassGoalsAndNothingElseIs() {
+        #expect(AchievementSignal.itemsCovered.allowedScopes == [.classWide])
+        for signal in AchievementSignal.allCases where signal != .itemsCovered {
+            #expect(signal.allowedScopes == AchievementScope.allCases)
+        }
+    }
 }

--- a/Tests/CoreTests/JSONValueCppLiteralTests.swift
+++ b/Tests/CoreTests/JSONValueCppLiteralTests.swift
@@ -114,4 +114,17 @@ import Testing
         #expect(JSONValue.array([.int(1), .double(2)]).cppRenderabilityIssue == nil)
         #expect(JSONValue.object(["k": .string("v")]).cppRenderabilityIssue == nil)
     }
+
+    /// Kills the `SwapTernary` on the object arm's empty/unrenderable split
+    /// (2026-08-25 sweep, run 32886018037). Swapped, an empty object renders
+    /// the loud backstop while a mixed-value object renders a plausible empty
+    /// `std::map` — the silent wrong value the backstop exists to prevent.
+    /// The tests above pin the mixed object's *renderability issue* but never
+    /// the literal text either branch actually emits, which is why the swap
+    /// survived.
+    @Test func emptyObjectsRenderAsEmptyMapsAndUnrenderableOnesStayLoud() {
+        #expect(JSONValue.object([:]).cppLiteral == "std::map<std::string, double>{}")
+        let mixedObject = JSONValue.object(["a": .int(1), "b": .string("x")])
+        #expect(mixedObject.cppLiteral == "CK_UNRENDERABLE_OBJECT_HAS_NO_SINGLE_CPP_VALUE_TYPE")
+    }
 }

--- a/Tools/mutation/report.py
+++ b/Tools/mutation/report.py
@@ -332,12 +332,52 @@ def main() -> int:
     ledger = load_equivalent_ledger()
     equivalent = []
     if ledger:
+        # Verdict counts per site. Muter's rows carry no column, so a site
+        # holding several candidates gets one row PER candidate, every one
+        # naming the same (file, line, operator) -- the counts are the only
+        # per-candidate signal the raw report has.
+        survived_rows: dict[tuple[str, int, str], int] = {}
+        for base, line, operator, _ in survived:
+            row_key = (repo_path(base, cache), line, operator)
+            survived_rows[row_key] = survived_rows.get(row_key, 0) + 1
+        killed_rows: dict[tuple[str, int, str], int] = {}
+        for base, line, operator, _ in killed:
+            row_key = (repo_path(base, cache), line, operator)
+            killed_rows[row_key] = killed_rows.get(row_key, 0) + 1
+
         for key in list(mutation_of):
             path, _line, operator = key
             muts = mutation_of[key]
             if not muts:
                 continue
-            if all((path, operator, " ".join(m["mutated"].split())) in ledger for m in muts):
+            ledgered = sum(
+                1 for m in muts if (path, operator, " ".join(m["mutated"].split())) in ledger
+            )
+            if ledgered == len(muts):
+                equivalent.append(key)
+                continue
+            # A site can hold a ledgered equivalent BESIDE killable siblings,
+            # and requiring every candidate to be ledgered left such a site
+            # open forever: NotebookExtraction.swift:458 in run 32886018037
+            # carries the ledgered first-connector mutant plus a second
+            # connector the suite kills, so each week Muter reported the
+            # equivalent as survived and the site re-entered the queue --
+            # which can then never reach zero, the one number this whole
+            # filter exists to make honest.
+            #
+            # The verdict counts settle it without knowing which row is
+            # which: a correctly-ledgered equivalent always survives, so if
+            # the survived rows number exactly the ledgered candidates and
+            # the killed rows account for all the rest, every candidate ran
+            # and every survivor slot is a ledgered one. This inherits the
+            # ledger's existing trust model -- a WRONG entry could mask a
+            # real survivor when the counts happen to coincide, exactly as
+            # it already could when it was the only candidate at its site.
+            if (
+                0 < ledgered
+                and survived_rows.get(key, 0) == ledgered
+                and killed_rows.get(key, 0) == len(muts) - ledgered
+            ):
                 equivalent.append(key)
         if equivalent:
             eq_set = set(equivalent)

--- a/Tools/mutation/report_test.py
+++ b/Tools/mutation/report_test.py
@@ -289,14 +289,14 @@ if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"] 
 }
 '''
 
-    def _with_ledger(self, entries):
+    def _with_ledger(self, entries, raw=None, mutated=None):
         """Point report.py at a temporary ledger and run it."""
         real = os.path.join(HERE, "equivalent-mutants.json")
         backup = open(real).read() if os.path.exists(real) else None
         with open(real, "w") as fh:
             json.dump({"entries": entries}, fh)
         try:
-            return run(self.RAW, self.MUTATED)
+            return run(raw or self.RAW, mutated or self.MUTATED)
         finally:
             if backup is None:
                 os.unlink(real)
@@ -338,6 +338,76 @@ if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"] 
         }])
         self.assertNotEqual(code, 0)
         self.assertIsNone(summary)
+
+    # One site, two candidates: a ledgered equivalent beside a killable
+    # sibling. Muter's verdict rows carry no column, so the only per-candidate
+    # signal is their COUNT -- one row per candidate, all naming the same
+    # (file, line, operator). Run 32886018037's NotebookExtraction.swift:458
+    # is the real instance: the ledgered first-connector mutant survived, the
+    # second connector was killed by the suite, and requiring every candidate
+    # to be ledgered kept the site in the open queue forever.
+
+    MIXED_RAW = """\
+Probe.swift:10  ChangeLogicalConnector  mutant survived
+Probe.swift:10  ChangeLogicalConnector  mutant killed
+
+Of the 2 mutants introduced into your code, your test suite killed 1.
+Mutation Score of Test Suite: 50%
+Muter took 00:00:01.000
+"""
+
+    MIXED_MUTATED = (
+        'import class Foundation.ProcessInfo\n'
+        'if ProcessInfo.processInfo.environment["Probe_ChangeLogicalConnector_10_5_120"]'
+        ' != nil {\n'
+        '    return a && b || c\n'
+        '} else if ProcessInfo.processInfo.environment'
+        '["Probe_ChangeLogicalConnector_10_9_124"] != nil {\n'
+        '    return a || b && c\n'
+        '} else {\n'
+        '    return a || b || c\n'
+        '}\n'
+    )
+
+    LEDGERED_FIRST_CONNECTOR = {
+        "file": "Probe.swift",
+        "operator": "ChangeLogicalConnector",
+        "mutated": "return a && b || c",
+        "reason": "Fixture argument in the real entries' shape: the first disjunct "
+                  "is subsumed for every reachable input, so conjoining the first "
+                  "pair cannot change the expression's value.",
+    }
+
+    def test_a_mixed_site_is_answered_when_killed_rows_account_for_the_rest(self):
+        """Survived rows == ledgered candidates, killed rows == the rest: every
+        candidate ran and every survivor slot is a ledgered one."""
+        _code, report, summary = self._with_ledger(
+            [self.LEDGERED_FIRST_CONNECTOR],
+            raw=self.MIXED_RAW, mutated=self.MIXED_MUTATED)
+        self.assertEqual(summary["survived"], 0)
+        self.assertEqual(len(summary["answeredWithReason"]), 1)
+        self.assertIn("Already answered", report)
+
+    def test_a_mixed_site_stays_open_when_more_than_the_ledgered_survive(self):
+        """Two survivors against one ledger entry: at least one open question."""
+        both_survived = self.MIXED_RAW.replace("mutant killed", "mutant survived")
+        _code, _report, summary = self._with_ledger(
+            [self.LEDGERED_FIRST_CONNECTOR],
+            raw=both_survived, mutated=self.MIXED_MUTATED)
+        self.assertEqual(summary["survived"], 2)
+        self.assertEqual(summary["answeredWithReason"], [])
+
+    def test_a_mixed_site_stays_open_when_a_candidate_has_no_verdict(self):
+        """A candidate with no row at all might be the one that survived
+        somewhere the report cannot see; without every candidate accounted
+        for, the counts prove nothing."""
+        no_killed_row = "\n".join(
+            line for line in self.MIXED_RAW.splitlines() if "killed" not in line) + "\n"
+        _code, _report, summary = self._with_ledger(
+            [self.LEDGERED_FIRST_CONNECTOR],
+            raw=no_killed_row, mutated=self.MIXED_MUTATED)
+        self.assertEqual(summary["survived"], 1)
+        self.assertEqual(summary["answeredWithReason"], [])
 
 
 if __name__ == "__main__":

--- a/changelog.d/mutation-2026-08-25-triage.md
+++ b/changelog.d/mutation-2026-08-25-triage.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **The 2026-08-25 mutation sweep's six survivors are answered** (#1496). Five
+  were real gaps, each confirmed SURVIVED by the verifier before a test was
+  written and KILLED by the new test after. Four sat in the union-class-goal
+  family — `isUnionClassGoal`, `coveredItemsRequirement`, the section scoping
+  of `coveredItemNames`, and `AchievementSignal.allowedScopes` — whose only
+  assertions lived in `Tests/APITests`, the suite the sweep skips, so the
+  Core model invariants now have Core-layer tests. The fifth pinned the C++
+  object literal's empty/unrenderable split, where the swapped mutant
+  rendered a plausible empty `std::map` for an unrenderable object — the
+  silent wrong value the loud backstop exists to prevent. The sixth site
+  needed no test: one candidate is the ledgered first-connector equivalent in
+  `isSafeTopLevelStatement`, the other is already killed by
+  `NotebookExtractionPredicateTests`, and `report.py` now files such a mixed
+  site as answered when the survived rows number exactly the ledgered
+  candidates and the killed rows account for the rest — before this rule a
+  site holding a ledgered equivalent beside a killable sibling re-entered the
+  open queue every week, and the queue could never reach zero.


### PR DESCRIPTION
## What

Closes out [#1496](https://github.com/JimWallace/Chickadee/issues/1496) (the 2026-08-25 sweep, 366 killed / 6 survived) per `docs/mutation-triage.md`: every survivor was run through `Tools/mutation/verify-survivor.py` **before** anything was written (all six `SURVIVED`) and **again after** (the five real gaps `KILLED`, each naming the new suite that caught it).

## The five gaps → five tests

**Four in the union-class-goal family** (`Tests/CoreTests/AchievementClassificationTests.swift`), one cause: their only assertions lived in `Tests/APITests/ClassUnionGoalTests` — the suite the sweep skips — the "right invariant, wrong layer" shape the triage doc names. They are Core model invariants and now have Core-layer tests:

| survivor | what the mutant did |
|---|---|
| `isUnionClassGoal` `&&`→`\|\|` | every grade-counted class goal reads as union-counted, graded on coverage it never accumulates |
| `coveredItemsRequirement` `==`→`!=` | the lookup finds nothing on exactly the one-condition shape the sweep admits — every union goal reads "no requirement" |
| `coveredItemNames` `==`→`!=` | a section scope counts every *other* section's items (the well-formedness gate instead of the bug hunt) |
| `allowedScopes` SwapTernary | offers a per-student scope for `itemsCovered` — the badge that saves cleanly and never fires |

**The fifth** (`Tests/CoreTests/JSONValueCppLiteralTests.swift`): the C++ object literal's empty/unrenderable split. The suite pinned the mixed object's renderability *issue* but never the literal *text*, so the SwapTernary survived — and swapped, an unrenderable object renders a plausible empty `std::map`, the silent wrong value the loud backstop exists to prevent.

## The sixth needed no test — it produced a report.py rule

`NotebookExtraction.swift:458` carries two candidates: the **ledgered first-connector equivalent** (still `SURVIVED`, as an equivalent must — the entry text matches today's code exactly) and a second connector **already `KILLED` by `NotebookExtractionPredicateTests`**. Shard 3's raw rows show exactly one `survived` and one `killed` verdict at the site.

`report.py` required *every* candidate at a site to be ledgered before filing it as answered, so this mixed site re-entered the open queue every week — and the queue could never reach zero, the one number the whole filter exists to make honest. It now files a site as answered when the survived rows number exactly the ledgered candidates and the killed rows account for all the rest: a correctly-ledgered equivalent always survives, so the counts pin every survivor slot to a ledgered candidate. The rule inherits the ledger's existing trust model; three new `report_test.py` cases pin it (answered when counts match, open when both survive, open when a candidate has no verdict), the first **seen to fail** against the previous logic.

## Verification

- Verifier before: 6/6 `SURVIVED`. Verifier after: 5 `KILLED` (4× `AchievementClassificationTests`, 1× `JSONValueCppLiteralTests`), candidate 2 `KILLED` (existing test), candidate 1 `SURVIVED` (ledgered equivalent — correct).
- Python tooling: 20/20 (`report_test.py`), with the mixed-site test failing against stashed pre-change `report.py`.
- Swift: 839 tests in the sweep's own configuration (`--skip APITests --skip WorkerTests/ --skip ZipProcessEnvironmentTests`) green on the clean tree.

After this merges, the open survivor queue for the logic tier is **zero**.

Refs #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgtL16bqbvwksSMzckiWZp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgtL16bqbvwksSMzckiWZp)_